### PR TITLE
feat: temporal navigation — time-based recall queries

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1336,6 +1336,8 @@
             <button class="suggestion-pill" onclick="sendSuggestion('What are my goals?')">What are my goals?</button>
             <button class="suggestion-pill" onclick="sendSuggestion('What ideas do I have?')">What ideas do I
               have?</button>
+            <button class="suggestion-pill" onclick="sendSuggestion('What happened last week?')">Last week</button>
+            <button class="suggestion-pill" onclick="sendSuggestion('What did I decide this month?')">This month</button>
           </div>
           <div class="input-bar">
             <div class="input-inner">
@@ -1360,6 +1362,13 @@
               <i class="ti ti-tag" style="color:var(--text-tertiary);font-size:13px;flex-shrink:0;"></i>
               <select class="filter-field" id="tag-filter-recent" onchange="onTagChange(this.value)">
                 <option value="">All tags</option>
+              </select>
+              <select class="filter-field" id="time-filter-recent" onchange="onTimeRangeChange(this.value)" style="min-width:0;">
+                <option value="">All time</option>
+                <option value="today">Today</option>
+                <option value="7">Last 7 days</option>
+                <option value="30">Last 30 days</option>
+                <option value="month">This month</option>
               </select>
               <button class="refresh-btn" id="refresh-btn" onclick="loadRecent()"><i class="ti ti-refresh"></i></button>
             </div>
@@ -1461,7 +1470,7 @@
   <script>
     let WORKER_URL = '', AUTH_TOKEN = '', allEntries = [];
     let pendingForgetId = null, pendingAppendId = null, pendingForgetCard = null;
-    let currentTab = 'recall', selectedTag = '';
+    let currentTab = 'recall', selectedTag = '', selectedTimeRange = '';
 
     function init() {
       // Auto-populate URL from the current page origin (UI is hosted on the same Worker)
@@ -1522,7 +1531,40 @@
         const el = document.getElementById(id);
         if (el) el.value = tag;
       });
-      if (currentTab === 'recent') filterRecent(tag);
+      if (currentTab === 'recent') applyRecentFilters();
+    }
+
+    function onTimeRangeChange(val) {
+      selectedTimeRange = val;
+      applyRecentFilters();
+    }
+
+    function applyRecentFilters() {
+      let entries = allEntries;
+      if (selectedTag) {
+        const tag = selectedTag.replace(/^#/, '').toLowerCase().trim();
+        entries = entries.filter(e => {
+          try { return JSON.parse(e.tags || '[]').some(t => t.toLowerCase() === tag); } catch { return false; }
+        });
+      }
+      if (selectedTimeRange) {
+        const now = Date.now(), MS_DAY = 86400000;
+        let cutoff;
+        if (selectedTimeRange === 'today') {
+          const d = new Date(); cutoff = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+        } else if (selectedTimeRange === 'month') {
+          const d = new Date(); cutoff = new Date(d.getFullYear(), d.getMonth(), 1).getTime();
+        } else {
+          cutoff = now - parseInt(selectedTimeRange) * MS_DAY;
+        }
+        entries = entries.filter(e => e.created_at >= cutoff);
+      }
+      renderRecent(entries);
+    }
+
+    function filterRecent(val) {
+      selectedTag = val;
+      applyRecentFilters();
     }
 
     function logout() {
@@ -1741,9 +1783,23 @@
       }
       const groups = {}, now = new Date();
       const today = toDateStr(now), yesterday = toDateStr(new Date(now - 86400000));
+      const sevenDaysAgo = now.getTime() - 7 * 86400000;
       entries.forEach(entry => {
         const d = new Date(entry.created_at), ds = toDateStr(d);
-        const label = ds === today ? 'Today' : ds === yesterday ? 'Yesterday' : d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+        let label;
+        if (ds === today) {
+          label = 'Today';
+        } else if (ds === yesterday) {
+          label = 'Yesterday';
+        } else if (entry.created_at >= sevenDaysAgo) {
+          label = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+        } else {
+          // Group by week: find the Monday of that week
+          const dow = d.getDay();
+          const diff = dow === 0 ? -6 : 1 - dow;
+          const weekStart = new Date(d.getFullYear(), d.getMonth(), d.getDate() + diff);
+          label = 'Week of ' + weekStart.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+        }
         if (!groups[label]) groups[label] = [];
         groups[label].push(entry);
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,54 @@ function rerankWithTimeDecay(matches: VectorizeMatch[]): VectorizeMatch[] {
     .sort((a, b) => b.score - a.score);
 }
 
+// ─── Temporal phrase parsing ──────────────────────────────────────────────────
+function parseTimePhrase(query: string, now: number): { after?: number; before?: number; cleanQuery: string } {
+  const MS_DAY = 86400000;
+  const MS_WEEK = 7 * MS_DAY;
+  const d = new Date(now);
+  const startOfDay = (date: Date) => new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+  const startOfWeek = (date: Date) => {
+    const dow = date.getDay();
+    const diff = dow === 0 ? -6 : 1 - dow;
+    return startOfDay(new Date(date.getFullYear(), date.getMonth(), date.getDate() + diff));
+  };
+
+  type TimeResult = { after?: number; before?: number };
+  const patterns: Array<[RegExp, (m: RegExpMatchArray) => TimeResult]> = [
+    [/\blast\s+(\d+)\s+days?\b/i, m => ({ after: now - parseInt(m[1]) * MS_DAY })],
+    [/\blast\s+(\d+)\s+weeks?\b/i, m => ({ after: now - parseInt(m[1]) * MS_WEEK })],
+    [/\blast\s+week\b/i, () => ({ after: now - MS_WEEK })],
+    [/\bthis\s+week\b/i, () => ({ after: startOfWeek(d) })],
+    [/\blast\s+month\b/i, () => ({
+      after: new Date(d.getFullYear(), d.getMonth() - 1, 1).getTime(),
+      before: new Date(d.getFullYear(), d.getMonth(), 1).getTime(),
+    })],
+    [/\bthis\s+month\b/i, () => ({ after: new Date(d.getFullYear(), d.getMonth(), 1).getTime() })],
+    [/\byesterday\b/i, () => {
+      const s = startOfDay(d) - MS_DAY;
+      return { after: s, before: s + MS_DAY };
+    }],
+    [/\btoday\b/i, () => ({ after: startOfDay(d) })],
+    [/\baround\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+(\d{1,2})\b/i, m => {
+      const MONTHS: Record<string, number> = { jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5, jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11 };
+      const month = MONTHS[m[1].toLowerCase().slice(0, 3)];
+      const center = new Date(d.getFullYear(), month, parseInt(m[2])).getTime();
+      return { after: center - 3 * MS_DAY, before: center + 3 * MS_DAY };
+    }],
+  ];
+
+  for (const [pattern, handler] of patterns) {
+    const match = query.match(pattern);
+    if (match) {
+      const { after, before } = handler(match);
+      const cleanQuery = query.replace(pattern, '').replace(/\s+/g, ' ').trim() || query;
+      return { after, before, cleanQuery };
+    }
+  }
+
+  return { cleanQuery: query };
+}
+
 // ─── Store entry (full embed + chunk) ────────────────────────────────────────
 // Returns the list of vector IDs inserted so forget() can clean up exactly.
 
@@ -367,9 +415,20 @@ function buildMcpServer(env: Env): McpServer {
       query: z.string().describe("Natural language search query"),
       topK: z.number().int().min(1).max(20).default(5).describe("Number of results"),
       tag: z.string().optional().describe("Filter by a specific tag"),
+      after: z.number().int().optional().describe("Only return entries after this Unix ms timestamp"),
+      before: z.number().int().optional().describe("Only return entries before this Unix ms timestamp"),
     },
-    async ({ query, topK, tag }) => {
-      const values = await embed(query, env);
+    async ({ query, topK, tag, after, before }) => {
+      const now = Date.now();
+      let embedQuery = query;
+      if (after === undefined && before === undefined) {
+        const parsed = parseTimePhrase(query, now);
+        after = parsed.after;
+        before = parsed.before;
+        embedQuery = parsed.cleanQuery;
+      }
+
+      const values = await embed(embedQuery, env);
 
       // If tag filter, resolve matching IDs from D1 first (D1 is source of truth for tags)
       let tagFilterIds: Set<string> | null = null;
@@ -409,12 +468,14 @@ function buildMcpServer(env: Env): McpServer {
         return { content: [{ type: "text", text: "Nothing found matching that query." }] };
       }
 
-      // Fetch full content from D1 for all matched parent IDs
+      // Fetch full content from D1 for all matched parent IDs, applying time filter if set
       const parentIds = deduped.map((m) => (m.metadata as any)?.parentId ?? m.id);
       const placeholders = parentIds.map(() => "?").join(", ");
-      const { results: d1Rows } = await env.DB.prepare(
-        `SELECT id, content, tags, source, created_at FROM entries WHERE id IN (${placeholders})`
-      ).bind(...parentIds).all() as { results: Record<string, any>[] };
+      const d1Bindings: (string | number)[] = [...parentIds];
+      let d1Sql = `SELECT id, content, tags, source, created_at FROM entries WHERE id IN (${placeholders})`;
+      if (after !== undefined) { d1Sql += ` AND created_at >= ?`; d1Bindings.push(after); }
+      if (before !== undefined) { d1Sql += ` AND created_at <= ?`; d1Bindings.push(before); }
+      const { results: d1Rows } = await env.DB.prepare(d1Sql).bind(...d1Bindings).all() as { results: Record<string, any>[] };
 
       const d1Map = new Map(d1Rows.map((r) => [r.id as string, r]));
 
@@ -451,11 +512,17 @@ function buildMcpServer(env: Env): McpServer {
     {
       n: z.number().int().min(1).max(50).default(10),
       tag: z.string().optional(),
+      after: z.number().int().optional().describe("Only return entries after this Unix ms timestamp"),
+      before: z.number().int().optional().describe("Only return entries before this Unix ms timestamp"),
     },
-    async ({ n, tag }) => {
-      let q = `SELECT id, content, tags, source, created_at FROM entries`;
+    async ({ n, tag, after, before }) => {
+      const conds: string[] = [];
       const p: (string | number)[] = [];
-      if (tag) { q += ` WHERE tags LIKE ?`; p.push(`%"${tag}"%`); }
+      if (tag) { conds.push(`tags LIKE ?`); p.push(`%"${tag}"%`); }
+      if (after !== undefined) { conds.push(`created_at >= ?`); p.push(after); }
+      if (before !== undefined) { conds.push(`created_at <= ?`); p.push(before); }
+      let q = `SELECT id, content, tags, source, created_at FROM entries`;
+      if (conds.length) q += ` WHERE ` + conds.join(` AND `);
       q += ` ORDER BY created_at DESC LIMIT ?`; p.push(n);
 
       const { results } = await env.DB.prepare(q).bind(...p).all();


### PR DESCRIPTION
Adds time-based recall to the second brain. parseTimePhrase() converts natural language 
  time phrases into epoch ranges and strips them from the query before embedding. recall and list_recent both get after/before params. Web UI gets a time range dropdown on the Recent tab, 
  week grouping for older entries, and temporal suggestion pills on the Recall tab. Resolves #13