### PR TITLE
Update actions/checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: "22"


### PR DESCRIPTION
Upgrades actions/checkout from v4 to v6 to resolve Node.js 20 deprecation warning on GitHub Actions runners.