### PR TITLE
feat: enrich recall responses with LLM-synthesized insight (Resolves #59)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -430,6 +430,54 @@ async function appendToEntry(
   ).bind(JSON.stringify([...existing, newChunkId]), id).run();
 }
 
+// ─── Synthesize insight from retrieved memories ───────────────────────────────
+
+export async function synthesizeInsight(
+  query: string,
+  rows: { id: string; content: string }[],
+  env: Env
+): Promise<string> {
+  if (!rows.length) return "";
+
+  const memoriesList = rows
+    .map((r, i) => `[${i + 1}] ID: ${r.id}\n${r.content}`)
+    .join("\n\n");
+
+  const prompt = `You are a second brain assistant. Given the user's query and their relevant stored memories, synthesize what they most need to know. Be specific and concise.
+
+Query: "${query}"
+
+Relevant memories:
+${memoriesList}
+
+Provide a brief insight (2-4 sentences) focused on what's most relevant to this query.`;
+
+  let insight = "";
+  try {
+    const stream = await (env.AI as any).run(LLM_MODEL as any, {
+      messages: [{ role: "user", content: prompt }],
+      max_tokens: 300,
+      stream: true,
+    });
+    const reader = (stream as ReadableStream).getReader();
+    const decoder = new TextDecoder();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      decoder.decode(value).split("\n").forEach(line => {
+        if (line.startsWith("data: ") && !line.includes("[DONE]")) {
+          try { const d = JSON.parse(line.slice(6)); if (d.response) insight += d.response; } catch { }
+        }
+      });
+    }
+    reader.releaseLock();
+  } catch (e) {
+    console.error("synthesizeInsight LLM call failed (non-fatal):", e);
+  }
+
+  return insight.trim();
+}
+
 // ─── MCP Server ───────────────────────────────────────────────────────────────
 
 function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
@@ -677,7 +725,9 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         return `${i + 1}. [${date}${src}${tagList}] (${score}% match)${updateLabel}\n${meta?.content ?? ""}`;
       }).join("\n\n");
 
-      return { content: [{ type: "text", text }] };
+      const insight = await synthesizeInsight(embedQuery, d1Rows as { id: string; content: string }[], env);
+      const finalText = insight ? `**Insight:** ${insight}\n\n---\n\n${text}` : text;
+      return { content: [{ type: "text", text: finalText }] };
     }
   );
 

--- a/test/unit/synthesize-insight.test.ts
+++ b/test/unit/synthesize-insight.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { synthesizeInsight } from "../../src/index";
+import { makeTestEnv } from "../helpers/make-env";
+
+function makeSseStream(response: string) {
+  return new ReadableStream({
+    start(c) {
+      c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+      c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+      c.close();
+    },
+  });
+}
+
+function aiMock(response: string) {
+  return { run: vi.fn().mockResolvedValue(makeSseStream(response)) } as unknown as Ai;
+}
+
+describe("synthesizeInsight()", () => {
+  it("returns empty string immediately when rows is empty — AI not called", async () => {
+    const env = makeTestEnv();
+    const result = await synthesizeInsight("some query", [], env);
+    expect(result).toBe("");
+    expect(env.AI.run).not.toHaveBeenCalled();
+  });
+
+  it("returns LLM response on happy path", async () => {
+    const env = makeTestEnv(undefined, { AI: aiMock("Use JWT with short expiry and refresh tokens.") });
+    const result = await synthesizeInsight(
+      "auth strategy",
+      [{ id: "1", content: "We chose JWT with 1hr expiry" }],
+      env
+    );
+    expect(result).toBe("Use JWT with short expiry and refresh tokens.");
+  });
+
+  it("returns empty string when LLM throws — does not propagate error", async () => {
+    const env = makeTestEnv(undefined, {
+      AI: { run: vi.fn().mockRejectedValue(new Error("AI unavailable")) } as unknown as Ai,
+    });
+    const result = await synthesizeInsight("query", [{ id: "1", content: "content" }], env);
+    expect(result).toBe("");
+  });
+
+  it("returns empty string when LLM response text is empty", async () => {
+    const env = makeTestEnv(undefined, { AI: aiMock("") });
+    const result = await synthesizeInsight("query", [{ id: "1", content: "content" }], env);
+    expect(result).toBe("");
+  });
+
+  it("trims whitespace from LLM response", async () => {
+    const env = makeTestEnv(undefined, { AI: aiMock("  padded insight  ") });
+    const result = await synthesizeInsight("query", [{ id: "1", content: "content" }], env);
+    expect(result).toBe("padded insight");
+  });
+
+  it("includes the query in the prompt sent to LLM", async () => {
+    const env = makeTestEnv(undefined, { AI: aiMock("ok") });
+    await synthesizeInsight("fintech auth strategy", [{ id: "1", content: "note" }], env);
+    const [, { messages }] = (env.AI.run as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(messages[0].content).toContain("fintech auth strategy");
+  });
+
+  it("includes all row content in the prompt", async () => {
+    const env = makeTestEnv(undefined, { AI: aiMock("ok") });
+    await synthesizeInsight("query", [
+      { id: "1", content: "JWT decision" },
+      { id: "2", content: "switched to Postgres" },
+    ], env);
+    const [, { messages }] = (env.AI.run as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(messages[0].content).toContain("JWT decision");
+    expect(messages[0].content).toContain("switched to Postgres");
+  });
+});


### PR DESCRIPTION
Every recall result now opens with a synthesized paragraph highlighting
what's most relevant to the query, so Claude surfaces actionable context
without requiring a separate tool call or system instruction change.
