### PR TITLE
fix incorrect count of memories in web ui

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1592,9 +1592,9 @@
 
     async function updateStatus() {
       try {
-        const res = await fetch(`${WORKER_URL}/list?n=1000`, { headers: { 'Authorization': `Bearer ${AUTH_TOKEN}` } });
+        const res = await fetch(`${WORKER_URL}/count`, { headers: { 'Authorization': `Bearer ${AUTH_TOKEN}` } });
         const data = await res.json();
-        const count = Array.isArray(data) ? data.length : 0;
+        const count = data.count ?? 0;
         const text = count === 0 ? 'always remembers' : `${count} memor${count === 1 ? 'y' : 'ies'} stored`;
         document.getElementById('topbar-status').textContent = text;
         const sb = document.getElementById('sb-status');

--- a/src/index.ts
+++ b/src/index.ts
@@ -950,6 +950,13 @@ export default {
       });
     }
 
+    // GET /count
+    if (url.pathname === "/count" && request.method === "GET") {
+      if (!isAuthorized(request, env)) return json({ error: "Unauthorized" }, 401);
+      const row = await env.DB.prepare(`SELECT COUNT(*) as count FROM entries`).first() as Record<string, any> | null;
+      return json({ count: (row?.count as number) ?? 0 });
+    }
+
     // GET /tags
     if (url.pathname === "/tags" && request.method === "GET") {
       if (!isAuthorized(request, env)) return json({ error: "Unauthorized" }, 401);


### PR DESCRIPTION
  Previously updateStatus() fetched /list?n=1000 and counted rows, but
  /list is capped at 100 — so users with >100 memories always saw "100
  memories stored". Adds a GET /count route (SELECT COUNT(*)) and updates
  the UI to call it directly.
