### PR TITLE
fix: refresh tag dropdowns after forget to clear stale tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1903,7 +1903,7 @@
           setTimeout(() => cardElement?.remove(), 400);
         }
         allEntries = allEntries.filter(e => e.id !== idToForget);
-        updateStatus();
+        updateStatus(); loadTags();
       } catch (e) {
         alert('Could not forget: ' + e.message);
       } finally {


### PR DESCRIPTION
Resolves #60

  Tags were loaded once on init and never refreshed after a forget action, leaving deleted tags visible in the filter dropdowns. Added loadTags() call after each successful forget so dropdowns
   always reflect the current DB state.