### PR TITLE
fix: add .npmrc with legacy-peer-deps to resolve upgrade install errors

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Resolves #75

  Users upgrading to newer versions encountered peer dependency errors during npm install. Adding an .npmrc with legacy-peer-deps=true resolves the conflict.