### PR TITLE
perf: skip synthesizeInsight LLM call when recall returns a single result

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -748,7 +748,9 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         return `${i + 1}. [${date}${src}${tagList}] (${score}% match)${updateLabel}\n${meta?.content ?? ""}`;
       }).join("\n\n");
 
-      const insight = await synthesizeInsight(embedQuery, d1Rows as { id: string; content: string }[], env);
+      const insight = d1Rows.length > 1
+        ? await synthesizeInsight(embedQuery, d1Rows as { id: string; content: string }[], env)
+        : "";
       const finalText = insight ? `**Insight:** ${insight}\n\n---\n\n${text}` : text;
       return { content: [{ type: "text", text: finalText }] };
     }


### PR DESCRIPTION
Resolves #65

  synthesizeInsight was called unconditionally, even when recall returned only one memory. Summarizing a single entry adds a full LLM round trip with no value. Guarded the call with 
  d1Rows.length > 1 — zero-result case was already handled inside synthesizeInsight itself.