### PR TITLE
refactor: collapse appendToEntry 3 D1 calls into 2 with combined UPDATE

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -402,14 +402,16 @@ async function appendToEntry(
   tags: string[],
   source: string
 ): Promise<void> {
+  // Read existing vector_ids upfront so we can do a single UPDATE at the end
+  const row = await env.DB.prepare(
+    `SELECT vector_ids FROM entries WHERE id = ?`
+  ).bind(id).first() as Record<string, any> | null;
+
+  const existingVectorIds: string[] = JSON.parse(row?.vector_ids ?? "[]");
+
   const timestamp = new Date().toLocaleDateString();
   const separator = `\n\n[Update ${timestamp}]: `;
   const newContent = existingContent + separator + addition;
-
-  // Update full content in D1
-  await env.DB.prepare(
-    `UPDATE entries SET content = ? WHERE id = ?`
-  ).bind(newContent, id).run();
 
   // Timestamp-based suffix guarantees uniqueness across concurrent appends
   const newChunkId = `${id}-update-${Date.now()}`;
@@ -435,15 +437,10 @@ async function appendToEntry(
     metadata,
   }]);
 
-  // Append the new chunk ID to the tracked vector_ids list in D1
-  const row = await env.DB.prepare(
-    `SELECT vector_ids FROM entries WHERE id = ?`
-  ).bind(id).first() as Record<string, any> | null;
-
-  const existing: string[] = JSON.parse(row?.vector_ids ?? "[]");
+  // Single UPDATE for both content and vector_ids — saves one D1 round trip
   await env.DB.prepare(
-    `UPDATE entries SET vector_ids = ? WHERE id = ?`
-  ).bind(JSON.stringify([...existing, newChunkId]), id).run();
+    `UPDATE entries SET content = ?, vector_ids = ? WHERE id = ?`
+  ).bind(newContent, JSON.stringify([...existingVectorIds, newChunkId]), id).run();
 }
 
 // ─── Synthesize insight from retrieved memories ───────────────────────────────

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -12,6 +12,12 @@ export class D1Mock {
           db.entries.push({ id, content, tags, source, created_at, vector_ids, recall_count: 0, importance_score: 0 });
           return { meta: { changes: 1 } };
         }
+        if (s.startsWith("UPDATE entries SET content = ?, vector_ids")) {
+          const [content, vector_ids, id] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row) { row.content = content; row.vector_ids = vector_ids; }
+          return { meta: { changes: row ? 1 : 0 } };
+        }
         if (s.startsWith("UPDATE entries SET vector_ids")) {
           const [vector_ids, id] = args;
           const row = db.entries.find((e: any) => e.id === id);


### PR DESCRIPTION
Resolves #68. Reordered appendToEntry to SELECT vector_ids upfront, then 
  after the Vectorize insert write both content and vector_ids in a single combined UPDATE. Reduces 3 D1 round trips to 2 on every append with no behaviour change. Updated D1Mock to handle the
   combined UPDATE pattern.