### PR TITLE
perf: merge checkDuplicate + checkContradiction into single Vectorize query

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,22 +124,6 @@ export function getDuplicateCheckSample(content: string): string {
   return `${start}\n...\n${middle}\n...\n${end}`;
 }
 
-async function checkDuplicate(content: string, env: Env): Promise<DuplicateResult> {
-  const sample = getDuplicateCheckSample(content);
-  const values = await embed(sample, env);
-  const results = await env.VECTORIZE.query(values, { topK: 1, returnMetadata: "all" });
-
-  if (!results.matches.length) return { status: "unique" };
-
-  const top = results.matches[0];
-  const score = top.score;
-  const matchId = (top.metadata as any)?.parentId ?? top.id;
-
-  if (score >= DUPLICATE_BLOCK_THRESHOLD) return { status: "blocked", matchId, score };
-  if (score >= DUPLICATE_FLAG_THRESHOLD) return { status: "flagged", matchId, score };
-  return { status: "unique" };
-}
-
 // ─── Contradiction Detection ──────────────────────────────────────────────────
 
 interface ContradictionResult {
@@ -148,29 +132,45 @@ interface ContradictionResult {
   reason?: string;
 }
 
-export async function checkContradiction(content: string, env: Env): Promise<ContradictionResult> {
-  const values = await embed(content, env);
-  const results = await env.VECTORIZE.query(values, { topK: 5, returnMetadata: "all" });
+// Merges duplicate detection and contradiction detection into a single embed +
+// Vectorize query, saving 1 AI call and 1 Vectorize round trip on every write.
+export async function checkDuplicateAndContradiction(content: string, env: Env): Promise<{
+  duplicate: DuplicateResult;
+  contradiction: ContradictionResult;
+}> {
+  const sample = getDuplicateCheckSample(content);
+  const values = await embed(sample, env);
+  const { matches } = await env.VECTORIZE.query(values, { topK: 5, returnMetadata: "all" });
 
-  const candidates = results.matches.filter(m => m.score >= CANDIDATE_SCORE_THRESHOLD);
-  if (!candidates.length) return { detected: false };
+  // ── Duplicate: derived from top match ───────────────────────────────────────
+  let duplicate: DuplicateResult = { status: "unique" };
+  if (matches.length) {
+    const top = matches[0];
+    const matchId = (top.metadata as any)?.parentId ?? top.id;
+    if (top.score >= DUPLICATE_BLOCK_THRESHOLD) duplicate = { status: "blocked", matchId, score: top.score };
+    else if (top.score >= DUPLICATE_FLAG_THRESHOLD) duplicate = { status: "flagged", matchId, score: top.score };
+  }
 
-  const parentIds = [...new Set(
-    candidates.map(m => (m.metadata as any)?.parentId ?? m.id)
-  )] as string[];
+  // ── Contradiction: skip entirely if we're blocking anyway ───────────────────
+  let contradiction: ContradictionResult = { detected: false };
+  if (duplicate.status !== "blocked") {
+    const candidates = matches.filter(m => m.score >= CANDIDATE_SCORE_THRESHOLD);
+    if (candidates.length) {
+      const parentIds = [...new Set(
+        candidates.map(m => (m.metadata as any)?.parentId ?? m.id)
+      )] as string[];
 
-  const placeholders = parentIds.map(() => "?").join(", ");
-  const { results: rows } = await env.DB.prepare(
-    `SELECT id, content FROM entries WHERE id IN (${placeholders})`
-  ).bind(...parentIds).all() as { results: { id: string; content: string }[] };
+      const placeholders = parentIds.map(() => "?").join(", ");
+      const { results: rows } = await env.DB.prepare(
+        `SELECT id, content FROM entries WHERE id IN (${placeholders})`
+      ).bind(...parentIds).all() as { results: { id: string; content: string }[] };
 
-  if (!rows.length) return { detected: false };
+      if (rows.length) {
+        const existingList = rows
+          .map((r, i) => `[${i + 1}] ID: ${r.id}\n${r.content}`)
+          .join("\n\n");
 
-  const existingList = rows
-    .map((r, i) => `[${i + 1}] ID: ${r.id}\n${r.content}`)
-    .join("\n\n");
-
-  const prompt = `You are checking if a new memory contradicts existing memories.
+        const prompt = `You are checking if a new memory contradicts existing memories.
 
 New memory: "${content}"
 
@@ -182,24 +182,29 @@ A contradiction means the new memory states something that DIRECTLY CONFLICTS wi
 Respond with JSON only. No text outside the JSON object.
 {"contradicts": false} OR {"contradicts": true, "conflicting_id": "<exact_id>", "reason": "<10 words max>"}`;
 
-  try {
-    const stream = await (env.AI as any).run(LLM_MODEL as any, {
-      messages: [{ role: "user", content: prompt }],
-      max_tokens: CONTRADICTION_MAX_TOKENS,
-      stream: true,
-    });
-    const text = await readStreamText(stream as ReadableStream);
-    const match = text.match(/\{[\s\S]*\}/);
-    if (!match) return { detected: false };
-    const parsed = JSON.parse(match[0]);
-    if (parsed.contradicts && parsed.conflicting_id) {
-      const validId = parentIds.find(id => id === parsed.conflicting_id);
-      if (validId) return { detected: true, conflicting_id: validId, reason: parsed.reason };
+        try {
+          const stream = await (env.AI as any).run(LLM_MODEL as any, {
+            messages: [{ role: "user", content: prompt }],
+            max_tokens: CONTRADICTION_MAX_TOKENS,
+            stream: true,
+          });
+          const text = await readStreamText(stream as ReadableStream);
+          const match = text.match(/\{[\s\S]*\}/);
+          if (match) {
+            const parsed = JSON.parse(match[0]);
+            if (parsed.contradicts && parsed.conflicting_id) {
+              const validId = parentIds.find(id => id === parsed.conflicting_id);
+              if (validId) contradiction = { detected: true, conflicting_id: validId, reason: parsed.reason };
+            }
+          }
+        } catch {
+          // non-fatal — contradiction stays { detected: false }
+        }
+      }
     }
-    return { detected: false };
-  } catch {
-    return { detected: false };
   }
+
+  return { duplicate, contradiction };
 }
 
 // ─── Chunking ─────────────────────────────────────────────────────────────────
@@ -501,7 +506,7 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       const t = [...new Set([...(tags ?? []).map(tag => tag.toLowerCase()), ...hashtags])];
       const s = source ?? "claude";
 
-      const dup = await checkDuplicate(c, env);
+      const { duplicate: dup, contradiction } = await checkDuplicateAndContradiction(c, env);
 
       if (dup.status === "blocked") {
         return {
@@ -511,8 +516,6 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
           }],
         };
       }
-
-      const contradiction = await checkContradiction(c, env);
 
       const id = crypto.randomUUID();
       const now = Date.now();
@@ -833,7 +836,7 @@ export default {
       const t = [...new Set([...(body.tags ?? []).map(tag => tag.toLowerCase()), ...hashtags])];
       const s = body.source ?? "api";
 
-      const dup = await checkDuplicate(c, env);
+      const { duplicate: dup, contradiction } = await checkDuplicateAndContradiction(c, env);
 
       if (dup.status === "blocked") {
         return json({
@@ -844,8 +847,6 @@ export default {
           message: "Near-exact duplicate detected — not stored",
         });
       }
-
-      const contradiction = await checkContradiction(c, env);
 
       const id = crypto.randomUUID();
       const now = Date.now();

--- a/test/unit/check-contradiction.test.ts
+++ b/test/unit/check-contradiction.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { checkContradiction } from "../../src/index";
+import { checkDuplicateAndContradiction } from "../../src/index";
 import { makeTestDb, makeVectorizeMock } from "../helpers/make-env";
 import type { Env } from "../../src/index";
 
@@ -36,21 +36,22 @@ function match(id: string, score: number) {
   return { id, score, metadata: { parentId: id } };
 }
 
-describe("checkContradiction()", () => {
-  it("returns not detected when all matches are below threshold", async () => {
+describe("checkDuplicateAndContradiction()", () => {
+  it("returns unique + no contradiction when all matches are below threshold", async () => {
     const env = makeEnv("", [match("a", 0.3)], [entry("a", "I enjoy hiking")]);
-    const result = await checkContradiction("I live in Paris", env);
-    expect(result.detected).toBe(false);
+    const { duplicate, contradiction } = await checkDuplicateAndContradiction("I live in Paris", env);
+    expect(duplicate.status).toBe("unique");
+    expect(contradiction.detected).toBe(false);
   });
 
-  it("returns not detected when LLM says no contradiction", async () => {
+  it("returns no contradiction when LLM says no contradiction", async () => {
     const env = makeEnv(
       '{"contradicts": false}',
       [match("a", 0.7)],
       [entry("a", "I enjoy hiking")]
     );
-    const result = await checkContradiction("I live in NYC", env);
-    expect(result.detected).toBe(false);
+    const { contradiction } = await checkDuplicateAndContradiction("I live in NYC", env);
+    expect(contradiction.detected).toBe(false);
   });
 
   it("detects a contradiction and returns conflicting_id and reason", async () => {
@@ -59,10 +60,10 @@ describe("checkContradiction()", () => {
       [match("abc123", 0.72)],
       [entry("abc123", "I live in NYC")]
     );
-    const result = await checkContradiction("I moved to LA last year", env);
-    expect(result.detected).toBe(true);
-    expect(result.conflicting_id).toBe("abc123");
-    expect(result.reason).toBe("different city");
+    const { contradiction } = await checkDuplicateAndContradiction("I moved to LA last year", env);
+    expect(contradiction.detected).toBe(true);
+    expect(contradiction.conflicting_id).toBe("abc123");
+    expect(contradiction.reason).toBe("different city");
   });
 
   it("ignores a hallucinated ID not in the candidate results", async () => {
@@ -71,21 +72,21 @@ describe("checkContradiction()", () => {
       [match("real-id", 0.72)],
       [entry("real-id", "I live in NYC")]
     );
-    const result = await checkContradiction("I moved to LA", env);
-    expect(result.detected).toBe(false);
+    const { contradiction } = await checkDuplicateAndContradiction("I moved to LA", env);
+    expect(contradiction.detected).toBe(false);
   });
 
-  it("returns not detected when LLM returns malformed JSON", async () => {
+  it("returns no contradiction when LLM returns malformed JSON", async () => {
     const env = makeEnv(
       "Sorry, I cannot help with that.",
       [match("a", 0.7)],
       [entry("a", "I live in NYC")]
     );
-    const result = await checkContradiction("I moved to LA", env);
-    expect(result.detected).toBe(false);
+    const { contradiction } = await checkDuplicateAndContradiction("I moved to LA", env);
+    expect(contradiction.detected).toBe(false);
   });
 
-  it("returns not detected when AI throws", async () => {
+  it("returns no contradiction when AI throws", async () => {
     const db = makeTestDb();
     db.entries = [entry("a", "I live in NYC")];
     const env: Env = {
@@ -101,7 +102,24 @@ describe("checkContradiction()", () => {
       } as unknown as Ai,
       AUTH_TOKEN: "test-token",
     };
-    const result = await checkContradiction("I moved to LA", env);
-    expect(result.detected).toBe(false);
+    const { contradiction } = await checkDuplicateAndContradiction("I moved to LA", env);
+    expect(contradiction.detected).toBe(false);
+  });
+
+  it("returns blocked duplicate and skips contradiction check", async () => {
+    const queryFn = vi.fn().mockResolvedValue({ matches: [match("a", 0.96)] });
+    const env = makeEnv("", [match("a", 0.96)], [entry("a", "Original content")]);
+    (env.VECTORIZE as any).query = queryFn;
+    const { duplicate, contradiction } = await checkDuplicateAndContradiction("Original content", env);
+    expect(duplicate.status).toBe("blocked");
+    expect(contradiction.detected).toBe(false);
+    // AI should only have been called once (for embed), not for contradiction LLM check
+    expect((env.AI.run as any).mock.calls.length).toBe(1);
+  });
+
+  it("returns flagged duplicate status", async () => {
+    const env = makeEnv('{"contradicts": false}', [match("a", 0.88)], [entry("a", "Similar content")]);
+    const { duplicate } = await checkDuplicateAndContradiction("Similar content", env);
+    expect(duplicate.status).toBe("flagged");
   });
 });


### PR DESCRIPTION
Resolves #64. Every write was making 2 embed calls and 2 Vectorize 
  queries sequentially. For short content both embed calls used the same text. Merged into checkDuplicateAndContradiction() — one embed, one topK 5 query, duplicate derived from top match, 
  contradiction skipped entirely on blocked duplicates. Updated tests to cover the combined function including the new blocked-skips-LLM behaviour.