### PR TITLE
feat: export button, stats panel, and /stats endpoint (Resolves #57)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1026,6 +1026,64 @@
       color: #c0392b;
     }
 
+    .stats-panel {
+      border-top: 0.5px solid var(--border);
+      padding: 16px 0 8px;
+      margin-bottom: 4px;
+    }
+
+    .stats-kpi-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+      margin-bottom: 12px;
+    }
+
+    .stats-kpi-card {
+      background: var(--bg-secondary, rgba(128,128,128,0.06));
+      border: 0.5px solid var(--border);
+      border-radius: 12px;
+      padding: 12px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .stats-kpi-value {
+      font-size: 22px;
+      font-weight: 600;
+      color: var(--text-primary);
+      font-variant-numeric: tabular-nums;
+      line-height: 1.1;
+    }
+
+    .stats-kpi-label {
+      font-size: 11px;
+      color: var(--text-tertiary);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      font-weight: 500;
+    }
+
+    .stats-top-tags {
+      margin-top: 2px;
+    }
+
+    .stats-top-tags-label {
+      font-size: 11px;
+      color: var(--text-tertiary);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      font-weight: 500;
+      margin-bottom: 7px;
+    }
+
+    .stats-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+    }
+
     #sidebar {
       width: 240px;
       flex-shrink: 0;
@@ -1458,8 +1516,30 @@
   <div id="menu-sheet">
     <div class="menu-inner">
       <h3>Second Brain</h3>
+      <div class="stats-panel" id="stats-panel">
+        <div class="stats-kpi-row">
+          <div class="stats-kpi-card">
+            <div class="stats-kpi-value" id="stats-count">—</div>
+            <div class="stats-kpi-label">Memories</div>
+          </div>
+          <div class="stats-kpi-card">
+            <div class="stats-kpi-value" id="stats-importance">—</div>
+            <div class="stats-kpi-label">Avg Importance</div>
+          </div>
+        </div>
+        <div class="stats-top-tags">
+          <div class="stats-top-tags-label">Most used tags</div>
+          <div class="stats-tags" id="stats-tags"></div>
+        </div>
+      </div>
       <button class="menu-item" onclick="closeMenu(); switchTab('recent')">
         <i class="ti ti-clock"></i> View all memories
+      </button>
+      <button class="menu-item" onclick="exportMemories('json')">
+        <i class="ti ti-download"></i> Export as JSON
+      </button>
+      <button class="menu-item" onclick="exportMemories('markdown')">
+        <i class="ti ti-markdown"></i> Export as Markdown
       </button>
       <button class="menu-item danger" onclick="logout()">
         <i class="ti ti-logout"></i> Disconnect
@@ -1472,6 +1552,7 @@
     let WORKER_URL = '', AUTH_TOKEN = '', allEntries = [];
     let pendingForgetId = null, pendingAppendId = null, pendingForgetCard = null;
     let currentTab = 'recall', selectedTag = '', selectedTimeRange = '';
+    let currentCount = 0;
 
     function init() {
       // Auto-populate URL from the current page origin (UI is hosted on the same Worker)
@@ -1594,8 +1675,8 @@
       try {
         const res = await fetch(`${WORKER_URL}/count`, { headers: { 'Authorization': `Bearer ${AUTH_TOKEN}` } });
         const data = await res.json();
-        const count = data.count ?? 0;
-        const text = count === 0 ? 'always remembers' : `${count} memor${count === 1 ? 'y' : 'ies'} stored`;
+        currentCount = data.count ?? 0;
+        const text = currentCount === 0 ? 'always remembers' : `${currentCount} memor${currentCount === 1 ? 'y' : 'ies'} stored`;
         document.getElementById('topbar-status').textContent = text;
         const sb = document.getElementById('sb-status');
         if (sb) sb.textContent = text;
@@ -1911,8 +1992,70 @@
       }
     }
 
-    function openMenu() { document.getElementById('menu-sheet').classList.add('open'); }
+    function openMenu() {
+      document.getElementById('menu-sheet').classList.add('open');
+      loadMenuStats();
+    }
     function closeMenu() { document.getElementById('menu-sheet').classList.remove('open'); }
+
+    async function loadMenuStats() {
+      try {
+        const res = await fetch(`${WORKER_URL}/stats`, { headers: { 'Authorization': `Bearer ${AUTH_TOKEN}` } });
+        const data = await res.json();
+        document.getElementById('stats-count').textContent = (data.count ?? 0).toLocaleString();
+        document.getElementById('stats-importance').textContent =
+          data.avg_importance != null ? data.avg_importance.toFixed(1) + ' / 10' : '—';
+        const tagsEl = document.getElementById('stats-tags');
+        tagsEl.innerHTML = data.top_tags?.length
+          ? data.top_tags.map(t => `<span class="tag-chip">${escHtml(t)}</span>`).join('')
+          : '<span style="font-size:13px;color:var(--text-tertiary)">No tags yet</span>';
+      } catch { }
+    }
+
+    async function exportMemories(format) {
+      closeMenu();
+      try {
+        const res = await fetch(`${WORKER_URL}/list?n=9999`, { headers: { 'Authorization': `Bearer ${AUTH_TOKEN}` } });
+        if (!res.ok) throw new Error(`Server error: ${res.status}`);
+        const entries = await res.json();
+
+        let content, filename, mime;
+        const ts = new Date().toISOString().slice(0, 10);
+
+        if (format === 'json') {
+          content = JSON.stringify(entries, null, 2);
+          filename = `second-brain-export-${ts}.json`;
+          mime = 'application/json';
+        } else {
+          const lines = [`# Second Brain Export`, `Exported: ${ts}`, ''];
+          entries.forEach((e, i) => {
+            let tags = [];
+            try { tags = JSON.parse(e.tags || '[]'); } catch { }
+            const date = new Date(e.created_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+            lines.push(`## Memory ${i + 1}`);
+            lines.push(`**Date:** ${date}`);
+            if (tags.length) lines.push(`**Tags:** ${tags.join(', ')}`);
+            if (e.source) lines.push(`**Source:** ${e.source}`);
+            lines.push('');
+            lines.push(e.content);
+            lines.push('');
+            lines.push('---');
+            lines.push('');
+          });
+          content = lines.join('\n');
+          filename = `second-brain-export-${ts}.md`;
+          mime = 'text/markdown';
+        }
+
+        const blob = new Blob([content], { type: mime });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url; a.download = filename; a.click();
+        URL.revokeObjectURL(url);
+      } catch (e) {
+        alert('Export failed: ' + e.message);
+      }
+    }
 
     function openView(entry, cardElement) {
       document.getElementById('view-content-text').textContent = entry.content;

--- a/src/index.ts
+++ b/src/index.ts
@@ -956,6 +956,20 @@ export default {
       return json((results as any[]).map(r => r.value as string));
     }
 
+    // GET /stats
+    if (url.pathname === "/stats" && request.method === "GET") {
+      if (!isAuthorized(request, env)) return json({ error: "Unauthorized" }, 401);
+      const [summary, tagRows] = await Promise.all([
+        env.DB.prepare(`SELECT COUNT(*) as count, AVG(importance_score) as avg_importance FROM entries`).first() as Promise<Record<string, any> | null>,
+        env.DB.prepare(`SELECT value, COUNT(*) as n FROM entries, json_each(entries.tags) GROUP BY value ORDER BY n DESC LIMIT 5`).all(),
+      ]);
+      return json({
+        count: (summary?.count as number) ?? 0,
+        avg_importance: summary?.avg_importance != null ? Math.round((summary.avg_importance as number) * 10) / 10 : null,
+        top_tags: (tagRows.results as any[]).map(r => r.value as string),
+      });
+    }
+
     // GET /list
     if (url.pathname === "/list" && request.method === "GET") {
       if (!isAuthorized(request, env)) return json({ error: "Unauthorized" }, 401);

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -55,6 +55,17 @@ export class D1Mock {
           const row = db.entries.find((e: any) => e.id === args[0]);
           return row ? { vector_ids: row.vector_ids } : null;
         }
+        if (s.includes("COUNT(*) as count") && s.includes("AVG(importance_score)")) {
+          const count = db.entries.length;
+          const scored = db.entries.filter((e: any) => typeof e.importance_score === "number");
+          const avg_importance = scored.length > 0
+            ? scored.reduce((sum: number, e: any) => sum + e.importance_score, 0) / scored.length
+            : null;
+          return { count, avg_importance };
+        }
+        if (s.includes("COUNT(*) as count")) {
+          return { count: db.entries.length };
+        }
         if (s.includes("WHERE id") && !s.includes("json_each")) {
           return db.entries.find((e: any) => e.id === args[0]) ?? null;
         }
@@ -73,7 +84,17 @@ export class D1Mock {
             .map((e: any) => ({ id: e.id, content: e.content }));
           return { results };
         }
+        if (s.includes("json_each(entries.tags)") && s.includes("GROUP BY value")) {
+          // Top tags by frequency — for /stats
+          const freq = new Map<string, number>();
+          db.entries.forEach((e: any) => {
+            (JSON.parse(e.tags ?? "[]") as string[]).forEach(t => freq.set(t, (freq.get(t) ?? 0) + 1));
+          });
+          const sorted = [...freq.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5);
+          return { results: sorted.map(([value, n]) => ({ value, n })) };
+        }
         if (s.includes("json_each(entries.tags)")) {
+          // Distinct sorted tags — for /tags
           const tags = new Set<string>();
           db.entries.forEach((e: any) => {
             (JSON.parse(e.tags ?? "[]") as string[]).forEach(t => tags.add(t));

--- a/test/integration/stats.test.ts
+++ b/test/integration/stats.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+function entry(id: string, tags: string[], importance: number) {
+  return { id, content: `Content ${id}`, tags: JSON.stringify(tags), source: "api", created_at: Date.now(), vector_ids: "[]", recall_count: 0, importance_score: importance };
+}
+
+describe("GET /stats", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await worker.fetch(req("GET", "/stats", { token: null }), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns zeroed stats when no entries", async () => {
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.count).toBe(0);
+    expect(data.avg_importance).toBeNull();
+    expect(data.top_tags).toEqual([]);
+  });
+
+  it("returns correct total count", async () => {
+    db.entries.push(entry("a", [], 5), entry("b", [], 7));
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.count).toBe(2);
+  });
+
+  it("returns avg importance rounded to 1 decimal", async () => {
+    db.entries.push(entry("a", [], 5), entry("b", [], 8));
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.avg_importance).toBe(6.5);
+  });
+
+  it("returns top tags ordered by frequency", async () => {
+    db.entries.push(
+      entry("a", ["work", "react"], 5),
+      entry("b", ["work", "typescript"], 6),
+      entry("c", ["work"], 7),
+    );
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.top_tags[0]).toBe("work"); // 3 occurrences — must be first
+    expect(data.top_tags).toContain("react");
+    expect(data.top_tags).toContain("typescript");
+  });
+
+  it("limits top tags to 5", async () => {
+    db.entries.push(entry("a", ["a", "b", "c", "d", "e", "f"], 5));
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.top_tags.length).toBeLessThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
## What
  
  - Adds `GET /stats` endpoint returning total count, avg importance score, and top 5 tags by frequency in a single pair of SQL queries
  - Adds a stats panel to the Settings menu with two KPI cards (Memories, Avg Importance) and a Most Used Tags row
  - Adds Export as JSON and Export as Markdown buttons to the Settings menu
  - Adds `test/integration/stats.test.ts` with 6 tests covering auth, empty state, count, avg importance, tag frequency ordering, and 5-tag limit
  - Updates `D1Mock` with handlers for the COUNT/AVG and GROUP BY frequency queries
  
  ## Changes
  - `src/index.ts` — new `GET /stats` endpoint
  - `public/index.html` — stats panel, KPI cards, export buttons
  - `test/integration/stats.test.ts` — new test file
  - `test/helpers/d1-mock.ts` — two new SQL handlers
  
  Both `second-brain-template` and `second-brain-worker` updated.