### PR TITLE
refactor: extract shared captureEntry function (Resolves #69)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -485,6 +485,75 @@ Provide a brief insight (2-4 sentences) focused on what's most relevant to this 
   return insight.trim();
 }
 
+// ─── Shared write path ────────────────────────────────────────────────────────
+
+export type CaptureResult =
+  | { status: "blocked"; matchId: string; score: number }
+  | { status: "stored"; id: string }
+  | { status: "flagged"; id: string; matchId: string; score: number }
+  | { status: "contradiction"; id: string; resolvedConflict: string; reason?: string };
+
+export async function captureEntry(
+  rawContent: string,
+  tags: string[],
+  source: string,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<CaptureResult> {
+  const raw = rawContent.trim();
+  const { cleanContent, hashtags } = extractHashtags(raw);
+  const c = cleanContent || raw;
+  const t = [...new Set([...tags.map(tag => tag.toLowerCase()), ...hashtags])];
+
+  const { duplicate: dup, contradiction } = await checkDuplicateAndContradiction(c, env);
+
+  if (dup.status === "blocked") {
+    return { status: "blocked", matchId: dup.matchId, score: dup.score };
+  }
+
+  const id = crypto.randomUUID();
+  const now = Date.now();
+  const baseTags = contradiction.detected ? [...t, "contradiction-resolved"] : t;
+  const finalTags = dup.status === "flagged" ? [...baseTags, "duplicate-candidate"] : baseTags;
+
+  await env.DB.prepare(
+    `INSERT INTO entries (id, content, tags, source, created_at, vector_ids) VALUES (?, ?, ?, ?, ?, ?)`
+  ).bind(id, c, JSON.stringify(finalTags), source, now, "[]").run();
+
+  try {
+    await storeEntry(env, id, c, finalTags, source, now);
+  } catch (e) {
+    console.error("Vectorize insert failed (non-fatal):", e);
+  }
+
+  ctx.waitUntil(
+    scoreImportance(c, env)
+      .then(score => env.DB.prepare(`UPDATE entries SET importance_score = ? WHERE id = ?`).bind(score, id).run())
+      .catch(e => console.error("Importance scoring failed (non-fatal):", e))
+  );
+
+  if (contradiction.detected && contradiction.conflicting_id) {
+    const conflictId = contradiction.conflicting_id;
+    try {
+      const conflictRow = await env.DB.prepare(
+        `SELECT vector_ids FROM entries WHERE id = ?`
+      ).bind(conflictId).first() as Record<string, any> | null;
+      const conflictVectorIds: string[] = JSON.parse(conflictRow?.vector_ids ?? "[]");
+      await env.DB.prepare(`DELETE FROM entries WHERE id = ?`).bind(conflictId).run();
+      if (conflictVectorIds.length) await env.VECTORIZE.deleteByIds(conflictVectorIds);
+    } catch (e) {
+      console.error("Contradiction resolution cleanup failed (non-fatal):", e);
+    }
+    return { status: "contradiction", id, resolvedConflict: conflictId, reason: contradiction.reason };
+  }
+
+  if (dup.status === "flagged") {
+    return { status: "flagged", id, matchId: dup.matchId, score: dup.score };
+  }
+
+  return { status: "stored", id };
+}
+
 // ─── MCP Server ───────────────────────────────────────────────────────────────
 
 function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
@@ -500,74 +569,17 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       source: z.string().optional().describe("Origin: phone, browser, voice, claude"),
     },
     async ({ content, tags, source }) => {
-      const raw = content.trim();
-      const { cleanContent, hashtags } = extractHashtags(raw);
-      const c = cleanContent || raw;
-      const t = [...new Set([...(tags ?? []).map(tag => tag.toLowerCase()), ...hashtags])];
-      const s = source ?? "claude";
-
-      const { duplicate: dup, contradiction } = await checkDuplicateAndContradiction(c, env);
-
-      if (dup.status === "blocked") {
-        return {
-          content: [{
-            type: "text",
-            text: `Duplicate detected (${(dup.score * 100).toFixed(0)}% match) — not stored. Existing entry ID: ${dup.matchId}`,
-          }],
-        };
+      const result = await captureEntry(content, tags ?? [], source ?? "claude", env, ctx);
+      if (result.status === "blocked") {
+        return { content: [{ type: "text", text: `Duplicate detected (${(result.score * 100).toFixed(0)}% match) — not stored. Existing entry ID: ${result.matchId}` }] };
       }
-
-      const id = crypto.randomUUID();
-      const now = Date.now();
-      const baseTags = contradiction.detected ? [...t, "contradiction-resolved"] : t;
-      const finalTags = dup.status === "flagged" ? [...baseTags, "duplicate-candidate"] : baseTags;
-
-      await env.DB.prepare(
-        `INSERT INTO entries (id, content, tags, source, created_at, vector_ids) VALUES (?, ?, ?, ?, ?, ?)`
-      ).bind(id, c, JSON.stringify(finalTags), s, now, "[]").run();
-
-      try {
-        await storeEntry(env, id, c, finalTags, s, now);
-      } catch (e) {
-        console.error("Vectorize insert failed (non-fatal):", e);
+      if (result.status === "contradiction") {
+        return { content: [{ type: "text", text: `Stored. ID: ${result.id} — resolved contradiction with entry ${result.resolvedConflict}${result.reason ? `: ${result.reason}` : ""}.` }] };
       }
-
-      ctx.waitUntil(
-        scoreImportance(c, env)
-          .then(score => env.DB.prepare(`UPDATE entries SET importance_score = ? WHERE id = ?`).bind(score, id).run())
-          .catch(e => console.error("Importance scoring failed (non-fatal):", e))
-      );
-
-      if (contradiction.detected && contradiction.conflicting_id) {
-        const conflictId = contradiction.conflicting_id;
-        try {
-          const conflictRow = await env.DB.prepare(
-            `SELECT vector_ids FROM entries WHERE id = ?`
-          ).bind(conflictId).first() as Record<string, any> | null;
-          const conflictVectorIds: string[] = JSON.parse(conflictRow?.vector_ids ?? "[]");
-          await env.DB.prepare(`DELETE FROM entries WHERE id = ?`).bind(conflictId).run();
-          if (conflictVectorIds.length) await env.VECTORIZE.deleteByIds(conflictVectorIds);
-        } catch (e) {
-          console.error("Contradiction resolution cleanup failed (non-fatal):", e);
-        }
-        return {
-          content: [{
-            type: "text",
-            text: `Stored. ID: ${id} — resolved contradiction with entry ${contradiction.conflicting_id}${contradiction.reason ? `: ${contradiction.reason}` : ""}.`,
-          }],
-        };
+      if (result.status === "flagged") {
+        return { content: [{ type: "text", text: `Stored with ID: ${result.id} — note: similar entry exists (${(result.score * 100).toFixed(0)}% match, ID: ${result.matchId}). Tagged as duplicate-candidate.` }] };
       }
-
-      if (dup.status === "flagged") {
-        return {
-          content: [{
-            type: "text",
-            text: `Stored with ID: ${id} — note: similar entry exists (${(dup.score * 100).toFixed(0)}% match, ID: ${dup.matchId}). Tagged as duplicate-candidate.`,
-          }],
-        };
-      }
-
-      return { content: [{ type: "text", text: `Stored. ID: ${id}` }] };
+      return { content: [{ type: "text", text: `Stored. ID: ${result.id}` }] };
     }
   );
 
@@ -830,77 +842,31 @@ export default {
       try { body = await request.json(); } catch { return json({ error: "Invalid JSON" }, 400); }
       if (!body.content?.trim()) return json({ error: "content is required" }, 400);
 
-      const raw = body.content.trim();
-      const { cleanContent, hashtags } = extractHashtags(raw);
-      const c = cleanContent || raw;
-      const t = [...new Set([...(body.tags ?? []).map(tag => tag.toLowerCase()), ...hashtags])];
-      const s = body.source ?? "api";
+      const result = await captureEntry(body.content, body.tags ?? [], body.source ?? "api", env, ctx);
 
-      const { duplicate: dup, contradiction } = await checkDuplicateAndContradiction(c, env);
-
-      if (dup.status === "blocked") {
+      if (result.status === "blocked") {
         return json({
           ok: false,
           duplicate: true,
-          matchId: dup.matchId,
-          score: parseFloat((dup.score * 100).toFixed(1)),
+          matchId: result.matchId,
+          score: parseFloat((result.score * 100).toFixed(1)),
           message: "Near-exact duplicate detected — not stored",
         });
       }
-
-      const id = crypto.randomUUID();
-      const now = Date.now();
-      const baseTags = contradiction.detected ? [...t, "contradiction-resolved"] : t;
-      const finalTags = dup.status === "flagged" ? [...baseTags, "duplicate-candidate"] : baseTags;
-
-      await env.DB.prepare(
-        `INSERT INTO entries (id, content, tags, source, created_at, vector_ids) VALUES (?, ?, ?, ?, ?, ?)`
-      ).bind(id, c, JSON.stringify(finalTags), s, now, "[]").run();
-
-      try {
-        await storeEntry(env, id, c, finalTags, s, now);
-      } catch (e) {
-        console.error("Vectorize insert failed (non-fatal):", e);
+      if (result.status === "contradiction") {
+        return json({ ok: true, id: result.id, resolved_conflict: result.resolvedConflict, reason: result.reason });
       }
-
-      ctx.waitUntil(
-        scoreImportance(c, env)
-          .then(score => env.DB.prepare(`UPDATE entries SET importance_score = ? WHERE id = ?`).bind(score, id).run())
-          .catch(e => console.error("Importance scoring failed (non-fatal):", e))
-      );
-
-      if (contradiction.detected && contradiction.conflicting_id) {
-        const conflictId = contradiction.conflicting_id;
-        try {
-          const conflictRow = await env.DB.prepare(
-            `SELECT vector_ids FROM entries WHERE id = ?`
-          ).bind(conflictId).first() as Record<string, any> | null;
-          const conflictVectorIds: string[] = JSON.parse(conflictRow?.vector_ids ?? "[]");
-          await env.DB.prepare(`DELETE FROM entries WHERE id = ?`).bind(conflictId).run();
-          if (conflictVectorIds.length) await env.VECTORIZE.deleteByIds(conflictVectorIds);
-        } catch (e) {
-          console.error("Contradiction resolution cleanup failed (non-fatal):", e);
-        }
+      if (result.status === "flagged") {
         return json({
           ok: true,
-          id,
-          resolved_conflict: conflictId,
-          reason: contradiction.reason,
-        });
-      }
-
-      if (dup.status === "flagged") {
-        return json({
-          ok: true,
-          id,
+          id: result.id,
           warning: "similar",
-          matchId: dup.matchId,
-          score: parseFloat((dup.score * 100).toFixed(1)),
+          matchId: result.matchId,
+          score: parseFloat((result.score * 100).toFixed(1)),
           message: "Stored but similar entry exists — tagged as duplicate-candidate",
         });
       }
-
-      return json({ ok: true, id });
+      return json({ ok: true, id: result.id });
     }
 
     // POST /append

--- a/test/unit/capture-entry.test.ts
+++ b/test/unit/capture-entry.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { captureEntry } from "../../src/index";
+import { makeTestDb, makeTestEnv, makeVectorizeMock } from "../helpers/make-env";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+function makeCtx() {
+  const pending: Promise<any>[] = [];
+  return {
+    ctx: { waitUntil: (p: Promise<any>) => pending.push(p) } as any as ExecutionContext,
+    drain: () => Promise.allSettled(pending),
+  };
+}
+
+function makeContradictionAI(response: string) {
+  return {
+    run: vi.fn().mockImplementation(async (model: string) => {
+      if (model === "@cf/baai/bge-small-en-v1.5")
+        return { data: [new Array(384).fill(0.1)] };
+      return new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+          c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+          c.close();
+        },
+      });
+    }),
+  } as unknown as Ai;
+}
+
+describe("captureEntry()", () => {
+  let db: D1Mock;
+  let env: Env;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  // ── Happy path ──────────────────────────────────────────────────────────────
+
+  it("stores a plain entry and returns status=stored with a UUID id", async () => {
+    const { ctx } = makeCtx();
+    const result = await captureEntry("My first memory", [], "api", env, ctx);
+    expect(result.status).toBe("stored");
+    if (result.status !== "stored") return;
+    expect(result.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(db.entries).toHaveLength(1);
+    expect(db.entries[0].content).toBe("My first memory");
+    expect(db.entries[0].source).toBe("api");
+  });
+
+  it("uses the provided source value", async () => {
+    const { ctx } = makeCtx();
+    await captureEntry("Memory from claude", [], "claude", env, ctx);
+    expect(db.entries[0].source).toBe("claude");
+  });
+
+  // ── Hashtag extraction ──────────────────────────────────────────────────────
+
+  it("strips hashtags from content and stores them as tags", async () => {
+    const { ctx } = makeCtx();
+    const result = await captureEntry("went for a run #health #fitness", [], "api", env, ctx);
+    expect(result.status).toBe("stored");
+    expect(db.entries[0].content).toBe("went for a run");
+    const tags = JSON.parse(db.entries[0].tags);
+    expect(tags).toContain("health");
+    expect(tags).toContain("fitness");
+  });
+
+  it("merges explicit tags with hashtag tags and deduplicates case-insensitively", async () => {
+    const { ctx } = makeCtx();
+    await captureEntry("note #health", ["Health", "fitness"], "api", env, ctx);
+    const tags: string[] = JSON.parse(db.entries[0].tags);
+    expect(tags.filter(t => t === "health")).toHaveLength(1);
+    expect(tags).toContain("fitness");
+  });
+
+  it("falls back to raw content when input is only hashtags", async () => {
+    const { ctx } = makeCtx();
+    await captureEntry("#task", [], "api", env, ctx);
+    expect(db.entries[0].content).toBe("#task");
+    const tags = JSON.parse(db.entries[0].tags);
+    expect(tags).toContain("task");
+  });
+
+  it("trims leading/trailing whitespace before storing", async () => {
+    const { ctx } = makeCtx();
+    await captureEntry("  padded note  ", [], "api", env, ctx);
+    expect(db.entries[0].content).toBe("padded note");
+  });
+
+  // ── Duplicate: blocked ──────────────────────────────────────────────────────
+
+  it("returns status=blocked and does not insert when similarity >= 0.95", async () => {
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing", score: 0.97, metadata: { parentId: "existing" } }],
+        }),
+      }),
+    });
+    const { ctx } = makeCtx();
+    const result = await captureEntry("Duplicate content", [], "api", env, ctx);
+    expect(result.status).toBe("blocked");
+    if (result.status !== "blocked") return;
+    expect(result.matchId).toBe("existing");
+    expect(result.score).toBeCloseTo(0.97);
+    expect(db.entries).toHaveLength(0);
+  });
+
+  it("does not call ctx.waitUntil when blocked (no scoring needed)", async () => {
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing", score: 0.97, metadata: { parentId: "existing" } }],
+        }),
+      }),
+    });
+    const pending: Promise<any>[] = [];
+    const ctx = { waitUntil: (p: Promise<any>) => pending.push(p) } as any as ExecutionContext;
+    await captureEntry("Duplicate content", [], "api", env, ctx);
+    expect(pending).toHaveLength(0);
+  });
+
+  // ── Duplicate: flagged ──────────────────────────────────────────────────────
+
+  it("returns status=flagged, stores entry, and adds duplicate-candidate tag", async () => {
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "near", score: 0.88, metadata: { parentId: "near" } }],
+        }),
+      }),
+    });
+    const { ctx } = makeCtx();
+    const result = await captureEntry("Similar note", [], "api", env, ctx);
+    expect(result.status).toBe("flagged");
+    if (result.status !== "flagged") return;
+    expect(result.matchId).toBe("near");
+    expect(db.entries).toHaveLength(1);
+    const tags: string[] = JSON.parse(db.entries[0].tags);
+    expect(tags).toContain("duplicate-candidate");
+  });
+
+  // ── Contradiction ───────────────────────────────────────────────────────────
+
+  it("returns status=contradiction, stores new entry, and removes conflicting entry", async () => {
+    db.entries.push({
+      id: "old-entry",
+      content: "I live in NYC",
+      tags: "[]",
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: "[]",
+      recall_count: 0,
+      importance_score: 0,
+    });
+
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "old-entry", score: 0.72, metadata: { parentId: "old-entry" } }],
+        }),
+      }),
+      AI: makeContradictionAI('{"contradicts": true, "conflicting_id": "old-entry", "reason": "different city"}'),
+    });
+
+    const { ctx } = makeCtx();
+    const result = await captureEntry("I moved to LA", [], "api", env, ctx);
+
+    expect(result.status).toBe("contradiction");
+    if (result.status !== "contradiction") return;
+    expect(result.resolvedConflict).toBe("old-entry");
+    expect(result.reason).toBe("different city");
+    expect(typeof result.id).toBe("string");
+
+    // New entry stored, conflicting entry removed
+    expect(db.entries.some(e => e.id === result.id)).toBe(true);
+    expect(db.entries.some(e => e.id === "old-entry")).toBe(false);
+  });
+
+  it("adds contradiction-resolved tag when contradiction detected", async () => {
+    db.entries.push({
+      id: "conflict",
+      content: "I live in NYC",
+      tags: "[]",
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: "[]",
+      recall_count: 0,
+      importance_score: 0,
+    });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "conflict", score: 0.72, metadata: { parentId: "conflict" } }],
+        }),
+      }),
+      AI: makeContradictionAI('{"contradicts": true, "conflicting_id": "conflict", "reason": "changed location"}'),
+    });
+    const { ctx } = makeCtx();
+    const result = await captureEntry("I moved to LA", [], "api", env, ctx);
+    expect(result.status).toBe("contradiction");
+    if (result.status !== "contradiction") return;
+    const storedEntry = db.entries.find(e => e.id === result.id);
+    const tags: string[] = JSON.parse(storedEntry!.tags);
+    expect(tags).toContain("contradiction-resolved");
+  });
+
+  // ── Importance scoring ──────────────────────────────────────────────────────
+
+  it("schedules importance scoring via ctx.waitUntil for stored entries", async () => {
+    const { ctx, drain } = makeCtx();
+    await captureEntry("Important decision", [], "api", env, ctx);
+    await drain();
+    expect(db.entries[0].importance_score).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── Non-fatal error handling ────────────────────────────────────────────────
+
+  it("stores to D1 and returns stored even when Vectorize insert throws", async () => {
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        insert: vi.fn().mockRejectedValue(new Error("Vectorize unavailable")),
+      }),
+    });
+    const { ctx } = makeCtx();
+    const result = await captureEntry("Note with broken vectorize", [], "api", env, ctx);
+    expect(result.status).toBe("stored");
+    expect(db.entries).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Extracts the shared write path from the remember MCP tool and POST /capture into a single
  captureEntry() function.
  
  Both call sites were ~75 lines of near-identical logic. They now delegate to captureEntry() and format their own response from the structured result.
  
  Changes:
  - src/index.ts: new CaptureResult type + captureEntry() exported function
  - remember MCP handler: reduced from 70 to 8 lines
  - POST /capture handler: reduced from 75 to 20 lines
  - test/unit/capture-entry.test.ts: 13 new unit tests covering all paths

  Test count: 94 -> 107 (all passing)