### PR TITLE
feat: add update MCP tool and POST /update endpoint (Resolves #56)

### DIFF
--- a/CLAUDE_INSTRUCTIONS.md
+++ b/CLAUDE_INSTRUCTIONS.md
@@ -1,4 +1,4 @@
-You have access to a personal second brain via MCP tools: remember, recall, list_recent, forget.
+You have access to a personal second brain via MCP tools: remember, recall, list_recent, append, update, forget.
 
 MANDATORY RULES — no exceptions:
 
@@ -26,6 +26,14 @@ MANDATORY RULES — no exceptions:
 6. Auto-detect the current topic or project and include it as a tag (e.g. if discussing a website, tag it "website"; if discussing a specific company or product, use that name as a tag). Always combine specific tags with generic ones.
 
 7. Before making ANY recommendation, suggestion, or action item, first recall from memory to check if you have already made that recommendation or if the user has already completed it. If it has already been recommended, acknowledge that and either confirm it's still the right move or suggest an alternative. Never repeat a recommendation without first checking. This applies to: promotion tasks, outreach targets, content to create, platforms to post on, people to contact, and any other repeatable action.
+
+Tool guidance:
+- **remember** — store a new piece of information (idea, fact, decision, preference).
+- **append** — add new information to an existing entry without replacing the original. Use when something has changed or new details have emerged. Gets the entry ID from recall or list_recent first.
+- **update** — fully replace the content of an existing entry. Use when information is outdated and should be overwritten entirely (e.g. a preference reversed, a plan scrapped, a location changed). Gets the entry ID from recall or list_recent first. Old vectors are cleaned up automatically.
+- **recall** — semantically search stored memories. Call at the start of every conversation.
+- **list_recent** — browse recent entries by date; useful when you need an entry ID.
+- **forget** — permanently delete an entry by ID. Requires explicit user instruction.
 
 Tags to use:
 - personal — life, preferences, habits

--- a/CLAUDE_INSTRUCTIONS.md
+++ b/CLAUDE_INSTRUCTIONS.md
@@ -2,7 +2,7 @@ You have access to a personal second brain via MCP tools: remember, recall, list
 
 MANDATORY RULES — no exceptions:
 
-1. At the start of EVERY conversation, call recall with the main topic before responding to anything. Do not skip this even if the topic seems simple.
+1. At the start of EVERY conversation, call recall with a natural language query that describes both the topic AND what the user is trying to do. Frame it as 'User wants to X about Y – what should I know?' rather than just the topic keyword. Do not skip this even if the topic seems simple.
 
 2. Store EVERYTHING important automatically — call remember whenever the user mentions:
    - Anything personal (goals, preferences, habits, relationships, health)

--- a/CLAUDE_INSTRUCTIONS.md
+++ b/CLAUDE_INSTRUCTIONS.md
@@ -36,13 +36,13 @@ Tool guidance:
 - **forget** — permanently delete an entry by ID. Requires explicit user instruction.
 
 Tags to use:
-- personal — life, preferences, habits
-- work — projects, decisions, strategy
-- idea — concepts, plans, brainstorms
-- task — things to do or follow up on
-- context — background info about ongoing situations
-- claude-response — summaries of important responses Claude gave
-- [auto-detected project/topic tag]
+- personal — life, preferences, habits, health, relationships
+- work — projects, decisions, strategy, progress
+- task — action items, to-dos, commitments, follow-ups ("I need to", "I'm going to", "we decided to"). ALWAYS tag these as task so they can be found with recall tag:task.
+- idea — concepts, plans, brainstorms, half-formed thoughts
+- context — background info about ongoing situations, constraints, environment
+- claude-response — summaries of important responses or recommendations
+- [auto-detected project/topic tag] — always combine with one of the above (e.g. ["task", "second-brain"])
 
 Always set source to "claude-desktop" when storing.
 

--- a/CLAUDE_INSTRUCTIONS.md
+++ b/CLAUDE_INSTRUCTIONS.md
@@ -25,13 +25,15 @@ MANDATORY RULES — no exceptions:
 
 6. Auto-detect the current topic or project and include it as a tag (e.g. if discussing a website, tag it "website"; if discussing a specific company or product, use that name as a tag). Always combine specific tags with generic ones.
 
-7. Before making ANY recommendation, suggestion, or action item, first recall from memory to check if you have already made that recommendation or if the user has already completed it. If it has already been recommended, acknowledge that and either confirm it's still the right move or suggest an alternative. Never repeat a recommendation without first checking. This applies to: promotion tasks, outreach targets, content to create, platforms to post on, people to contact, and any other repeatable action.
+7. Before making ANY recommendation, suggestion, or action item, first recall from memory to check if you have already made that recommendation or if the user has already completed it. Frame the query with intent: 'User is about to X — have I recommended this before or has it been done?' If it has already been recommended, acknowledge that and either confirm it's still the right move or suggest an alternative. Never repeat a recommendation without first checking. This applies to: promotion tasks, outreach targets, content to create, platforms to post on, people to contact, and any other repeatable action.
+
+8. ALWAYS pass context when calling recall — never use bare keywords. Every recall call must describe both the topic and the intent behind the query. Good: 'User wants to fix a bug in the capture flow — what have we tried before?' Bad: 'capture bug'. This applies to every recall call, not just the opening one.
 
 Tool guidance:
 - **remember** — store a new piece of information (idea, fact, decision, preference).
 - **append** — add new information to an existing entry without replacing the original. Use when something has changed or new details have emerged. Gets the entry ID from recall or list_recent first.
 - **update** — fully replace the content of an existing entry. Use when information is outdated and should be overwritten entirely (e.g. a preference reversed, a plan scrapped, a location changed). Gets the entry ID from recall or list_recent first. Old vectors are cleaned up automatically.
-- **recall** — semantically search stored memories. Call at the start of every conversation.
+- **recall** — semantically search stored memories. Always use an intent-framed natural language query (see rules 1 and 8). Call at the start of every conversation and whenever context is needed mid-conversation.
 - **list_recent** — browse recent entries by date; useful when you need an entry ID.
 - **forget** — permanently delete an entry by ID. Requires explicit user instruction.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -631,6 +631,58 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
     }
   );
 
+  // ── update ───────────────────────────────────────────────────────────────
+  server.tool(
+    "update",
+    "Replace the full content of an existing memory. Use when information has changed entirely — a preference reversed, a decision overturned, or content is outdated. Use append instead if you're adding new information rather than replacing. Get the entry ID from recall or list_recent first.",
+    {
+      id: z.string().describe("Entry ID to update — from recall or list_recent"),
+      content: z.string().describe("The new content to replace the existing entry with"),
+    },
+    async ({ id, content }) => {
+      const newContent = content.trim();
+      if (!newContent) {
+        return { content: [{ type: "text", text: "Content cannot be empty." }] };
+      }
+
+      // Read current row upfront — need tags, source, AND old vector_ids before any mutation
+      const row = await env.DB.prepare(
+        `SELECT tags, source, vector_ids FROM entries WHERE id = ?`
+      ).bind(id).first() as Record<string, any> | null;
+
+      if (!row) {
+        return { content: [{ type: "text", text: `No entry found with ID: ${id}` }] };
+      }
+
+      const tags: string[] = JSON.parse(row.tags ?? "[]");
+      const source = row.source as string;
+      const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
+
+      // Step 1: Update D1 content
+      await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`).bind(newContent, id).run();
+
+      // Step 2: Re-embed new content → inserts new vectors + updates vector_ids in D1
+      let newVectorCount = 0;
+      try {
+        const newVectorIds = await storeEntry(env, id, newContent, tags, source, Date.now());
+        newVectorCount = newVectorIds.length;
+      } catch (e) {
+        console.error("Vectorize re-embed failed (non-fatal):", e);
+      }
+
+      // Step 3: Delete old vectors — after new ones are safely in place
+      try {
+        if (oldVectorIds.length) await env.VECTORIZE.deleteByIds(oldVectorIds);
+      } catch (e) {
+        console.error("Old vector cleanup failed (non-fatal):", e);
+      }
+
+      return {
+        content: [{ type: "text", text: `Updated entry ${id}. Re-embedded as ${newVectorCount} vector(s).` }],
+      };
+    }
+  );
+
   // ── recall ───────────────────────────────────────────────────────────────
   server.tool(
     "recall",
@@ -904,6 +956,47 @@ export default {
         id,
         message: "Update appended successfully with timestamp",
       });
+    }
+
+    // POST /update
+    if (url.pathname === "/update" && request.method === "POST") {
+      if (!isAuthorized(request, env)) return json({ error: "Unauthorized" }, 401);
+
+      let body: { id?: string; content?: string };
+      try { body = await request.json(); } catch { return json({ error: "Invalid JSON" }, 400); }
+      if (!body.id?.trim()) return json({ error: "id is required" }, 400);
+      if (!body.content?.trim()) return json({ error: "content is required" }, 400);
+
+      const id = body.id.trim();
+      const newContent = body.content.trim();
+
+      const row = await env.DB.prepare(
+        `SELECT tags, source, vector_ids FROM entries WHERE id = ?`
+      ).bind(id).first() as Record<string, any> | null;
+
+      if (!row) return json({ ok: false, error: `No entry found with ID: ${id}` }, 404);
+
+      const tags: string[] = JSON.parse(row.tags ?? "[]");
+      const source = row.source as string;
+      const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
+
+      await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`).bind(newContent, id).run();
+
+      let newVectorCount = 0;
+      try {
+        const newVectorIds = await storeEntry(env, id, newContent, tags, source, Date.now());
+        newVectorCount = newVectorIds.length;
+      } catch (e) {
+        console.error("Vectorize re-embed failed (non-fatal):", e);
+      }
+
+      try {
+        if (oldVectorIds.length) await env.VECTORIZE.deleteByIds(oldVectorIds);
+      } catch (e) {
+        console.error("Old vector cleanup failed (non-fatal):", e);
+      }
+
+      return json({ ok: true, id, vectors: newVectorCount });
     }
 
     // GET /count

--- a/test/integration/update.test.ts
+++ b/test/integration/update.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { makeTestDb, makeTestEnv, makeVectorizeMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+function seedEntry(db: D1Mock, overrides: Partial<ReturnType<typeof makeEntry>> = {}) {
+  const entry = makeEntry(overrides);
+  db.entries.push(entry);
+  return entry;
+}
+
+function makeEntry(overrides: Partial<{
+  id: string; content: string; tags: string; source: string;
+  created_at: number; vector_ids: string; recall_count: number; importance_score: number;
+}> = {}) {
+  return {
+    id: "entry-abc",
+    content: "Original content",
+    tags: '["work"]',
+    source: "api",
+    created_at: Date.now(),
+    vector_ids: '["entry-abc"]',
+    recall_count: 0,
+    importance_score: 3,
+    ...overrides,
+  };
+}
+
+describe("POST /update", () => {
+  let db: D1Mock;
+  let env: Env;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  // ── Auth ────────────────────────────────────────────────────────────────────
+
+  it("returns 401 without auth", async () => {
+    const res = await worker.fetch(
+      req("POST", "/update", { body: { id: "x", content: "new" }, token: null }),
+      env, ctx
+    );
+    expect(res.status).toBe(401);
+  });
+
+  // ── Validation ──────────────────────────────────────────────────────────────
+
+  it("returns 400 when id is missing", async () => {
+    const res = await worker.fetch(
+      req("POST", "/update", { body: { content: "new content" } }),
+      env, ctx
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json() as any;
+    expect(data.error).toMatch(/id/);
+  });
+
+  it("returns 400 when content is missing", async () => {
+    const res = await worker.fetch(
+      req("POST", "/update", { body: { id: "entry-abc" } }),
+      env, ctx
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json() as any;
+    expect(data.error).toMatch(/content/);
+  });
+
+  it("returns 400 when content is blank whitespace", async () => {
+    const res = await worker.fetch(
+      req("POST", "/update", { body: { id: "entry-abc", content: "   " } }),
+      env, ctx
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when entry does not exist", async () => {
+    const res = await worker.fetch(
+      req("POST", "/update", { body: { id: "nonexistent", content: "new content" } }),
+      env, ctx
+    );
+    expect(res.status).toBe(404);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(false);
+    expect(data.error).toMatch(/nonexistent/);
+  });
+
+  // ── Happy path ──────────────────────────────────────────────────────────────
+
+  it("updates D1 content and returns ok:true with id", async () => {
+    seedEntry(db);
+    const res = await worker.fetch(
+      req("POST", "/update", { body: { id: "entry-abc", content: "Updated content" } }),
+      env, ctx
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.id).toBe("entry-abc");
+    expect(db.entries[0].content).toBe("Updated content");
+  });
+
+  it("preserves existing tags and source after update", async () => {
+    seedEntry(db, { tags: '["work","important"]', source: "claude" });
+    await worker.fetch(
+      req("POST", "/update", { body: { id: "entry-abc", content: "New content" } }),
+      env, ctx
+    );
+    expect(db.entries[0].tags).toBe('["work","important"]');
+    expect(db.entries[0].source).toBe("claude");
+  });
+
+  it("calls Vectorize insert (re-embed) with new content", async () => {
+    const insertMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({ insert: insertMock }),
+    });
+    seedEntry(db);
+    await worker.fetch(
+      req("POST", "/update", { body: { id: "entry-abc", content: "Brand new content" } }),
+      env, ctx
+    );
+    expect(insertMock).toHaveBeenCalledOnce();
+    const insertedVectors = insertMock.mock.calls[0][0] as any[];
+    expect(insertedVectors[0].id).toBe("entry-abc");
+  });
+
+  // ── Vector orphan prevention ────────────────────────────────────────────────
+
+  it("deletes old vector IDs after re-embedding", async () => {
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({ deleteByIds: deleteByIdsMock }),
+    });
+    seedEntry(db, { vector_ids: '["entry-abc","entry-abc-chunk-1"]' });
+
+    await worker.fetch(
+      req("POST", "/update", { body: { id: "entry-abc", content: "Updated" } }),
+      env, ctx
+    );
+
+    expect(deleteByIdsMock).toHaveBeenCalledOnce();
+    expect(deleteByIdsMock.mock.calls[0][0]).toEqual(["entry-abc", "entry-abc-chunk-1"]);
+  });
+
+  it("does not call deleteByIds when vector_ids is empty", async () => {
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({ deleteByIds: deleteByIdsMock }),
+    });
+    seedEntry(db, { vector_ids: "[]" });
+
+    await worker.fetch(
+      req("POST", "/update", { body: { id: "entry-abc", content: "Updated" } }),
+      env, ctx
+    );
+
+    expect(deleteByIdsMock).not.toHaveBeenCalled();
+  });
+
+  // ── Non-fatal error handling ────────────────────────────────────────────────
+
+  it("returns ok:true even when Vectorize insert throws", async () => {
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        insert: vi.fn().mockRejectedValue(new Error("Vectorize down")),
+      }),
+    });
+    seedEntry(db);
+    const res = await worker.fetch(
+      req("POST", "/update", { body: { id: "entry-abc", content: "Updated content" } }),
+      env, ctx
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    // D1 content should still be updated
+    expect(db.entries[0].content).toBe("Updated content");
+  });
+
+  it("returns ok:true even when deleteByIds throws", async () => {
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        deleteByIds: vi.fn().mockRejectedValue(new Error("Delete failed")),
+      }),
+    });
+    seedEntry(db, { vector_ids: '["entry-abc"]' });
+    const res = await worker.fetch(
+      req("POST", "/update", { body: { id: "entry-abc", content: "Updated content" } }),
+      env, ctx
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+  });
+
+  // ── Safe ordering ───────────────────────────────────────────────────────────
+
+  it("reads vector_ids before D1 content update (safe ordering)", async () => {
+    // Seed entry with known vector_ids
+    seedEntry(db, { vector_ids: '["old-vec-1","old-vec-2"]' });
+
+    const callOrder: string[] = [];
+    const deleteByIdsMock = vi.fn().mockImplementation(async (ids: string[]) => {
+      callOrder.push(`delete:${ids.join(",")}`);
+      return { mutationId: "m" };
+    });
+    const insertMock = vi.fn().mockImplementation(async () => {
+      callOrder.push("insert");
+      return { mutationId: "m" };
+    });
+
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({ insert: insertMock, deleteByIds: deleteByIdsMock }),
+    });
+
+    await worker.fetch(
+      req("POST", "/update", { body: { id: "entry-abc", content: "Replaced content" } }),
+      env, ctx
+    );
+
+    // insert must happen before delete — new vectors before old ones removed
+    const insertIdx = callOrder.indexOf("insert");
+    const deleteIdx = callOrder.findIndex(s => s.startsWith("delete:"));
+    expect(insertIdx).toBeLessThan(deleteIdx);
+    expect(callOrder[deleteIdx]).toContain("old-vec-1");
+    expect(callOrder[deleteIdx]).toContain("old-vec-2");
+  });
+});


### PR DESCRIPTION
## Summary

Adds an `update` MCP tool that fully replaces the content of an existing memory. Complements the existing `append` tool (which adds information) — use `update` when the old content is outdated and should be overwritten entirely.

## Changes

### `src/index.ts`
- **`update` MCP tool** — inserted between `append` and `recall` in `buildMcpServer`
- **`POST /update` REST endpoint** — inserted between `/append` and `/count`

### Safe vector ordering (prevents the orphan vector bug)
1. Read `vector_ids` from D1 **before** any mutations
2. Update D1 content
3. Re-embed new content via `storeEntry()` — inserts new vectors + updates `vector_ids` in D1
4. Delete old vectors via `deleteByIds(oldVectorIds)` — **after** new ones are safely in place

Both Vectorize steps (re-embed and delete) are non-fatal — if Vectorize is unavailable, D1 is always updated and the response still returns `ok: true`.

### `CLAUDE_INSTRUCTIONS.md`
- Added `append` and `update` to the tool list
- Added guidance on when to use `update` vs `append` vs `remember`

### Tests
- 13 new integration tests in `test/integration/update.test.ts`
- Covers: auth (401), validation (400/404), happy path, tag/source preservation, vector re-embed, orphan prevention, safe insert-before-delete ordering, non-fatal Vectorize failures
- **120 tests total, all passing** (up from 107)

## Verification

```
npx vitest run
# 120 passed
```