### PR TITLE
feat: smart merge for near-duplicate memories + MCP SDK migration (Resolves #55)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ const CHUNK_OVERLAP_CHARS = 200;
 // ─── Token limits ─────────────────────────────────────────────────────────────
 
 const CONTRADICTION_MAX_TOKENS = 80;
+const SMART_MERGE_MAX_TOKENS = 250;
 const INSIGHT_MAX_TOKENS = 300;
 
 // ─── Vectorize constants ──────────────────────────────────────────────────────
@@ -132,11 +133,23 @@ interface ContradictionResult {
   reason?: string;
 }
 
-// Merges duplicate detection and contradiction detection into a single embed +
-// Vectorize query, saving 1 AI call and 1 Vectorize round trip on every write.
+// ─── Smart Merge ──────────────────────────────────────────────────────────────
+// Only applies to the flagged band (0.85–0.95). The combined prompt handles
+// both contradiction detection and merge/replace decisions in a single LLM call,
+// keeping total LLM calls the same as before.
+
+export type MergeAction =
+  | { action: "keep_both" }
+  | { action: "replace"; target_id: string }
+  | { action: "merge"; target_id: string; merged_content: string };
+
+// Merges duplicate detection, contradiction detection, and smart merge into a
+// single embed + Vectorize query. For flagged entries (0.85–0.95) the combined
+// prompt replaces the contradiction-only prompt — same number of LLM calls.
 export async function checkDuplicateAndContradiction(content: string, env: Env): Promise<{
   duplicate: DuplicateResult;
   contradiction: ContradictionResult;
+  mergeAction: MergeAction | null;
 }> {
   const sample = getDuplicateCheckSample(content);
   const values = await embed(sample, env);
@@ -151,8 +164,10 @@ export async function checkDuplicateAndContradiction(content: string, env: Env):
     else if (top.score >= DUPLICATE_FLAG_THRESHOLD) duplicate = { status: "flagged", matchId, score: top.score };
   }
 
-  // ── Contradiction: skip entirely if we're blocking anyway ───────────────────
+  // ── Skip all LLM work if blocked ─────────────────────────────────────────────
   let contradiction: ContradictionResult = { detected: false };
+  let mergeAction: MergeAction | null = null;
+
   if (duplicate.status !== "blocked") {
     const candidates = matches.filter(m => m.score >= CANDIDATE_SCORE_THRESHOLD);
     if (candidates.length) {
@@ -170,7 +185,62 @@ export async function checkDuplicateAndContradiction(content: string, env: Env):
           .map((r, i) => `[${i + 1}] ID: ${r.id}\n${r.content}`)
           .join("\n\n");
 
-        const prompt = `You are checking if a new memory contradicts existing memories.
+        if (duplicate.status === "flagged") {
+          // ── Combined prompt: contradiction + merge decision (flagged band only) ──
+          // Replaces the contradiction-only prompt — same 1 LLM call, richer result.
+          const prompt = `You are deciding what to do with a new memory that is very similar to existing memories.
+
+New memory: "${content}"
+
+Similar existing memories:
+${existingList}
+
+Choose exactly one action. Prioritise in this order:
+1. "contradiction" — new memory DIRECTLY CONFLICTS with an existing one (opposite location, reversed decision, changed fact). Include conflicting_id and reason.
+2. "replace" — new memory clearly supersedes an existing one (updated version of the same fact, original is now stale). Include target_id.
+3. "merge" — both memories are complementary and better as one combined entry. Include target_id and merged_content (max 400 chars).
+4. "keep_both" — memories are different enough to coexist, or you are uncertain. This is the safe default.
+
+Respond with JSON only. No text outside the JSON.
+{"action":"keep_both"} OR {"action":"contradiction","conflicting_id":"<id>","reason":"<10 words max>"} OR {"action":"replace","target_id":"<id>"} OR {"action":"merge","target_id":"<id>","merged_content":"<text>"}`;
+
+          try {
+            const stream = await (env.AI as any).run(LLM_MODEL as any, {
+              messages: [{ role: "user", content: prompt }],
+              max_tokens: SMART_MERGE_MAX_TOKENS,
+              stream: true,
+            });
+            const text = await readStreamText(stream as ReadableStream);
+            const jsonMatch = text.match(/\{[\s\S]*\}/);
+            if (jsonMatch) {
+              const parsed = JSON.parse(jsonMatch[0]);
+              const action = parsed.action as string;
+
+              if (action === "contradiction" && parsed.conflicting_id) {
+                const validId = parentIds.find(id => id === parsed.conflicting_id);
+                if (validId) contradiction = { detected: true, conflicting_id: validId, reason: parsed.reason };
+                // mergeAction stays null — contradiction path handles cleanup
+              } else if (action === "replace" && parsed.target_id) {
+                const validId = parentIds.find(id => id === parsed.target_id);
+                mergeAction = validId ? { action: "replace", target_id: validId } : { action: "keep_both" };
+              } else if (action === "merge" && parsed.target_id && parsed.merged_content?.trim()) {
+                const validId = parentIds.find(id => id === parsed.target_id);
+                mergeAction = validId
+                  ? { action: "merge", target_id: validId, merged_content: parsed.merged_content.trim() }
+                  : { action: "keep_both" };
+              } else {
+                mergeAction = { action: "keep_both" };
+              }
+            } else {
+              mergeAction = { action: "keep_both" };
+            }
+          } catch {
+            // non-fatal — default to keep_both (current behaviour)
+            mergeAction = { action: "keep_both" };
+          }
+        } else {
+          // ── Contradiction only (0.45–0.85 range — unchanged) ─────────────────
+          const prompt = `You are checking if a new memory contradicts existing memories.
 
 New memory: "${content}"
 
@@ -182,29 +252,30 @@ A contradiction means the new memory states something that DIRECTLY CONFLICTS wi
 Respond with JSON only. No text outside the JSON object.
 {"contradicts": false} OR {"contradicts": true, "conflicting_id": "<exact_id>", "reason": "<10 words max>"}`;
 
-        try {
-          const stream = await (env.AI as any).run(LLM_MODEL as any, {
-            messages: [{ role: "user", content: prompt }],
-            max_tokens: CONTRADICTION_MAX_TOKENS,
-            stream: true,
-          });
-          const text = await readStreamText(stream as ReadableStream);
-          const match = text.match(/\{[\s\S]*\}/);
-          if (match) {
-            const parsed = JSON.parse(match[0]);
-            if (parsed.contradicts && parsed.conflicting_id) {
-              const validId = parentIds.find(id => id === parsed.conflicting_id);
-              if (validId) contradiction = { detected: true, conflicting_id: validId, reason: parsed.reason };
+          try {
+            const stream = await (env.AI as any).run(LLM_MODEL as any, {
+              messages: [{ role: "user", content: prompt }],
+              max_tokens: CONTRADICTION_MAX_TOKENS,
+              stream: true,
+            });
+            const text = await readStreamText(stream as ReadableStream);
+            const jsonMatch = text.match(/\{[\s\S]*\}/);
+            if (jsonMatch) {
+              const parsed = JSON.parse(jsonMatch[0]);
+              if (parsed.contradicts && parsed.conflicting_id) {
+                const validId = parentIds.find(id => id === parsed.conflicting_id);
+                if (validId) contradiction = { detected: true, conflicting_id: validId, reason: parsed.reason };
+              }
             }
+          } catch {
+            // non-fatal — contradiction stays { detected: false }
           }
-        } catch {
-          // non-fatal — contradiction stays { detected: false }
         }
       }
     }
   }
 
-  return { duplicate, contradiction };
+  return { duplicate, contradiction, mergeAction };
 }
 
 // ─── Chunking ─────────────────────────────────────────────────────────────────
@@ -491,7 +562,9 @@ export type CaptureResult =
   | { status: "blocked"; matchId: string; score: number }
   | { status: "stored"; id: string }
   | { status: "flagged"; id: string; matchId: string; score: number }
-  | { status: "contradiction"; id: string; resolvedConflict: string; reason?: string };
+  | { status: "contradiction"; id: string; resolvedConflict: string; reason?: string }
+  | { status: "merged"; id: string }
+  | { status: "replaced"; id: string };
 
 export async function captureEntry(
   rawContent: string,
@@ -505,10 +578,44 @@ export async function captureEntry(
   const c = cleanContent || raw;
   const t = [...new Set([...tags.map(tag => tag.toLowerCase()), ...hashtags])];
 
-  const { duplicate: dup, contradiction } = await checkDuplicateAndContradiction(c, env);
+  const { duplicate: dup, contradiction, mergeAction } = await checkDuplicateAndContradiction(c, env);
 
   if (dup.status === "blocked") {
     return { status: "blocked", matchId: dup.matchId, score: dup.score };
+  }
+
+  // ── Smart merge: replace/merge existing entry — no new entry inserted ────────
+  if (dup.status === "flagged" && mergeAction && mergeAction.action !== "keep_both") {
+    const targetId = mergeAction.target_id;
+    const newContent = mergeAction.action === "merge" ? mergeAction.merged_content : c;
+
+    const targetRow = await env.DB.prepare(
+      `SELECT tags, source, vector_ids FROM entries WHERE id = ?`
+    ).bind(targetId).first() as Record<string, any> | null;
+
+    if (targetRow) {
+      const existingTags: string[] = JSON.parse(targetRow.tags ?? "[]");
+      const existingSource = targetRow.source as string;
+      const oldVectorIds: string[] = JSON.parse(targetRow.vector_ids ?? "[]");
+
+      // Step 1: Update D1 content
+      await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`).bind(newContent, targetId).run();
+
+      // Step 2: Re-embed new content — inserts new vectors, updates vector_ids in D1
+      try {
+        await storeEntry(env, targetId, newContent, existingTags, existingSource, Date.now());
+      } catch (e) { console.error("Vectorize re-embed failed (non-fatal):", e); }
+
+      // Step 3: Delete old vectors after new ones are safely in place
+      try {
+        if (oldVectorIds.length) await env.VECTORIZE.deleteByIds(oldVectorIds);
+      } catch (e) { console.error("Old vector cleanup failed (non-fatal):", e); }
+
+      return mergeAction.action === "merge"
+        ? { status: "merged", id: targetId }
+        : { status: "replaced", id: targetId };
+    }
+    // target not found in DB — fall through to normal insert
   }
 
   const id = crypto.randomUUID();
@@ -560,13 +667,15 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
   const server = new McpServer({ name: "second-brain", version: "1.0.0" });
 
   // ── remember ────────────────────────────────────────────────────────────
-  server.tool(
+  server.registerTool(
     "remember",
-    "Store an idea, task, or note in your second brain. Call this automatically whenever the user shares context, goals, decisions, or preferences.",
     {
-      content: z.string().describe("The idea, task, or note to store"),
-      tags: z.array(z.string()).optional().describe("Optional tags for filtering"),
-      source: z.string().optional().describe("Origin: phone, browser, voice, claude"),
+      description: "Store an idea, task, or note in your second brain. Call this automatically whenever the user shares context, goals, decisions, or preferences.",
+      inputSchema: {
+        content: z.string().describe("The idea, task, or note to store"),
+        tags: z.array(z.string()).optional().describe("Optional tags for filtering"),
+        source: z.string().optional().describe("Origin: phone, browser, voice, claude"),
+      },
     },
     async ({ content, tags, source }) => {
       const result = await captureEntry(content, tags ?? [], source ?? "claude", env, ctx);
@@ -576,6 +685,12 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       if (result.status === "contradiction") {
         return { content: [{ type: "text", text: `Stored. ID: ${result.id} — resolved contradiction with entry ${result.resolvedConflict}${result.reason ? `: ${result.reason}` : ""}.` }] };
       }
+      if (result.status === "replaced") {
+        return { content: [{ type: "text", text: `Memory updated — new content replaced outdated entry (ID: ${result.id}).` }] };
+      }
+      if (result.status === "merged") {
+        return { content: [{ type: "text", text: `Memories merged — combined into existing entry (ID: ${result.id}).` }] };
+      }
       if (result.status === "flagged") {
         return { content: [{ type: "text", text: `Stored with ID: ${result.id} — note: similar entry exists (${(result.score * 100).toFixed(0)}% match, ID: ${result.matchId}). Tagged as duplicate-candidate.` }] };
       }
@@ -584,12 +699,14 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
   );
 
   // ── append ───────────────────────────────────────────────────────────────
-  server.tool(
+  server.registerTool(
     "append",
-    "Append new information to an existing entry in your second brain. Use when something has changed or been updated — preserves the original and adds the update with a timestamp. Get the entry ID from recall or list_recent first.",
     {
-      id: z.string().describe("Entry ID to append to — from recall or list_recent"),
-      addition: z.string().describe("The new information to add to the existing entry"),
+      description: "Append new information to an existing entry in your second brain. Use when something has changed or been updated — preserves the original and adds the update with a timestamp. Get the entry ID from recall or list_recent first.",
+      inputSchema: {
+        id: z.string().describe("Entry ID to append to — from recall or list_recent"),
+        addition: z.string().describe("The new information to add to the existing entry"),
+      },
     },
     async ({ id, addition }) => {
       const row = await env.DB.prepare(
@@ -632,12 +749,14 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
   );
 
   // ── update ───────────────────────────────────────────────────────────────
-  server.tool(
+  server.registerTool(
     "update",
-    "Replace the full content of an existing memory. Use when information has changed entirely — a preference reversed, a decision overturned, or content is outdated. Use append instead if you're adding new information rather than replacing. Get the entry ID from recall or list_recent first.",
     {
-      id: z.string().describe("Entry ID to update — from recall or list_recent"),
-      content: z.string().describe("The new content to replace the existing entry with"),
+      description: "Replace the full content of an existing memory. Use when information has changed entirely — a preference reversed, a decision overturned, or content is outdated. Use append instead if you're adding new information rather than replacing. Get the entry ID from recall or list_recent first.",
+      inputSchema: {
+        id: z.string().describe("Entry ID to update — from recall or list_recent"),
+        content: z.string().describe("The new content to replace the existing entry with"),
+      },
     },
     async ({ id, content }) => {
       const newContent = content.trim();
@@ -684,15 +803,17 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
   );
 
   // ── recall ───────────────────────────────────────────────────────────────
-  server.tool(
+  server.registerTool(
     "recall",
-    "Recall: semantically search your second brain for relevant notes and context. Call recall automatically at the start of every conversation and every 3-4 messages.",
     {
-      query: z.string().describe("Natural language search query"),
-      topK: z.number().int().min(1).max(20).default(5).describe("Number of results"),
-      tag: z.string().optional().describe("Filter by a specific tag"),
-      after: z.number().int().optional().describe("Only return entries after this Unix ms timestamp"),
-      before: z.number().int().optional().describe("Only return entries before this Unix ms timestamp"),
+      description: "Recall: semantically search your second brain for relevant notes and context. Call recall automatically at the start of every conversation and every 3-4 messages.",
+      inputSchema: {
+        query: z.string().describe("Natural language search query"),
+        topK: z.number().int().min(1).max(20).default(5).describe("Number of results"),
+        tag: z.string().optional().describe("Filter by a specific tag"),
+        after: z.number().int().optional().describe("Only return entries after this Unix ms timestamp"),
+        before: z.number().int().optional().describe("Only return entries before this Unix ms timestamp"),
+      },
     },
     async ({ query, topK, tag, after, before }) => {
       const now = Date.now();
@@ -803,14 +924,16 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
   );
 
   // ── list_recent ──────────────────────────────────────────────────────────
-  server.tool(
+  server.registerTool(
     "list_recent",
-    "list_recent: List the most recent entries by date from your second brain. Use when you need to browse recent entries or find an entry ID. Not the same as recall — returns entries by time, not by meaning.",
     {
-      n: z.number().int().min(1).max(50).default(10),
-      tag: z.string().optional(),
-      after: z.number().int().optional().describe("Only return entries after this Unix ms timestamp"),
-      before: z.number().int().optional().describe("Only return entries before this Unix ms timestamp"),
+      description: "list_recent: List the most recent entries by date from your second brain. Use when you need to browse recent entries or find an entry ID. Not the same as recall — returns entries by time, not by meaning.",
+      inputSchema: {
+        n: z.number().int().min(1).max(50).default(10),
+        tag: z.string().optional(),
+        after: z.number().int().optional().describe("Only return entries after this Unix ms timestamp"),
+        before: z.number().int().optional().describe("Only return entries before this Unix ms timestamp"),
+      },
     },
     async ({ n, tag, after, before }) => {
       const conds: string[] = [];
@@ -840,10 +963,14 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
   );
 
   // ── forget ───────────────────────────────────────────────────────────────
-  server.tool(
+  server.registerTool(
     "forget",
-    "Permanently delete an entry from your second brain by ID. Only call when the user explicitly asks to delete something. Confirm the entry ID using recall or list_recent first. This action cannot be undone.",
-    { id: z.string().describe("Entry ID from recall or list_recent") },
+    {
+      description: "Permanently delete an entry from your second brain by ID. Only call when the user explicitly asks to delete something. Confirm the entry ID using recall or list_recent first. This action cannot be undone.",
+      inputSchema: {
+        id: z.string().describe("Entry ID from recall or list_recent"),
+      },
+    },
     async ({ id }) => {
       // Fetch tracked vector IDs before deleting the D1 row
       const row = await env.DB.prepare(
@@ -907,6 +1034,12 @@ export default {
       }
       if (result.status === "contradiction") {
         return json({ ok: true, id: result.id, resolved_conflict: result.resolvedConflict, reason: result.reason });
+      }
+      if (result.status === "replaced") {
+        return json({ ok: true, id: result.id, action: "replaced", message: "New memory replaced an outdated existing entry" });
+      }
+      if (result.status === "merged") {
+        return json({ ok: true, id: result.id, action: "merged", message: "Memories merged into a single combined entry" });
       }
       if (result.status === "flagged") {
         return json({

--- a/test/integration/smart-merge.test.ts
+++ b/test/integration/smart-merge.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { makeTestDb, makeTestEnv, makeVectorizeMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+// AI mock that returns a specific LLM response while still handling embed calls
+function makeMergeAI(response: string): Ai {
+  return {
+    run: vi.fn().mockImplementation(async (model: string) => {
+      if (model === "@cf/baai/bge-small-en-v1.5")
+        return { data: [new Array(384).fill(0.1)] };
+      return new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+          c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+          c.close();
+        },
+      });
+    }),
+  } as unknown as Ai;
+}
+
+function seedEntry(db: D1Mock, id = "existing-id", content = "I use VSCode", vectorIds = '["existing-id"]') {
+  db.entries.push({
+    id,
+    content,
+    tags: '["work"]',
+    source: "api",
+    created_at: Date.now() - 1000,
+    vector_ids: vectorIds,
+    recall_count: 0,
+    importance_score: 3,
+  });
+}
+
+describe("POST /capture — smart merge (flagged band 0.85–0.95)", () => {
+  let db: D1Mock;
+  let env: Env;
+
+  beforeEach(() => {
+    db = makeTestDb();
+  });
+
+  // ── Replace ─────────────────────────────────────────────────────────────────
+
+  it("returns action=replaced, updates existing entry, does not insert a new one", async () => {
+    seedEntry(db);
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
+        }),
+      }),
+      AI: makeMergeAI('{"action":"replace","target_id":"existing-id"}'),
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/capture", { body: { content: "I switched to Cursor IDE" } }),
+      env, ctx
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.action).toBe("replaced");
+    expect(data.id).toBe("existing-id");
+
+    expect(db.entries).toHaveLength(1);
+    expect(db.entries[0].content).toBe("I switched to Cursor IDE");
+  });
+
+  it("replace: deletes old vectors and re-embeds with new content", async () => {
+    seedEntry(db, "existing-id", "I use VSCode", '["existing-id","existing-id-chunk-1"]');
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    const insertMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
+        }),
+        insert: insertMock,
+        deleteByIds: deleteByIdsMock,
+      }),
+      AI: makeMergeAI('{"action":"replace","target_id":"existing-id"}'),
+    });
+
+    await worker.fetch(
+      req("POST", "/capture", { body: { content: "I switched to Cursor" } }),
+      env, ctx
+    );
+
+    expect(insertMock).toHaveBeenCalledOnce();
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["existing-id", "existing-id-chunk-1"]);
+  });
+
+  it("replace: new vector is inserted before old ones are deleted (safe ordering)", async () => {
+    seedEntry(db, "existing-id", "I use VSCode", '["old-vec"]');
+    const callOrder: string[] = [];
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
+        }),
+        insert: vi.fn().mockImplementation(async () => { callOrder.push("insert"); return { mutationId: "m" }; }),
+        deleteByIds: vi.fn().mockImplementation(async () => { callOrder.push("delete"); return { mutationId: "m" }; }),
+      }),
+      AI: makeMergeAI('{"action":"replace","target_id":"existing-id"}'),
+    });
+
+    await worker.fetch(req("POST", "/capture", { body: { content: "Cursor IDE" } }), env, ctx);
+    expect(callOrder.indexOf("insert")).toBeLessThan(callOrder.indexOf("delete"));
+  });
+
+  // ── Merge ───────────────────────────────────────────────────────────────────
+
+  it("returns action=merged, updates existing entry with merged_content, no new entry", async () => {
+    seedEntry(db, "existing-id", "I prefer dark mode");
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
+        }),
+      }),
+      AI: makeMergeAI('{"action":"merge","target_id":"existing-id","merged_content":"I prefer dark mode in all apps, especially at night"}'),
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/capture", { body: { content: "I like dark mode especially at night" } }),
+      env, ctx
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.action).toBe("merged");
+    expect(data.id).toBe("existing-id");
+
+    expect(db.entries).toHaveLength(1);
+    expect(db.entries[0].content).toBe("I prefer dark mode in all apps, especially at night");
+  });
+
+  it("merge: embeds merged_content (not the raw new content)", async () => {
+    seedEntry(db, "existing-id", "I prefer dark mode");
+    const insertMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
+        }),
+        insert: insertMock,
+      }),
+      AI: makeMergeAI('{"action":"merge","target_id":"existing-id","merged_content":"THE MERGED RESULT"}'),
+    });
+
+    await worker.fetch(
+      req("POST", "/capture", { body: { content: "I like dark mode at night" } }),
+      env, ctx
+    );
+
+    const insertedVectors = insertMock.mock.calls[0][0] as any[];
+    expect(insertedVectors[0].metadata.content).toBe("THE MERGED RESULT");
+  });
+
+  it("merge: deletes old vectors after re-embedding", async () => {
+    seedEntry(db, "existing-id", "I prefer dark mode", '["v1","v2"]');
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
+        }),
+        deleteByIds: deleteByIdsMock,
+      }),
+      AI: makeMergeAI('{"action":"merge","target_id":"existing-id","merged_content":"Combined"}'),
+    });
+
+    await worker.fetch(
+      req("POST", "/capture", { body: { content: "I like dark mode at night" } }),
+      env, ctx
+    );
+
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["v1", "v2"]);
+  });
+
+  // ── keep_both → existing flagged behaviour unchanged ─────────────────────────
+
+  it("keep_both: stores new entry with duplicate-candidate tag (existing behaviour preserved)", async () => {
+    seedEntry(db, "near-id", "I prefer dark mode");
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "near-id", score: 0.88, metadata: { parentId: "near-id" } }],
+        }),
+      }),
+      AI: makeMergeAI('{"action":"keep_both"}'),
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/capture", { body: { content: "I like dark themes generally" } }),
+      env, ctx
+    );
+
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.warning).toBe("similar");
+    expect(db.entries).toHaveLength(2);
+    const newTags: string[] = JSON.parse(db.entries[1].tags);
+    expect(newTags).toContain("duplicate-candidate");
+  });
+
+  // ── Contradiction via combined prompt ─────────────────────────────────────────
+
+  it("contradiction detected via combined prompt in flagged band — new entry stored, conflicting removed", async () => {
+    seedEntry(db, "old-id", "I live in NYC");
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "old-id", score: 0.88, metadata: { parentId: "old-id" } }],
+        }),
+      }),
+      AI: makeMergeAI('{"action":"contradiction","conflicting_id":"old-id","reason":"different city"}'),
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/capture", { body: { content: "I moved to LA" } }),
+      env, ctx
+    );
+
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.resolved_conflict).toBe("old-id");
+    expect(data.reason).toBe("different city");
+    expect(db.entries.some((e: any) => e.id === "old-id")).toBe(false);
+    expect(db.entries).toHaveLength(1);
+  });
+
+  // ── Non-fatal error handling ──────────────────────────────────────────────────
+
+  it("replace: returns ok:true even when Vectorize re-embed throws", async () => {
+    seedEntry(db);
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
+        }),
+        insert: vi.fn().mockRejectedValue(new Error("Vectorize down")),
+      }),
+      AI: makeMergeAI('{"action":"replace","target_id":"existing-id"}'),
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/capture", { body: { content: "I switched to Cursor" } }),
+      env, ctx
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    // D1 content still updated even if Vectorize failed
+    expect(db.entries[0].content).toBe("I switched to Cursor");
+  });
+
+  it("merge: returns ok:true even when deleteByIds throws", async () => {
+    seedEntry(db, "existing-id", "I prefer dark mode", '["old-vec"]');
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
+        }),
+        deleteByIds: vi.fn().mockRejectedValue(new Error("delete failed")),
+      }),
+      AI: makeMergeAI('{"action":"merge","target_id":"existing-id","merged_content":"Combined"}'),
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/capture", { body: { content: "I like dark mode at night" } }),
+      env, ctx
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.action).toBe("merged");
+  });
+
+  // ── Existing functionality unaffected ─────────────────────────────────────────
+
+  it("blocked (≥0.95): still blocked, no LLM call for merge", async () => {
+    const aiRunMock = vi.fn().mockImplementation(async (model: string) => {
+      if (model === "@cf/baai/bge-small-en-v1.5") return { data: [new Array(384).fill(0.1)] };
+      throw new Error("LLM should not be called for blocked entries");
+    });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "dup", score: 0.97, metadata: { parentId: "dup" } }],
+        }),
+      }),
+      AI: { run: aiRunMock } as unknown as Ai,
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/capture", { body: { content: "Duplicate" } }),
+      env, ctx
+    );
+
+    const data = await res.json() as any;
+    expect(data.ok).toBe(false);
+    expect(data.duplicate).toBe(true);
+    // LLM called only once — for embed, never for contradiction/merge
+    expect(aiRunMock).toHaveBeenCalledOnce();
+  });
+});

--- a/test/unit/capture-entry.test.ts
+++ b/test/unit/capture-entry.test.ts
@@ -208,6 +208,157 @@ describe("captureEntry()", () => {
     expect(tags).toContain("contradiction-resolved");
   });
 
+  // ── Smart merge: replace ────────────────────────────────────────────────────
+
+  it("replace: updates existing entry content, does NOT insert a new entry", async () => {
+    db.entries.push({
+      id: "existing", content: "I use VSCode", tags: '["work"]', source: "api",
+      created_at: Date.now(), vector_ids: '["existing"]', recall_count: 0, importance_score: 3,
+    });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing", score: 0.88, metadata: { parentId: "existing" } }],
+        }),
+      }),
+      AI: makeContradictionAI('{"action":"replace","target_id":"existing"}'),
+    });
+    const { ctx } = makeCtx();
+    const result = await captureEntry("I switched to Cursor", [], "api", env, ctx);
+    expect(result.status).toBe("replaced");
+    if (result.status !== "replaced") return;
+    expect(result.id).toBe("existing");
+    // No new entry — only the existing one remains
+    expect(db.entries).toHaveLength(1);
+    expect(db.entries[0].content).toBe("I switched to Cursor");
+  });
+
+  it("replace: deletes old vectors after re-embedding", async () => {
+    db.entries.push({
+      id: "existing", content: "I use VSCode", tags: "[]", source: "api",
+      created_at: Date.now(), vector_ids: '["existing","existing-chunk-1"]', recall_count: 0, importance_score: 0,
+    });
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing", score: 0.88, metadata: { parentId: "existing" } }],
+        }),
+        deleteByIds: deleteByIdsMock,
+      }),
+      AI: makeContradictionAI('{"action":"replace","target_id":"existing"}'),
+    });
+    const { ctx } = makeCtx();
+    await captureEntry("I switched to Cursor", [], "api", env, ctx);
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["existing", "existing-chunk-1"]);
+  });
+
+  it("replace: falls through to normal insert when target not found in DB", async () => {
+    // Vectorize returns a match but D1 has no corresponding entry
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "ghost-id", score: 0.88, metadata: { parentId: "ghost-id" } }],
+        }),
+      }),
+      AI: makeContradictionAI('{"action":"replace","target_id":"ghost-id"}'),
+    });
+    const { ctx } = makeCtx();
+    const result = await captureEntry("I switched to Cursor", [], "api", env, ctx);
+    // Falls through → stores as a new entry
+    expect(result.status).toBe("flagged");
+    expect(db.entries).toHaveLength(1);
+  });
+
+  // ── Smart merge: merge ──────────────────────────────────────────────────────
+
+  it("merge: updates existing entry with merged_content, does NOT insert a new entry", async () => {
+    db.entries.push({
+      id: "existing", content: "I prefer dark mode", tags: '["personal"]', source: "api",
+      created_at: Date.now(), vector_ids: '["existing"]', recall_count: 0, importance_score: 2,
+    });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing", score: 0.88, metadata: { parentId: "existing" } }],
+        }),
+      }),
+      AI: makeContradictionAI('{"action":"merge","target_id":"existing","merged_content":"I prefer dark mode in all apps, especially at night"}'),
+    });
+    const { ctx } = makeCtx();
+    const result = await captureEntry("I like dark mode especially at night", [], "api", env, ctx);
+    expect(result.status).toBe("merged");
+    if (result.status !== "merged") return;
+    expect(result.id).toBe("existing");
+    expect(db.entries).toHaveLength(1);
+    expect(db.entries[0].content).toBe("I prefer dark mode in all apps, especially at night");
+  });
+
+  it("merge: uses merged_content (not new content) for re-embedding", async () => {
+    db.entries.push({
+      id: "existing", content: "I prefer dark mode", tags: "[]", source: "api",
+      created_at: Date.now(), vector_ids: '["existing"]', recall_count: 0, importance_score: 0,
+    });
+    const insertMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing", score: 0.88, metadata: { parentId: "existing" } }],
+        }),
+        insert: insertMock,
+      }),
+      AI: makeContradictionAI('{"action":"merge","target_id":"existing","merged_content":"Combined merged memory"}'),
+    });
+    const { ctx } = makeCtx();
+    await captureEntry("I like dark mode at night", [], "api", env, ctx);
+    // The inserted vector metadata should contain the merged content
+    const insertedVectors = insertMock.mock.calls[0][0] as any[];
+    expect(insertedVectors[0].metadata.content).toBe("Combined merged memory");
+  });
+
+  it("merge: deletes old vectors after re-embedding", async () => {
+    db.entries.push({
+      id: "existing", content: "I prefer dark mode", tags: "[]", source: "api",
+      created_at: Date.now(), vector_ids: '["existing","existing-chunk-1"]', recall_count: 0, importance_score: 0,
+    });
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing", score: 0.88, metadata: { parentId: "existing" } }],
+        }),
+        deleteByIds: deleteByIdsMock,
+      }),
+      AI: makeContradictionAI('{"action":"merge","target_id":"existing","merged_content":"Combined"}'),
+    });
+    const { ctx } = makeCtx();
+    await captureEntry("I like dark mode at night", [], "api", env, ctx);
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["existing", "existing-chunk-1"]);
+  });
+
+  // ── Smart merge: keep_both falls back to flagged (existing behaviour) ────────
+
+  it("keep_both: stores new entry with duplicate-candidate tag (unchanged behaviour)", async () => {
+    db.entries.push({
+      id: "near", content: "I prefer dark mode", tags: "[]", source: "api",
+      created_at: Date.now(), vector_ids: "[]", recall_count: 0, importance_score: 0,
+    });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "near", score: 0.88, metadata: { parentId: "near" } }],
+        }),
+      }),
+      AI: makeContradictionAI('{"action":"keep_both"}'),
+    });
+    const { ctx } = makeCtx();
+    const result = await captureEntry("I like dark themes", [], "api", env, ctx);
+    expect(result.status).toBe("flagged");
+    expect(db.entries).toHaveLength(2);
+    const tags: string[] = JSON.parse(db.entries[1].tags);
+    expect(tags).toContain("duplicate-candidate");
+  });
+
   // ── Importance scoring ──────────────────────────────────────────────────────
 
   it("schedules importance scoring via ctx.waitUntil for stored entries", async () => {

--- a/test/unit/check-contradiction.test.ts
+++ b/test/unit/check-contradiction.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { checkDuplicateAndContradiction } from "../../src/index";
+import type { MergeAction } from "../../src/index";
 import { makeTestDb, makeVectorizeMock } from "../helpers/make-env";
 import type { Env } from "../../src/index";
 
@@ -118,8 +119,141 @@ describe("checkDuplicateAndContradiction()", () => {
   });
 
   it("returns flagged duplicate status", async () => {
-    const env = makeEnv('{"contradicts": false}', [match("a", 0.88)], [entry("a", "Similar content")]);
-    const { duplicate } = await checkDuplicateAndContradiction("Similar content", env);
+    // score 0.88 → flagged band; combined prompt runs; "keep_both" is the safe default
+    const env = makeEnv('{"action":"keep_both"}', [match("a", 0.88)], [entry("a", "Similar content")]);
+    const { duplicate, mergeAction } = await checkDuplicateAndContradiction("Similar content", env);
     expect(duplicate.status).toBe("flagged");
+    expect(mergeAction).toEqual({ action: "keep_both" });
+  });
+
+  // ── Smart merge (flagged band 0.85–0.95) ────────────────────────────────────
+
+  it("returns mergeAction=keep_both for flagged entry when LLM says keep_both", async () => {
+    const env = makeEnv('{"action":"keep_both"}', [match("near", 0.88)], [entry("near", "I prefer dark mode")]);
+    const { mergeAction } = await checkDuplicateAndContradiction("I like dark mode", env);
+    expect(mergeAction).toEqual({ action: "keep_both" });
+  });
+
+  it("returns mergeAction=replace with validated target_id for flagged entry", async () => {
+    const env = makeEnv(
+      '{"action":"replace","target_id":"near"}',
+      [match("near", 0.88)],
+      [entry("near", "I use VSCode")]
+    );
+    const { mergeAction } = await checkDuplicateAndContradiction("I switched to Cursor", env);
+    expect(mergeAction).toEqual({ action: "replace", target_id: "near" });
+  });
+
+  it("returns mergeAction=merge with target_id and merged_content for flagged entry", async () => {
+    const env = makeEnv(
+      '{"action":"merge","target_id":"near","merged_content":"I prefer dark mode in all apps, especially at night"}',
+      [match("near", 0.88)],
+      [entry("near", "I prefer dark mode")]
+    );
+    const { mergeAction } = await checkDuplicateAndContradiction("I like dark mode especially at night", env);
+    expect(mergeAction).toEqual({
+      action: "merge",
+      target_id: "near",
+      merged_content: "I prefer dark mode in all apps, especially at night",
+    });
+  });
+
+  it("returns contradiction (not mergeAction) when combined prompt returns contradiction for flagged entry", async () => {
+    const env = makeEnv(
+      '{"action":"contradiction","conflicting_id":"near","reason":"different city"}',
+      [match("near", 0.88)],
+      [entry("near", "I live in NYC")]
+    );
+    const { contradiction, mergeAction } = await checkDuplicateAndContradiction("I live in LA", env);
+    expect(contradiction.detected).toBe(true);
+    expect(contradiction.conflicting_id).toBe("near");
+    expect(mergeAction).toBeNull();
+  });
+
+  it("falls back to keep_both when flagged LLM throws", async () => {
+    const db = makeTestDb();
+    db.entries = [entry("near", "I prefer dark mode")];
+    const env: Env = {
+      DB: db as unknown as D1Database,
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({ matches: [match("near", 0.88)] }),
+      }),
+      AI: {
+        run: vi.fn().mockImplementation(async (model: string) => {
+          if (model === "@cf/baai/bge-small-en-v1.5") return { data: [new Array(384).fill(0.1)] };
+          throw new Error("AI unavailable");
+        }),
+      } as unknown as Ai,
+      AUTH_TOKEN: "test-token",
+    };
+    const { mergeAction } = await checkDuplicateAndContradiction("I like dark mode", env);
+    expect(mergeAction).toEqual({ action: "keep_both" });
+  });
+
+  it("falls back to keep_both when flagged LLM returns malformed JSON", async () => {
+    const env = makeEnv("Sorry, I cannot help.", [match("near", 0.88)], [entry("near", "I prefer dark mode")]);
+    const { mergeAction } = await checkDuplicateAndContradiction("I like dark mode", env);
+    expect(mergeAction).toEqual({ action: "keep_both" });
+  });
+
+  it("falls back to keep_both when replace target_id is a hallucinated ID", async () => {
+    const env = makeEnv(
+      '{"action":"replace","target_id":"made-up-id"}',
+      [match("real-id", 0.88)],
+      [entry("real-id", "I use VSCode")]
+    );
+    const { mergeAction } = await checkDuplicateAndContradiction("I switched to Cursor", env);
+    expect(mergeAction).toEqual({ action: "keep_both" });
+  });
+
+  it("falls back to keep_both when merge target_id is hallucinated", async () => {
+    const env = makeEnv(
+      '{"action":"merge","target_id":"fake-id","merged_content":"combined text"}',
+      [match("real-id", 0.88)],
+      [entry("real-id", "I prefer dark mode")]
+    );
+    const { mergeAction } = await checkDuplicateAndContradiction("I like dark mode at night", env);
+    expect(mergeAction).toEqual({ action: "keep_both" });
+  });
+
+  it("falls back to keep_both when merge merged_content is empty", async () => {
+    const env = makeEnv(
+      '{"action":"merge","target_id":"near","merged_content":"   "}',
+      [match("near", 0.88)],
+      [entry("near", "I prefer dark mode")]
+    );
+    const { mergeAction } = await checkDuplicateAndContradiction("I like dark mode", env);
+    expect(mergeAction).toEqual({ action: "keep_both" });
+  });
+
+  it("returns mergeAction=null for non-flagged entries (0.45–0.85 range unchanged)", async () => {
+    const env = makeEnv(
+      '{"contradicts": false}',
+      [match("a", 0.72)],
+      [entry("a", "I enjoy hiking")]
+    );
+    const { mergeAction, contradiction } = await checkDuplicateAndContradiction("I live in Paris", env);
+    expect(mergeAction).toBeNull();
+    expect(contradiction.detected).toBe(false);
+  });
+
+  it("returns mergeAction=null for blocked entries", async () => {
+    const env = makeEnv("", [match("a", 0.97)], [entry("a", "Original content")]);
+    const { mergeAction, contradiction } = await checkDuplicateAndContradiction("Original content", env);
+    expect(mergeAction).toBeNull();
+    expect(contradiction.detected).toBe(false);
+  });
+
+  it("uses contradiction-only prompt (not combined) for 0.45–0.85 range", async () => {
+    // AI mock returns old contradiction format — should still be parsed correctly
+    const env = makeEnv(
+      '{"contradicts": true, "conflicting_id": "abc123", "reason": "different city"}',
+      [match("abc123", 0.72)],
+      [entry("abc123", "I live in NYC")]
+    );
+    const { contradiction, mergeAction } = await checkDuplicateAndContradiction("I moved to LA", env);
+    expect(contradiction.detected).toBe(true);
+    expect(contradiction.conflicting_id).toBe("abc123");
+    expect(mergeAction).toBeNull();
   });
 });


### PR DESCRIPTION
## Smart merge (Resolves #55)

When a new memory scores 85–95% similar to an existing one, a single LLM call decides the action instead of blindly storing both as `duplicate-candidate`:

- `keep_both` — store as-is with `duplicate-candidate` tag (existing behaviour preserved)
- `replace` — new content replaces the existing entry, re-embedded, old vectors deleted
- `merge` — LLM-generated combined content replaces the existing entry, re-embedded, old vectors deleted
- `contradiction` — existing contradiction path (unchanged)

**Zero extra LLM calls.** The combined prompt replaces the contradiction-only prompt for the flagged band (0.85–0.95) — same 1 call, richer result. The 0.45–0.85 contradiction path and ≥0.95 blocked path are completely unchanged.

Safe vector ordering: read old `vector_ids` → update D1 → re-embed via `storeEntry` → `deleteByIds(old)`. Both Vectorize steps are non-fatal.

## MCP SDK migration

All 6 MCP tools migrated from deprecated `server.tool()` to `server.registerTool(name, { description, inputSchema }, cb)`. No behaviour change — clears TypeScript deprecation warnings [6387].

## Tests

- 30 new tests: unit `check-contradiction` (12), unit `capture-entry` (10), integration `smart-merge` (8)
- All 120 existing tests unmodified and passing
- **150 tests total, all passing**

## Both repos updated

All changes mirrored to `second-brain-worker`.