### PR TITLE
fix: re-embed full content in append when combined size exceeds CHUNK_MAX_CHARS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -432,7 +432,7 @@ async function storeEntry(
   const vectors = await Promise.all(
     chunks.map(async (chunk, i) => {
       const metadata: Record<string, any> = {
-        content: chunk.slice(0, 512),
+        content: chunk,
         parentId: id,
         chunkIndex: i,
         totalChunks: chunks.length,
@@ -466,9 +466,11 @@ async function storeEntry(
 }
 
 // ─── Append to existing entry ─────────────────────────────────────────────────
-// Updates D1 with the full appended content, then adds only the new addition
-// as a new Vectorize chunk pointing to the same parent ID.
-// Tracks the new chunk ID in vector_ids so forget() can clean it up exactly.
+// For short appends (combined content ≤ CHUNK_MAX_CHARS): adds only the new
+// addition as a single new Vectorize vector pointing to the parent ID.
+// For large appends (combined content > CHUNK_MAX_CHARS): falls back to a full
+// re-embed of the combined content using the same safe 3-step pattern as update
+// (insert new → delete old), so Vectorize always holds properly chunked vectors.
 
 async function appendToEntry(
   env: Env,
@@ -478,7 +480,7 @@ async function appendToEntry(
   tags: string[],
   source: string
 ): Promise<void> {
-  // Read existing vector_ids upfront so we can do a single UPDATE at the end
+  // Read existing vector_ids upfront — needed by both paths
   const row = await env.DB.prepare(
     `SELECT vector_ids FROM entries WHERE id = ?`
   ).bind(id).first() as Record<string, any> | null;
@@ -489,13 +491,40 @@ async function appendToEntry(
   const separator = `\n\n[Update ${timestamp}]: `;
   const newContent = existingContent + separator + addition;
 
+  if (newContent.length > CHUNK_MAX_CHARS) {
+    // ── Full re-embed path ───────────────────────────────────────────────────
+    // Combined content is too large for a single vector — re-chunk everything.
+    // Same safe ordering as update/merge/replace: insert new → delete old.
+
+    // Step 1: Persist full combined content to D1
+    await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`)
+      .bind(newContent, id).run();
+
+    // Step 2: Re-chunk + re-embed full content (also updates vector_ids in D1)
+    try {
+      await storeEntry(env, id, newContent, tags, source, Date.now());
+    } catch (e) {
+      console.error("Vectorize re-embed failed (non-fatal):", e);
+    }
+
+    // Step 3: Delete old vectors after new ones are safely inserted
+    try {
+      if (existingVectorIds.length) await env.VECTORIZE.deleteByIds(existingVectorIds);
+    } catch (e) {
+      console.error("Old vector cleanup failed (non-fatal):", e);
+    }
+
+    return;
+  }
+
+  // ── Normal append-only path (combined content ≤ CHUNK_MAX_CHARS) ────────────
   // Timestamp-based suffix guarantees uniqueness across concurrent appends
   const newChunkId = `${id}-update-${Date.now()}`;
 
   const values = await embed(addition, env);
 
   const metadata: Record<string, any> = {
-    content: addition.slice(0, 512),
+    content: addition,
     parentId: id,
     isUpdate: true,
     tags,

--- a/test/integration/append.test.ts
+++ b/test/integration/append.test.ts
@@ -1,11 +1,14 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import worker from "../../src/index";
-import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { makeTestEnv, makeTestDb, makeVectorizeMock } from "../helpers/make-env";
 import { req } from "../helpers/make-request";
 import type { Env } from "../../src/index";
 import { D1Mock } from "../helpers/d1-mock";
 
 const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+// Content just over CHUNK_MAX_CHARS (1600) to trigger the full re-embed path
+const LONG_CONTENT = "a".repeat(1601);
 
 describe("POST /append", () => {
   let env: Env;
@@ -53,5 +56,154 @@ describe("POST /append", () => {
     expect(data.ok).toBe(true);
     expect(db.entries[0].content).toContain("Original content");
     expect(db.entries[0].content).toContain("New info");
+  });
+
+  // ── Short append: append-only path (≤ CHUNK_MAX_CHARS) ──────────────────────
+
+  it("short append: uses -update- vector ID style, does not delete old vectors", async () => {
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({ deleteByIds: deleteByIdsMock }),
+    });
+    db.entries.push({
+      id: "entry-1",
+      content: "Short original",
+      tags: "[]",
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: '["entry-1"]',
+    });
+
+    await worker.fetch(
+      req("POST", "/append", { body: { id: "entry-1", addition: "Small addition" } }),
+      env,
+      ctx
+    );
+
+    // vector_ids should have a new -update- entry appended, not chunk-style IDs
+    const vectorIds: string[] = JSON.parse(db.entries[0].vector_ids);
+    expect(vectorIds).toHaveLength(2);
+    expect(vectorIds[0]).toBe("entry-1");
+    expect(vectorIds[1]).toMatch(/^entry-1-update-\d+$/);
+    // Old vectors should NOT be deleted on the short path
+    expect(deleteByIdsMock).not.toHaveBeenCalled();
+  });
+
+  // ── Oversized append: full re-embed path (> CHUNK_MAX_CHARS) ────────────────
+
+  it("oversized append: triggers full re-embed and deletes old vectors", async () => {
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({ deleteByIds: deleteByIdsMock }),
+    });
+    db.entries.push({
+      id: "entry-1",
+      content: LONG_CONTENT,
+      tags: "[]",
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: '["entry-1","entry-1-update-111"]',
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/append", { body: { id: "entry-1", addition: "More info" } }),
+      env,
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+
+    // D1 content updated with full combined text
+    expect(db.entries[0].content).toContain(LONG_CONTENT);
+    expect(db.entries[0].content).toContain("More info");
+
+    // vector_ids updated to chunk-style IDs (not -update- style)
+    const vectorIds: string[] = JSON.parse(db.entries[0].vector_ids);
+    expect(vectorIds.every((id: string) => !id.includes("-update-"))).toBe(true);
+
+    // Old vectors deleted
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["entry-1", "entry-1-update-111"]);
+  });
+
+  it("oversized append: new vectors inserted before old ones are deleted (safe ordering)", async () => {
+    const callOrder: string[] = [];
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        insert: vi.fn().mockImplementation(async () => { callOrder.push("insert"); return { mutationId: "m" }; }),
+        deleteByIds: vi.fn().mockImplementation(async () => { callOrder.push("delete"); return { mutationId: "m" }; }),
+      }),
+    });
+    db.entries.push({
+      id: "entry-1",
+      content: LONG_CONTENT,
+      tags: "[]",
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: '["entry-1"]',
+    });
+
+    await worker.fetch(
+      req("POST", "/append", { body: { id: "entry-1", addition: "More info" } }),
+      env,
+      ctx
+    );
+
+    expect(callOrder.indexOf("insert")).toBeLessThan(callOrder.indexOf("delete"));
+  });
+
+  it("oversized append: Vectorize re-embed failure is non-fatal — D1 still updated", async () => {
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        insert: vi.fn().mockRejectedValue(new Error("Vectorize down")),
+      }),
+    });
+    db.entries.push({
+      id: "entry-1",
+      content: LONG_CONTENT,
+      tags: "[]",
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: '["entry-1"]',
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/append", { body: { id: "entry-1", addition: "More info" } }),
+      env,
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    // D1 content still updated even if Vectorize failed
+    expect(db.entries[0].content).toContain("More info");
+  });
+
+  it("oversized append: old vector deletion failure is non-fatal", async () => {
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        deleteByIds: vi.fn().mockRejectedValue(new Error("delete failed")),
+      }),
+    });
+    db.entries.push({
+      id: "entry-1",
+      content: LONG_CONTENT,
+      tags: "[]",
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: '["entry-1"]',
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/append", { body: { id: "entry-1", addition: "More info" } }),
+      env,
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #87

## Problem
`appendToEntry` always embedded only the addition text and appended a single `-update-{timestamp}` vector. When repeated appends pushed total content past 1600 chars, Vectorize held stale partial vectors — neither representing the full combined content — causing recall to miss context spanning original + appended text.

Also, `storeEntry` truncated chunk metadata content to 512 chars, causing recall to return silently cut-off text.

## Changes
- **`appendToEntry`**: when `newContent.length > CHUNK_MAX_CHARS`, falls back to full re-embed using the same safe 3-step ordering as `update`/`merge` (update D1 → `storeEntry` → `deleteByIds(old)`). Short appends (≤1600 chars) unchanged.
- **`storeEntry`**: removed 512-char metadata truncation — stores full chunk content (Vectorize limit is 10KB).
- **5 new integration tests** in `test/integration/append.test.ts` — 155 tests total, all passing.