### PR TITLE
fix: cap Vectorize topK at 50 to avoid error 40025 with returnMetadata=all

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -869,8 +869,10 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       }
 
       // Query Vectorize without filter — tag filtering happens in-memory below
+      // Cloudflare Vectorize caps topK at 50 when returnMetadata="all" (error 40025)
+      const vectorizeTopK = Math.min(topK * VECTORIZE_TOP_K_MULTIPLIER, 50);
       const results = await env.VECTORIZE.query(values, {
-        topK: topK * VECTORIZE_TOP_K_MULTIPLIER,
+        topK: vectorizeTopK,
         returnMetadata: "all",
       });
 


### PR DESCRIPTION
Cloudflare Vectorize limits topK to 50 when returnMetadata='all' is used.
The recall tool allows users to request up to 20 results, which with the 3x
oversampling multiplier produces topK=60 — exceeding the limit and throwing:

  VECTOR_QUERY_ERROR (code = 40025): max top K is 50, but got 60

Fix: clamp the effective Vectorize topK to Math.min(topK * multiplier, 50).
Users requesting ≤16 results still get full 3x oversampling; users requesting
17–20 get 50 candidates (still sufficient for reranking + deduplication).