### PR TITLE
fix: recall ranking — short append chunk bias + shallow Vectorize cutoff

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -335,8 +335,11 @@ export function rerankWithTimeDecay(
       const recencyMultiplier = Math.exp(-ageMs / halfLifeMs);
       // log(1+0)=0 would zero out unrecalled entries; (1 + log1p(rc)) gives baseline 1.0
       const frequencyMultiplier = 1 + Math.log1p(rc);
+      const isShortAppend = match.id.includes("-update-") &&
+        typeof meta?.content === "string" && meta.content.length < CHUNK_OVERLAP_CHARS;
+      const appendPenalty = isShortAppend ? 0.2 : 1.0;
 
-      return { ...match, score: match.score * recencyMultiplier * frequencyMultiplier };
+      return { ...match, score: match.score * recencyMultiplier * frequencyMultiplier * appendPenalty };
     })
     .sort((a, b) => b.score - a.score);
 }
@@ -871,10 +874,17 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       // Query Vectorize without filter — tag filtering happens in-memory below
       // Cloudflare Vectorize caps topK at 50 when returnMetadata="all" (error 40025)
       const vectorizeTopK = Math.min(topK * VECTORIZE_TOP_K_MULTIPLIER, 50);
-      const results = await env.VECTORIZE.query(values, {
+      let results = await env.VECTORIZE.query(values, {
         topK: vectorizeTopK,
         returnMetadata: "all",
       });
+
+      if (results.matches.length && results.matches[0].score < DUPLICATE_FLAG_THRESHOLD) {
+        results = await env.VECTORIZE.query(values, {
+          topK: 50,
+          returnMetadata: "all",
+        });
+      }
 
       if (!results.matches.length) {
         return { content: [{ type: "text", text: "Nothing found matching that query." }] };


### PR DESCRIPTION
Two bugs cause recall to miss or misrank entries. (1) Short append chunks embed only 
  the addition text, creating a concentrated vector that outscores full entries. Fix: penalise -update- chunks under CHUNK_OVERLAP_CHARS in rerankWithTimeDecay. (2) Dense indexes push the 
  correct entry past the topK cutoff. Fix: if top score < DUPLICATE_FLAG_THRESHOLD (0.85), re-query Vectorize at topK=50.