### PR TITLE
fix: wrap Vectorize insert in ctx.waitUntil to prevent CPU time cutoff (#92)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -659,11 +659,10 @@ export async function captureEntry(
     `INSERT INTO entries (id, content, tags, source, created_at, vector_ids) VALUES (?, ?, ?, ?, ?, ?)`
   ).bind(id, c, JSON.stringify(finalTags), source, now, "[]").run();
 
-  try {
-    await storeEntry(env, id, c, finalTags, source, now);
-  } catch (e) {
-    console.error("Vectorize insert failed (non-fatal):", e);
-  }
+  ctx.waitUntil(
+    storeEntry(env, id, c, finalTags, source, now)
+      .catch(e => console.error("Vectorize insert failed (non-fatal):", e))
+  );
 
   ctx.waitUntil(
     scoreImportance(c, env)


### PR DESCRIPTION
## Summary

- `storeEntry` (embed → Vectorize insert → D1 `vector_ids` update) was `await`ed inline inside `captureEntry`, so the MCP framework could return the response and expire the Worker's CPU budget before the Vectorize insert completed
- Moved `storeEntry` into `ctx.waitUntil` — it now runs after the response is sent, outside the response-phase CPU limit, matching the existing pattern for `scoreImportance`
- D1 `INSERT` for the new entry still runs synchronously before `captureEntry` returns, so the row is immediately available

## Test plan

- [x] All 155 existing tests pass (`npm test`)
- [x] Blocked entries still produce zero `waitUntil` calls
- [x] Vectorize insert errors are caught non-fatally via `.catch()`

Closes #92