### PR TITLE
Cap combined multiplier at 1.0 in rerankWithTimeDecay

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -333,13 +333,15 @@ export function rerankWithTimeDecay(
 
       const halfLifeMs = getHalfLifeMs(tags);
       const recencyMultiplier = Math.exp(-ageMs / halfLifeMs);
-      // log(1+0)=0 would zero out unrecalled entries; (1 + log1p(rc)) gives baseline 1.0
+      // Frequency can compensate for recency loss but never push above a fresh entry (cap at 1.0).
+      // Without the cap, high recall counts overwhelm recency and bury newly-stored memories.
       const frequencyMultiplier = 1 + Math.log1p(rc);
+      const combinedMultiplier = Math.min(1.0, recencyMultiplier * frequencyMultiplier);
       const isShortAppend = match.id.includes("-update-") &&
         typeof meta?.content === "string" && meta.content.length < CHUNK_OVERLAP_CHARS;
       const appendPenalty = isShortAppend ? 0.2 : 1.0;
 
-      return { ...match, score: match.score * recencyMultiplier * frequencyMultiplier * appendPenalty };
+      return { ...match, score: match.score * combinedMultiplier * appendPenalty };
     })
     .sort((a, b) => b.score - a.score);
 }
@@ -937,7 +939,7 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         const meta = m.metadata as Record<string, any>;
         const parentId = (meta?.parentId ?? m.id) as string;
         const row = d1Map.get(parentId);
-        const score = (Math.min(1, m.score) * 100).toFixed(0);
+        const score = (m.score * 100).toFixed(0);
         const updateLabel = meta?.isUpdate ? " [updated]" : "";
 
         if (row) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -937,7 +937,7 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         const meta = m.metadata as Record<string, any>;
         const parentId = (meta?.parentId ?? m.id) as string;
         const row = d1Map.get(parentId);
-        const score = (m.score * 100).toFixed(0);
+        const score = (Math.min(1, m.score) * 100).toFixed(0);
         const updateLabel = meta?.isUpdate ? " [updated]" : "";
 
         if (row) {

--- a/test/unit/rerank.test.ts
+++ b/test/unit/rerank.test.ts
@@ -65,4 +65,21 @@ describe("rerankWithTimeDecay", () => {
     const withDefault = rerankWithTimeDecay(matches);
     expect(withDefault[0].score).toBeCloseTo(withEmpty[0].score, 6);
   });
+
+  it("frequently-recalled old memory does not outrank a new memory with similar vector score", () => {
+    // Regression: unbounded frequencyMultiplier buried memories stored today behind
+    // context-tagged entries recalled 20+ times.
+    const oldHighRecall = match("old", 0.88, NOW - 11 * MS_DAY, ["context"]);
+    const newFresh = match("new", 0.90, NOW);
+    const counts = new Map([["old", 24]]);
+    const result = rerankWithTimeDecay([oldHighRecall, newFresh], counts);
+    expect(result[0].id).toBe("new");
+  });
+
+  it("combined multiplier never exceeds 1.0 regardless of recall count", () => {
+    const m = match("entry", 1.0, NOW - 14 * MS_DAY, ["context"]);
+    const counts = new Map([["entry", 100]]);
+    const [result] = rerankWithTimeDecay([m], counts);
+    expect(result.score).toBeLessThanOrEqual(1.0);
+  });
 });


### PR DESCRIPTION
## Summary
Fixed a regression in the memory reranking algorithm where frequently-recalled old memories could outrank newer memories with better vector similarity scores. The issue was caused by an unbounded frequency multiplier that could grow without limit based on recall count.

## Changes
- **Added cap on combined multiplier**: The product of `recencyMultiplier` and `frequencyMultiplier` is now capped at 1.0 using `Math.min()`, preventing frequency from overwhelming recency decay
- **Updated scoring logic**: Changed from `score * recencyMultiplier * frequencyMultiplier * appendPenalty` to `score * combinedMultiplier * appendPenalty` to apply the cap before the append penalty
- **Improved comments**: Clarified that frequency can compensate for recency loss but should never push a score above that of a fresh entry

## Implementation Details
The fix ensures that:
1. Newly stored memories (high recency) cannot be buried by old memories with high recall counts
2. The maximum possible multiplier is 1.0, preserving the original vector similarity score as the upper bound
3. Frequency still provides a meaningful boost for frequently-recalled entries, but within reasonable bounds

This prevents pathological cases where context-tagged entries recalled 20+ times would rank above today's entries with similar or better vector scores.
