### PR TITLE
test: increase code coverage — 204 tests, 100% utils.js branches, 91.6% function coverage

### DIFF
--- a/test/integration/append.test.ts
+++ b/test/integration/append.test.ts
@@ -206,4 +206,51 @@ describe("POST /append", () => {
     const data = await res.json() as any;
     expect(data.ok).toBe(true);
   });
+
+  it("populates per-tag metadata keys when entry has non-empty tags (short path)", async () => {
+    db.entries.push({
+      id: "tagged-entry",
+      content: "Original",
+      tags: '["work","idea"]',
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: "[]",
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/append", { body: { id: "tagged-entry", addition: "Short update" } }),
+      env, ctx
+    );
+    expect(res.status).toBe(200);
+
+    // Verify Vectorize.insert was called with tag_* metadata fields
+    const insertMock = env.VECTORIZE.insert as ReturnType<typeof import("vitest").vi.fn>;
+    const vectors = insertMock.mock.calls[0][0] as any[];
+    expect(vectors[0].metadata).toMatchObject({ tag_work: true, tag_idea: true });
+  });
+
+  it("returns 500 when appendToEntry throws due to Vectorize failure (short path)", async () => {
+    db.entries.push({
+      id: "fail-entry",
+      content: "Short content",
+      tags: "[]",
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: "[]",
+    });
+
+    const failEnv = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        insert: vi.fn().mockRejectedValue(new Error("Vectorize unavailable")),
+      }),
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/append", { body: { id: "fail-entry", addition: "short addition" } }),
+      failEnv, ctx
+    );
+    expect(res.status).toBe(500);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(false);
+  });
 });

--- a/test/integration/chat.test.ts
+++ b/test/integration/chat.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+describe("POST /chat", () => {
+  let env: Env;
+
+  beforeEach(() => {
+    env = makeTestEnv(makeTestDb());
+  });
+
+  it("rejects missing auth token → 401", async () => {
+    const res = await worker.fetch(req("POST", "/chat", { token: null, body: { query: "hello" } }), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const res = await worker.fetch(
+      new Request("http://localhost/chat", {
+        method: "POST",
+        headers: { "Authorization": "Bearer test-token", "Content-Type": "application/json" },
+        body: "not json",
+      }),
+      env, ctx
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when query is missing", async () => {
+    const res = await worker.fetch(req("POST", "/chat", { body: {} }), env, ctx);
+    expect(res.status).toBe(400);
+    const data = await res.json() as { error: string };
+    expect(data.error).toMatch(/query/i);
+  });
+
+  it("returns 400 when query is empty string", async () => {
+    const res = await worker.fetch(req("POST", "/chat", { body: { query: "   " } }), env, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns SSE stream on happy path", async () => {
+    const res = await worker.fetch(
+      req("POST", "/chat", { body: { query: "what do I know about React?", memories: "React is a UI library." } }),
+      env, ctx
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+  });
+
+  it("passes query and memories to the AI model", async () => {
+    const query = "summarise my notes";
+    const memories = "Note A. Note B.";
+    await worker.fetch(req("POST", "/chat", { body: { query, memories } }), env, ctx);
+
+    const aiMock = env.AI.run as ReturnType<typeof import("vitest").vi.fn>;
+    const [, callArgs] = aiMock.mock.calls[0] as [string, { messages: { role: string; content: string }[] }];
+    const userMsg = callArgs.messages.find((m: { role: string }) => m.role === "user")?.content ?? "";
+    expect(userMsg).toContain(query);
+    expect(userMsg).toContain(memories);
+  });
+});

--- a/test/integration/count.test.ts
+++ b/test/integration/count.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+describe("GET /count", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("rejects missing auth token → 401", async () => {
+    const res = await worker.fetch(req("GET", "/count", { token: null }), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns count 0 for empty DB", async () => {
+    const res = await worker.fetch(req("GET", "/count"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as { count: number };
+    expect(data.count).toBe(0);
+  });
+
+  it("returns correct count after entries are added", async () => {
+    db.entries.push(
+      { id: "a", content: "First", tags: "[]", source: "api", created_at: 1000, vector_ids: "[]" },
+      { id: "b", content: "Second", tags: "[]", source: "api", created_at: 2000, vector_ids: "[]" },
+      { id: "c", content: "Third", tags: "[]", source: "api", created_at: 3000, vector_ids: "[]" },
+    );
+    const res = await worker.fetch(req("GET", "/count"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as { count: number };
+    expect(data.count).toBe(3);
+  });
+});

--- a/test/integration/list.test.ts
+++ b/test/integration/list.test.ts
@@ -44,4 +44,24 @@ describe("GET /list", () => {
     const data = await res.json() as any[];
     expect(data).toHaveLength(5);
   });
+
+  it("caps ?n= at 100 even when a larger value is requested", async () => {
+    for (let i = 0; i < 110; i++) {
+      db.entries.push({ id: `e${i}`, content: `Entry ${i}`, tags: "[]", source: "api", created_at: i, vector_ids: "[]" });
+    }
+
+    const res = await worker.fetch(req("GET", "/list?n=200"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any[];
+    expect(data.length).toBeLessThanOrEqual(100);
+  });
+
+  it("returns a valid response when ?n= is non-numeric", async () => {
+    db.entries.push({ id: "x", content: "One", tags: "[]", source: "api", created_at: 1000, vector_ids: "[]" });
+
+    const res = await worker.fetch(req("GET", "/list?n=abc"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
 });

--- a/test/integration/misc.test.ts
+++ b/test/integration/misc.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+describe("Unmatched routes", () => {
+  let env: Env;
+
+  beforeEach(() => {
+    env = makeTestEnv(makeTestDb());
+  });
+
+  it("returns 404 for an unknown path", async () => {
+    const res = await worker.fetch(req("GET", "/no-such-route"), env, ctx);
+    expect(res.status).toBe(404);
+  });
+});

--- a/test/ui/utils.test.ts
+++ b/test/ui/utils.test.ts
@@ -56,6 +56,116 @@ describe("parseRecallResult", () => {
   });
 });
 
+describe("parseRecallResult — direct object input (non-string path)", () => {
+  it("accepts a plain JS object with a .results array (skips JSON.parse)", () => {
+    const results = parseRecallResult({ results: [{ score: 80, content: "direct object", tags: [], id: "o1" }] });
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("direct object");
+    expect(results[0].score).toBe(80);
+  });
+});
+
+describe("parseRecallResult — text block with no score", () => {
+  it("defaults score to 0 when no [NN%] marker is present", () => {
+    const text = "- A note with no score at all";
+    const results = parseRecallResult(text);
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(0);
+    expect(results[0].content).toBe("A note with no score at all");
+  });
+});
+
+describe("normalizeEntry (via parseRecallResult JSON path)", () => {
+  it("parses tags when they are a JSON string", () => {
+    const json = JSON.stringify([{ score: 50, content: "note", tags: '["a","b"]', id: "1" }]);
+    const results = parseRecallResult(json);
+    expect(results[0].tags).toEqual(["a", "b"]);
+  });
+
+  it("coerces a plain string tag into a single-element array", () => {
+    const json = JSON.stringify([{ score: 50, content: "note", tags: "mytag", id: "1" }]);
+    const results = parseRecallResult(json);
+    expect(results[0].tags).toEqual(["mytag"]);
+  });
+
+  it("uses e.similarity as score fallback when e.score is absent", () => {
+    const json = JSON.stringify([{ similarity: 0.72, content: "note", tags: [], id: "1" }]);
+    const results = parseRecallResult(json);
+    expect(results[0].score).toBe(72);
+  });
+
+  it("uses e.text as content fallback when e.content is absent", () => {
+    const json = JSON.stringify([{ score: 50, text: "fallback content", tags: [], id: "1" }]);
+    const results = parseRecallResult(json);
+    expect(results[0].content).toBe("fallback content");
+  });
+
+  it("score 0.0 stays 0 (boundary: not in 0–1 range)", () => {
+    const json = JSON.stringify([{ score: 0.0, content: "note", tags: [], id: "1" }]);
+    const results = parseRecallResult(json);
+    expect(results[0].score).toBe(0);
+  });
+
+  it("score 1.0 converts to 100 (boundary: exactly 1)", () => {
+    const json = JSON.stringify([{ score: 1.0, content: "note", tags: [], id: "1" }]);
+    const results = parseRecallResult(json);
+    expect(results[0].score).toBe(100);
+  });
+
+  it("score defaults to 0 when both score and similarity are absent", () => {
+    const json = JSON.stringify([{ content: "note", tags: [], id: "1" }]);
+    const results = parseRecallResult(json);
+    expect(results[0].score).toBe(0);
+  });
+
+  it("coerces a falsy string tag ('') to an empty array", () => {
+    const json = JSON.stringify([{ score: 50, content: "note", tags: "", id: "1" }]);
+    const results = parseRecallResult(json);
+    expect(results[0].tags).toEqual([]);
+  });
+
+  it("coerces a non-array non-string tags value (number) to an empty array", () => {
+    const json = JSON.stringify([{ score: 50, content: "note", tags: 42, id: "1" }]);
+    const results = parseRecallResult(json);
+    expect(results[0].tags).toEqual([]);
+  });
+
+  it("returns empty string for content when both content and text are absent", () => {
+    const json = JSON.stringify([{ score: 50, tags: [], id: "1" }]);
+    const results = parseRecallResult(json);
+    expect(results[0].content).toBe("");
+  });
+
+  it("returns null for id when id field is absent", () => {
+    const json = JSON.stringify([{ score: 50, content: "note", tags: [] }]);
+    const results = parseRecallResult(json);
+    expect(results[0].id).toBeNull();
+  });
+});
+
+describe("parseRecallResult — JSON property fallbacks", () => {
+  it("extracts entries from a .results wrapper object", () => {
+    const json = JSON.stringify({ results: [{ score: 80, content: "from results", tags: [], id: "r1" }] });
+    const results = parseRecallResult(json);
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("from results");
+  });
+
+  it("extracts entries from a .memories wrapper object", () => {
+    const json = JSON.stringify({ memories: [{ score: 70, content: "from memories", tags: [], id: "m1" }] });
+    const results = parseRecallResult(json);
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("from memories");
+  });
+
+  it("extracts entries from an .entries wrapper object", () => {
+    const json = JSON.stringify({ entries: [{ score: 60, content: "from entries", tags: [], id: "e1" }] });
+    const results = parseRecallResult(json);
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("from entries");
+  });
+});
+
 describe("escHtml", () => {
   it("escapes < and >", () => {
     expect(escHtml("<script>")).toBe("&lt;script&gt;");
@@ -72,6 +182,14 @@ describe("escHtml", () => {
   it("leaves safe strings unchanged", () => {
     expect(escHtml("hello world")).toBe("hello world");
   });
+
+  it("returns empty string for null input", () => {
+    expect(escHtml(null)).toBe("");
+  });
+
+  it("escapes single quotes to &#39;", () => {
+    expect(escHtml("it's")).toBe("it&#39;s");
+  });
 });
 
 describe("escAttr", () => {
@@ -86,6 +204,14 @@ describe("escAttr", () => {
   it("escapes backslashes", () => {
     expect(escAttr("C:\\path")).toBe("C:\\\\path");
   });
+
+  it("removes carriage returns", () => {
+    expect(escAttr("line1\rline2")).toBe("line1line2");
+  });
+
+  it("returns empty string for null input", () => {
+    expect(escAttr(null)).toBe("");
+  });
 });
 
 describe("toDateStr", () => {
@@ -97,5 +223,10 @@ describe("toDateStr", () => {
   it("zero-pads single-digit month and day", () => {
     const d = new Date(2026, 0, 1); // January 1 2026
     expect(toDateStr(d)).toBe("2026-01-01");
+  });
+
+  it("zero-pads December correctly", () => {
+    const d = new Date(2026, 11, 31); // December 31 2026
+    expect(toDateStr(d)).toBe("2026-12-31");
   });
 });

--- a/test/unit/chunk-text.test.ts
+++ b/test/unit/chunk-text.test.ts
@@ -34,4 +34,36 @@ describe("chunkText", () => {
     expect(combined).toContain("word");
     expect(chunks.length).toBeGreaterThan(1);
   });
+
+  it("returns a single chunk for text exactly at the default maxChars boundary", () => {
+    const text = "a".repeat(1600);
+    const chunks = chunkText(text);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe(text);
+  });
+
+  it("splits into multiple chunks for text one char over the boundary", () => {
+    const text = "a".repeat(1601);
+    const chunks = chunkText(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    chunks.forEach(c => expect(c.length).toBeLessThanOrEqual(1600));
+  });
+
+  it("respects a custom maxChars parameter", () => {
+    const text = "x".repeat(300);
+    const chunks = chunkText(text, 100, 10);
+    chunks.forEach(c => expect(c.length).toBeLessThanOrEqual(100));
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+
+  it("produces non-overlapping chunks when overlapChars is 0", () => {
+    const text = "ab".repeat(100); // 200 chars, no sentence breaks
+    const chunks = chunkText(text, 80, 0);
+    // With zero overlap each chunk should start exactly where the previous ended
+    let pos = 0;
+    for (const chunk of chunks) {
+      expect(text.indexOf(chunk, pos)).toBe(pos);
+      pos += chunk.length;
+    }
+  });
 });

--- a/test/unit/get-duplicate-check-sample.test.ts
+++ b/test/unit/get-duplicate-check-sample.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { getDuplicateCheckSample } from "../../src/index";
+
+describe("getDuplicateCheckSample", () => {
+  it("returns content unchanged when at or under 1500 chars", () => {
+    const content = "a".repeat(1500);
+    expect(getDuplicateCheckSample(content)).toBe(content);
+  });
+
+  it("returns a sample string with ellipsis separators for content over 1500 chars", () => {
+    // For very long content the sample (500+500+500 + separators) is shorter than the original
+    const content = "a".repeat(2500);
+    const sample = getDuplicateCheckSample(content);
+    expect(sample).toContain("...");
+    expect(sample.length).toBeLessThan(content.length);
+  });
+
+  it("samples start, middle, and end sections of long content", () => {
+    const start = "S".repeat(500);
+    const middle = "M".repeat(800);
+    const end = "E".repeat(500);
+    const content = start + middle + end; // 1800 chars
+    const sample = getDuplicateCheckSample(content);
+    expect(sample.startsWith("S".repeat(500))).toBe(true);
+    expect(sample.endsWith("E".repeat(500))).toBe(true);
+    expect(sample).toContain("M");
+  });
+});

--- a/test/unit/parse-temporal.test.ts
+++ b/test/unit/parse-temporal.test.ts
@@ -46,4 +46,20 @@ describe("parseTimePhrase", () => {
     expect(r.after).toBeDefined();
     expect(r.before).toBeDefined();
   });
+
+  it("'this week' called on a Sunday walks back 6 days to Monday", () => {
+    // Jan 4, 2026 is a Sunday (Jan 1 = Thursday, +3 = Sunday)
+    const sunday = new Date(2026, 0, 4, 12, 0, 0).getTime();
+    const r = parseTimePhrase("this week", sunday);
+    // Expected Monday = Dec 29, 2025 (midnight local)
+    const expectedMonday = new Date(2025, 11, 29).getTime();
+    expect(r.after).toBe(expectedMonday);
+  });
+
+  it("parses 'around month day' and sets a 6-day window centred on that date", () => {
+    const r = parseTimePhrase("around january 4", NOW);
+    expect(r.after).toBeDefined();
+    expect(r.before).toBeDefined();
+    expect(r.before! - r.after!).toBe(6 * DAY);
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     coverage: {
       provider: "v8",
-      include: ["src/**/*.ts"],
+      include: ["src/**/*.ts", "public/utils.js"],
       reporter: ["text", "html", "json-summary", "json"],
       reportsDirectory: "coverage",
     },


### PR DESCRIPTION
## Summary

- **160 → 204 tests** across 21 test files
- `public/utils.js` now at **100% branch coverage** (added to vitest coverage include)
- `src/index.ts` function coverage **83% → 91.6%**, branch coverage **89% → 90.3%**

## What changed

**New test files:**
- `test/integration/chat.test.ts` — covers `POST /chat` (auth, validation, SSE response, AI call args)
- `test/integration/count.test.ts` — covers `GET /count` (auth, empty DB, non-empty count)
- `test/integration/misc.test.ts` — covers the 404 fallback handler
- `test/unit/get-duplicate-check-sample.test.ts` — covers the long-content sampling path (lines 120–126)

**Expanded test files:**
- `test/ui/utils.test.ts` — `normalizeEntry` edge cases (falsy tags, numeric tags, missing score/similarity/content/id), JSON wrapper fallbacks (`.results`/`.memories`/`.entries`), direct object input to `parseRecallResult`, no-score text blocks, `escAttr(null)`, `toDateStr` December
- `test/unit/chunk-text.test.ts` — boundary at exactly 1600/1601 chars, custom `maxChars`, zero-overlap correctness
- `test/unit/parse-temporal.test.ts` — Sunday `startOfWeek` branch (`-6` offset), `"around Month Day"` pattern (lines 378–381)
- `test/integration/append.test.ts` — tag metadata populated in short-path Vectorize vectors (line 541), 500 error when `appendToEntry` throws (lines 1126–1127)
- `test/integration/list.test.ts` — `n=200` capped to 100, `n=abc` non-numeric robustness

**Config:**
- `vitest.config.ts` — added `"public/utils.js"` to coverage `include` so client-side utilities appear in reports

## Remaining uncovered lines

`buildMcpServer` and the 6 MCP tool handlers (lines 699–1040) and the `/mcp` route (1224–1228) are the only remaining uncovered blocks. These require MCP protocol transport to exercise and are not worth adding without first extracting handler logic into separately testable functions.

## Test plan

```
npm run test           # 204 tests, 0 failures
npm run test:coverage  # utils.js 100% branches, index.ts 91.6% functions
```