### PR TITLE
feat: async pattern derivation + dual-model reasoning upgrade

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export interface Env {
 }
 
 const LLM_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
+const LLM_MODEL_REASONING = "@cf/qwen/qwen3-30b-a3b-fp8";
 
 // ─── CORS ─────────────────────────────────────────────────────────────────────
 
@@ -44,6 +45,7 @@ const CHUNK_OVERLAP_CHARS = 200;
 const CONTRADICTION_MAX_TOKENS = 80;
 const SMART_MERGE_MAX_TOKENS = 250;
 const INSIGHT_MAX_TOKENS = 300;
+const PATTERN_MAX_TOKENS = 100;
 
 // ─── Vectorize constants ──────────────────────────────────────────────────────
 
@@ -577,7 +579,7 @@ Provide a brief insight (2-4 sentences) focused on what's most relevant to this 
 
   let insight = "";
   try {
-    const stream = await (env.AI as any).run(LLM_MODEL as any, {
+    const stream = await (env.AI as any).run(LLM_MODEL_REASONING as any, {
       messages: [{ role: "user", content: prompt }],
       max_tokens: INSIGHT_MAX_TOKENS,
       stream: true,
@@ -588,6 +590,47 @@ Provide a brief insight (2-4 sentences) focused on what's most relevant to this 
   }
 
   return insight.trim();
+}
+
+// ─── Async pattern derivation ─────────────────────────────────────────────────
+
+export async function derivePattern(
+  rows: { id: string; content: string }[],
+  env: Env,
+  ctx: ExecutionContext
+): Promise<void> {
+  const sample = rows.slice(0, 20);
+  const memoriesList = sample.map((r, i) => `[${i + 1}] ${r.content}`).join("\n\n");
+
+  const prompt = `You are analyzing stored memories to find genuine recurring themes.
+
+Memories:
+${memoriesList}
+
+Find a pattern that appears across 3 or more of these memories — a real tendency, preference, or recurring theme about this person. Do NOT summarize individual memories. Do NOT describe any single event.
+
+If you find a genuine cross-memory pattern, respond with exactly ONE sentence starting with exactly one of: "You tend to", "There's a recurring", or "Across your memories".
+
+If no genuine pattern exists across 3+ memories, respond with exactly: NONE`;
+
+  try {
+    const stream = await (env.AI as any).run(LLM_MODEL_REASONING as any, {
+      messages: [{ role: "user", content: prompt }],
+      max_tokens: PATTERN_MAX_TOKENS,
+      stream: true,
+    });
+    const text = await readStreamText(stream as ReadableStream);
+    const trimmed = text.trim();
+
+    if (!trimmed || trimmed === "NONE") return;
+
+    const validStarters = ["You tend to", "There's a recurring", "Across your memories"];
+    if (!validStarters.some(s => trimmed.startsWith(s))) return;
+
+    await captureEntry(trimmed, ["auto-pattern"], "system", env, ctx);
+  } catch (e) {
+    console.error("derivePattern LLM call failed (non-fatal):", e);
+  }
 }
 
 // ─── Shared write path ────────────────────────────────────────────────────────
@@ -919,7 +962,7 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       const parentIds = deduped.map((m) => (m.metadata as any)?.parentId ?? m.id);
       const placeholders = parentIds.map(() => "?").join(", ");
       const d1Bindings: (string | number)[] = [...parentIds];
-      let d1Sql = `SELECT id, content, tags, source, created_at FROM entries WHERE id IN (${placeholders})`;
+      let d1Sql = `SELECT id, content, tags, source, created_at FROM entries WHERE id IN (${placeholders}) AND tags NOT LIKE '%"auto-pattern"%'`;
       if (after !== undefined) { d1Sql += ` AND created_at >= ?`; d1Bindings.push(after); }
       if (before !== undefined) { d1Sql += ` AND created_at <= ?`; d1Bindings.push(before); }
       const { results: d1Rows } = await env.DB.prepare(d1Sql).bind(...d1Bindings).all() as { results: Record<string, any>[] };
@@ -960,6 +1003,14 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       const insight = d1Rows.length > 1
         ? await synthesizeInsight(embedQuery, d1Rows as { id: string; content: string }[], env)
         : "";
+
+      if (d1Rows.length >= 5) {
+        ctx.waitUntil(
+          derivePattern(d1Rows as { id: string; content: string }[], env, ctx)
+            .catch(e => console.error("derivePattern failed (non-fatal):", e))
+        );
+      }
+
       const finalText = insight ? `**Insight:** ${insight}\n\n---\n\n${text}` : text;
       return { content: [{ type: "text", text: finalText }] };
     }

--- a/test/unit/derive-pattern.test.ts
+++ b/test/unit/derive-pattern.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { derivePattern } from "../../src/index";
+import { makeTestDb, makeTestEnv, makeVectorizeMock } from "../helpers/make-env";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+function makeSseStream(response: string) {
+  return new ReadableStream({
+    start(c) {
+      c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+      c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+      c.close();
+    },
+  });
+}
+
+function makePatternAI(response: string) {
+  return {
+    run: vi.fn().mockImplementation(async (model: string) => {
+      if (model === "@cf/baai/bge-small-en-v1.5")
+        return { data: [new Array(384).fill(0.1)] };
+      return makeSseStream(response);
+    }),
+  } as unknown as Ai;
+}
+
+function makeCtx() {
+  const pending: Promise<any>[] = [];
+  return {
+    ctx: { waitUntil: (p: Promise<any>) => pending.push(p) } as any as ExecutionContext,
+    drain: () => Promise.allSettled(pending),
+  };
+}
+
+const sampleRows = [
+  { id: "1", content: "I prefer building things in TypeScript over JavaScript." },
+  { id: "2", content: "I always reach for TypeScript when starting a new project." },
+  { id: "3", content: "I chose TypeScript for this project because of type safety." },
+  { id: "4", content: "Switched another service to TypeScript this week." },
+  { id: "5", content: "I like TypeScript's type inference features." },
+];
+
+describe("derivePattern()", () => {
+  let db: D1Mock;
+  let env: Env;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("stores pattern when LLM returns sentence starting with 'You tend to'", async () => {
+    env = makeTestEnv(db, { AI: makePatternAI("You tend to reach for TypeScript for all new projects.") });
+    const { ctx, drain } = makeCtx();
+    await derivePattern(sampleRows, env, ctx);
+    await drain();
+    expect(db.entries).toHaveLength(1);
+    expect(db.entries[0].content).toBe("You tend to reach for TypeScript for all new projects.");
+  });
+
+  it("stores pattern when LLM returns sentence starting with \"There's a recurring\"", async () => {
+    env = makeTestEnv(db, { AI: makePatternAI("There's a recurring preference for strongly-typed languages.") });
+    const { ctx, drain } = makeCtx();
+    await derivePattern(sampleRows, env, ctx);
+    await drain();
+    expect(db.entries).toHaveLength(1);
+    expect(db.entries[0].content).toBe("There's a recurring preference for strongly-typed languages.");
+  });
+
+  it("stores pattern when LLM returns sentence starting with 'Across your memories'", async () => {
+    env = makeTestEnv(db, { AI: makePatternAI("Across your memories, TypeScript is your default choice.") });
+    const { ctx, drain } = makeCtx();
+    await derivePattern(sampleRows, env, ctx);
+    await drain();
+    expect(db.entries).toHaveLength(1);
+    expect(db.entries[0].content).toBe("Across your memories, TypeScript is your default choice.");
+  });
+
+  it("stores pattern with auto-pattern tag", async () => {
+    env = makeTestEnv(db, { AI: makePatternAI("You tend to prefer TypeScript in all your projects.") });
+    const { ctx, drain } = makeCtx();
+    await derivePattern(sampleRows, env, ctx);
+    await drain();
+    const tags: string[] = JSON.parse(db.entries[0].tags);
+    expect(tags).toContain("auto-pattern");
+  });
+
+  it("stores pattern with source=system", async () => {
+    env = makeTestEnv(db, { AI: makePatternAI("You tend to prefer TypeScript in all your projects.") });
+    const { ctx, drain } = makeCtx();
+    await derivePattern(sampleRows, env, ctx);
+    await drain();
+    expect(db.entries[0].source).toBe("system");
+  });
+
+  it("does not store when LLM returns NONE", async () => {
+    env = makeTestEnv(db, { AI: makePatternAI("NONE") });
+    const { ctx, drain } = makeCtx();
+    await derivePattern(sampleRows, env, ctx);
+    await drain();
+    expect(db.entries).toHaveLength(0);
+  });
+
+  it("does not store when LLM returns empty string", async () => {
+    env = makeTestEnv(db, { AI: makePatternAI("") });
+    const { ctx, drain } = makeCtx();
+    await derivePattern(sampleRows, env, ctx);
+    await drain();
+    expect(db.entries).toHaveLength(0);
+  });
+
+  it("does not store when LLM returns a sentence with invalid prefix", async () => {
+    env = makeTestEnv(db, { AI: makePatternAI("This person really likes TypeScript.") });
+    const { ctx, drain } = makeCtx();
+    await derivePattern(sampleRows, env, ctx);
+    await drain();
+    expect(db.entries).toHaveLength(0);
+  });
+
+  it("does not throw when LLM call fails — non-fatal", async () => {
+    env = makeTestEnv(db, {
+      AI: {
+        run: vi.fn().mockImplementation(async (model: string) => {
+          if (model === "@cf/baai/bge-small-en-v1.5")
+            return { data: [new Array(384).fill(0.1)] };
+          throw new Error("AI unavailable");
+        }),
+      } as unknown as Ai,
+    });
+    const { ctx } = makeCtx();
+    await expect(derivePattern(sampleRows, env, ctx)).resolves.toBeUndefined();
+  });
+
+  it("uses the reasoning model (not the fast model) for the LLM call", async () => {
+    env = makeTestEnv(db, { AI: makePatternAI("You tend to prefer TypeScript.") });
+    const { ctx, drain } = makeCtx();
+    await derivePattern(sampleRows, env, ctx);
+    await drain();
+    const aiRunMock = env.AI.run as ReturnType<typeof vi.fn>;
+    const nonEmbedCalls = aiRunMock.mock.calls.filter(
+      ([model]: [string]) => model !== "@cf/baai/bge-small-en-v1.5"
+    );
+    expect(nonEmbedCalls[0][0]).toBe("@cf/qwen/qwen3-30b-a3b-fp8");
+  });
+
+  it("samples at most 20 rows from the input", async () => {
+    const lotsOfRows = Array.from({ length: 30 }, (_, i) => ({
+      id: String(i),
+      content: `Memory ${i}`,
+    }));
+    env = makeTestEnv(db, { AI: makePatternAI("NONE") });
+    const { ctx } = makeCtx();
+    await derivePattern(lotsOfRows, env, ctx);
+    const aiRunMock = env.AI.run as ReturnType<typeof vi.fn>;
+    const nonEmbedCall = aiRunMock.mock.calls.find(
+      ([model]: [string]) => model !== "@cf/baai/bge-small-en-v1.5"
+    );
+    const prompt: string = nonEmbedCall![1].messages[0].content;
+    // Only memories [1]–[20] should appear in the prompt
+    expect(prompt).toContain("[20]");
+    expect(prompt).not.toContain("[21]");
+  });
+
+  it("includes memory content in the prompt", async () => {
+    env = makeTestEnv(db, { AI: makePatternAI("NONE") });
+    const { ctx } = makeCtx();
+    await derivePattern(sampleRows, env, ctx);
+    const aiRunMock = env.AI.run as ReturnType<typeof vi.fn>;
+    const nonEmbedCall = aiRunMock.mock.calls.find(
+      ([model]: [string]) => model !== "@cf/baai/bge-small-en-v1.5"
+    );
+    const prompt: string = nonEmbedCall![1].messages[0].content;
+    expect(prompt).toContain("I prefer building things in TypeScript");
+  });
+});

--- a/test/unit/synthesize-insight.test.ts
+++ b/test/unit/synthesize-insight.test.ts
@@ -71,4 +71,11 @@ describe("synthesizeInsight()", () => {
     expect(messages[0].content).toContain("JWT decision");
     expect(messages[0].content).toContain("switched to Postgres");
   });
+
+  it("uses the reasoning model for LLM calls", async () => {
+    const env = makeTestEnv(undefined, { AI: aiMock("insight text") });
+    await synthesizeInsight("query", [{ id: "1", content: "content" }], env);
+    const [model] = (env.AI.run as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(model).toBe("@cf/qwen/qwen3-30b-a3b-fp8");
+  });
 });


### PR DESCRIPTION
Closes #105

## Summary
- Splits LLM usage into two models: fast Scout for write-time ops (contradiction, scoring, dedup) and Qwen3-30b for reasoning-heavy tasks (synthesis, pattern derivation)
- Adds background `derivePattern` that fires via `ctx.waitUntil` after every recall with 5+ results, storing genuine cross-memory patterns as `auto-pattern` entries
- Filters `auto-pattern` entries from normal recall results via SQL condition so they don't pollute regular responses

## Changes
- Added `LLM_MODEL_REASONING = "@cf/qwen/qwen3-30b-a3b-fp8"` and `PATTERN_MAX_TOKENS = 100` constants
- Updated `synthesizeInsight` to use `LLM_MODEL_REASONING` instead of `LLM_MODEL`
- Added exported `derivePattern(rows, env, ctx)` function with valid-prefix guard and NONE short-circuit
- Added `AND tags NOT LIKE '%"auto-pattern"%'` to recall's D1 SQL query
- Wired `derivePattern` into recall tool via `ctx.waitUntil` when `d1Rows.length >= 5`

## Tests
- New `test/unit/derive-pattern.test.ts` with 11 cases covering: valid starters ("You tend to", "There's a recurring", "Across your memories"), NONE/empty/invalid-prefix guards, non-fatal error handling, reasoning model selection, 20-row sampling cap, and prompt content inclusion
- Added test to `synthesize-insight.test.ts` asserting `@cf/qwen/qwen3-30b-a3b-fp8` is used
- All 217 tests pass

🤖

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcDcgMA5yZzLYaN8DEX35D)_