### PR TITLE
Add OAuth 2.0 to the /mcp endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ curl -X POST https://<your-worker-url>/capture \
 # → {"ok":true,"id":"..."}
 ```
 
+### OAuth for browser-based clients (claude.ai, ChatGPT)
+
+The `/mcp` endpoint also supports **OAuth 2.0**, so MCP clients that open a browser
+to authenticate — like claude.ai and ChatGPT — can connect without putting a token in
+the URL. When you add `https://<your-worker-url>/mcp` as a connector, you’ll see a
+hosted login page; **enter your `AUTH_TOKEN`** to authorize. Claude Desktop, Claude
+Code, and `mcp-remote` keep using the `Authorization: Bearer <AUTH_TOKEN>` header as
+before — no change needed.
+
+OAuth needs a KV namespace (`OAUTH_KV`) to store tokens and client registrations. The
+**Deploy to Cloudflare** button provisions it automatically. Deploying manually? Create
+it once and paste the id into `wrangler.toml`:
+
+```bash
+wrangler kv namespace create OAUTH_KV
+```
+
 -----
 
 ## Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "second-brain",
       "version": "1.0.0",
       "dependencies": {
+        "@cloudflare/workers-oauth-provider": "^0.7.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "agents": "^0.12.4",
         "zod": "^4.0.0"
@@ -414,6 +415,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-oauth-provider": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.7.1.tgz",
+      "integrity": "sha512-zgjuZhSHH92IsxNMYcKIGGoFiQ9bSCFa7Y6tkmdnthGtAX+sKl8eL+ixXUEUlkpHAbEqXDBs6BSxGx2L5KJo5Q==",
+      "license": "MIT"
     },
     "node_modules/@cloudflare/workers-types": {
       "version": "4.20260520.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@cloudflare/workers-oauth-provider": "^0.7.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "agents": "^0.12.4",
     "zod": "^4.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createMcpHandler } from "agents/mcp";
+import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
 import { z } from "zod";
 
 export interface Env {
@@ -12,6 +13,7 @@ export interface Env {
   VECTORIZE: VectorizeIndex;
   AI: Ai;
   AUTH_TOKEN: string;
+  OAUTH_KV: KVNamespace;
 }
 
 const LLM_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
@@ -83,6 +85,62 @@ function json(data: unknown, status = 200): Response {
     status,
     headers: { "Content-Type": "application/json", ...CORS_HEADERS },
   });
+}
+
+// Hosted OAuth login page. Styled to match the dashboard's token-entry card
+// (#auth-overlay in public/index.html) — same fonts, palette, and layout.
+function loginHtml(error?: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="theme-color" content="#F4F1EA" />
+  <title>Second Brain</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@2.44.0/tabler-icons.min.css" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #f4f1ea; --bg-card: #fcfbf7;
+      --accent: #b26641; --accent-press: #9c522f; --accent-soft: rgba(178, 102, 65, 0.1); --on-accent: #fcfbf7;
+      --text-primary: #26241f; --text-secondary: #6e6b62; --text-tertiary: #a8a498;
+      --border-input: rgba(38, 36, 31, 0.11); --danger: #b3261e;
+      --font-serif: 'Lora', Georgia, serif; --font-sans: 'DM Sans', system-ui, sans-serif;
+      --ease: cubic-bezier(0.22, 1, 0.36, 1);
+    }
+    body { background: var(--bg); font-family: var(--font-sans); color: var(--text-primary); min-height: 100vh; display: flex; align-items: center; justify-content: center; }
+    .auth-card { width: 100%; max-width: 400px; padding: 40px 32px; display: flex; flex-direction: column; align-items: center; animation: fade-in 0.5s var(--ease); }
+    @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+    .brain-logo { width: 70px; height: 70px; border-radius: 50%; background: var(--accent-soft); color: var(--accent); display: flex; align-items: center; justify-content: center; margin-bottom: 24px; position: relative; }
+    .brain-logo i { font-size: 33px; }
+    .brain-logo::after { content: ''; position: absolute; inset: -7px; border-radius: 50%; border: 1px solid var(--accent-soft); }
+    h1 { font-family: var(--font-serif); font-size: 29px; font-weight: 500; margin-bottom: 9px; letter-spacing: -0.015em; }
+    p { font-size: 14px; color: var(--text-secondary); margin-bottom: 34px; text-align: center; line-height: 1.6; max-width: 300px; }
+    form { width: 100%; display: flex; flex-direction: column; gap: 11px; margin-bottom: 14px; }
+    input { width: 100%; padding: 14px 16px; background: var(--bg-card); border: 0.5px solid var(--border-input); border-radius: 13px; font-family: var(--font-sans); font-size: 15px; color: var(--text-primary); outline: none; transition: border-color 0.18s, box-shadow 0.18s; }
+    input::placeholder { color: var(--text-tertiary); }
+    input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+    button { width: 100%; padding: 15px; background: var(--accent); color: var(--on-accent); border: none; border-radius: 13px; font-family: var(--font-sans); font-size: 15px; font-weight: 600; cursor: pointer; transition: background 0.18s, transform 0.12s var(--ease); }
+    button:hover { background: var(--accent-press); }
+    button:active { transform: scale(0.985); }
+    .auth-error { font-size: 13px; color: var(--danger); text-align: center; margin-top: 10px; min-height: 18px; }
+  </style>
+</head>
+<body>
+  <div class="auth-card">
+    <div class="brain-logo"><i class="ti ti-brain"></i></div>
+    <h1>Second Brain</h1>
+    <p>Enter your Bearer token to connect to your personal memory layer.</p>
+    <form method="POST">
+      <input type="password" name="password" placeholder="Bearer token" autofocus autocomplete="current-password" />
+      <button type="submit">Connect</button>
+    </form>
+    <div class="auth-error">${error ? error : ""}</div>
+  </div>
+</body>
+</html>`;
 }
 
 async function embed(text: string, env: Env): Promise<number[]> {
@@ -1097,11 +1155,56 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
   return server;
 }
 
-// ─── Main handler ─────────────────────────────────────────────────────────────
+// ─── OAuth API handler — /mcp only ────────────────────────────────────────────
+// OAuthProvider validates the token (OAuth grant, or the static AUTH_TOKEN via
+// resolveExternalToken) before delegating to this handler.
 
-export default {
+const apiHandler = {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    if (!dbReady) {
+      ctx.waitUntil(initializeDatabase(env).then(() => { dbReady = true; }));
+    }
+    const server = buildMcpServer(env, ctx);
+    return createMcpHandler(server)(request, env, ctx);
+  },
+};
+
+// ─── Default handler — all non-MCP routes ────────────────────────────────────
+
+const defaultHandler = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
+
+    // OAuth authorize endpoint — hosted login page for browser-based MCP clients.
+    if (url.pathname === "/oauth/authorize") {
+      let oauthReq: any;
+      try {
+        // workers-oauth-provider mis-parses POST bodies; pass a URL-only GET clone
+        // so parseAuthRequest reads the query params cleanly.
+        const parseReq = request.method === "POST" ? new Request(request.url, { method: "GET" }) : request;
+        oauthReq = await (env as any).OAUTH_PROVIDER.parseAuthRequest(parseReq);
+      } catch {
+        return new Response("Invalid authorization request — this page must be opened by an MCP client.", {
+          status: 400, headers: { "Content-Type": "text/plain" },
+        });
+      }
+      if (request.method === "POST") {
+        const form = await request.formData();
+        if (form.get("password") !== env.AUTH_TOKEN) {
+          return new Response(loginHtml("Invalid token"), {
+            status: 401, headers: { "Content-Type": "text/html" },
+          });
+        }
+        const { redirectTo } = await (env as any).OAUTH_PROVIDER.completeAuthorization({
+          request: oauthReq,
+          userId: "owner",
+          scope: oauthReq.scope,
+          props: { userId: "owner" },
+        });
+        return Response.redirect(redirectTo, 302);
+      }
+      return new Response(loginHtml(), { headers: { "Content-Type": "text/html" } });
+    }
 
     if (!dbReady) {
       ctx.waitUntil(
@@ -1276,13 +1379,6 @@ export default {
       return json(results);
     }
 
-    // /mcp
-    if (url.pathname === "/mcp") {
-      if (!isAuthorized(request, env)) return json({ error: "Unauthorized" }, 401);
-      const server = buildMcpServer(env, ctx);
-      return createMcpHandler(server)(request, env, ctx);
-    }
-
     // POST /chat
     if (url.pathname === "/chat" && request.method === "POST") {
       if (!isAuthorized(request, env)) return json({ error: "Unauthorized" }, 401);
@@ -1312,3 +1408,23 @@ export default {
     return new Response("Not found", { status: 404 });
   },
 };
+
+// ─── Export ───────────────────────────────────────────────────────────────────
+// Wrap both handlers in OAuthProvider. It auto-serves the OAuth metadata,
+// /oauth/token, and /oauth/register (RFC 7591) endpoints, and gates /mcp.
+
+export default new OAuthProvider({
+  apiRoute: "/mcp",
+  apiHandler,
+  defaultHandler,
+  authorizeEndpoint: "/oauth/authorize",
+  tokenEndpoint: "/oauth/token",
+  clientRegistrationEndpoint: "/oauth/register",
+  // Accept the static AUTH_TOKEN for Claude Desktop + mcp-remote (no browser flow).
+  resolveExternalToken: async ({ token, env }) => {
+    if (token === (env as Env).AUTH_TOKEN) {
+      return { props: { userId: "owner" } };
+    }
+    return null;
+  },
+});

--- a/test/helpers/make-env.ts
+++ b/test/helpers/make-env.ts
@@ -32,12 +32,22 @@ export function makeAIMock(): Ai {
 
 export function makeTestDb() { return new D1Mock(); }
 
+export function makeKVMock(): KVNamespace {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue({ keys: [], list_complete: true, cacheStatus: null }),
+  } as unknown as KVNamespace;
+}
+
 export function makeTestEnv(db?: D1Mock, overrides: Partial<Env> = {}): Env {
   return {
     DB: (db ?? new D1Mock()) as unknown as D1Database,
     VECTORIZE: makeVectorizeMock(),
     AI: makeAIMock(),
     AUTH_TOKEN: "test-token",
+    OAUTH_KV: makeKVMock(),
     ...overrides,
   };
 }

--- a/test/unit/check-contradiction.test.ts
+++ b/test/unit/check-contradiction.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { checkDuplicateAndContradiction } from "../../src/index";
 import type { MergeAction } from "../../src/index";
-import { makeTestDb, makeVectorizeMock } from "../helpers/make-env";
+import { makeTestDb, makeVectorizeMock, makeKVMock } from "../helpers/make-env";
 import type { Env } from "../../src/index";
 
 function makeEnv(aiResponse: string, vectorMatches: any[] = [], dbEntries: any[] = []): Env {
@@ -26,6 +26,7 @@ function makeEnv(aiResponse: string, vectorMatches: any[] = [], dbEntries: any[]
       }),
     } as unknown as Ai,
     AUTH_TOKEN: "test-token",
+    OAUTH_KV: makeKVMock(),
   };
 }
 
@@ -102,6 +103,7 @@ describe("checkDuplicateAndContradiction()", () => {
         }),
       } as unknown as Ai,
       AUTH_TOKEN: "test-token",
+      OAUTH_KV: makeKVMock(),
     };
     const { contradiction } = await checkDuplicateAndContradiction("I moved to LA", env);
     expect(contradiction.detected).toBe(false);
@@ -185,6 +187,7 @@ describe("checkDuplicateAndContradiction()", () => {
         }),
       } as unknown as Ai,
       AUTH_TOKEN: "test-token",
+      OAUTH_KV: makeKVMock(),
     };
     const { mergeAction } = await checkDuplicateAndContradiction("I like dark mode", env);
     expect(mergeAction).toEqual({ action: "keep_both" });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -3,3 +3,29 @@ import { vi } from "vitest";
 vi.mock("agents/mcp", () => ({
   createMcpHandler: vi.fn().mockReturnValue(() => new Response("mcp")),
 }));
+
+// workers-oauth-provider imports `cloudflare:workers`, which the node test
+// loader can't resolve. Stub it with a minimal router that mirrors the real
+// provider's behaviour for tests: delegate non-apiRoute requests to the
+// defaultHandler, and gate the apiRoute with resolveExternalToken (the static
+// AUTH_TOKEN path) so the existing auth tests still pass.
+vi.mock("@cloudflare/workers-oauth-provider", () => ({
+  OAuthProvider: class {
+    options: any;
+    constructor(options: any) { this.options = options; }
+    async fetch(request: Request, env: any, ctx: any): Promise<Response> {
+      const url = new URL(request.url);
+      if (url.pathname === this.options.apiRoute) {
+        const token = (request.headers.get("Authorization") || "").replace(/^Bearer\s+/i, "");
+        const grant = token ? await this.options.resolveExternalToken?.({ token, env }) : null;
+        if (!grant) {
+          return new Response(JSON.stringify({ error: "Unauthorized" }), {
+            status: 401, headers: { "Content-Type": "application/json" },
+          });
+        }
+        return this.options.apiHandler.fetch(request, env, ctx);
+      }
+      return this.options.defaultHandler.fetch(request, env, ctx);
+    }
+  },
+}));

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -22,5 +22,12 @@ metric = "cosine"
 [ai]
 binding = "AI"
 
+# Stores OAuth tokens and dynamic client registrations for the /mcp endpoint.
+[[kv_namespaces]]
+binding = "OAUTH_KV"
+id = ""
+# Create manually: wrangler kv namespace create OAUTH_KV
+# then paste the returned id above.
+
 [assets]
 directory = "./public"


### PR DESCRIPTION
Implements #114 — OAuth 2.0 for `/mcp` so browser-based MCP clients (claude.ai, ChatGPT) can connect without a token in the URL.

Per the discussion on the issue, this reuses `AUTH_TOKEN` as the login credential (no new secret) and stores OAuth state in KV rather than a D1 table.

## What it does

- Wraps the Worker in [`@cloudflare/workers-oauth-provider`](https://github.com/cloudflare/workers-oauth-provider) (Cloudflare's official OAuth package), which auto-serves `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`, `/oauth/token`, and `/oauth/register` (RFC 7591 dynamic client registration).
- Adds a hosted login page at `/oauth/authorize` — the user enters their **`AUTH_TOKEN`** to authorize. It's styled to match the dashboard's existing token-entry card (same fonts/palette).
- **Preserves the static `Authorization: Bearer <AUTH_TOKEN>` path** via `resolveExternalToken`, so Claude Desktop / Claude Code / `mcp-remote` need no changes.
- Adds an `OAUTH_KV` namespace (tokens + client registrations).

## Setup notes

- New KV namespace `OAUTH_KV` — the "Deploy to Cloudflare" button provisions it; manual deployers run `wrangler kv namespace create OAUTH_KV` and paste the id into `wrangler.toml` (left blank in the repo, matching the D1/Vectorize convention). README updated.
- No new secrets — the login page validates against the existing `AUTH_TOKEN`.

## One quirk worth flagging

`parseAuthRequest` mis-reads POST bodies (the form submission). The fix is to hand it a URL-only GET clone before parsing: `new Request(request.url, { method: "GET" })`.

## Tests

`workers-oauth-provider` imports `cloudflare:workers`, which the existing node-based vitest runner can't load, so the provider is stubbed in `vitest.setup.ts` (the stub routes the `apiRoute` through `resolveExternalToken` so the auth tests still exercise the static-token gate). Full suite passes (228) and `tsc --noEmit` is clean. Happy to adjust the test approach if you'd prefer the Workers vitest pool instead.

## Tested clients

Claude desktop + iOS, ChatGPT desktop + iOS. The static Bearer path still works for Claude Desktop / Claude Code / `mcp-remote`.

## Out of scope

The token-in-URL fallback in `isAuthorized()` is left as-is — removing it would be a separate breaking change for existing users. Wiki/Connect-to-AI-Clients docs for the OAuth flow will follow separately.