### PR TITLE
Fix: Remove hash prefix from PR number field in second-brain-sync workflow

### DIFF
--- a/.github/workflows/second-brain-sync.yaml
+++ b/.github/workflows/second-brain-sync.yaml
@@ -52,4 +52,4 @@ jobs:
           PR_COMMITS: ${{ steps.commits.outputs.messages }}
           REPO: ${{ github.repository }}
         run: |
-          brain remember "PR merged: $PR_TITLE | Repo: $REPO | PR: \#$PR_NUMBER | Author: $PR_AUTHOR | Merged by: $PR_MERGED_BY | Branch: $PR_HEAD -> $PR_BASE | Description: $PR_BODY | Commits: $PR_COMMITS"
+          brain remember "PR merged: $PR_TITLE | Repo: $REPO | PR: $PR_NUMBER | Author: $PR_AUTHOR | Merged by: $PR_MERGED_BY | Branch: $PR_HEAD -> $PR_BASE | Description: $PR_BODY | Commits: $PR_COMMITS"


### PR DESCRIPTION
## What

The  escape before  was rendering as a literal backslash rather than a hash, so the PR number field showed  instead of the correct number.

## Fix

Removed the  prefix entirely. The field now renders as  which is clean and unambiguous.

## Testing

Verified via previous workflow run that the PR number was not rendering correctly with the escaped hash.