### PR TITLE
feat: semantic compression — rolling digests and recall deprioritization (#9)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -964,6 +964,20 @@
         box-shadow: var(--shadow-float);
       }
 
+      .memory-card.card--rolled-up {
+        opacity: 0.65;
+      }
+
+      .memory-card.card--synthesized {
+        border-left: 3px solid var(--accent);
+      }
+
+      .tag-chip.tag-chip--synthesized {
+        background: var(--accent);
+        color: var(--on-accent);
+        font-weight: 500;
+      }
+
       .match-line {
         display: flex;
         align-items: center;
@@ -1491,6 +1505,8 @@
       }
       .menu-inner {
         padding: 24px 22px calc(34px + env(safe-area-inset-bottom));
+        max-height: 80vh;
+        overflow-y: auto;
       }
 
       .view-inner {
@@ -1896,6 +1912,96 @@
         display: flex;
         flex-wrap: wrap;
         gap: 6px;
+      }
+
+      .digest-section {
+        margin-bottom: 6px;
+      }
+
+      .digest-section-label {
+        font-size: 11px;
+        color: var(--text-tertiary);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-weight: 500;
+        margin-bottom: 9px;
+      }
+
+      .digest-candidate-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 8px 0;
+        border-bottom: 0.5px solid var(--line-soft);
+      }
+
+      .digest-candidate-row:last-of-type {
+        border-bottom: none;
+      }
+
+      .digest-candidate-label {
+        font-size: 13px;
+        color: var(--text-secondary);
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .digest-candidate-count {
+        font-size: 11px;
+        color: var(--text-tertiary);
+      }
+
+      .digest-btn {
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--accent);
+        background: var(--accent-soft);
+        border: none;
+        border-radius: var(--radius-pill);
+        padding: 5px 12px;
+        cursor: pointer;
+        white-space: nowrap;
+        transition: background 0.15s;
+      }
+
+      .digest-btn:hover {
+        background: rgba(178, 102, 65, 0.18);
+      }
+
+      .digest-btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .digest-btn--loading i {
+        animation: spin 0.7s linear infinite;
+        display: inline-block;
+      }
+
+      .digest-note {
+        font-size: 12px;
+        color: var(--text-tertiary);
+        line-height: 1.5;
+        margin-bottom: 10px;
+      }
+
+      .digest-result {
+        font-size: 12px;
+        color: var(--text-secondary);
+        margin-top: 6px;
+        line-height: 1.5;
+        padding: 8px 10px;
+        background: var(--accent-soft);
+        border-radius: 8px;
+      }
+
+      .digest-result-meta {
+        margin-top: 6px;
+        font-size: 11px;
+        color: var(--good);
+        font-weight: 500;
       }
 
       /* ============ DESKTOP SIDEBAR ============ */
@@ -2361,6 +2467,7 @@
             <div class="stats-tags" id="stats-tags"></div>
           </div>
         </div>
+        <div class="digest-section" id="digest-section" style="display:none"></div>
         <div class="theme-row">
           <span class="theme-row-label">Appearance</span>
           <div class="theme-toggle" id="theme-toggle">
@@ -2673,7 +2780,9 @@
 
       function makeRecallCard(entry) {
         const card = document.createElement('div')
-        card.className = 'memory-card'
+        const isSynthesized = entry.tags.includes('synthesized')
+        const isRolledUp = entry.tags.includes('rolled-up')
+        card.className = 'memory-card' + (isSynthesized ? ' card--synthesized' : '') + (isRolledUp ? ' card--rolled-up' : '')
         card.innerHTML = `
     <div class="match-line">
       <span class="match-pct">${entry.score}%</span>
@@ -2681,7 +2790,7 @@
     </div>
     <div class="card-content" style="cursor: pointer;">${escHtml(entry.content)}</div>
     <div class="card-footer">
-      <div class="card-tags">${entry.tags.map((t) => `<span class="tag-chip">${escHtml(t)}</span>`).join('')}</div>
+      <div class="card-tags">${entry.tags.map((t) => `<span class="tag-chip${t === 'synthesized' ? ' tag-chip--synthesized' : ''}">${escHtml(t)}</span>`).join('')}</div>
       <div class="card-actions">
         ${
           entry.id
@@ -2777,13 +2886,15 @@
         try {
           tags = JSON.parse(entry.tags || '[]')
         } catch {}
+        const isSynthesized = tags.includes('synthesized')
+        const isRolledUp = tags.includes('rolled-up')
         const card = document.createElement('div')
-        card.className = 'memory-card'
+        card.className = 'memory-card' + (isSynthesized ? ' card--synthesized' : '') + (isRolledUp ? ' card--rolled-up' : '')
         card.dataset.id = entry.id
         card.innerHTML = `
     <div class="card-content" style="cursor: pointer;">${escHtml(entry.content)}</div>
     <div class="card-footer">
-      <div class="card-tags">${tags.map((t) => `<span class="tag-chip">${escHtml(t)}</span>`).join('')}</div>
+      <div class="card-tags">${tags.map((t) => `<span class="tag-chip${t === 'synthesized' ? ' tag-chip--synthesized' : ''}">${escHtml(t)}</span>`).join('')}</div>
       <div class="card-actions">
         <button class="card-action-btn" onclick="openAppend('${escAttr(entry.id)}', '${escAttr(entry.content.slice(0, 80))}')"><i class="ti ti-writing"></i> Append</button>
         <button class="card-action-btn edit-btn"><i class="ti ti-pencil"></i> Edit</button>
@@ -2979,7 +3090,66 @@
           tagsEl.innerHTML = data.top_tags?.length
             ? data.top_tags.map((t) => `<span class="tag-chip">${escHtml(t)}</span>`).join('')
             : '<span style="font-size:13px;color:var(--text-tertiary)">No tags yet</span>'
+          renderDigestSection(data.digest_candidates ?? [])
         } catch {}
+      }
+
+      function renderDigestSection(candidates) {
+        const el = document.getElementById('digest-section')
+        if (!candidates.length) { el.style.display = 'none'; return }
+        el.style.display = ''
+        el.innerHTML = `
+          <div class="digest-section-label">Ready to compress</div>
+          <p class="digest-note">Originals are never deleted — digest adds a summary and ranks originals lower in recall so they don't crowd results.</p>
+          ${candidates.map(c => `
+            <div class="digest-candidate-row" id="digest-row-${escAttr(c.tag)}">
+              <div class="digest-candidate-label">
+                <span>${escHtml(c.tag)}</span>
+                <span class="digest-candidate-count">${c.count} entries</span>
+              </div>
+              <button class="digest-btn" onclick="runDigest('${escAttr(c.tag)}', this)">Digest →</button>
+            </div>
+          `).join('')}
+        `
+      }
+
+      async function runDigest(tag, btn) {
+        btn.disabled = true
+        btn.classList.add('digest-btn--loading')
+        btn.innerHTML = '<i class="ti ti-loader-2"></i> Working…'
+        const row = document.getElementById('digest-row-' + tag)
+        try {
+          const res = await fetch(`${WORKER_URL}/digest?tag=${encodeURIComponent(tag)}`, {
+            headers: { Authorization: `Bearer ${AUTH_TOKEN}` }
+          })
+          const data = await res.json()
+          if (data.synthesis) {
+            btn.classList.remove('digest-btn--loading')
+            btn.innerHTML = '<i class="ti ti-check"></i> Done'
+            btn.style.color = 'var(--good)'
+            setTimeout(() => {
+              row.innerHTML = `<div class="digest-result"><strong>${escHtml(tag)}</strong> — ${escHtml(data.synthesis)}<div class="digest-result-meta"><i class="ti ti-lock"></i> ${data.source_count} original memories preserved &amp; still searchable</div></div>`
+            }, 700)
+          } else {
+            btn.classList.remove('digest-btn--loading')
+            btn.innerHTML = '<i class="ti ti-alert-triangle"></i> ' + escHtml(data.error ?? 'Could not create digest')
+            btn.style.color = 'var(--danger)'
+            setTimeout(() => {
+              btn.disabled = false
+              btn.innerHTML = 'Digest →'
+              btn.style.color = ''
+            }, 3000)
+          }
+        } catch {
+          btn.classList.remove('digest-btn--loading')
+          btn.innerHTML = '<i class="ti ti-wifi-off"></i> Request failed'
+          btn.style.color = 'var(--danger)'
+          setTimeout(() => {
+            btn.disabled = false
+            btn.innerHTML = 'Digest →'
+            btn.style.color = ''
+          }, 3000)
+        }
       }
 
       async function exportMemories(format) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1052,12 +1052,13 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         return { content: [{ type: "text", text: `No entry found with ID: ${id}` }] };
       }
 
-      const tags: string[] = JSON.parse(row.tags ?? "[]");
+      const tags: string[] = JSON.parse(row.tags ?? "[]").filter((t: string) => t !== "rolled-up");
       const source = row.source as string;
       const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
 
-      // Step 1: Update D1 content
-      await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`).bind(newContent, id).run();
+      // Step 1: Update D1 content and tags (strip rolled-up so updated entry ranks normally)
+      await env.DB.prepare(`UPDATE entries SET content = ?, tags = ? WHERE id = ?`)
+        .bind(newContent, JSON.stringify(tags), id).run();
 
       // Step 2: Re-embed new content → inserts new vectors + updates vector_ids in D1
       let newVectorCount = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ const CONTRADICTION_MAX_TOKENS = 80;
 const SMART_MERGE_MAX_TOKENS = 250;
 const INSIGHT_MAX_TOKENS = 300;
 const PATTERN_MAX_TOKENS = 100;
+const DIGEST_MAX_TOKENS = 400;
 
 // ─── Vectorize constants ──────────────────────────────────────────────────────
 
@@ -401,13 +402,14 @@ export function rerankWithTimeDecay(
       const isShortAppend = match.id.includes("-update-") &&
         typeof meta?.content === "string" && meta.content.length < CHUNK_OVERLAP_CHARS;
       const appendPenalty = isShortAppend ? 0.2 : 1.0;
+      const rolledUpPenalty = tags.includes("rolled-up") ? 0.4 : 1.0;
 
       // importance_score 0 = unscored (neutral). 1–5 scales from 0.88 → 1.20.
       // Lets high-importance memories surface above the recency cap without dominating.
       const imp = importanceScores.get(parentId) ?? 0;
       const importanceMultiplier = imp === 0 ? 1.0 : 0.8 + (imp / 5) * 0.4;
 
-      return { ...match, score: match.score * combinedMultiplier * appendPenalty * importanceMultiplier };
+      return { ...match, score: match.score * combinedMultiplier * appendPenalty * rolledUpPenalty * importanceMultiplier };
     })
     .sort((a, b) => b.score - a.score);
 }
@@ -663,7 +665,13 @@ export async function derivePattern(
   env: Env,
   ctx: ExecutionContext
 ): Promise<void> {
-  if (rows.length < 5) return;
+  if (rows.length < 10) return;
+
+  // At most one auto-pattern per 48h to prevent spam across repeated recalls
+  const recentPattern = await env.DB.prepare(
+    `SELECT id FROM entries WHERE tags LIKE '%"auto-pattern"%' AND created_at > ? LIMIT 1`
+  ).bind(Date.now() - 172800000).first();
+  if (recentPattern) return;
 
   const sample = rows.slice(0, 20);
   const memoriesList = sample
@@ -701,6 +709,124 @@ If no genuine pattern exists across 3+ memories, respond with exactly: NONE`;
     await captureEntry(trimmed, ["auto-pattern"], "system", env, ctx);
   } catch (e) {
     console.error("derivePattern failed (non-fatal):", String(e));
+  }
+}
+
+// ─── Semantic compression ─────────────────────────────────────────────────────
+
+export async function synthesizeDigest(
+  tag: string,
+  rows: { id: string; content: string }[],
+  env: Env
+): Promise<string> {
+  if (!rows.length) return "";
+
+  const memoriesList = rows
+    .map((r, i) => `[${i + 1}] ${r.content.slice(0, 400)}`)
+    .join("\n\n");
+
+  const prompt = `You are a second brain assistant. Based on these stored memories tagged "${tag}", write a single cohesive paragraph describing the current state of this area — what has been done, decided, and is being worked toward. Write as one flowing paragraph, not a list.
+
+Memories:
+${memoriesList}
+
+State of "${tag}":`;
+
+  let digest = "";
+  try {
+    const stream = await (env.AI as any).run(LLM_MODEL as any, {
+      messages: [{ role: "user", content: prompt }],
+      max_tokens: DIGEST_MAX_TOKENS,
+      stream: true,
+    });
+    digest = await readStreamText(stream as ReadableStream);
+  } catch (e) {
+    console.error("synthesizeDigest LLM call failed (non-fatal):", e);
+  }
+
+  return digest.trim();
+}
+
+export async function compressTag(
+  tag: string,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<{ synthesizedId: string | null; entriesUsed: number; text: string }> {
+  const recentSynth = await env.DB.prepare(`
+    SELECT id FROM entries
+    WHERE tags LIKE '%"synthesized"%'
+      AND tags LIKE ?
+      AND created_at > ?
+    LIMIT 1
+  `).bind(`%"${tag}"%`, Date.now() - 86400000).first();
+
+  if (recentSynth) {
+    return { synthesizedId: null, entriesUsed: 0, text: "" };
+  }
+
+  // Fetch compressible entries: tagged with this tag, not system-tagged, not high-importance
+  const { results: rawEntries } = await env.DB.prepare(`
+    SELECT id, content FROM entries
+    WHERE tags LIKE ?
+      AND tags NOT LIKE '%"synthesized"%'
+      AND tags NOT LIKE '%"auto-pattern"%'
+      AND tags NOT LIKE '%"rolled-up"%'
+      AND (importance_score IS NULL OR importance_score < 4)
+    ORDER BY created_at DESC
+    LIMIT 50
+  `).bind(`%"${tag}"%`).all();
+
+  if (rawEntries.length < 10) {
+    return { synthesizedId: null, entriesUsed: 0, text: "" };
+  }
+
+  const rows = rawEntries.map(r => ({ id: r.id as string, content: r.content as string }));
+  const text = await synthesizeDigest(tag, rows, env);
+  if (!text) return { synthesizedId: null, entriesUsed: 0, text: "" };
+
+  const content = `[Synthesized from ${rows.length} entries tagged "${tag}"]\n\n${text}`;
+  const result = await captureEntry(content, ["synthesized", tag], "system", env, ctx);
+
+  if (result.status !== "stored") {
+    return { synthesizedId: null, entriesUsed: 0, text };
+  }
+
+  for (const id of rows.map(r => r.id)) {
+    try {
+      await env.DB.prepare(
+        `UPDATE entries SET tags = json_insert(tags, '$[#]', 'rolled-up'), content = content || ? WHERE id = ?`
+      ).bind(`\n\n[Digest: ${result.id}]`, id).run();
+    } catch (e) {
+      console.error(`Failed to update source entry ${id} (non-fatal):`, e);
+    }
+  }
+
+  return { synthesizedId: result.id, entriesUsed: rows.length, text };
+}
+
+async function runNightlyCompression(env: Env, ctx: ExecutionContext): Promise<void> {
+  await initializeDatabase(env);
+
+  const { results } = await env.DB.prepare(`
+    SELECT value as tag, COUNT(*) as count
+    FROM entries, json_each(entries.tags)
+    WHERE value NOT IN ('synthesized', 'auto-pattern', 'duplicate-candidate', 'contradiction-resolved', 'rolled-up')
+      AND entries.tags NOT LIKE '%"rolled-up"%'
+      AND entries.tags NOT LIKE '%"synthesized"%'
+      AND entries.tags NOT LIKE '%"auto-pattern"%'
+      AND (entries.importance_score IS NULL OR entries.importance_score < 4)
+    GROUP BY value
+    HAVING count > 10
+    ORDER BY count DESC
+  `).all();
+
+  for (const row of results) {
+    const tag = row.tag as string;
+    try {
+      await compressTag(tag, env, ctx);
+    } catch (e) {
+      console.error(`Compression failed for tag "${tag}" (non-fatal):`, e);
+    }
   }
 }
 
@@ -1371,14 +1497,38 @@ const defaultHandler = {
     // GET /stats
     if (url.pathname === "/stats" && request.method === "GET") {
       if (!isAuthorized(request, env)) return json({ error: "Unauthorized" }, 401);
-      const [summary, tagRows] = await Promise.all([
+      const [summary, tagRows, candidateRows] = await Promise.all([
         env.DB.prepare(`SELECT COUNT(*) as count, AVG(importance_score) as avg_importance FROM entries`).first() as Promise<Record<string, any> | null>,
         env.DB.prepare(`SELECT value, COUNT(*) as n FROM entries, json_each(entries.tags) GROUP BY value ORDER BY n DESC LIMIT 5`).all(),
+        env.DB.prepare(`
+          SELECT value as tag, COUNT(*) as count
+          FROM entries, json_each(entries.tags)
+          WHERE value NOT IN ('synthesized', 'auto-pattern', 'duplicate-candidate', 'contradiction-resolved', 'rolled-up')
+            AND entries.tags NOT LIKE '%"rolled-up"%'
+            AND entries.tags NOT LIKE '%"synthesized"%'
+            AND entries.tags NOT LIKE '%"auto-pattern"%'
+            AND (entries.importance_score IS NULL OR entries.importance_score < 4)
+          GROUP BY value
+          HAVING count > 10
+          ORDER BY count DESC
+          LIMIT 10
+        `).all(),
       ]);
+
+      const cutoff = Date.now() - 86400000;
+      const digestCandidates: { tag: string; count: number }[] = [];
+      for (const row of candidateRows.results as any[]) {
+        const existing = await env.DB.prepare(
+          `SELECT id FROM entries WHERE tags LIKE '%"synthesized"%' AND tags LIKE ? AND created_at > ? LIMIT 1`
+        ).bind(`%"${row.tag}"%`, cutoff).first();
+        if (!existing) digestCandidates.push({ tag: row.tag as string, count: row.count as number });
+      }
+
       return json({
         count: (summary?.count as number) ?? 0,
         avg_importance: summary?.avg_importance != null ? Math.round((summary.avg_importance as number) * 10) / 10 : null,
         top_tags: (tagRows.results as any[]).map(r => r.value as string),
+        digest_candidates: digestCandidates,
       });
     }
 
@@ -1418,6 +1568,21 @@ const defaultHandler = {
       });
     }
 
+    // GET /digest
+    if (url.pathname === "/digest" && request.method === "GET") {
+      if (!isAuthorized(request, env)) return json({ error: "Unauthorized" }, 401);
+      const tag = url.searchParams.get("tag")?.trim();
+      if (!tag) return json({ error: "tag parameter is required" }, 400);
+
+      const result = await compressTag(tag, env, ctx);
+
+      if (!result.synthesizedId) {
+        return json({ tag, error: "Could not create digest — tag may have fewer than 20 entries or was recently compressed", source_count: result.entriesUsed });
+      }
+
+      return json({ tag, synthesis: result.text, entry_id: result.synthesizedId, source_count: result.entriesUsed });
+    }
+
     return new Response("Not found", { status: 404 });
   },
 };
@@ -1425,8 +1590,9 @@ const defaultHandler = {
 // ─── Export ───────────────────────────────────────────────────────────────────
 // Wrap both handlers in OAuthProvider. It auto-serves the OAuth metadata,
 // /oauth/token, and /oauth/register (RFC 7591) endpoints, and gates /mcp.
+// The scheduled handler runs the nightly compression cron alongside the fetch handler.
 
-export default new OAuthProvider({
+const oauthProvider = new OAuthProvider({
   apiRoute: "/mcp",
   apiHandler,
   defaultHandler,
@@ -1441,3 +1607,11 @@ export default new OAuthProvider({
     return null;
   },
 });
+
+export default {
+  fetch: (req: Request, env: Env, ctx: ExecutionContext) =>
+    oauthProvider.fetch(req, env as any, ctx),
+  scheduled: async (_event: ScheduledEvent, env: Env, ctx: ExecutionContext) => {
+    ctx.waitUntil(runNightlyCompression(env, ctx));
+  },
+};

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -36,6 +36,27 @@ export class D1Mock {
           if (row) row.content = content;
           return { meta: { changes: row ? 1 : 0 } };
         }
+        if (s.startsWith("UPDATE entries SET tags = json_insert(tags, '$[#]', 'rolled-up'), content = content ||")) {
+          const [addition, id] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row) {
+            const tags: string[] = JSON.parse(row.tags ?? "[]");
+            if (!tags.includes("rolled-up")) tags.push("rolled-up");
+            row.tags = JSON.stringify(tags);
+            row.content = row.content + addition;
+          }
+          return { meta: { changes: row ? 1 : 0 } };
+        }
+        if (s.startsWith("UPDATE entries SET tags = json_insert(tags, '$[#]'")) {
+          const [tag, id] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row) {
+            const tags: string[] = JSON.parse(row.tags ?? "[]");
+            if (!tags.includes(tag)) tags.push(tag);
+            row.tags = JSON.stringify(tags);
+          }
+          return { meta: { changes: row ? 1 : 0 } };
+        }
         if (s.startsWith("UPDATE entries SET recall_count")) {
           const [id] = args;
           const row = db.entries.find((e: any) => e.id === id);
@@ -75,6 +96,23 @@ export class D1Mock {
         if (s.includes("WHERE id") && !s.includes("json_each")) {
           return db.entries.find((e: any) => e.id === args[0]) ?? null;
         }
+        if (s.includes("WHERE tags LIKE") && s.includes("created_at >")) {
+          // Cooldown check: find entries matching arg LIKE patterns + any hardcoded tags in SQL
+          const likePatterns: string[] = args.slice(0, -1).map((a: any) => String(a));
+          const cutoff = args[args.length - 1] as number;
+          // Extract hardcoded tags from SQL (e.g. '%"synthesized"%')
+          const hardcoded = [...s.matchAll(/'%"(\w+)"%'/g)].map(m => m[1]);
+          const match = db.entries.find((e: any) => {
+            if (e.created_at <= cutoff) return false;
+            const tags: string[] = JSON.parse(e.tags ?? "[]");
+            if (!hardcoded.every(t => tags.includes(t))) return false;
+            return likePatterns.every((p: string) => {
+              const tag = p.replace(/%"/g, "").replace(/"%/g, "");
+              return tags.includes(tag);
+            });
+          });
+          return match ? { id: match.id } : null;
+        }
         return null;
       },
       async all() {
@@ -82,6 +120,26 @@ export class D1Mock {
           const results = db.entries
             .filter((e: any) => args.includes(e.id))
             .map((e: any) => ({ id: e.id, recall_count: e.recall_count ?? 0 }));
+          return { results };
+        }
+        if (s.includes("SELECT id, content FROM entries") && s.includes("WHERE tags LIKE") && s.includes("ORDER BY created_at DESC")) {
+          // compressTag raw entries query — filter by tag, exclude system tags and high importance
+          const tagPattern = args[0] as string;
+          const tag = tagPattern.replace(/%"/g, "").replace(/"%/g, "");
+          const results = [...db.entries]
+            .filter((e: any) => {
+              const tags: string[] = JSON.parse(e.tags ?? "[]");
+              return (
+                tags.includes(tag) &&
+                !tags.includes("synthesized") &&
+                !tags.includes("auto-pattern") &&
+                !tags.includes("rolled-up") &&
+                (e.importance_score == null || e.importance_score < 4)
+              );
+            })
+            .sort((a: any, b: any) => b.created_at - a.created_at)
+            .slice(0, 50)
+            .map((e: any) => ({ id: e.id, content: e.content }));
           return { results };
         }
         if (s.includes("SELECT id, content FROM entries WHERE id IN")) {

--- a/test/unit/compress-tag.test.ts
+++ b/test/unit/compress-tag.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { compressTag } from "../../src/index";
+import { makeTestDb, makeTestEnv } from "../helpers/make-env";
+import { D1Mock } from "../helpers/d1-mock";
+import type { Env } from "../../src/index";
+
+function makeSseStream(response: string) {
+  return new ReadableStream({
+    start(c) {
+      c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+      c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+      c.close();
+    },
+  });
+}
+
+function makeDigestAI(digestText = "Work on the API redesign is progressing well with REST chosen over GraphQL.") {
+  return {
+    run: vi.fn().mockImplementation(async (_model: string, opts: any) => {
+      if (_model === "@cf/baai/bge-small-en-v1.5")
+        return { data: [new Array(384).fill(0.1)] };
+      if (opts?.stream)
+        return makeSseStream(digestText);
+      return { response: "3" };
+    }),
+  } as unknown as Ai;
+}
+
+function makeCtx() {
+  const pending: Promise<any>[] = [];
+  return {
+    ctx: { waitUntil: (p: Promise<any>) => pending.push(p) } as any as ExecutionContext,
+    drain: () => Promise.allSettled(pending),
+  };
+}
+
+function seedEntries(db: D1Mock, tag: string, count: number, overrides: Partial<any> = {}) {
+  for (let i = 0; i < count; i++) {
+    db.entries.push({
+      id: `entry-${i}`,
+      content: `Memory about ${tag} number ${i + 1}`,
+      tags: JSON.stringify([tag]),
+      source: "api",
+      created_at: Date.now() - i * 1000,
+      vector_ids: "[]",
+      recall_count: 0,
+      importance_score: 0,
+      ...overrides,
+    });
+  }
+}
+
+describe("compressTag()", () => {
+  let db: D1Mock;
+  let env: Env;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db, { AI: makeDigestAI() });
+  });
+
+  // ── Early-return guards ──────────────────────────────────────────────────────
+
+  it("returns early when fewer than 10 compressible entries exist", async () => {
+    seedEntries(db, "work", 9);
+    const { ctx } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    expect(result.synthesizedId).toBeNull();
+    expect(result.entriesUsed).toBe(0);
+  });
+
+  it("excludes rolled-up entries from the compressible count", async () => {
+    seedEntries(db, "work", 9);
+    db.entries.push({
+      id: "rolled", content: "old memory", tags: JSON.stringify(["work", "rolled-up"]),
+      source: "api", created_at: Date.now(), vector_ids: "[]", recall_count: 0, importance_score: 0,
+    });
+    const { ctx } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    // 9 compressible + 1 rolled-up = still < 10 compressible → bail
+    expect(result.synthesizedId).toBeNull();
+  });
+
+  it("excludes high-importance entries (score >= 4) from the compressible count", async () => {
+    seedEntries(db, "work", 9);
+    db.entries.push({
+      id: "critical", content: "critical memory", tags: JSON.stringify(["work"]),
+      source: "api", created_at: Date.now(), vector_ids: "[]", recall_count: 0, importance_score: 4,
+    });
+    const { ctx } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    // 9 compressible + 1 high-importance (excluded) → bail
+    expect(result.synthesizedId).toBeNull();
+  });
+
+  it("returns early when a synthesized entry for this tag exists within 24h", async () => {
+    seedEntries(db, "work", 15);
+    db.entries.push({
+      id: "recent-synth",
+      content: "[Synthesized from 15 entries tagged \"work\"]\n\nExisting digest.",
+      tags: JSON.stringify(["synthesized", "work"]),
+      source: "system",
+      created_at: Date.now() - 3600000, // 1h ago
+      vector_ids: "[]",
+      recall_count: 0,
+      importance_score: 0,
+    });
+    const { ctx } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    expect(result.synthesizedId).toBeNull();
+    expect(env.AI.run).not.toHaveBeenCalled();
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────────────────
+
+  it("stores a digest entry with clean header (no source_ids)", async () => {
+    seedEntries(db, "work", 12);
+    const { ctx, drain } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    await drain();
+    expect(result.synthesizedId).not.toBeNull();
+    const digest = db.entries.find(e => e.id === result.synthesizedId);
+    expect(digest).toBeDefined();
+    expect(digest.content).toContain("[Synthesized from 12 entries tagged \"work\"]");
+    expect(digest.content).not.toContain("source_ids");
+  });
+
+  it("digest entry is tagged synthesized and with the target tag", async () => {
+    seedEntries(db, "work", 12);
+    const { ctx, drain } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    await drain();
+    const digest = db.entries.find(e => e.id === result.synthesizedId);
+    const tags: string[] = JSON.parse(digest.tags);
+    expect(tags).toContain("synthesized");
+    expect(tags).toContain("work");
+  });
+
+  it("tags all source entries as rolled-up", async () => {
+    seedEntries(db, "work", 12);
+    const { ctx, drain } = makeCtx();
+    await compressTag("work", env, ctx);
+    await drain();
+    const sources = db.entries.filter(e => !JSON.parse(e.tags).includes("synthesized"));
+    expect(sources.length).toBe(12);
+    sources.forEach(e => {
+      expect(JSON.parse(e.tags)).toContain("rolled-up");
+    });
+  });
+
+  it("appends [Digest: {id}] to each source entry's content", async () => {
+    seedEntries(db, "work", 12);
+    const { ctx, drain } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    await drain();
+    const sources = db.entries.filter(e => !JSON.parse(e.tags).includes("synthesized"));
+    sources.forEach(e => {
+      expect(e.content).toContain(`[Digest: ${result.synthesizedId}]`);
+    });
+  });
+
+  it("returns entriesUsed equal to the number of source entries", async () => {
+    seedEntries(db, "work", 12);
+    const { ctx, drain } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    await drain();
+    expect(result.entriesUsed).toBe(12);
+  });
+
+  it("returns the synthesis text", async () => {
+    seedEntries(db, "work", 12);
+    const { ctx, drain } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    await drain();
+    expect(result.text).toBe("Work on the API redesign is progressing well with REST chosen over GraphQL.");
+  });
+
+  it("does not roll up high-importance entries but still uses them in synthesis", async () => {
+    seedEntries(db, "work", 10);
+    db.entries.push({
+      id: "critical", content: "critical strategy decision", tags: JSON.stringify(["work"]),
+      source: "api", created_at: Date.now(), vector_ids: "[]", recall_count: 0, importance_score: 5,
+    });
+    const { ctx, drain } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    await drain();
+    // Digest succeeds on the 10 compressible entries
+    expect(result.synthesizedId).not.toBeNull();
+    // High-importance entry is NOT rolled-up
+    const critical = db.entries.find(e => e.id === "critical");
+    expect(JSON.parse(critical.tags)).not.toContain("rolled-up");
+    expect(critical.content).not.toContain("[Digest:");
+  });
+});

--- a/test/unit/derive-pattern.test.ts
+++ b/test/unit/derive-pattern.test.ts
@@ -62,15 +62,15 @@ describe("derivePattern()", () => {
     expect(env.AI.run).not.toHaveBeenCalled();
   });
 
-  it("returns without calling AI when rows.length is 4 (below threshold)", async () => {
+  it("returns without calling AI when rows.length is 9 (below threshold)", async () => {
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(4), env, ctx);
+    await derivePattern(makeRows(9), env, ctx);
     expect(env.AI.run).not.toHaveBeenCalled();
   });
 
-  it("calls AI when rows.length is exactly 5 (at threshold)", async () => {
+  it("calls AI when rows.length is exactly 10 (at threshold)", async () => {
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(env.AI.run).toHaveBeenCalled();
   });
 
@@ -90,7 +90,7 @@ describe("derivePattern()", () => {
   it("truncates each memory's content to 300 characters in the prompt", async () => {
     const long = "x".repeat(400);
     const { ctx } = makeCtx();
-    await derivePattern([...makeRows(4), { id: "long", content: long }], env, ctx);
+    await derivePattern([...makeRows(9), { id: "long", content: long }], env, ctx);
     const calls = (env.AI.run as ReturnType<typeof vi.fn>).mock.calls;
     const llmCall = calls.find((call: any[]) => call[0] !== "@cf/baai/bge-small-en-v1.5");
     const prompt: string = llmCall![1].messages[0].content;
@@ -106,8 +106,9 @@ describe("derivePattern()", () => {
       { id: "d", content: "Unique memory delta" },
       { id: "e", content: "Unique memory epsilon" },
     ];
+    const allRows = [...rows, ...makeRows(5).map(r => ({ ...r, id: `filler-${r.id}` }))];
     const { ctx } = makeCtx();
-    await derivePattern(rows, env, ctx);
+    await derivePattern(allRows, env, ctx);
     const calls = (env.AI.run as ReturnType<typeof vi.fn>).mock.calls;
     const llmCall = calls.find((call: any[]) => call[0] !== "@cf/baai/bge-small-en-v1.5");
     const prompt: string = llmCall![1].messages[0].content;
@@ -116,7 +117,7 @@ describe("derivePattern()", () => {
 
   it("sends a non-streaming request to AI (no stream flag)", async () => {
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     const calls = (env.AI.run as ReturnType<typeof vi.fn>).mock.calls;
     const llmCall = calls.find((call: any[]) => call[0] !== "@cf/baai/bge-small-en-v1.5");
     expect(llmCall![1].stream).toBeUndefined();
@@ -128,42 +129,42 @@ describe("derivePattern()", () => {
   it("does not store entry when AI returns NONE", async () => {
     env = makeTestEnv(db, { AI: makePatternAI("NONE") });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(db.entries).toHaveLength(0);
   });
 
   it("does not store entry when AI returns empty string", async () => {
     env = makeTestEnv(db, { AI: makePatternAI("") });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(db.entries).toHaveLength(0);
   });
 
   it("does not store entry when AI returns only whitespace", async () => {
     env = makeTestEnv(db, { AI: makePatternAI("   ") });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(db.entries).toHaveLength(0);
   });
 
   it("does not store entry when AI returns NONE with surrounding whitespace", async () => {
     env = makeTestEnv(db, { AI: makePatternAI("  NONE  ") });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(db.entries).toHaveLength(0);
   });
 
   it("does not store entry when AI response lacks a valid starter", async () => {
     env = makeTestEnv(db, { AI: makePatternAI("I notice you tend to work late.") });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(db.entries).toHaveLength(0);
   });
 
   it("does not store entry when AI response begins with similar-but-wrong prefix", async () => {
     env = makeTestEnv(db, { AI: makePatternAI("You tend") }); // incomplete — still valid prefix but no trailing text
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     // "You tend" does start with "You tend to"? No — "You tend to" !== "You tend"
     // "You tend".startsWith("You tend to") === false
     expect(db.entries).toHaveLength(0);
@@ -175,7 +176,7 @@ describe("derivePattern()", () => {
     const pattern = "You tend to start new projects on Mondays.";
     env = makeTestEnv(db, { AI: makePatternAI(pattern) });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(db.entries).toHaveLength(1);
     expect(db.entries[0].content).toBe(pattern);
   });
@@ -184,7 +185,7 @@ describe("derivePattern()", () => {
     const pattern = "There's a recurring theme of late-night coding sessions.";
     env = makeTestEnv(db, { AI: makePatternAI(pattern) });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(db.entries).toHaveLength(1);
     expect(db.entries[0].content).toBe(pattern);
   });
@@ -193,7 +194,7 @@ describe("derivePattern()", () => {
     const pattern = "Across your memories, exercise features heavily on weekends.";
     env = makeTestEnv(db, { AI: makePatternAI(pattern) });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(db.entries).toHaveLength(1);
     expect(db.entries[0].content).toBe(pattern);
   });
@@ -201,7 +202,7 @@ describe("derivePattern()", () => {
   it("stores pattern with 'auto-pattern' tag", async () => {
     env = makeTestEnv(db, { AI: makePatternAI("You tend to prefer async communication.") });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     const tags: string[] = JSON.parse(db.entries[0].tags);
     expect(tags).toContain("auto-pattern");
   });
@@ -209,7 +210,7 @@ describe("derivePattern()", () => {
   it("stores pattern with source 'system'", async () => {
     env = makeTestEnv(db, { AI: makePatternAI("You tend to prefer async communication.") });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(db.entries[0].source).toBe("system");
   });
 
@@ -217,7 +218,7 @@ describe("derivePattern()", () => {
     const pattern = "You tend to journal in the mornings.";
     env = makeTestEnv(db, { AI: makePatternAI(`  ${pattern}  `) });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(db.entries).toHaveLength(1);
     expect(db.entries[0].content).toBe(pattern);
   });
@@ -237,7 +238,7 @@ describe("derivePattern()", () => {
       } as unknown as Ai,
     });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(db.entries).toHaveLength(1);
     expect(db.entries[0].content).toBe(pattern);
   });
@@ -255,7 +256,7 @@ describe("derivePattern()", () => {
       } as unknown as Ai,
     });
     const { ctx } = makeCtx();
-    await derivePattern(makeRows(5), env, ctx);
+    await derivePattern(makeRows(10), env, ctx);
     expect(db.entries[0].content).toBe(fromChoices);
   });
 
@@ -264,7 +265,7 @@ describe("derivePattern()", () => {
   it("does not throw when AI call rejects — error is non-fatal", async () => {
     env = makeTestEnv(db, { AI: makePatternAI(null) });
     const { ctx } = makeCtx();
-    await expect(derivePattern(makeRows(5), env, ctx)).resolves.toBeUndefined();
+    await expect(derivePattern(makeRows(10), env, ctx)).resolves.toBeUndefined();
     expect(db.entries).toHaveLength(0);
   });
 });

--- a/test/unit/synthesize-digest.test.ts
+++ b/test/unit/synthesize-digest.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { synthesizeDigest } from "../../src/index";
+import { makeTestEnv } from "../helpers/make-env";
+
+function makeSseStream(response: string) {
+  return new ReadableStream({
+    start(c) {
+      c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+      c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+      c.close();
+    },
+  });
+}
+
+function aiMock(response: string) {
+  return { run: vi.fn().mockResolvedValue(makeSseStream(response)) } as unknown as Ai;
+}
+
+describe("synthesizeDigest()", () => {
+  it("returns empty string immediately when rows is empty — AI not called", async () => {
+    const env = makeTestEnv();
+    const result = await synthesizeDigest("work", [], env);
+    expect(result).toBe("");
+    expect(env.AI.run).not.toHaveBeenCalled();
+  });
+
+  it("returns LLM response on happy path", async () => {
+    const env = makeTestEnv(undefined, { AI: aiMock("The work on the API redesign is progressing well.") });
+    const result = await synthesizeDigest(
+      "work",
+      [{ id: "1", content: "Started API redesign" }, { id: "2", content: "Decided on REST over GraphQL" }],
+      env
+    );
+    expect(result).toBe("The work on the API redesign is progressing well.");
+  });
+
+  it("returns empty string when LLM throws — does not propagate error", async () => {
+    const env = makeTestEnv(undefined, {
+      AI: { run: vi.fn().mockRejectedValue(new Error("AI unavailable")) } as unknown as Ai,
+    });
+    const result = await synthesizeDigest("work", [{ id: "1", content: "content" }], env);
+    expect(result).toBe("");
+  });
+
+  it("returns empty string when LLM response text is empty", async () => {
+    const env = makeTestEnv(undefined, { AI: aiMock("") });
+    const result = await synthesizeDigest("work", [{ id: "1", content: "content" }], env);
+    expect(result).toBe("");
+  });
+
+  it("trims whitespace from LLM response", async () => {
+    const env = makeTestEnv(undefined, { AI: aiMock("  padded digest  ") });
+    const result = await synthesizeDigest("work", [{ id: "1", content: "content" }], env);
+    expect(result).toBe("padded digest");
+  });
+
+  it("includes the tag in the prompt sent to LLM", async () => {
+    const env = makeTestEnv(undefined, { AI: aiMock("ok") });
+    await synthesizeDigest("second-brain", [{ id: "1", content: "note" }], env);
+    const [, { messages }] = (env.AI.run as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(messages[0].content).toContain("second-brain");
+  });
+
+  it("includes all row content in the prompt", async () => {
+    const env = makeTestEnv(undefined, { AI: aiMock("ok") });
+    await synthesizeDigest("work", [
+      { id: "1", content: "Shipped v1.4.0" },
+      { id: "2", content: "Contradiction detection added" },
+    ], env);
+    const [, { messages }] = (env.AI.run as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(messages[0].content).toContain("Shipped v1.4.0");
+    expect(messages[0].content).toContain("Contradiction detection added");
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -31,3 +31,6 @@ id = ""
 
 [assets]
 directory = "./public"
+
+[triggers]
+crons = ["0 1 * * *"]


### PR DESCRIPTION
## Summary
- Nightly cron compresses tags with >10 compressible entries into a single synthesized digest entry
-  endpoint for on-demand compression triggered from the Settings UI
-  source entries penalized 0.4× in recall scoring so digests surface above originals
- Digest header is clean; each source entry gets  appended in D1 only (no re-embedding), enabling future un-digest
- Stats  query mirrors  filters exactly (importance < 4, ) so UI counts match reality
- Settings sheet renders eligible tags with Digest buttons; menu scrolls safely at 
-  cards render at 0.65 opacity;  cards get accent-colored left border
-  tightened: threshold raised to 10, 48h cooldown via D1 check to prevent spam
- Originals are never deleted — digests are additive

## Test plan
- [x] Open Settings, confirm tags with ≥10 compressible entries appear in the digest section
- [x] Click Digest on a tag — confirm button shows spinner, then success with entry count
- [x] Run  for a query related to the compressed tag — synthesized digest should rank above rolled-up originals
- [x] Confirm rolled-up cards appear dimmed (0.65 opacity) and digest cards have accent border in both Recall and Recent views
- [x] Confirm originals are still searchable via  with high  or tag filter
- [x] confirm nightly handler logs per-tag compression
- [x] Run test suite — 249 tests pass