### PR TITLE
fix: re-embed deletes the vector it just inserted (single-chunk entries vanish from recall)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -569,6 +569,15 @@ async function storeEntry(
   return vectorIds;
 }
 
+// Delete vectors that are no longer referenced after a re-embed. Ids reused by
+// the new embedding must survive: single-chunk entries are keyed by the entry
+// id, so the re-embedded vector reuses the old id. Deleting the full old set
+// would remove the vector we just inserted, leaving the entry unsearchable.
+async function deleteStaleVectors(env: Env, oldIds: string[], newIds: string[]): Promise<void> {
+  const stale = oldIds.filter(v => !newIds.includes(v));
+  if (stale.length) await env.VECTORIZE.deleteByIds(stale);
+}
+
 // ─── Append to existing entry ─────────────────────────────────────────────────
 // For short appends (combined content ≤ CHUNK_MAX_CHARS): adds only the new
 // addition as a single new Vectorize vector pointing to the parent ID.
@@ -605,15 +614,16 @@ async function appendToEntry(
       .bind(newContent, id).run();
 
     // Step 2: Re-chunk + re-embed full content (also updates vector_ids in D1)
+    let newVectorIds: string[] = [];
     try {
-      await storeEntry(env, id, newContent, tags, source, Date.now());
+      newVectorIds = await storeEntry(env, id, newContent, tags, source, Date.now());
     } catch (e) {
       console.error("Vectorize re-embed failed (non-fatal):", e);
     }
 
-    // Step 3: Delete old vectors after new ones are safely inserted
+    // Step 3: Delete only stale vectors — ids reused by the re-embed must survive
     try {
-      if (existingVectorIds.length) await env.VECTORIZE.deleteByIds(existingVectorIds);
+      await deleteStaleVectors(env, existingVectorIds, newVectorIds);
     } catch (e) {
       console.error("Old vector cleanup failed (non-fatal):", e);
     }
@@ -1066,13 +1076,14 @@ export async function captureEntry(
       await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`).bind(newContent, targetId).run();
 
       // Step 2: Re-embed new content — inserts new vectors, updates vector_ids in D1
+      let newVectorIds: string[] = [];
       try {
-        await storeEntry(env, targetId, newContent, existingTags, existingSource, Date.now());
+        newVectorIds = await storeEntry(env, targetId, newContent, existingTags, existingSource, Date.now());
       } catch (e) { console.error("Vectorize re-embed failed (non-fatal):", e); }
 
-      // Step 3: Delete old vectors after new ones are safely in place
+      // Step 3: Delete only stale vectors — ids reused by the re-embed must survive
       try {
-        if (oldVectorIds.length) await env.VECTORIZE.deleteByIds(oldVectorIds);
+        await deleteStaleVectors(env, oldVectorIds, newVectorIds);
       } catch (e) { console.error("Old vector cleanup failed (non-fatal):", e); }
 
       return mergeAction.action === "merge"
@@ -1276,17 +1287,17 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         .bind(newContent, JSON.stringify(tags), id).run();
 
       // Step 2: Re-embed new content → inserts new vectors + updates vector_ids in D1
-      let newVectorCount = 0;
+      let newVectorIds: string[] = [];
       try {
-        const newVectorIds = await storeEntry(env, id, newContent, tags, source, Date.now());
-        newVectorCount = newVectorIds.length;
+        newVectorIds = await storeEntry(env, id, newContent, tags, source, Date.now());
       } catch (e) {
         console.error("Vectorize re-embed failed (non-fatal):", e);
       }
+      const newVectorCount = newVectorIds.length;
 
-      // Step 3: Delete old vectors — after new ones are safely in place
+      // Step 3: Delete only stale vectors — ids reused by the re-embed must survive
       try {
-        if (oldVectorIds.length) await env.VECTORIZE.deleteByIds(oldVectorIds);
+        await deleteStaleVectors(env, oldVectorIds, newVectorIds);
       } catch (e) {
         console.error("Old vector cleanup failed (non-fatal):", e);
       }
@@ -1553,16 +1564,16 @@ const defaultHandler = {
       await env.DB.prepare(`UPDATE entries SET content = ?, tags = ? WHERE id = ?`)
         .bind(finalContent, JSON.stringify(mergedTags), id).run();
 
-      let newVectorCount = 0;
+      let newVectorIds: string[] = [];
       try {
-        const newVectorIds = await storeEntry(env, id, finalContent, mergedTags, source, Date.now());
-        newVectorCount = newVectorIds.length;
+        newVectorIds = await storeEntry(env, id, finalContent, mergedTags, source, Date.now());
       } catch (e) {
         console.error("Vectorize re-embed failed (non-fatal):", e);
       }
+      const newVectorCount = newVectorIds.length;
 
       try {
-        if (oldVectorIds.length) await env.VECTORIZE.deleteByIds(oldVectorIds);
+        await deleteStaleVectors(env, oldVectorIds, newVectorIds);
       } catch (e) {
         console.error("Old vector cleanup failed (non-fatal):", e);
       }

--- a/test/integration/smart-merge.test.ts
+++ b/test/integration/smart-merge.test.ts
@@ -94,7 +94,8 @@ describe("POST /capture — smart merge (flagged band 0.85–0.95)", () => {
     );
 
     expect(insertMock).toHaveBeenCalledOnce();
-    expect(deleteByIdsMock).toHaveBeenCalledWith(["existing-id", "existing-id-chunk-1"]);
+    // Only the stale chunk is deleted; the reused "existing-id" vector survives.
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["existing-id-chunk-1"]);
   });
 
   it("replace: new vector is inserted before old ones are deleted (safe ordering)", async () => {

--- a/test/integration/update.test.ts
+++ b/test/integration/update.test.ts
@@ -159,7 +159,10 @@ describe("POST /update", () => {
 
   // ── Vector orphan prevention ────────────────────────────────────────────────
 
-  it("deletes old vector IDs after re-embedding", async () => {
+  it("deletes only stale vectors, preserving the re-embedded (reused) id", async () => {
+    // Entry previously had 2 chunks. The short update re-embeds to a single
+    // chunk keyed by the entry id ("entry-abc"), which must NOT be deleted —
+    // only the now-orphaned "entry-abc-chunk-1" should be removed.
     const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({ deleteByIds: deleteByIdsMock }),
@@ -172,7 +175,24 @@ describe("POST /update", () => {
     );
 
     expect(deleteByIdsMock).toHaveBeenCalledOnce();
-    expect(deleteByIdsMock.mock.calls[0][0]).toEqual(["entry-abc", "entry-abc-chunk-1"]);
+    expect(deleteByIdsMock.mock.calls[0][0]).toEqual(["entry-abc-chunk-1"]);
+  });
+
+  it("does NOT delete the re-embedded single-chunk vector (id-reuse regression)", async () => {
+    // Single-chunk entry: vector id == entry id. The re-embed reuses that id,
+    // so there is nothing stale — deleting it would make the entry unsearchable.
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({ deleteByIds: deleteByIdsMock }),
+    });
+    seedEntry(db, { vector_ids: '["entry-abc"]' });
+
+    await worker.fetch(
+      req("POST", "/update", { body: { id: "entry-abc", content: "Updated" } }),
+      env, ctx
+    );
+
+    expect(deleteByIdsMock).not.toHaveBeenCalled();
   });
 
   it("does not call deleteByIds when vector_ids is empty", async () => {

--- a/test/unit/capture-entry.test.ts
+++ b/test/unit/capture-entry.test.ts
@@ -250,7 +250,8 @@ describe("captureEntry()", () => {
     });
     const { ctx } = makeCtx();
     await captureEntry("I switched to Cursor", [], "api", env, ctx);
-    expect(deleteByIdsMock).toHaveBeenCalledWith(["existing", "existing-chunk-1"]);
+    // Only the stale chunk is deleted; the reused "existing" vector survives.
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["existing-chunk-1"]);
   });
 
   it("replace: falls through to normal insert when target not found in DB", async () => {
@@ -333,7 +334,8 @@ describe("captureEntry()", () => {
     });
     const { ctx } = makeCtx();
     await captureEntry("I like dark mode at night", [], "api", env, ctx);
-    expect(deleteByIdsMock).toHaveBeenCalledWith(["existing", "existing-chunk-1"]);
+    // Only the stale chunk is deleted; the reused "existing" vector survives.
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["existing-chunk-1"]);
   });
 
   // ── Smart merge: keep_both falls back to flagged (existing behaviour) ────────


### PR DESCRIPTION
## Summary
For single-chunk entries, re-embedding could delete the entry's vector from Vectorize, leaving the row in D1 but unsearchable. This deletes only genuinely-stale vectors instead.

## Root cause
`storeEntry` keys a single chunk by the entry id:

```ts
id: chunks.length === 1 ? id : `${id}-chunk-${i}`
```

The re-embed paths use "insert new → delete old", deleting the *full* previous `vector_ids` set. For a single-chunk entry the new vector reuses the old id, so the cleanup step deletes the vector that was just inserted. The entry then exists in D1 with `vector_ids` pointing at a vector that's no longer in the index, so `recall` never returns it — semantic search, and even exact-term queries, miss it.

Affected: `POST /update`, the MCP `update` tool, the large-append re-embed, and the smart-merge / replace capture paths.

## Fix
Add `deleteStaleVectors(old, new)` which deletes only ids not reused by the new embedding, and route the four re-embed sites through it. The genuine full-deletes (`forget`, conflicting-entry removal) are unchanged.

## Reproduce (before this PR)
1. Capture a short (single-chunk) memory.
2. Update it (`POST /update`), or trigger a smart-merge / replace.
3. `recall` no longer returns it; `wrangler vectorize get-vectors <index> --ids <entryId>` returns nothing, though D1 still lists it in `vector_ids`.

## Testing
- Updated the four tests that asserted the old full-delete behavior.
- Added a single-chunk id-reuse regression test.
- `npm run typecheck` clean; `npm run test:coverage` → 271 tests pass.
