### PR TITLE
feat: exact tag-scoped recall via getByIds (#141)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2736,12 +2736,21 @@
         const loadingEl = appendLoading(msgs)
         msgs.scrollTop = msgs.scrollHeight
         try {
-          const result = await apiMcp('recall', { query, topK: 5, ...(selectedTag ? { tag: selectedTag } : {}) })
+          // Use the REST endpoint for structured results — parsing the MCP tool's
+          // formatted text miscounts sources when memory content contains list items
+          const params = new URLSearchParams({ query, topK: '5' })
+          if (selectedTag) params.set('tag', selectedTag)
+          const recallRes = await fetch(`${WORKER_URL}/recall?${params}`, { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } })
+          const data = await recallRes.json()
+          // Server/auth errors must not render as "no results" — let the catch handle them
+          if (!recallRes.ok || !data.ok) throw new Error(data.error || 'recall failed')
           loadingEl.remove()
-          if (!result || result.includes('Nothing found')) {
+          if (!data.results || !data.results.length) {
             appendBrainBubble(msgs, "I couldn't find anything matching that. Try different words, or check Recent.", 'recall-sys')
           } else {
-            const entries = parseRecallResult(result)
+            // REST scores are already 0–100 (one decimal); map directly rather than via
+            // normalizeEntry, whose 0–1 rescale heuristic would turn a 0.8% match into 80%
+            const entries = data.results.map((m) => ({ id: m.id, content: m.content, tags: m.tags || [], score: Math.min(100, Math.round(m.score)) }))
             const answerBubble = document.createElement('div')
             answerBubble.className = 'ex-a-row'
             const answerEl = document.createElement('div')
@@ -2749,10 +2758,20 @@
             answerBubble.appendChild(answerEl)
             msgs.appendChild(answerBubble)
 
+            // Serialize results for the /chat LLM context, mirroring the MCP tool's
+            // format — dates/tags/source are needed for temporal questions
+            const memories =
+              (data.insight ? `Insight: ${data.insight}\n\n` : '') +
+              data.results.map((m, i) => {
+                const date = new Date(m.created_at).toLocaleDateString()
+                const tagList = m.tags && m.tags.length ? ` [${m.tags.join(', ')}]` : ''
+                const src = m.source ? ` · ${m.source}` : ''
+                return `${i + 1}. [${date}${src}${tagList}] (${Math.min(100, Math.round(m.score))}% match)${m.updated ? ' [updated]' : ''}\n${m.content}`
+              }).join('\n\n')
             const res = await fetch(`${WORKER_URL}/chat`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${AUTH_TOKEN}` },
-              body: JSON.stringify({ query, memories: result }),
+              body: JSON.stringify({ query, memories }),
             })
 
             const reader = res.body.getReader()

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ const DIGEST_MAX_TOKENS = 400;
 const VECTORIZE_TOP_K_MULTIPLIER = 3;
 // getByIds batch size for tag-scoped recall — keeps each call well under request limits
 const VECTORIZE_GET_BY_IDS_BATCH = 500;
+// D1 allows at most 100 bound parameters per query
+const D1_MAX_BOUND_PARAMS = 100;
 
 // ─── Runtime state ────────────────────────────────────────────────────────────
 
@@ -977,12 +979,19 @@ export async function recallEntries(
 
   if (!results.matches.length) return { matches: [], insight: "" };
 
-  // Fetch recall_count and importance_score for all candidates to use in scoring
+  // Fetch recall_count and importance_score for all candidates to use in scoring.
+  // The tag path can produce far more than 100 candidates, so chunk the IN query
+  // to stay under D1's bound-parameter limit.
   const candidateIds = [...new Set(results.matches.map(m => (m.metadata as any)?.parentId ?? m.id))] as string[];
-  const rcPlaceholders = candidateIds.map(() => "?").join(", ");
-  const { results: rcRows } = await env.DB.prepare(
-    `SELECT id, recall_count, importance_score FROM entries WHERE id IN (${rcPlaceholders})`
-  ).bind(...candidateIds).all() as { results: { id: string; recall_count: number; importance_score: number }[] };
+  const rcRows: { id: string; recall_count: number; importance_score: number }[] = [];
+  for (let i = 0; i < candidateIds.length; i += D1_MAX_BOUND_PARAMS) {
+    const batch = candidateIds.slice(i, i + D1_MAX_BOUND_PARAMS);
+    const rcPlaceholders = batch.map(() => "?").join(", ");
+    const { results: rows } = await env.DB.prepare(
+      `SELECT id, recall_count, importance_score FROM entries WHERE id IN (${rcPlaceholders})`
+    ).bind(...batch).all() as { results: { id: string; recall_count: number; importance_score: number }[] };
+    rcRows.push(...rows);
+  }
   const recallCounts = new Map(rcRows.map(r => [r.id, r.recall_count ?? 0]));
   const importanceScores = new Map(rcRows.map(r => [r.id, r.importance_score ?? 0]));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,8 +399,8 @@ export function cosineSim(a: ArrayLike<number>, b: ArrayLike<number>): number {
     normA += a[i] * a[i];
     normB += b[i] * b[i];
   }
-  const denom = Math.sqrt(normA) * Math.sqrt(normB);
-  return denom === 0 ? 0 : dot / denom;
+  // Guard on the raw norms, not the sqrt product — the product can underflow to 0
+  return normA === 0 || normB === 0 ? 0 : dot / Math.sqrt(normA * normB);
 }
 
 export function rerankWithTimeDecay(

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,8 +57,9 @@ const DIGEST_MAX_TOKENS = 400;
 // ─── Vectorize constants ──────────────────────────────────────────────────────
 
 const VECTORIZE_TOP_K_MULTIPLIER = 3;
-// getByIds batch size for tag-scoped recall — keeps each call well under request limits
-const VECTORIZE_GET_BY_IDS_BATCH = 500;
+// getByIds batch size for tag-scoped recall — Vectorize rejects more than 20 IDs
+// per call (VECTOR_GET_ERROR, code 40007)
+const VECTORIZE_GET_BY_IDS_BATCH = 20;
 // D1 allows at most 100 bound parameters per query
 const D1_MAX_BOUND_PARAMS = 100;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -389,6 +389,20 @@ export function getHalfLifeMs(tags: string[]): number {
   return 30 * 24 * 60 * 60 * 1000; // 30 days default
 }
 
+// Cosine similarity between two vectors. BGE embeddings are not normalized,
+// so the denominator matters — this keeps tag-path scores on the same scale
+// as Vectorize's cosine query scores.
+export function cosineSim(a: ArrayLike<number>, b: ArrayLike<number>): number {
+  let dot = 0, normA = 0, normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom === 0 ? 0 : dot / denom;
+}
+
 export function rerankWithTimeDecay(
   matches: VectorizeMatch[],
   recallCounts: Map<string, number> = new Map(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,8 @@ const DIGEST_MAX_TOKENS = 400;
 // ─── Vectorize constants ──────────────────────────────────────────────────────
 
 const VECTORIZE_TOP_K_MULTIPLIER = 3;
+// getByIds batch size for tag-scoped recall — keeps each call well under request limits
+const VECTORIZE_GET_BY_IDS_BATCH = 500;
 
 // ─── Runtime state ────────────────────────────────────────────────────────────
 
@@ -929,29 +931,48 @@ export async function recallEntries(
 
   const values = await embed(embedQuery, env);
 
-  // If tag filter, resolve matching IDs from D1 first (D1 is source of truth for tags)
-  let tagFilterIds: Set<string> | null = null;
+  let results: { matches: VectorizeMatch[] };
   if (tag) {
+    // Tag path: score the tag's own vectors directly. An unconstrained Vectorize
+    // query caps at 50 candidates, silently dropping tagged entries whose global
+    // semantic rank falls outside the top 50 (issue #141). D1 is the source of
+    // truth for tags and already stores each entry's vector_ids.
     const { results: tagRows } = await env.DB.prepare(
-      `SELECT id FROM entries WHERE tags LIKE ?`
+      `SELECT id, vector_ids FROM entries WHERE tags LIKE ?`
     ).bind(`%"${tag}"%`).all();
-    tagFilterIds = new Set((tagRows as any[]).map(r => r.id as string));
-    if (tagFilterIds.size === 0) return { matches: [], insight: "" };
-  }
+    if (!tagRows.length) return { matches: [], insight: "" };
 
-  // Query Vectorize without filter — tag filtering happens in-memory below
-  // Cloudflare Vectorize caps topK at 50 when returnMetadata="all" (error 40025)
-  const vectorizeTopK = Math.min(topK * VECTORIZE_TOP_K_MULTIPLIER, 50);
-  let results = await env.VECTORIZE.query(values, {
-    topK: vectorizeTopK,
-    returnMetadata: "all",
-  });
+    const vectorIds = [...new Set(
+      (tagRows as any[]).flatMap(r => JSON.parse((r.vector_ids as string) ?? "[]") as string[])
+    )];
+    if (!vectorIds.length) return { matches: [], insight: "" };
 
-  if (results.matches.length && results.matches[0].score < DUPLICATE_FLAG_THRESHOLD) {
+    const vectors: VectorizeVector[] = [];
+    for (let i = 0; i < vectorIds.length; i += VECTORIZE_GET_BY_IDS_BATCH) {
+      vectors.push(...await env.VECTORIZE.getByIds(vectorIds.slice(i, i + VECTORIZE_GET_BY_IDS_BATCH)));
+    }
+
+    results = {
+      matches: vectors.map(v => ({
+        id: v.id,
+        score: cosineSim(values, v.values as number[]),
+        metadata: v.metadata,
+      })) as VectorizeMatch[],
+    };
+  } else {
+    // Cloudflare Vectorize caps topK at 50 when returnMetadata="all" (error 40025)
+    const vectorizeTopK = Math.min(topK * VECTORIZE_TOP_K_MULTIPLIER, 50);
     results = await env.VECTORIZE.query(values, {
-      topK: 50,
+      topK: vectorizeTopK,
       returnMetadata: "all",
     });
+
+    if (results.matches.length && results.matches[0].score < DUPLICATE_FLAG_THRESHOLD) {
+      results = await env.VECTORIZE.query(values, {
+        topK: 50,
+        returnMetadata: "all",
+      });
+    }
   }
 
   if (!results.matches.length) return { matches: [], insight: "" };
@@ -971,8 +992,6 @@ export async function recallEntries(
   const deduped = reranked.filter((m) => {
     const parentId = (m.metadata as any)?.parentId ?? m.id;
     if (seen.has(parentId)) return false;
-    // Apply tag filter against D1-resolved IDs
-    if (tagFilterIds && !tagFilterIds.has(parentId)) return false;
     seen.add(parentId);
     return true;
   }).slice(0, topK);

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -125,12 +125,12 @@ export class D1Mock {
         return null;
       },
       async all() {
-        if (s === "SELECT id FROM entries WHERE tags LIKE ?") {
+        if (s === "SELECT id FROM entries WHERE tags LIKE ?" || s === "SELECT id, vector_ids FROM entries WHERE tags LIKE ?") {
           const pattern = String(args[0]);
           const tag = pattern.replace(/%"/g, "").replace(/"%/g, "");
           const results = db.entries
             .filter((e: any) => (JSON.parse(e.tags ?? "[]") as string[]).includes(tag))
-            .map((e: any) => ({ id: e.id }));
+            .map((e: any) => ({ id: e.id, vector_ids: e.vector_ids ?? "[]" }));
           return { results };
         }
         if (s.includes("SELECT id, recall_count, importance_score FROM entries")) {

--- a/test/integration/recall.test.ts
+++ b/test/integration/recall.test.ts
@@ -172,13 +172,14 @@ describe("GET /recall", () => {
     db.entries.push(
       { id: "entry-1", content: "Orphaned memory", tags: '["work"]', source: "api", created_at: 1000, vector_ids: '["entry-1"]', recall_count: 0, importance_score: 0 },
     );
-    // Default getByIds mock resolves to [] — every ID is stale
-    env = makeTestEnv(db);
+    const getByIdsMock = vi.fn().mockResolvedValue([]);
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ getByIds: getByIdsMock }) });
 
     const res = await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
     const data = await res.json() as any;
     expect(data.ok).toBe(true);
     expect(data.results).toEqual([]);
+    expect(getByIdsMock).toHaveBeenCalledWith(["entry-1"]);
   });
 
   it("returns empty without calling Vectorize when tagged entries have no vectors", async () => {
@@ -206,8 +207,8 @@ describe("GET /recall", () => {
 
     await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
     expect(getByIdsMock).toHaveBeenCalledTimes(2);
-    expect(getByIdsMock.mock.calls[0][0]).toHaveLength(500);
-    expect(getByIdsMock.mock.calls[1][0]).toHaveLength(1);
+    expect(getByIdsMock.mock.calls[0][0]).toEqual(manyIds.slice(0, 500));
+    expect(getByIdsMock.mock.calls[1][0]).toEqual(manyIds.slice(500));
   });
 
   it("dedupes duplicate vector IDs shared across tagged entries before fetching", async () => {
@@ -221,5 +222,37 @@ describe("GET /recall", () => {
     await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
     expect(getByIdsMock).toHaveBeenCalledTimes(1);
     expect(getByIdsMock.mock.calls[0][0]).toEqual(["shared-vec"]);
+  });
+
+  it("respects topK in tag-scoped recall", async () => {
+    for (let i = 1; i <= 5; i++) {
+      db.entries.push(
+        { id: `entry-${i}`, content: `Memory ${i}`, tags: '["work"]', source: "api", created_at: 1000 + i, vector_ids: `["entry-${i}"]`, recall_count: 0, importance_score: 0 },
+      );
+    }
+    const getByIdsMock = vi.fn().mockResolvedValue(
+      Array.from({ length: 5 }, (_, i) => ({ id: `entry-${i + 1}`, values: SIMILAR_VEC, metadata: { parentId: `entry-${i + 1}`, isUpdate: false } })),
+    );
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ getByIds: getByIdsMock }) });
+
+    const res = await worker.fetch(req("GET", "/recall?query=memory&tag=work&topK=2"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.results).toHaveLength(2);
+  });
+
+  it("dedupes tag-scoped chunk vectors that share the same parentId", async () => {
+    db.entries.push(
+      { id: "entry-1", content: "Chunked memory", tags: '["work"]', source: "api", created_at: 1000, vector_ids: '["entry-1-chunk-0","entry-1-chunk-1"]', recall_count: 0, importance_score: 0 },
+    );
+    const getByIdsMock = vi.fn().mockResolvedValue([
+      { id: "entry-1-chunk-0", values: SIMILAR_VEC, metadata: { parentId: "entry-1", isUpdate: false } },
+      { id: "entry-1-chunk-1", values: SIMILAR_VEC, metadata: { parentId: "entry-1", isUpdate: false } },
+    ]);
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ getByIds: getByIdsMock }) });
+
+    const res = await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].id).toBe("entry-1");
   });
 });

--- a/test/integration/recall.test.ts
+++ b/test/integration/recall.test.ts
@@ -197,8 +197,8 @@ describe("GET /recall", () => {
     expect(queryMock).not.toHaveBeenCalled();
   });
 
-  it("batches getByIds calls at 500 IDs", async () => {
-    const manyIds = Array.from({ length: 501 }, (_, i) => `entry-1-chunk-${i}`);
+  it("batches getByIds calls at 20 IDs (Vectorize error 40007 above that)", async () => {
+    const manyIds = Array.from({ length: 41 }, (_, i) => `entry-1-chunk-${i}`);
     db.entries.push(
       { id: "entry-1", content: "Heavily chunked memory", tags: '["work"]', source: "api", created_at: 1000, vector_ids: JSON.stringify(manyIds), recall_count: 0, importance_score: 0 },
     );
@@ -206,9 +206,10 @@ describe("GET /recall", () => {
     env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ getByIds: getByIdsMock }) });
 
     await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
-    expect(getByIdsMock).toHaveBeenCalledTimes(2);
-    expect(getByIdsMock.mock.calls[0][0]).toEqual(manyIds.slice(0, 500));
-    expect(getByIdsMock.mock.calls[1][0]).toEqual(manyIds.slice(500));
+    expect(getByIdsMock).toHaveBeenCalledTimes(3);
+    expect(getByIdsMock.mock.calls[0][0]).toEqual(manyIds.slice(0, 20));
+    expect(getByIdsMock.mock.calls[1][0]).toEqual(manyIds.slice(20, 40));
+    expect(getByIdsMock.mock.calls[2][0]).toEqual(manyIds.slice(40));
   });
 
   it("dedupes duplicate vector IDs shared across tagged entries before fetching", async () => {

--- a/test/integration/recall.test.ts
+++ b/test/integration/recall.test.ts
@@ -255,4 +255,26 @@ describe("GET /recall", () => {
     expect(data.results).toHaveLength(1);
     expect(data.results[0].id).toBe("entry-1");
   });
+
+  it("chunks the candidate scoring query for tags with more than 100 entries", async () => {
+    const count = 150;
+    for (let i = 1; i <= count; i++) {
+      db.entries.push(
+        { id: `entry-${i}`, content: `Memory ${i}`, tags: '["work"]', source: "api", created_at: 1000 + i, vector_ids: `["entry-${i}"]`, recall_count: 0, importance_score: 0 },
+      );
+    }
+    const getByIdsMock = vi.fn().mockResolvedValue(
+      Array.from({ length: count }, (_, i) => ({ id: `entry-${i + 1}`, values: SIMILAR_VEC, metadata: { parentId: `entry-${i + 1}`, isUpdate: false } })),
+    );
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ getByIds: getByIdsMock }) });
+    const prepareSpy = vi.spyOn(db, "prepare");
+
+    const res = await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.results).toHaveLength(5); // default topK
+    // D1 allows max 100 bound parameters per query — 150 candidates must be chunked into 2 calls
+    const scoringCalls = prepareSpy.mock.calls.filter(([sql]) => sql.includes("recall_count, importance_score"));
+    expect(scoringCalls).toHaveLength(2);
+  });
 });

--- a/test/integration/recall.test.ts
+++ b/test/integration/recall.test.ts
@@ -15,6 +15,11 @@ function makeMatch(id: string, score: number, overrides: Record<string, any> = {
   };
 }
 
+// The AI mock embeds every query as 384 dims of 0.1 (make-env.ts) —
+// SIMILAR_VEC scores cosine 1.0 against it, DISSIMILAR_VEC scores ~0.
+const SIMILAR_VEC = new Array(384).fill(0.1);
+const DISSIMILAR_VEC = Array.from({ length: 384 }, (_, i) => (i % 2 === 0 ? 0.1 : -0.1));
+
 describe("GET /recall", () => {
   let env: Env;
   let db: D1Mock;
@@ -87,28 +92,31 @@ describe("GET /recall", () => {
     expect(data.results[0].id).toBe("entry-1");
   });
 
-  it("filters out matches whose parent entry doesn't carry the requested tag", async () => {
+  it("surfaces tagged entries via getByIds even when a global query would miss them", async () => {
     db.entries.push(
-      { id: "entry-1", content: "Work memory", tags: '["work"]', source: "api", created_at: 1000, vector_ids: "[]", recall_count: 0, importance_score: 0 },
-      { id: "entry-2", content: "Idea memory", tags: '["idea"]', source: "api", created_at: 2000, vector_ids: "[]", recall_count: 0, importance_score: 0 },
+      { id: "entry-1", content: "Work memory", tags: '["work"]', source: "api", created_at: 1000, vector_ids: '["entry-1"]', recall_count: 0, importance_score: 0 },
+      { id: "entry-2", content: "Idea memory", tags: '["idea"]', source: "api", created_at: 2000, vector_ids: '["entry-2"]', recall_count: 0, importance_score: 0 },
     );
-    env = makeTestEnv(db, {
-      VECTORIZE: makeVectorizeMock({
-        query: vi.fn().mockResolvedValue({
-          matches: [makeMatch("entry-1", 0.9), makeMatch("entry-2", 0.85)],
-        }),
-      }),
-    });
+    // Global semantic query returns nothing — the old path would lose this entry entirely
+    const queryMock = vi.fn().mockResolvedValue({ matches: [] });
+    const getByIdsMock = vi.fn().mockResolvedValue([
+      { id: "entry-1", values: SIMILAR_VEC, metadata: { parentId: "entry-1", isUpdate: false } },
+    ]);
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ query: queryMock, getByIds: getByIdsMock }) });
 
     const res = await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
     const data = await res.json() as any;
     expect(data.results).toHaveLength(1);
     expect(data.results[0].id).toBe("entry-1");
+    // Only the tag's own vectors are fetched; the global query is never used
+    expect(getByIdsMock).toHaveBeenCalledWith(["entry-1"]);
+    expect(queryMock).not.toHaveBeenCalled();
   });
 
   it("returns empty results immediately when the tag has no matching entries", async () => {
     const queryMock = vi.fn().mockResolvedValue({ matches: [makeMatch("entry-1", 0.9)] });
-    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ query: queryMock }) });
+    const getByIdsMock = vi.fn().mockResolvedValue([]);
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ query: queryMock, getByIds: getByIdsMock }) });
 
     const res = await worker.fetch(req("GET", "/recall?query=memory&tag=nonexistent"), env, ctx);
     const data = await res.json() as any;
@@ -116,6 +124,7 @@ describe("GET /recall", () => {
     expect(data.results).toEqual([]);
     // Short-circuits before hitting Vectorize since the tag resolves to no IDs in D1
     expect(queryMock).not.toHaveBeenCalled();
+    expect(getByIdsMock).not.toHaveBeenCalled();
   });
 
   it("clamps ?topK= to the 1-20 range", async () => {
@@ -125,5 +134,92 @@ describe("GET /recall", () => {
     await worker.fetch(req("GET", "/recall?query=memory&topK=999"), env, ctx);
     const [, opts] = queryMock.mock.calls[0];
     expect(opts.topK).toBeLessThanOrEqual(50);
+  });
+
+  it("ranks tag-scoped results by cosine similarity to the query", async () => {
+    db.entries.push(
+      { id: "entry-1", content: "Less similar", tags: '["work"]', source: "api", created_at: 1000, vector_ids: '["entry-1"]', recall_count: 0, importance_score: 0 },
+      { id: "entry-2", content: "More similar", tags: '["work"]', source: "api", created_at: 2000, vector_ids: '["entry-2"]', recall_count: 0, importance_score: 0 },
+    );
+    const getByIdsMock = vi.fn().mockResolvedValue([
+      { id: "entry-1", values: DISSIMILAR_VEC, metadata: { parentId: "entry-1", isUpdate: false } },
+      { id: "entry-2", values: SIMILAR_VEC, metadata: { parentId: "entry-2", isUpdate: false } },
+    ]);
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ getByIds: getByIdsMock }) });
+
+    const res = await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.results.map((r: any) => r.id)).toEqual(["entry-2", "entry-1"]);
+    expect(data.results[0].score).toBeGreaterThan(data.results[1].score);
+  });
+
+  it("omits stale vector IDs that getByIds does not return", async () => {
+    db.entries.push(
+      { id: "entry-1", content: "Live memory", tags: '["work"]', source: "api", created_at: 1000, vector_ids: '["entry-1","entry-1-stale"]', recall_count: 0, importance_score: 0 },
+    );
+    const getByIdsMock = vi.fn().mockResolvedValue([
+      { id: "entry-1", values: SIMILAR_VEC, metadata: { parentId: "entry-1", isUpdate: false } },
+    ]);
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ getByIds: getByIdsMock }) });
+
+    const res = await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].id).toBe("entry-1");
+  });
+
+  it("returns empty results when all of the tag's vectors are stale", async () => {
+    db.entries.push(
+      { id: "entry-1", content: "Orphaned memory", tags: '["work"]', source: "api", created_at: 1000, vector_ids: '["entry-1"]', recall_count: 0, importance_score: 0 },
+    );
+    // Default getByIds mock resolves to [] — every ID is stale
+    env = makeTestEnv(db);
+
+    const res = await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.results).toEqual([]);
+  });
+
+  it("returns empty without calling Vectorize when tagged entries have no vectors", async () => {
+    db.entries.push(
+      { id: "entry-1", content: "Unvectorized memory", tags: '["work"]', source: "api", created_at: 1000, vector_ids: "[]", recall_count: 0, importance_score: 0 },
+    );
+    const queryMock = vi.fn().mockResolvedValue({ matches: [] });
+    const getByIdsMock = vi.fn().mockResolvedValue([]);
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ query: queryMock, getByIds: getByIdsMock }) });
+
+    const res = await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.results).toEqual([]);
+    expect(getByIdsMock).not.toHaveBeenCalled();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("batches getByIds calls at 500 IDs", async () => {
+    const manyIds = Array.from({ length: 501 }, (_, i) => `entry-1-chunk-${i}`);
+    db.entries.push(
+      { id: "entry-1", content: "Heavily chunked memory", tags: '["work"]', source: "api", created_at: 1000, vector_ids: JSON.stringify(manyIds), recall_count: 0, importance_score: 0 },
+    );
+    const getByIdsMock = vi.fn().mockResolvedValue([]);
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ getByIds: getByIdsMock }) });
+
+    await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
+    expect(getByIdsMock).toHaveBeenCalledTimes(2);
+    expect(getByIdsMock.mock.calls[0][0]).toHaveLength(500);
+    expect(getByIdsMock.mock.calls[1][0]).toHaveLength(1);
+  });
+
+  it("dedupes duplicate vector IDs shared across tagged entries before fetching", async () => {
+    db.entries.push(
+      { id: "entry-1", content: "First", tags: '["work"]', source: "api", created_at: 1000, vector_ids: '["shared-vec"]', recall_count: 0, importance_score: 0 },
+      { id: "entry-2", content: "Second", tags: '["work"]', source: "api", created_at: 2000, vector_ids: '["shared-vec"]', recall_count: 0, importance_score: 0 },
+    );
+    const getByIdsMock = vi.fn().mockResolvedValue([]);
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ getByIds: getByIdsMock }) });
+
+    await worker.fetch(req("GET", "/recall?query=memory&tag=work"), env, ctx);
+    expect(getByIdsMock).toHaveBeenCalledTimes(1);
+    expect(getByIdsMock.mock.calls[0][0]).toEqual(["shared-vec"]);
   });
 });

--- a/test/ui/utils.test.ts
+++ b/test/ui/utils.test.ts
@@ -63,6 +63,26 @@ describe("parseRecallResult — direct object input (non-string path)", () => {
     expect(results[0].content).toBe("direct object");
     expect(results[0].score).toBe(80);
   });
+
+  it("parses the GET /recall REST response shape — one entry per result, regardless of content", () => {
+    // Contract test: the REST response shape must yield one entry per result,
+    // never splitting on list items inside content (the old text-parsing bug).
+    // The recall chat flow now maps data.results directly (inline in index.html,
+    // not testable here); this pins the shape both depend on.
+    const restResponse = {
+      ok: true,
+      results: [
+        { id: "r1", content: "Changelog:\n- item one\n- item two\n1. numbered line", score: 87.3, tags: ["work"], source: "api", created_at: 1717000000000, updated: false },
+        { id: "r2", content: "Plain note", score: 64.9, tags: [], source: "claude-desktop", created_at: 1717000001000, updated: true },
+      ],
+      insight: "Some synthesized insight.",
+    };
+    const results = parseRecallResult(restResponse);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ id: "r1", score: 87, tags: ["work"] });
+    expect(results[0].content).toContain("- item one");
+    expect(results[1]).toMatchObject({ id: "r2", score: 65, content: "Plain note" });
+  });
 });
 
 describe("parseRecallResult — text block with no score", () => {

--- a/test/unit/cosine-sim.test.ts
+++ b/test/unit/cosine-sim.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { cosineSim } from "../../src/index";
+
+describe("cosineSim", () => {
+  it("returns 1 for identical vectors", () => {
+    expect(cosineSim([1, 2, 3], [1, 2, 3])).toBeCloseTo(1, 10);
+  });
+
+  it("returns 1 for parallel vectors of different magnitude (normalizes)", () => {
+    // BGE embeddings aren't normalized — magnitude must not affect the score
+    expect(cosineSim([1, 2, 3], [2, 4, 6])).toBeCloseTo(1, 10);
+  });
+
+  it("returns 0 for orthogonal vectors", () => {
+    expect(cosineSim([1, 0], [0, 1])).toBeCloseTo(0, 10);
+  });
+
+  it("returns -1 for opposite vectors", () => {
+    expect(cosineSim([1, 2], [-1, -2])).toBeCloseTo(-1, 10);
+  });
+
+  it("returns 0 when either vector is all zeros", () => {
+    expect(cosineSim([0, 0], [1, 2])).toBe(0);
+    expect(cosineSim([1, 2], [0, 0])).toBe(0);
+  });
+});


### PR DESCRIPTION
Resolves #141

## Summary
- Tag-filtered recall now scores the tag's own vectors directly (D1 `vector_ids` → batched `VECTORIZE.getByIds` → new `cosineSim` helper vs the query embedding) instead of post-filtering a global top-50 Vectorize query, so tagged memories can no longer be silently lost to the cap. Untagged recall is unchanged, including the low-score retry.
- The now-dead `tagFilterIds` in-memory post-filter was removed.
- Hardening fixes found in review and production testing: `cosineSim` guards on raw norms (float underflow); the candidate-scoring `IN` query is chunked at `D1_MAX_BOUND_PARAMS = 100` (the tag path can produce >100 candidates, exceeding D1's bound-parameter limit); `getByIds` batches capped at 20 (Vectorize rejects more with `VECTOR_GET_ERROR` 40007).
- Web UI: the Recall chat flow now uses the structured `GET /recall` REST endpoint instead of re-parsing the MCP tool's formatted text, fixing the inflated "sources" count when memory content contains list items. Source cards also gain real entry IDs (working Append/Forget), server errors no longer render as "no results", and the `/chat` context keeps dates/tags/source for temporal questions.

## Test Plan
- [x] 12 new/updated integration tests in `test/integration/recall.test.ts`: beyond-top-50 surfacing, cosine ranking, stale vector IDs (partial + total), no-vector short-circuit, 20-ID `getByIds` batching, shared-vector dedupe, chunk parentId dedupe, topK in tag path, >100-candidate D1 chunking
- [x] 5 new unit tests for `cosineSim`; 1 new UI contract test for the REST `/recall` response shape
- [x] Full suite: 300/300 passing; `tsc --noEmit` clean