### PR TITLE
feat: memory status layer — canonical / draft / deprecated (#119)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1304,6 +1304,17 @@ export async function deprecateEntry(id: string, env: Env): Promise<boolean> {
   return true;
 }
 
+// Apply a lifecycle status to an entry (issue #119). 'deprecated' deletes vectors
+// (via deprecateEntry); others swap the status:* tag in place. Returns ok=false if no such entry.
+export async function applyStatus(id: string, status: MemoryStatus, env: Env): Promise<boolean> {
+  if (status === "deprecated") return deprecateEntry(id, env);
+  const row = await env.DB.prepare(`SELECT tags FROM entries WHERE id = ?`).bind(id).first() as Record<string, any> | null;
+  if (!row) return false;
+  const tags: string[] = JSON.parse(row.tags ?? "[]");
+  await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`).bind(JSON.stringify(withStatus(tags, status)), id).run();
+  return true;
+}
+
 // ─── MCP Server ───────────────────────────────────────────────────────────────
 
 function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
@@ -1443,6 +1454,23 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       return {
         content: [{ type: "text", text: `Updated entry ${id}. Re-embedded as ${newVectorCount} vector(s).` }],
       };
+    }
+  );
+
+  // ── set_status ─────────────────────────────────────────────────────────────
+  server.registerTool(
+    "set_status",
+    {
+      description: "Set a memory's lifecycle status. 'canonical' = confirmed/authoritative (protected from auto-overwrite), 'draft' = tentative, 'deprecated' = no longer accurate (removed from recall, kept for audit). Get the entry ID from recall or list_recent first.",
+      inputSchema: {
+        id: z.string().describe("Entry ID — from recall or list_recent"),
+        status: z.enum([...STATUS_VALUES] as [string, ...string[]]).describe("canonical | draft | deprecated"),
+      },
+    },
+    async ({ id, status }) => {
+      const ok = await applyStatus(id, status as MemoryStatus, env);
+      if (!ok) return { content: [{ type: "text", text: `No entry found with ID: ${id}` }] };
+      return { content: [{ type: "text", text: status === "deprecated" ? `Entry ${id} deprecated — removed from recall, kept for audit.` : `Entry ${id} marked ${status}.` }] };
     }
   );
 
@@ -1848,6 +1876,29 @@ const defaultHandler = {
       }
 
       return json({ ok: true, id, deletedVectors: result.vectorCount });
+    }
+
+    // POST /status — set lifecycle status, mirrors the MCP `set_status` tool
+    if (url.pathname === "/status" && request.method === "POST") {
+      const authErr = requireAuth(request, env);
+      if (authErr) return authErr;
+
+      let body: { id?: string; status?: string };
+      try { body = await request.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
+      if (!body.id?.trim()) return json({ ok: false, error: "id is required" }, 400);
+      if (!(STATUS_VALUES as readonly string[]).includes(body.status ?? "")) {
+        return json({ ok: false, error: `status must be one of: ${STATUS_VALUES.join(", ")}` }, 400);
+      }
+
+      const id = body.id.trim();
+      const status = body.status as MemoryStatus;
+      const ok = await applyStatus(id, status, env);
+
+      if (!ok) {
+        return json({ ok: false, error: `No entry found with ID: ${id}` }, 404);
+      }
+
+      return json({ ok: true, id, status });
     }
 
     // POST /chat

--- a/src/index.ts
+++ b/src/index.ts
@@ -1174,9 +1174,10 @@ export async function captureEntry(
       const existingSource = targetRow.source as string;
       const oldVectorIds: string[] = JSON.parse(targetRow.vector_ids ?? "[]");
 
-      // Protect high-importance memories from being silently overwritten.
-      // Score ≥ 4 means the existing entry is critical — keep both rather than replace.
-      if ((targetRow.importance_score as number) >= 4) {
+      // Protect high-importance or canonical memories from being silently overwritten.
+      // Score ≥ 4 means the existing entry is critical; canonical = confirmed authoritative.
+      const targetStatus = getStatus(existingTags);
+      if ((targetRow.importance_score as number) >= 4 || targetStatus === "canonical") {
         return { status: "flagged", id: crypto.randomUUID(), matchId: targetId, score: dup.score };
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,26 @@ const VECTORIZE_GET_BY_IDS_BATCH = 20;
 // D1 allows at most 100 bound parameters per query
 const D1_MAX_BOUND_PARAMS = 100;
 
+// ─── Memory status layer (issue #119) ──────────────────────────────────────────
+// Status lives as a reserved tag (e.g. "status:canonical") on entries.tags — no
+// schema change. Absent status = unspecified = default behavior.
+
+export const STATUS_VALUES = ["canonical", "draft", "deprecated"] as const;
+export type MemoryStatus = (typeof STATUS_VALUES)[number];
+const STATUS_PREFIX = "status:";
+
+export function getStatus(tags: string[]): MemoryStatus | null {
+  const tag = tags.find(t => t.startsWith(STATUS_PREFIX));
+  if (!tag) return null;
+  const value = tag.slice(STATUS_PREFIX.length) as MemoryStatus;
+  return (STATUS_VALUES as readonly string[]).includes(value) ? value : null;
+}
+
+export function withStatus(tags: string[], status: MemoryStatus): string[] {
+  const cleaned = tags.filter(t => !t.startsWith(STATUS_PREFIX));
+  return [...cleaned, `${STATUS_PREFIX}${status}`];
+}
+
 // ─── Runtime state ────────────────────────────────────────────────────────────
 
 let dbReady = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1139,6 +1139,7 @@ export type CaptureResult =
   | { status: "stored"; id: string }
   | { status: "flagged"; id: string; matchId: string; score: number }
   | { status: "contradiction"; id: string; resolvedConflict: string; reason?: string }
+  | { status: "contradiction_protected"; id: string; canonicalId: string; reason?: string }
   | { status: "merged"; id: string }
   | { status: "replaced"; id: string };
 
@@ -1224,15 +1225,26 @@ export async function captureEntry(
 
   if (contradiction.detected && contradiction.conflicting_id) {
     const conflictId = contradiction.conflicting_id;
+    const conflictRow = await env.DB.prepare(
+      `SELECT tags FROM entries WHERE id = ?`
+    ).bind(conflictId).first() as Record<string, any> | null;
+    const conflictStatus = conflictRow ? getStatus(JSON.parse(conflictRow.tags ?? "[]")) : null;
+
+    if (conflictStatus === "canonical") {
+      // Don't overwrite a canonical memory — keep it, demote the new entry to draft.
+      // Strip "contradiction-resolved" — that tag marks entries that WON a contradiction;
+      // this entry lost, so it must not carry that tag.
+      const draftTags = finalTags.filter(t => t !== "contradiction-resolved");
+      await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`)
+        .bind(JSON.stringify(withStatus(draftTags, "draft")), id).run();
+      return { status: "contradiction_protected", id, canonicalId: conflictId, reason: contradiction.reason };
+    }
+
+    // Non-canonical loser: deprecate (keep row for audit) instead of hard-delete.
     try {
-      const conflictRow = await env.DB.prepare(
-        `SELECT vector_ids FROM entries WHERE id = ?`
-      ).bind(conflictId).first() as Record<string, any> | null;
-      const conflictVectorIds: string[] = JSON.parse(conflictRow?.vector_ids ?? "[]");
-      await env.DB.prepare(`DELETE FROM entries WHERE id = ?`).bind(conflictId).run();
-      if (conflictVectorIds.length) await env.VECTORIZE.deleteByIds(conflictVectorIds);
+      await deprecateEntry(conflictId, env);
     } catch (e) {
-      console.error("Contradiction resolution cleanup failed (non-fatal):", e);
+      console.error("Contradiction deprecation failed (non-fatal):", e);
     }
     return { status: "contradiction", id, resolvedConflict: conflictId, reason: contradiction.reason };
   }
@@ -1331,6 +1343,9 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       }
       if (result.status === "contradiction") {
         return { content: [{ type: "text", text: `Stored. ID: ${result.id} — resolved contradiction with entry ${result.resolvedConflict}${result.reason ? `: ${result.reason}` : ""}.` }] };
+      }
+      if (result.status === "contradiction_protected") {
+        return { content: [{ type: "text", text: `Stored as draft (ID: ${result.id}) — conflicts with a canonical memory (${result.canonicalId}), which was kept${result.reason ? `: ${result.reason}` : ""}.` }] };
       }
       if (result.status === "replaced") {
         return { content: [{ type: "text", text: `Memory updated — new content replaced outdated entry (ID: ${result.id}).` }] };
@@ -1636,6 +1651,9 @@ const defaultHandler = {
       }
       if (result.status === "contradiction") {
         return json({ ok: true, id: result.id, resolved_conflict: result.resolvedConflict, reason: result.reason });
+      }
+      if (result.status === "contradiction_protected") {
+        return json({ ok: true, id: result.id, status: "draft", kept_canonical: result.canonicalId, reason: result.reason });
       }
       if (result.status === "replaced") {
         return json({ ok: true, id: result.id, action: "replaced", message: "New memory replaced an outdated existing entry" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1282,6 +1282,28 @@ export async function forgetEntry(id: string, env: Env): Promise<ForgetResult> {
   return { status: "deleted", vectorCount: vectorIds.length };
 }
 
+// Deprecate (issue #119): keep the D1 row for audit but make the entry
+// unrecallable by deleting its vectors and tagging it status:deprecated.
+export async function deprecateEntry(id: string, env: Env): Promise<boolean> {
+  const row = await env.DB.prepare(
+    `SELECT tags, vector_ids FROM entries WHERE id = ?`
+  ).bind(id).first() as Record<string, any> | null;
+  if (!row) return false;
+
+  const tags: string[] = JSON.parse(row.tags ?? "[]");
+  const vectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
+
+  await env.DB.prepare(`UPDATE entries SET tags = ?, vector_ids = ? WHERE id = ?`)
+    .bind(JSON.stringify(withStatus(tags, "deprecated")), "[]", id).run();
+
+  try {
+    if (vectorIds.length) await env.VECTORIZE.deleteByIds(vectorIds);
+  } catch (e) {
+    console.error("Vectorize deleteByIds failed during deprecate (non-fatal):", e);
+  }
+  return true;
+}
+
 // ─── MCP Server ───────────────────────────────────────────────────────────────
 
 function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1080,7 +1080,7 @@ export async function recallEntries(
   const parentIds = deduped.map((m) => (m.metadata as any)?.parentId ?? m.id);
   const placeholders = parentIds.map(() => "?").join(", ");
   const d1Bindings: (string | number)[] = [...parentIds];
-  let d1Sql = `SELECT id, content, tags, source, created_at FROM entries WHERE id IN (${placeholders}) AND tags NOT LIKE '%"auto-pattern"%'`;
+  let d1Sql = `SELECT id, content, tags, source, created_at FROM entries WHERE id IN (${placeholders}) AND tags NOT LIKE '%"auto-pattern"%' AND tags NOT LIKE '%"status:deprecated"%'`;
   if (after !== undefined) { d1Sql += ` AND created_at >= ?`; d1Bindings.push(after); }
   if (before !== undefined) { d1Sql += ` AND created_at <= ?`; d1Bindings.push(before); }
   const { results: d1Rows } = await env.DB.prepare(d1Sql).bind(...d1Bindings).all() as { results: Record<string, any>[] };
@@ -1096,34 +1096,26 @@ export async function recallEntries(
     ).catch(e => console.error("recall_count update failed (non-fatal):", e))
   );
 
-  const matches: RecallMatch[] = deduped.map((m) => {
+  const matches: RecallMatch[] = deduped.flatMap((m) => {
     const meta = m.metadata as Record<string, any>;
     const parentId = (meta?.parentId ?? m.id) as string;
     const row = d1Map.get(parentId);
     const isUpdate = !!meta?.isUpdate;
 
-    if (row) {
-      return {
-        id: parentId,
-        content: row.content as string,
-        score: m.score,
-        createdAt: row.created_at as number,
-        tags: JSON.parse(row.tags ?? "[]"),
-        source: row.source as string,
-        isUpdate,
-      };
+    if (!row) {
+      // D1 row not found — either filtered out (e.g. status:deprecated) or genuinely missing
+      return [];
     }
 
-    // Fallback to metadata if D1 row not found (shouldn't happen)
-    return {
+    return [{
       id: parentId,
-      content: (meta?.content as string) ?? "",
+      content: row.content as string,
       score: m.score,
-      createdAt: (meta?.created_at as number) ?? now,
-      tags: Array.isArray(meta?.tags) ? (meta.tags as string[]) : [],
-      source: (meta?.source as string) ?? "",
+      createdAt: row.created_at as number,
+      tags: JSON.parse(row.tags ?? "[]"),
+      source: row.source as string,
       isUpdate,
-    };
+    }];
   });
 
   const insight = d1Rows.length > 1

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ const CHUNK_OVERLAP_CHARS = 200;
 
 // ─── Token limits ─────────────────────────────────────────────────────────────
 
+const CLASSIFY_MAX_TOKENS = 30;
 const CONTRADICTION_MAX_TOKENS = 80;
 const SMART_MERGE_MAX_TOKENS = 250;
 const INSIGHT_MAX_TOKENS = 300;
@@ -521,22 +522,34 @@ export function parseTimePhrase(query: string, now: number): { after?: number; b
   return { cleanQuery: query };
 }
 
-// ─── AI importance scoring ────────────────────────────────────────────────────
+// ─── AI classification (importance + canonical) ───────────────────────────────
 
-async function scoreImportance(content: string, env: Env): Promise<number> {
+export async function classifyEntry(content: string, env: Env): Promise<{ importance: number; canonical: boolean }> {
+  let text: string;
   try {
     const stream = await env.AI.run(LLM_MODEL as any, {
-      messages: [{
-        role: "user", content:
-          `Rate the long-term importance of this memory 1-5. Reply with only a single digit.\n1=trivial 3=useful context 5=critical decision or goal\n\nMemory: ${content.slice(0, 500)}`
+      messages: [{ role: "user", content:
+        `Analyze this memory and reply with ONLY JSON.\n` +
+        `1) "importance": long-term importance 1-5 (1=trivial, 3=useful context, 5=critical decision or goal).\n` +
+        `2) "canonical": true ONLY if this is a confirmed decision, durable fact, or stated permanent preference that should be authoritative and protected from being overwritten. Be conservative — false for anything tentative, one-off, time-bound, or event-like.\n` +
+        `JSON shape: {"importance": <1-5>, "canonical": <true|false>}\n\nMemory: ${content.slice(0, 500)}`,
       }],
+      max_tokens: CLASSIFY_MAX_TOKENS,
       stream: true,
     });
-    const text = await readStreamText(stream as ReadableStream);
-    const score = parseInt(text.trim(), 10);
-    return score >= 1 && score <= 5 ? score : 3;
+    text = await readStreamText(stream as ReadableStream);
   } catch {
-    return 0;
+    return { importance: 0, canonical: false }; // call/stream failure — hard sentinel
+  }
+  const json = text.match(/\{[^{}]*\}/);
+  if (!json) return { importance: 3, canonical: false };
+  try {
+    const parsed = JSON.parse(json[0]);
+    const importance = parsed.importance >= 1 && parsed.importance <= 5 ? parsed.importance : 3;
+    const canonical = parsed.canonical === true;
+    return { importance, canonical };
+  } catch {
+    return { importance: 3, canonical: false }; // unparseable model output — soft default
   }
 }
 
@@ -1218,9 +1231,18 @@ export async function captureEntry(
   );
 
   ctx.waitUntil(
-    scoreImportance(c, env)
-      .then(score => env.DB.prepare(`UPDATE entries SET importance_score = ? WHERE id = ?`).bind(score, id).run())
-      .catch(e => console.error("Importance scoring failed (non-fatal):", e))
+    classifyEntry(c, env)
+      .then(async ({ importance, canonical }) => {
+        await env.DB.prepare(`UPDATE entries SET importance_score = ? WHERE id = ?`).bind(importance, id).run();
+        if (!canonical) return;
+        const row = await env.DB.prepare(`SELECT tags FROM entries WHERE id = ?`).bind(id).first() as Record<string, any> | null;
+        if (!row) return;
+        const current: string[] = JSON.parse(row.tags ?? "[]");
+        if (getStatus(current) !== null) return; // don't override draft/deprecated/canonical already set
+        await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`)
+          .bind(JSON.stringify(withStatus(current, "canonical")), id).run();
+      })
+      .catch(e => console.error("Classification failed (non-fatal):", e))
   );
 
   if (contradiction.detected && contradiction.conflicting_id) {

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -30,6 +30,12 @@ export class D1Mock {
           if (row) row.vector_ids = vector_ids;
           return { meta: { changes: row ? 1 : 0 } };
         }
+        if (s.startsWith("UPDATE entries SET tags = ? WHERE id")) {
+          const [tags, id] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row) row.tags = tags;
+          return { meta: { changes: row ? 1 : 0 } };
+        }
         if (s.startsWith("UPDATE entries SET content = ?, tags")) {
           const [content, tags, id] = args;
           const row = db.entries.find((e: any) => e.id === id);

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -18,6 +18,12 @@ export class D1Mock {
           if (row) { row.content = content; row.vector_ids = vector_ids; }
           return { meta: { changes: row ? 1 : 0 } };
         }
+        if (s.startsWith("UPDATE entries SET tags = ?, vector_ids")) {
+          const [tags, vector_ids, id] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row) { row.tags = tags; row.vector_ids = vector_ids; }
+          return { meta: { changes: row ? 1 : 0 } };
+        }
         if (s.startsWith("UPDATE entries SET vector_ids")) {
           const [vector_ids, id] = args;
           const row = db.entries.find((e: any) => e.id === id);

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -158,9 +158,13 @@ export class D1Mock {
           const ids = args.slice(0, idCount);
           const rest = args.slice(idCount);
           let argIdx = 0;
-          let rows = db.entries.filter((e: any) =>
-            ids.includes(e.id) && !(JSON.parse(e.tags ?? "[]") as string[]).includes("auto-pattern")
-          );
+          let rows = db.entries.filter((e: any) => {
+            const tags: string[] = JSON.parse(e.tags ?? "[]");
+            if (!ids.includes(e.id)) return false;
+            if (tags.includes("auto-pattern")) return false;
+            if (s.includes('"status:deprecated"') && tags.includes("status:deprecated")) return false;
+            return true;
+          });
           if (s.includes("created_at >= ?")) {
             const after = Number(rest[argIdx++]);
             rows = rows.filter((e: any) => e.created_at >= after);

--- a/test/integration/deprecate-entry.test.ts
+++ b/test/integration/deprecate-entry.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { deprecateEntry } from "../../src/index";
+import { makeTestEnv, makeTestDb, makeVectorizeMock } from "../helpers/make-env";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+describe("deprecateEntry()", () => {
+  let db: D1Mock;
+  let env: Env;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let deleteByIdsMock: any;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({ deleteByIds: deleteByIdsMock }),
+    });
+  });
+
+  it("returns true, keeps D1 row, updates tags and vector_ids, calls Vectorize deleteByIds", async () => {
+    db.entries.push({
+      id: "entry-1",
+      content: "Some important work content",
+      tags: JSON.stringify(["work", "status:canonical"]),
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: JSON.stringify(["v1", "v2"]),
+    });
+
+    const result = await deprecateEntry("entry-1", env);
+
+    expect(result).toBe(true);
+
+    // Row must still exist
+    const row = db.entries.find((e: any) => e.id === "entry-1");
+    expect(row).toBeDefined();
+
+    // Tags: must contain status:deprecated, must NOT contain status:canonical
+    const tags: string[] = JSON.parse(row.tags);
+    expect(tags).toContain("status:deprecated");
+    expect(tags).not.toContain("status:canonical");
+
+    // vector_ids must be cleared
+    expect(row.vector_ids).toBe("[]");
+
+    // Vectorize deleteByIds must have been called with the original vector IDs
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["v1", "v2"]);
+  });
+
+  it("returns false for a missing id", async () => {
+    const result = await deprecateEntry("missing-id", env);
+    expect(result).toBe(false);
+    expect(deleteByIdsMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/integration/recall.test.ts
+++ b/test/integration/recall.test.ts
@@ -308,6 +308,27 @@ describe("GET /recall", () => {
     expect(llmCalls).toHaveLength(0);
   });
 
+  it("excludes status:deprecated entries from recall results", async () => {
+    db.entries.push(
+      { id: "entry-active", content: "Active memory", tags: '["work"]', source: "api", created_at: 1000, vector_ids: '["entry-active"]', recall_count: 0, importance_score: 0 },
+      { id: "entry-deprecated", content: "Deprecated memory", tags: '["work","status:deprecated"]', source: "api", created_at: 2000, vector_ids: '["entry-deprecated"]', recall_count: 0, importance_score: 0 },
+    );
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [makeMatch("entry-active", 0.9), makeMatch("entry-deprecated", 0.85)],
+        }),
+      }),
+    });
+
+    const res = await worker.fetch(req("GET", "/recall?query=memory"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].id).toBe("entry-active");
+  });
+
   it("query with no matching keywords exercises the LLM fallback for tag inference", async () => {
     db.entries.push(
       { id: "entry-1", content: "Office lease renewal", tags: '["work"]', source: "api", created_at: 1000, vector_ids: '["entry-1"]', recall_count: 0, importance_score: 0 },

--- a/test/integration/set-status.test.ts
+++ b/test/integration/set-status.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { applyStatus } from "../../src/index";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb, makeVectorizeMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+describe("applyStatus()", () => {
+  let db: D1Mock;
+  let env: Env;
+  let deleteByIdsMock: any;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({ deleteByIds: deleteByIdsMock }),
+    });
+
+    db.entries.push({
+      id: "entry-1",
+      content: "Some important work content",
+      tags: JSON.stringify(["work"]),
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: JSON.stringify(["v1"]),
+    });
+  });
+
+  it("canonical: returns true, sets status:canonical tag, vectors untouched", async () => {
+    const result = await applyStatus("entry-1", "canonical", env);
+    expect(result).toBe(true);
+
+    const row = db.entries.find((e: any) => e.id === "entry-1");
+    const tags: string[] = JSON.parse(row.tags);
+    expect(tags).toContain("status:canonical");
+    expect(row.vector_ids).toBe(JSON.stringify(["v1"]));
+    expect(deleteByIdsMock).not.toHaveBeenCalled();
+  });
+
+  it("draft: replaces status:canonical with status:draft (only one status tag)", async () => {
+    // First set to canonical
+    await applyStatus("entry-1", "canonical", env);
+
+    // Now set to draft
+    const result = await applyStatus("entry-1", "draft", env);
+    expect(result).toBe(true);
+
+    const row = db.entries.find((e: any) => e.id === "entry-1");
+    const tags: string[] = JSON.parse(row.tags);
+    expect(tags).toContain("status:draft");
+    expect(tags).not.toContain("status:canonical");
+    // Only one status tag
+    const statusTags = tags.filter((t: string) => t.startsWith("status:"));
+    expect(statusTags).toHaveLength(1);
+  });
+
+  it("deprecated: deletes vectors, clears vector_ids, sets status:deprecated", async () => {
+    const result = await applyStatus("entry-1", "deprecated", env);
+    expect(result).toBe(true);
+
+    const row = db.entries.find((e: any) => e.id === "entry-1");
+    const tags: string[] = JSON.parse(row.tags);
+    expect(tags).toContain("status:deprecated");
+    expect(row.vector_ids).toBe("[]");
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["v1"]);
+  });
+
+  it("returns false for a missing id", async () => {
+    const result = await applyStatus("missing-id", "canonical", env);
+    expect(result).toBe(false);
+  });
+});
+
+describe("POST /status", () => {
+  let db: D1Mock;
+  let env: Env;
+  let deleteByIdsMock: any;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({ deleteByIds: deleteByIdsMock }),
+    });
+
+    db.entries.push({
+      id: "entry-1",
+      content: "Some work content",
+      tags: JSON.stringify(["work"]),
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: JSON.stringify(["v1"]),
+    });
+  });
+
+  it("valid {id, status} applies the change and returns success", async () => {
+    const res = await worker.fetch(
+      req("POST", "/status", { body: { id: "entry-1", status: "canonical" } }),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.status).toBe("canonical");
+
+    const row = db.entries.find((e: any) => e.id === "entry-1");
+    const tags: string[] = JSON.parse(row.tags);
+    expect(tags).toContain("status:canonical");
+  });
+
+  it("invalid status returns 400 and makes no change", async () => {
+    const res = await worker.fetch(
+      req("POST", "/status", { body: { id: "entry-1", status: "bogus" } }),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(false);
+    expect(data.error).toBeDefined();
+
+    // Tags should be unchanged
+    const row = db.entries.find((e: any) => e.id === "entry-1");
+    const tags: string[] = JSON.parse(row.tags);
+    expect(tags).not.toContain("status:bogus");
+    expect(tags.filter((t: string) => t.startsWith("status:"))).toHaveLength(0);
+  });
+
+  it("returns 404-style error when id does not exist", async () => {
+    const res = await worker.fetch(
+      req("POST", "/status", { body: { id: "no-such-id", status: "draft" } }),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(404);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(false);
+    expect(data.error).toBeDefined();
+  });
+
+  it("missing id returns 400 with ok:false and id is required error", async () => {
+    const res = await worker.fetch(
+      req("POST", "/status", { body: { status: "canonical" } }),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(false);
+    expect(data.error).toBe("id is required");
+  });
+
+  it("deprecated via route: deletes vectors, clears vector_ids, sets status:deprecated tag", async () => {
+    const res = await worker.fetch(
+      req("POST", "/status", { body: { id: "entry-1", status: "deprecated" } }),
+      env,
+      ctx
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+
+    const row = db.entries.find((e: any) => e.id === "entry-1");
+    expect(row.vector_ids).toBe("[]");
+    const tags: string[] = JSON.parse(row.tags);
+    expect(tags).toContain("status:deprecated");
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["v1"]);
+  });
+});

--- a/test/integration/smart-merge.test.ts
+++ b/test/integration/smart-merge.test.ts
@@ -288,6 +288,50 @@ describe("POST /capture — smart merge (flagged band 0.85–0.95)", () => {
     expect(data.action).toBe("merged");
   });
 
+  // ── Canonical guard ───────────────────────────────────────────────────────────
+
+  it("replace: canonical target is NOT overwritten; new entry stored with status=flagged", async () => {
+    // importance_score=2 so the existing importance guard (>=4) would NOT fire.
+    // Only the new canonical guard should prevent overwrite.
+    db.entries.push({
+      id: "canonical-id",
+      content: "Canonical source of truth",
+      tags: '["work","status:canonical"]',
+      source: "api",
+      created_at: Date.now() - 1000,
+      vector_ids: '["canonical-id"]',
+      recall_count: 0,
+      importance_score: 2,
+    });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "canonical-id", score: 0.88, metadata: { parentId: "canonical-id" } }],
+        }),
+      }),
+      AI: makeMergeAI('{"action":"replace","target_id":"canonical-id"}'),
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/capture", { body: { content: "Replacement attempt" } }),
+      env, ctx
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    // Result is flagged (not replaced) — HTTP response uses warning:"similar"
+    expect(data.warning).toBe("similar");
+
+    // Canonical entry content must be unchanged — NOT overwritten
+    const canonical = db.entries.find((e: any) => e.id === "canonical-id");
+    expect(canonical?.content).toBe("Canonical source of truth");
+
+    // No new entry was inserted — the early-return guard returns a synthetic ID
+    // without persisting to DB (mirrors importance guard behaviour)
+    expect(db.entries).toHaveLength(1);
+  });
+
   // ── Existing functionality unaffected ─────────────────────────────────────────
 
   it("blocked (≥0.95): still blocked, no LLM call for merge", async () => {

--- a/test/integration/smart-merge.test.ts
+++ b/test/integration/smart-merge.test.ts
@@ -215,13 +215,15 @@ describe("POST /capture — smart merge (flagged band 0.85–0.95)", () => {
 
   // ── Contradiction via combined prompt ─────────────────────────────────────────
 
-  it("contradiction detected via combined prompt in flagged band — new entry stored, conflicting removed", async () => {
+  it("contradiction detected via combined prompt in flagged band — new entry stored, conflicting DEPRECATED (not deleted)", async () => {
     seedEntry(db, "old-id", "I live in NYC");
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({
         query: vi.fn().mockResolvedValue({
           matches: [{ id: "old-id", score: 0.88, metadata: { parentId: "old-id" } }],
         }),
+        deleteByIds: deleteByIdsMock,
       }),
       AI: makeMergeAI('{"action":"contradiction","conflicting_id":"old-id","reason":"different city"}'),
     });
@@ -235,8 +237,16 @@ describe("POST /capture — smart merge (flagged band 0.85–0.95)", () => {
     expect(data.ok).toBe(true);
     expect(data.resolved_conflict).toBe("old-id");
     expect(data.reason).toBe("different city");
-    expect(db.entries.some((e: any) => e.id === "old-id")).toBe(false);
-    expect(db.entries).toHaveLength(1);
+    // Conflicting row is deprecated (kept in D1), not deleted
+    const conflictRow = db.entries.find((e: any) => e.id === "old-id");
+    expect(conflictRow).toBeDefined();
+    const conflictTags: string[] = JSON.parse(conflictRow!.tags);
+    expect(conflictTags).toContain("status:deprecated");
+    expect(conflictRow!.vector_ids).toBe("[]");
+    // Vectors deleted from Vectorize
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["existing-id"]);
+    // New entry also stored (total: old deprecated + new = 2)
+    expect(db.entries).toHaveLength(2);
   });
 
   // ── Non-fatal error handling ──────────────────────────────────────────────────

--- a/test/unit/capture-entry.test.ts
+++ b/test/unit/capture-entry.test.ts
@@ -145,23 +145,25 @@ describe("captureEntry()", () => {
 
   // ── Contradiction ───────────────────────────────────────────────────────────
 
-  it("returns status=contradiction, stores new entry, and removes conflicting entry", async () => {
+  it("returns status=contradiction, stores new entry, and DEPRECATES (not deletes) the conflicting entry", async () => {
     db.entries.push({
       id: "old-entry",
       content: "I live in NYC",
       tags: "[]",
       source: "api",
       created_at: Date.now(),
-      vector_ids: "[]",
+      vector_ids: '["old-vec-1","old-vec-2"]',
       recall_count: 0,
       importance_score: 0,
     });
 
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({
         query: vi.fn().mockResolvedValue({
           matches: [{ id: "old-entry", score: 0.72, metadata: { parentId: "old-entry" } }],
         }),
+        deleteByIds: deleteByIdsMock,
       }),
       AI: makeContradictionAI('{"contradicts": true, "conflicting_id": "old-entry", "reason": "different city"}'),
     });
@@ -175,9 +177,66 @@ describe("captureEntry()", () => {
     expect(result.reason).toBe("different city");
     expect(typeof result.id).toBe("string");
 
-    // New entry stored, conflicting entry removed
+    // New entry stored
     expect(db.entries.some(e => e.id === result.id)).toBe(true);
-    expect(db.entries.some(e => e.id === "old-entry")).toBe(false);
+    // Conflicting entry row STILL EXISTS (deprecated, not deleted)
+    const conflictRow = db.entries.find(e => e.id === "old-entry");
+    expect(conflictRow).toBeDefined();
+    const conflictTags: string[] = JSON.parse(conflictRow!.tags);
+    expect(conflictTags).toContain("status:deprecated");
+    // Vectors cleared from D1 row
+    expect(conflictRow!.vector_ids).toBe("[]");
+    // Vectorize deleteByIds called with old vector ids
+    expect(deleteByIdsMock).toHaveBeenCalledWith(["old-vec-1", "old-vec-2"]);
+  });
+
+  it("returns status=contradiction_protected when conflicting entry is canonical — keeps canonical, demotes new to draft", async () => {
+    db.entries.push({
+      id: "canonical-entry",
+      content: "I live in NYC",
+      tags: '["status:canonical"]',
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: '["canonical-vec-1"]',
+      recall_count: 0,
+      importance_score: 0,
+    });
+
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "canonical-entry", score: 0.72, metadata: { parentId: "canonical-entry" } }],
+        }),
+        deleteByIds: deleteByIdsMock,
+      }),
+      AI: makeContradictionAI('{"contradicts": true, "conflicting_id": "canonical-entry", "reason": "different city"}'),
+    });
+
+    const { ctx } = makeCtx();
+    const result = await captureEntry("I moved to LA", [], "api", env, ctx);
+
+    expect(result.status).toBe("contradiction_protected");
+    if (result.status !== "contradiction_protected") return;
+    expect(result.id).toBeDefined();
+    expect(result.canonicalId).toBe("canonical-entry");
+    expect(result.reason).toBe("different city");
+
+    // Canonical entry is UNCHANGED
+    const canonicalRow = db.entries.find(e => e.id === "canonical-entry");
+    expect(canonicalRow).toBeDefined();
+    const canonicalTags: string[] = JSON.parse(canonicalRow!.tags);
+    expect(canonicalTags).toContain("status:canonical");
+    expect(canonicalRow!.vector_ids).toBe('["canonical-vec-1"]');
+    // deleteByIds NOT called on canonical vectors
+    expect(deleteByIdsMock).not.toHaveBeenCalled();
+
+    // New entry stored as draft
+    const newRow = db.entries.find(e => e.id === result.id);
+    expect(newRow).toBeDefined();
+    const newTags: string[] = JSON.parse(newRow!.tags);
+    expect(newTags).toContain("status:draft");
+    expect(newTags).not.toContain("contradiction-resolved");
   });
 
   it("adds contradiction-resolved tag when contradiction detected", async () => {

--- a/test/unit/capture-entry.test.ts
+++ b/test/unit/capture-entry.test.ts
@@ -429,6 +429,125 @@ describe("captureEntry()", () => {
     expect(db.entries[0].importance_score).toBeGreaterThanOrEqual(1);
   });
 
+  // ── Canonical auto-tagging ──────────────────────────────────────────────────
+
+  it("promotes entry to status:canonical when classifyEntry returns canonical:true", async () => {
+    function makeSseStream(response: string) {
+      return new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+          c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+          c.close();
+        },
+      });
+    }
+    env = makeTestEnv(db, {
+      AI: {
+        run: vi.fn().mockImplementation(async (model: string) => {
+          if (model === "@cf/baai/bge-small-en-v1.5")
+            return { data: [new Array(384).fill(0.1)] };
+          return makeSseStream('{"importance":5,"canonical":true}');
+        }),
+      } as unknown as Ai,
+    });
+    const { ctx, drain } = makeCtx();
+    const result = await captureEntry("I will always prefer TypeScript over JavaScript", [], "api", env, ctx);
+    expect(result.status).toBe("stored");
+    await drain();
+    const tags: string[] = JSON.parse(db.entries[0].tags);
+    expect(tags).toContain("status:canonical");
+  });
+
+  it("does NOT add status: tag when classifyEntry returns canonical:false", async () => {
+    function makeSseStream(response: string) {
+      return new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+          c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+          c.close();
+        },
+      });
+    }
+    env = makeTestEnv(db, {
+      AI: {
+        run: vi.fn().mockImplementation(async (model: string) => {
+          if (model === "@cf/baai/bge-small-en-v1.5")
+            return { data: [new Array(384).fill(0.1)] };
+          return makeSseStream('{"importance":2,"canonical":false}');
+        }),
+      } as unknown as Ai,
+    });
+    const { ctx, drain } = makeCtx();
+    const result = await captureEntry("Had a nice lunch today", [], "api", env, ctx);
+    expect(result.status).toBe("stored");
+    await drain();
+    const tags: string[] = JSON.parse(db.entries[0].tags);
+    const hasStatusTag = tags.some(t => t.startsWith("status:"));
+    expect(hasStatusTag).toBe(false);
+  });
+
+  // ── Re-read guard: status:draft blocks canonical auto-promotion ─────────────
+
+  it("does NOT overwrite status:draft with status:canonical when classifier returns canonical:true", async () => {
+    // Arrange: a canonical conflicting entry so the new entry is demoted to draft
+    // before the async classify promise drains.
+    db.entries.push({
+      id: "canonical-conflict",
+      content: "I live in NYC",
+      tags: '["status:canonical"]',
+      source: "api",
+      created_at: Date.now(),
+      vector_ids: '["canonical-vec"]',
+      recall_count: 0,
+      importance_score: 5,
+    });
+
+    // AI always returns canonical:true for the classification call, and the
+    // contradiction-check JSON for the smart-merge call.
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "canonical-conflict", score: 0.72, metadata: { parentId: "canonical-conflict" } }],
+        }),
+      }),
+      AI: {
+        run: vi.fn().mockImplementation(async (model: string) => {
+          if (model === "@cf/baai/bge-small-en-v1.5")
+            return { data: [new Array(384).fill(0.1)] };
+          // Both the smart-merge/contradiction call and the classify call get this
+          // stream. The contradiction handler parses "contradicts/conflicting_id";
+          // the classify handler parses "importance/canonical". Returning a JSON
+          // object that satisfies both decoders lets a single mock serve both calls.
+          return new ReadableStream({
+            start(c) {
+              const payload = '{"contradicts":true,"conflicting_id":"canonical-conflict","reason":"different city","importance":5,"canonical":true}';
+              c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(payload)}}\n\n`));
+              c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+              c.close();
+            },
+          });
+        }),
+      } as unknown as Ai,
+    });
+
+    const { ctx, drain } = makeCtx();
+    const result = await captureEntry("I moved to LA", [], "api", env, ctx);
+
+    // The capture itself must be contradiction_protected — new entry is stored as draft
+    expect(result.status).toBe("contradiction_protected");
+    if (result.status !== "contradiction_protected") return;
+
+    // Drain all async work including the classify waitUntil
+    await drain();
+
+    // Re-read guard: status:draft must be preserved — NOT overwritten to canonical
+    const newRow = db.entries.find(e => e.id === result.id);
+    expect(newRow).toBeDefined();
+    const tags: string[] = JSON.parse(newRow!.tags);
+    expect(tags).toContain("status:draft");
+    expect(tags).not.toContain("status:canonical");
+  });
+
   // ── Non-fatal error handling ────────────────────────────────────────────────
 
   it("stores to D1 and returns stored even when Vectorize insert throws", async () => {

--- a/test/unit/classify-entry.test.ts
+++ b/test/unit/classify-entry.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { classifyEntry } from "../../src/index";
+import { makeTestDb, makeTestEnv } from "../helpers/make-env";
+import type { Env } from "../../src/index";
+
+function makeSseStream(response: string) {
+  return new ReadableStream({
+    start(c) {
+      c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+      c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+      c.close();
+    },
+  });
+}
+
+function makeClassifyAI(response: string | null = null, shouldThrow = false) {
+  return {
+    run: vi.fn().mockImplementation(async (model: string) => {
+      if (model === "@cf/baai/bge-small-en-v1.5")
+        return { data: [new Array(384).fill(0.1)] };
+      if (shouldThrow) throw new Error("AI failure");
+      return makeSseStream(response ?? "");
+    }),
+  } as unknown as Ai;
+}
+
+describe("classifyEntry()", () => {
+  it('parses {"importance":5,"canonical":true} correctly', async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance":5,"canonical":true}'),
+    });
+    const result = await classifyEntry("I decided to quit my job and start a company", env);
+    expect(result).toEqual({ importance: 5, canonical: true });
+  });
+
+  it('parses {"importance":2,"canonical":false} correctly', async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance":2,"canonical":false}'),
+    });
+    const result = await classifyEntry("Had coffee this morning", env);
+    expect(result).toEqual({ importance: 2, canonical: false });
+  });
+
+  it("falls back to { importance: 3, canonical: false } when LLM returns unparseable text", async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI("sorry I cannot help with that"),
+    });
+    const result = await classifyEntry("Some memory", env);
+    expect(result).toEqual({ importance: 3, canonical: false });
+  });
+
+  it("falls back to { importance: 0, canonical: false } when env.AI.run throws", async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI(null, true),
+    });
+    const result = await classifyEntry("Some memory", env);
+    expect(result).toEqual({ importance: 0, canonical: false });
+  });
+});

--- a/test/unit/derive-pattern.test.ts
+++ b/test/unit/derive-pattern.test.ts
@@ -4,7 +4,7 @@ import { makeTestDb, makeTestEnv } from "../helpers/make-env";
 import { D1Mock } from "../helpers/d1-mock";
 import type { Env } from "../../src/index";
 
-// SSE stream helper — used by scoreImportance (streaming) inside captureEntry
+// SSE stream helper — used by classifyEntry (streaming) inside captureEntry
 function makeSseStream(response: string) {
   return new ReadableStream({
     start(c) {
@@ -17,7 +17,7 @@ function makeSseStream(response: string) {
 
 // AI mock that handles:
 //   - EMBEDDING_MODEL calls → vector data
-//   - streaming LLM calls (scoreImportance inside captureEntry) → SSE stream
+//   - streaming LLM calls (classifyEntry inside captureEntry) → SSE stream
 //   - non-streaming LLM call (derivePattern itself) → { response: string }
 function makePatternAI(patternResponse: string | null = "You tend to work in short focused bursts") {
   return {

--- a/test/unit/status-tags.test.ts
+++ b/test/unit/status-tags.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { getStatus, withStatus, STATUS_VALUES } from "../../src/index";
+
+describe("status tags", () => {
+  describe("getStatus", () => {
+    it("returns null for empty tags array", () => {
+      expect(getStatus([])).toBe(null);
+    });
+
+    it("extracts status from mixed tags", () => {
+      expect(getStatus(["work", "status:canonical"])).toBe("canonical");
+    });
+
+    it("returns null for unknown status values", () => {
+      expect(getStatus(["status:bogus"])).toBe(null);
+    });
+  });
+
+  describe("withStatus", () => {
+    it("adds status tag to tags array", () => {
+      expect(withStatus(["work"], "draft")).toEqual(["work", "status:draft"]);
+    });
+
+    it("replaces existing status tag without duplicating", () => {
+      expect(withStatus(["status:draft", "work"], "deprecated")).toEqual([
+        "work",
+        "status:deprecated",
+      ]);
+    });
+  });
+
+  describe("STATUS_VALUES", () => {
+    it("exports valid status values", () => {
+      expect(STATUS_VALUES).toEqual(["canonical", "draft", "deprecated"]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds a lifecycle **status** to every memory — `canonical`, `draft`, `deprecated` — so an authoritative memory isn't silently overwritten or deleted by a newer, lower-quality one. Implemented entirely as a reserved `status:<value>` **tag** on the existing `entries.tags` column — **no DB schema change, zero migration** for existing one-click-deploy / fork / clone installs.

- **Auto + manual:** `canonical` is auto-assigned at capture by the existing importance classifier (renamed `scoreImportance` → `classifyEntry`, now returns `{importance, canonical}` from one LLM call, conservative). Manual override via a new `set_status` MCP tool + `POST /status` (MCP↔REST parity).
- **Conflict resolution honors status:** the smart-merge replace/merge path and the contradiction path both refuse to clobber a `canonical` entry. On a contradiction, a non-canonical loser is now **deprecated (vectors deleted, D1 row kept for audit)** instead of hard-deleted; if the loser is canonical, the *new* entry is demoted to `draft` (`contradiction_protected`).
- **Recall excludes `deprecated`** (D1 filter + dropped the stale Vectorize-metadata fallback that could otherwise resurface a filtered entry).
- Absent status = today's behavior (the common default), so existing memories and the merge pipeline are unaffected.

## Design notes
- Back-catalog backfill for existing entries is intentionally deferred to #145 (shared with #12's `kind`).
- **Reviewer note (pre-existing behavior, not introduced here):** when a near-duplicate is blocked from overwriting a protected (canonical / importance≥4) entry, the *new* near-duplicate is dropped rather than stored separately — mirrors the existing importance-guard behavior. Worth revisiting separately if undesired.

## Test plan
- [x] `npm test` — 341 passing (was 314 baseline), 33 files
- [x] `npm run typecheck` — clean
- [x] No change to `entries` schema / `db/schema.sql`
- [x] Manual smoke on `wrangler dev --remote`: auto-canonical on a clear decision; `set_status`; canonical survives a contradicting capture (new → draft); `deprecated` hidden from recall but present via `list_recent`

Closes #119
