### PR TITLE
feat: episodic vs semantic memory classification (#12)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ const CHUNK_OVERLAP_CHARS = 200;
 
 // ─── Token limits ─────────────────────────────────────────────────────────────
 
-const CLASSIFY_MAX_TOKENS = 30;
+const CLASSIFY_MAX_TOKENS = 45;
 const CONTRADICTION_MAX_TOKENS = 80;
 const SMART_MERGE_MAX_TOKENS = 250;
 const INSIGHT_MAX_TOKENS = 300;
@@ -544,7 +544,7 @@ export function parseTimePhrase(query: string, now: number): { after?: number; b
 
 // ─── AI classification (importance + canonical) ───────────────────────────────
 
-export async function classifyEntry(content: string, env: Env): Promise<{ importance: number; canonical: boolean }> {
+export async function classifyEntry(content: string, env: Env): Promise<{ importance: number; canonical: boolean; kind: MemoryKind | null }> {
   let text: string;
   try {
     const stream = await env.AI.run(LLM_MODEL as any, {
@@ -552,24 +552,26 @@ export async function classifyEntry(content: string, env: Env): Promise<{ import
         `Analyze this memory and reply with ONLY JSON.\n` +
         `1) "importance": long-term importance 1-5 (1=trivial, 3=useful context, 5=critical decision or goal).\n` +
         `2) "canonical": true ONLY if this is a confirmed decision, durable fact, or stated permanent preference that should be authoritative and protected from being overwritten. Be conservative — false for anything tentative, one-off, time-bound, or event-like.\n` +
-        `JSON shape: {"importance": <1-5>, "canonical": <true|false>}\n\nMemory: ${content.slice(0, 500)}`,
+        `3) "kind": "episodic" for a specific event/decision/milestone that happened at a point in time; "semantic" for a general fact, preference, or piece of knowledge.\n` +
+        `JSON shape: {"importance": <1-5>, "canonical": <true|false>, "kind": "episodic"|"semantic"}\n\nMemory: ${content.slice(0, 500)}`,
       }],
       max_tokens: CLASSIFY_MAX_TOKENS,
       stream: true,
     });
     text = await readStreamText(stream as ReadableStream);
   } catch {
-    return { importance: 0, canonical: false }; // call/stream failure — hard sentinel
+    return { importance: 0, canonical: false, kind: null };
   }
   const json = text.match(/\{[^{}]*\}/);
-  if (!json) return { importance: 3, canonical: false };
+  if (!json) return { importance: 3, canonical: false, kind: null };
   try {
     const parsed = JSON.parse(json[0]);
     const importance = parsed.importance >= 1 && parsed.importance <= 5 ? parsed.importance : 3;
     const canonical = parsed.canonical === true;
-    return { importance, canonical };
+    const kind = (KIND_VALUES as readonly string[]).includes(parsed.kind) ? parsed.kind as MemoryKind : null;
+    return { importance, canonical, kind };
   } catch {
-    return { importance: 3, canonical: false }; // unparseable model output — soft default
+    return { importance: 3, canonical: false, kind: null };
   }
 }
 
@@ -1252,15 +1254,15 @@ export async function captureEntry(
 
   ctx.waitUntil(
     classifyEntry(c, env)
-      .then(async ({ importance, canonical }) => {
+      .then(async ({ importance, canonical, kind }) => {
         await env.DB.prepare(`UPDATE entries SET importance_score = ? WHERE id = ?`).bind(importance, id).run();
-        if (!canonical) return;
+        if (!kind && !canonical) return;
         const row = await env.DB.prepare(`SELECT tags FROM entries WHERE id = ?`).bind(id).first() as Record<string, any> | null;
         if (!row) return;
-        const current: string[] = JSON.parse(row.tags ?? "[]");
-        if (getStatus(current) !== null) return; // don't override draft/deprecated/canonical already set
-        await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`)
-          .bind(JSON.stringify(withStatus(current, "canonical")), id).run();
+        let tags: string[] = JSON.parse(row.tags ?? "[]");
+        if (kind) tags = withKind(tags, kind);
+        if (canonical && getStatus(tags) === null) tags = withStatus(tags, "canonical");
+        await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`).bind(JSON.stringify(tags), id).run();
       })
       .catch(e => console.error("Classification failed (non-fatal):", e))
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -554,6 +554,31 @@ function normalizeKind(raw: unknown): MemoryKind | null {
   return null;
 }
 
+// Parse the classifier's response. Tries strict JSON first, then falls back to
+// tolerant per-field extraction so one malformed field (small models intermittently
+// emit e.g. {"canonical":,}) doesn't discard the other valid fields.
+function parseClassification(text: string): { importance: number; canonical: boolean; kind: MemoryKind | null } {
+  const obj = text.match(/\{[^{}]*\}/);
+  if (obj) {
+    try {
+      const p = JSON.parse(obj[0]);
+      return {
+        importance: p.importance >= 1 && p.importance <= 5 ? p.importance : 3,
+        canonical: p.canonical === true,
+        kind: normalizeKind(p.kind),
+      };
+    } catch { /* fall through to tolerant extraction */ }
+  }
+  const imp = text.match(/"importance"\s*:\s*([1-5])/);
+  const can = text.match(/"canonical"\s*:\s*(true|false)/i);
+  const knd = text.match(/"kind"\s*:\s*"?([a-zA-Z]+)/);
+  return {
+    importance: imp ? parseInt(imp[1], 10) : 3,
+    canonical: can ? can[1].toLowerCase() === "true" : false,
+    kind: knd ? normalizeKind(knd[1]) : null,
+  };
+}
+
 export async function classifyEntry(content: string, env: Env): Promise<{ importance: number; canonical: boolean; kind: MemoryKind | null }> {
   let text: string;
   try {
@@ -573,17 +598,7 @@ export async function classifyEntry(content: string, env: Env): Promise<{ import
   } catch {
     return { importance: 0, canonical: false, kind: null };
   }
-  const json = text.match(/\{[^{}]*\}/);
-  if (!json) return { importance: 3, canonical: false, kind: null };
-  try {
-    const parsed = JSON.parse(json[0]);
-    const importance = parsed.importance >= 1 && parsed.importance <= 5 ? parsed.importance : 3;
-    const canonical = parsed.canonical === true;
-    const kind = normalizeKind(parsed.kind);
-    return { importance, canonical, kind };
-  } catch {
-    return { importance: 3, canonical: false, kind: null };
-  }
+  return parseClassification(text);
 }
 
 // ─── Hashtag extraction ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ const CHUNK_OVERLAP_CHARS = 200;
 
 // ─── Token limits ─────────────────────────────────────────────────────────────
 
-const CLASSIFY_MAX_TOKENS = 45;
+const CLASSIFY_MAX_TOKENS = 80;
 const CONTRADICTION_MAX_TOKENS = 80;
 const SMART_MERGE_MAX_TOKENS = 250;
 const INSIGHT_MAX_TOKENS = 300;
@@ -544,16 +544,27 @@ export function parseTimePhrase(query: string, now: number): { after?: number; b
 
 // ─── AI classification (importance + canonical) ───────────────────────────────
 
+// Map the model's free-text kind to our enum — tolerant of case, whitespace, and
+// common synonyms a small model emits (e.g. "event" → episodic, "fact" → semantic).
+function normalizeKind(raw: unknown): MemoryKind | null {
+  if (typeof raw !== "string") return null;
+  const v = raw.trim().toLowerCase();
+  if (/episod|event|decision|milestone|occurrence/.test(v)) return "episodic";
+  if (/semantic|fact|preference|knowledge|belief/.test(v)) return "semantic";
+  return null;
+}
+
 export async function classifyEntry(content: string, env: Env): Promise<{ importance: number; canonical: boolean; kind: MemoryKind | null }> {
   let text: string;
   try {
     const stream = await env.AI.run(LLM_MODEL as any, {
       messages: [{ role: "user", content:
-        `Analyze this memory and reply with ONLY JSON.\n` +
-        `1) "importance": long-term importance 1-5 (1=trivial, 3=useful context, 5=critical decision or goal).\n` +
-        `2) "canonical": true ONLY if this is a confirmed decision, durable fact, or stated permanent preference that should be authoritative and protected from being overwritten. Be conservative — false for anything tentative, one-off, time-bound, or event-like.\n` +
-        `3) "kind": "episodic" for a specific event/decision/milestone that happened at a point in time; "semantic" for a general fact, preference, or piece of knowledge.\n` +
-        `JSON shape: {"importance": <1-5>, "canonical": <true|false>, "kind": "episodic"|"semantic"}\n\nMemory: ${content.slice(0, 500)}`,
+        `Classify this memory. Respond with ONLY one JSON object and nothing else — no prose, no markdown, no code fences.\n` +
+        `{"importance": <1-5>, "canonical": <true|false>, "kind": "episodic"|"semantic"}\n` +
+        `importance: 1=trivial, 3=useful context, 5=critical decision or goal.\n` +
+        `canonical: true ONLY for a confirmed decision, durable fact, or stated permanent preference that should be authoritative (be conservative; false for anything tentative, one-off, or event-like).\n` +
+        `kind: "episodic" for a specific event/decision/milestone that happened at a point in time; "semantic" for a general fact, preference, or piece of knowledge.\n\n` +
+        `Memory: ${content.slice(0, 500)}`,
       }],
       max_tokens: CLASSIFY_MAX_TOKENS,
       stream: true,
@@ -568,7 +579,7 @@ export async function classifyEntry(content: string, env: Env): Promise<{ import
     const parsed = JSON.parse(json[0]);
     const importance = parsed.importance >= 1 && parsed.importance <= 5 ? parsed.importance : 3;
     const canonical = parsed.canonical === true;
-    const kind = (KIND_VALUES as readonly string[]).includes(parsed.kind) ? parsed.kind as MemoryKind : null;
+    const kind = normalizeKind(parsed.kind);
     return { importance, canonical, kind };
   } catch {
     return { importance: 3, canonical: false, kind: null };

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,26 @@ export function withStatus(tags: string[], status: MemoryStatus): string[] {
   return [...cleaned, `${STATUS_PREFIX}${status}`];
 }
 
+// ─── Memory kind layer (issue #12) ──────────────────────────────────────────────
+// Kind lives as a reserved tag (e.g. "kind:episodic") on entries.tags — no schema
+// change. Absent kind = unknown (unclassified). Orthogonal to status (#119).
+
+export const KIND_VALUES = ["episodic", "semantic"] as const;
+export type MemoryKind = (typeof KIND_VALUES)[number];
+const KIND_PREFIX = "kind:";
+
+export function getKind(tags: string[]): MemoryKind | null {
+  const tag = tags.find(t => t.startsWith(KIND_PREFIX));
+  if (!tag) return null;
+  const value = tag.slice(KIND_PREFIX.length) as MemoryKind;
+  return (KIND_VALUES as readonly string[]).includes(value) ? value : null;
+}
+
+export function withKind(tags: string[], kind: MemoryKind): string[] {
+  const cleaned = tags.filter(t => !t.startsWith(KIND_PREFIX));
+  return [...cleaned, `${KIND_PREFIX}${kind}`];
+}
+
 // ─── Runtime state ────────────────────────────────────────────────────────────
 
 let dbReady = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1176,6 +1176,25 @@ export async function recallEntries(
 
 // ─── Shared write path ────────────────────────────────────────────────────────
 
+// Classify an entry's content (importance + canonical + kind) and apply the tags,
+// asynchronously. Used for both newly-inserted entries and smart-merge targets.
+function scheduleClassifyAndTag(entryId: string, content: string, env: Env, ctx: ExecutionContext): void {
+  ctx.waitUntil(
+    classifyEntry(content, env)
+      .then(async ({ importance, canonical, kind }) => {
+        await env.DB.prepare(`UPDATE entries SET importance_score = ? WHERE id = ?`).bind(importance, entryId).run();
+        if (!kind && !canonical) return;
+        const row = await env.DB.prepare(`SELECT tags FROM entries WHERE id = ?`).bind(entryId).first() as Record<string, any> | null;
+        if (!row) return;
+        let tags: string[] = JSON.parse(row.tags ?? "[]");
+        if (kind) tags = withKind(tags, kind);
+        if (canonical && getStatus(tags) === null) tags = withStatus(tags, "canonical");
+        await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`).bind(JSON.stringify(tags), entryId).run();
+      })
+      .catch(e => console.error("Classification failed (non-fatal):", e))
+  );
+}
+
 export type CaptureResult =
   | { status: "blocked"; matchId: string; score: number }
   | { status: "stored"; id: string }
@@ -1238,6 +1257,9 @@ export async function captureEntry(
         await deleteStaleVectors(env, oldVectorIds, newVectorIds);
       } catch (e) { console.error("Old vector cleanup failed (non-fatal):", e); }
 
+      // Re-classify the merged/replaced content — updates importance_score + kind (and canonical if warranted) on the target.
+      scheduleClassifyAndTag(targetId, newContent, env, ctx);
+
       return mergeAction.action === "merge"
         ? { status: "merged", id: targetId }
         : { status: "replaced", id: targetId };
@@ -1259,20 +1281,7 @@ export async function captureEntry(
       .catch(e => console.error("Vectorize insert failed (non-fatal):", e))
   );
 
-  ctx.waitUntil(
-    classifyEntry(c, env)
-      .then(async ({ importance, canonical, kind }) => {
-        await env.DB.prepare(`UPDATE entries SET importance_score = ? WHERE id = ?`).bind(importance, id).run();
-        if (!kind && !canonical) return;
-        const row = await env.DB.prepare(`SELECT tags FROM entries WHERE id = ?`).bind(id).first() as Record<string, any> | null;
-        if (!row) return;
-        let tags: string[] = JSON.parse(row.tags ?? "[]");
-        if (kind) tags = withKind(tags, kind);
-        if (canonical && getStatus(tags) === null) tags = withStatus(tags, "canonical");
-        await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`).bind(JSON.stringify(tags), id).run();
-      })
-      .catch(e => console.error("Classification failed (non-fatal):", e))
-  );
+  scheduleClassifyAndTag(id, c, env, ctx);
 
   if (contradiction.detected && contradiction.conflicting_id) {
     const conflictId = contradiction.conflicting_id;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1016,12 +1016,12 @@ export interface RecallSearchResult {
 }
 
 export async function recallEntries(
-  params: { query: string; topK: number; tag?: string; after?: number; before?: number },
+  params: { query: string; topK: number; tag?: string; after?: number; before?: number; kind?: MemoryKind },
   env: Env,
   ctx: ExecutionContext
 ): Promise<RecallSearchResult> {
   const { query, topK } = params;
-  let { tag, after, before } = params;
+  let { tag, after, before, kind } = params;
   const now = Date.now();
 
   let embedQuery = query;
@@ -1111,11 +1111,18 @@ export async function recallEntries(
 
   if (!deduped.length) return { matches: [], insight: "" };
 
-  // Fetch full content from D1 for all matched parent IDs, applying time filter if set
+  // Fetch full content from D1 for all matched parent IDs, applying filters: auto-pattern
+  // exclusion, status:deprecated exclusion, optional kind match, and optional after/before range
   const parentIds = deduped.map((m) => (m.metadata as any)?.parentId ?? m.id);
   const placeholders = parentIds.map(() => "?").join(", ");
   const d1Bindings: (string | number)[] = [...parentIds];
   let d1Sql = `SELECT id, content, tags, source, created_at FROM entries WHERE id IN (${placeholders}) AND tags NOT LIKE '%"auto-pattern"%' AND tags NOT LIKE '%"status:deprecated"%'`;
+  if (kind && (KIND_VALUES as readonly string[]).includes(kind)) {
+    // Safe to interpolate: `kind` is validated against the KIND_VALUES enum just above,
+    // so only "episodic"/"semantic" can reach the string. Kept as a literal (not a bound
+    // param) so it doesn't shift the positional after/before bindings below.
+    d1Sql += ` AND tags LIKE '%"kind:${kind}"%'`;
+  }
   if (after !== undefined) { d1Sql += ` AND created_at >= ?`; d1Bindings.push(after); }
   if (before !== undefined) { d1Sql += ` AND created_at <= ?`; d1Bindings.push(before); }
   const { results: d1Rows } = await env.DB.prepare(d1Sql).bind(...d1Bindings).all() as { results: Record<string, any>[] };
@@ -1537,10 +1544,11 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         tag: z.string().optional().describe("Filter by a specific tag"),
         after: z.number().int().optional().describe("Only return entries after this Unix ms timestamp"),
         before: z.number().int().optional().describe("Only return entries before this Unix ms timestamp"),
+        kind: z.enum([...KIND_VALUES] as [string, ...string[]]).optional().describe("Filter to episodic (events) or semantic (facts/knowledge)"),
       },
     },
-    async ({ query, topK, tag, after, before }) => {
-      const { matches, insight } = await recallEntries({ query, topK, tag, after, before }, env, ctx);
+    async ({ query, topK, tag, after, before, kind }) => {
+      const { matches, insight } = await recallEntries({ query, topK, tag, after, before, kind: kind as MemoryKind | undefined }, env, ctx);
 
       if (!matches.length) {
         return { content: [{ type: "text", text: "Nothing found matching that query." }] };
@@ -1892,8 +1900,10 @@ const defaultHandler = {
       const tag = url.searchParams.get("tag")?.trim() || undefined;
       const after = url.searchParams.has("after") ? parseInt(url.searchParams.get("after")!, 10) : undefined;
       const before = url.searchParams.has("before") ? parseInt(url.searchParams.get("before")!, 10) : undefined;
+      const kindParam = url.searchParams.get("kind")?.trim();
+      const kind = kindParam && (KIND_VALUES as readonly string[]).includes(kindParam) ? kindParam as MemoryKind : undefined;
 
-      const { matches, insight } = await recallEntries({ query, topK, tag, after, before }, env, ctx);
+      const { matches, insight } = await recallEntries({ query, topK, tag, after, before, kind }, env, ctx);
 
       if (!matches.length) {
         return json({ ok: true, results: [], message: "Nothing found matching that query." });

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -158,11 +158,13 @@ export class D1Mock {
           const ids = args.slice(0, idCount);
           const rest = args.slice(idCount);
           let argIdx = 0;
+          const kindMatch = s.match(/tags LIKE '%"(kind:(?:episodic|semantic))"%'/);
           let rows = db.entries.filter((e: any) => {
             const tags: string[] = JSON.parse(e.tags ?? "[]");
             if (!ids.includes(e.id)) return false;
             if (tags.includes("auto-pattern")) return false;
             if (s.includes('"status:deprecated"') && tags.includes("status:deprecated")) return false;
+            if (kindMatch && !tags.includes(kindMatch[1])) return false;
             return true;
           });
           if (s.includes("created_at >= ?")) {

--- a/test/integration/recall.test.ts
+++ b/test/integration/recall.test.ts
@@ -329,6 +329,27 @@ describe("GET /recall", () => {
     expect(data.results[0].id).toBe("entry-active");
   });
 
+  it("filters recall results to only the requested kind", async () => {
+    db.entries.push(
+      { id: "entry-episodic", content: "Attended a team offsite in January", tags: '["work","kind:episodic"]', source: "api", created_at: 1000, vector_ids: '["entry-episodic"]', recall_count: 0, importance_score: 0 },
+      { id: "entry-semantic", content: "The company uses a monorepo structure", tags: '["work","kind:semantic"]', source: "api", created_at: 2000, vector_ids: '["entry-semantic"]', recall_count: 0, importance_score: 0 },
+    );
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [makeMatch("entry-episodic", 0.9), makeMatch("entry-semantic", 0.85)],
+        }),
+      }),
+    });
+
+    const res = await worker.fetch(req("GET", "/recall?query=memory&kind=episodic"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].id).toBe("entry-episodic");
+  });
+
   it("query with no matching keywords exercises the LLM fallback for tag inference", async () => {
     db.entries.push(
       { id: "entry-1", content: "Office lease renewal", tags: '["work"]', source: "api", created_at: 1000, vector_ids: '["entry-1"]', recall_count: 0, importance_score: 0 },

--- a/test/integration/smart-merge.test.ts
+++ b/test/integration/smart-merge.test.ts
@@ -7,6 +7,46 @@ import { D1Mock } from "../helpers/d1-mock";
 
 const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
 
+function makeCtx() {
+  const pending: Promise<any>[] = [];
+  return {
+    ctx: { waitUntil: (p: Promise<any>) => pending.push(p) } as any,
+    drain: () => Promise.allSettled(pending),
+  };
+}
+
+function makeSseStream(response: string) {
+  return new ReadableStream({
+    start(c) {
+      c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+      c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+      c.close();
+    },
+  });
+}
+
+// Prompt-aware AI stub that distinguishes 3 call types:
+//   1. embed  — model === "@cf/baai/bge-small-en-v1.5" → return vector
+//   2. merge  — prompt contains "Choose exactly one action" → return mergeResponse
+//   3. classify — prompt contains "reply with ONLY JSON" → return classifyResponse
+function makePromptAwareAI(mergeResponse: string, classifyResponse: string): Ai {
+  return {
+    run: vi.fn().mockImplementation(async (model: string, opts: any) => {
+      if (model === "@cf/baai/bge-small-en-v1.5")
+        return { data: [new Array(384).fill(0.1)] };
+      const prompt: string = (opts?.messages ?? []).map((m: any) => m.content).join("\n");
+      if (prompt.includes("Choose exactly one action")) {
+        return makeSseStream(mergeResponse);
+      }
+      // classify call
+      if (prompt.includes("reply with ONLY JSON")) {
+        return makeSseStream(classifyResponse);
+      }
+      throw new Error(`Unexpected AI.run call in makePromptAwareAI. Prompt starts: ${prompt.slice(0, 120)}`);
+    }),
+  } as unknown as Ai;
+}
+
 // AI mock that returns a specific LLM response while still handling embed calls
 function makeMergeAI(response: string): Ai {
   return {
@@ -340,6 +380,79 @@ describe("POST /capture — smart merge (flagged band 0.85–0.95)", () => {
     // No new entry was inserted — the early-return guard returns a synthetic ID
     // without persisting to DB (mirrors importance guard behaviour)
     expect(db.entries).toHaveLength(1);
+  });
+
+  // ── Classification on smart-merge path ───────────────────────────────────────
+
+  it("merge: classifies the TARGET entry (kind + importance_score set) after draining waitUntil", async () => {
+    seedEntry(db, "existing-id", "I prefer dark mode", '["existing-id"]');
+    // The seeded entry has no kind tag and importance_score=3 (from seedEntry default).
+    const { ctx: testCtx, drain } = makeCtx();
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
+        }),
+      }),
+      AI: makePromptAwareAI(
+        '{"action":"merge","target_id":"existing-id","merged_content":"I prefer dark mode in all apps"}',
+        '{"importance":4,"canonical":false,"kind":"semantic"}'
+      ),
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/capture", { body: { content: "I like dark mode everywhere" } }),
+      env, testCtx
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.action).toBe("merged");
+
+    // Before drain: classification hasn't run yet
+    const target = db.entries.find((e: any) => e.id === "existing-id");
+    expect(target).toBeDefined();
+
+    // Drain all waitUntil promises (classification fires here)
+    await drain();
+
+    // After drain: importance_score and kind:semantic tag must be set on the target
+    const updated = db.entries.find((e: any) => e.id === "existing-id");
+    expect(updated!.importance_score).toBe(4);
+    const updatedTags: string[] = JSON.parse(updated!.tags);
+    expect(updatedTags).toContain("kind:semantic");
+  });
+
+  it("replace: classifies the TARGET entry (kind + importance_score set) after draining waitUntil", async () => {
+    seedEntry(db, "existing-id", "I use VSCode", '["existing-id"]');
+    const { ctx: testCtx, drain } = makeCtx();
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
+        }),
+      }),
+      AI: makePromptAwareAI(
+        '{"action":"replace","target_id":"existing-id"}',
+        '{"importance":2,"canonical":false,"kind":"episodic"}'
+      ),
+    });
+
+    const res = await worker.fetch(
+      req("POST", "/capture", { body: { content: "I switched to Cursor IDE" } }),
+      env, testCtx
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.action).toBe("replaced");
+
+    await drain();
+
+    const updated = db.entries.find((e: any) => e.id === "existing-id");
+    expect(updated!.importance_score).toBe(2);
+    const updatedTags: string[] = JSON.parse(updated!.tags);
+    expect(updatedTags).toContain("kind:episodic");
   });
 
   // ── Existing functionality unaffected ─────────────────────────────────────────

--- a/test/integration/smart-merge.test.ts
+++ b/test/integration/smart-merge.test.ts
@@ -28,7 +28,7 @@ function makeSseStream(response: string) {
 // Prompt-aware AI stub that distinguishes 3 call types:
 //   1. embed  — model === "@cf/baai/bge-small-en-v1.5" → return vector
 //   2. merge  — prompt contains "Choose exactly one action" → return mergeResponse
-//   3. classify — prompt contains "reply with ONLY JSON" → return classifyResponse
+//   3. classify — prompt contains "Classify this memory" → return classifyResponse
 function makePromptAwareAI(mergeResponse: string, classifyResponse: string): Ai {
   return {
     run: vi.fn().mockImplementation(async (model: string, opts: any) => {
@@ -39,7 +39,7 @@ function makePromptAwareAI(mergeResponse: string, classifyResponse: string): Ai 
         return makeSseStream(mergeResponse);
       }
       // classify call
-      if (prompt.includes("reply with ONLY JSON")) {
+      if (prompt.includes("Classify this memory")) {
         return makeSseStream(classifyResponse);
       }
       throw new Error(`Unexpected AI.run call in makePromptAwareAI. Prompt starts: ${prompt.slice(0, 120)}`);

--- a/test/unit/capture-entry.test.ts
+++ b/test/unit/capture-entry.test.ts
@@ -548,6 +548,63 @@ describe("captureEntry()", () => {
     expect(tags).not.toContain("status:canonical");
   });
 
+  // ── Kind auto-tagging ───────────────────────────────────────────────────────
+
+  it("adds kind:episodic tag when classifyEntry returns kind:'episodic'", async () => {
+    function makeSseStream(response: string) {
+      return new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+          c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+          c.close();
+        },
+      });
+    }
+    env = makeTestEnv(db, {
+      AI: {
+        run: vi.fn().mockImplementation(async (model: string) => {
+          if (model === "@cf/baai/bge-small-en-v1.5")
+            return { data: [new Array(384).fill(0.1)] };
+          return makeSseStream('{"importance":2,"canonical":false,"kind":"episodic"}');
+        }),
+      } as unknown as Ai,
+    });
+    const { ctx, drain } = makeCtx();
+    const result = await captureEntry("Went for a run this morning", [], "api", env, ctx);
+    expect(result.status).toBe("stored");
+    await drain();
+    const tags: string[] = JSON.parse(db.entries[0].tags);
+    expect(tags).toContain("kind:episodic");
+  });
+
+  it("does NOT add any kind: tag when classifyEntry returns kind:null", async () => {
+    function makeSseStream(response: string) {
+      return new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+          c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+          c.close();
+        },
+      });
+    }
+    env = makeTestEnv(db, {
+      AI: {
+        run: vi.fn().mockImplementation(async (model: string) => {
+          if (model === "@cf/baai/bge-small-en-v1.5")
+            return { data: [new Array(384).fill(0.1)] };
+          return makeSseStream('{"importance":3,"canonical":false}');
+        }),
+      } as unknown as Ai,
+    });
+    const { ctx, drain } = makeCtx();
+    const result = await captureEntry("Some generic note", [], "api", env, ctx);
+    expect(result.status).toBe("stored");
+    await drain();
+    const tags: string[] = JSON.parse(db.entries[0].tags);
+    const hasKindTag = tags.some(t => t.startsWith("kind:"));
+    expect(hasKindTag).toBe(false);
+  });
+
   // ── Non-fatal error handling ────────────────────────────────────────────────
 
   it("stores to D1 and returns stored even when Vectorize insert throws", async () => {

--- a/test/unit/classify-entry.test.ts
+++ b/test/unit/classify-entry.test.ts
@@ -25,35 +25,51 @@ function makeClassifyAI(response: string | null = null, shouldThrow = false) {
 }
 
 describe("classifyEntry()", () => {
-  it('parses {"importance":5,"canonical":true} correctly', async () => {
+  it('parses {"importance":5,"canonical":true,"kind":"semantic"} correctly', async () => {
     const env = makeTestEnv(makeTestDb(), {
-      AI: makeClassifyAI('{"importance":5,"canonical":true}'),
+      AI: makeClassifyAI('{"importance":5,"canonical":true,"kind":"semantic"}'),
     });
     const result = await classifyEntry("I decided to quit my job and start a company", env);
-    expect(result).toEqual({ importance: 5, canonical: true });
+    expect(result).toEqual({ importance: 5, canonical: true, kind: "semantic" });
   });
 
-  it('parses {"importance":2,"canonical":false} correctly', async () => {
+  it('parses {"importance":2,"canonical":false,"kind":"episodic"} correctly', async () => {
     const env = makeTestEnv(makeTestDb(), {
-      AI: makeClassifyAI('{"importance":2,"canonical":false}'),
+      AI: makeClassifyAI('{"importance":2,"canonical":false,"kind":"episodic"}'),
     });
     const result = await classifyEntry("Had coffee this morning", env);
-    expect(result).toEqual({ importance: 2, canonical: false });
+    expect(result).toEqual({ importance: 2, canonical: false, kind: "episodic" });
   });
 
-  it("falls back to { importance: 3, canonical: false } when LLM returns unparseable text", async () => {
+  it("returns kind:null when JSON is missing kind field", async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance":3,"canonical":false}'),
+    });
+    const result = await classifyEntry("Some memory", env);
+    expect(result).toEqual({ importance: 3, canonical: false, kind: null });
+  });
+
+  it("returns kind:null when JSON has bogus kind value", async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance":3,"canonical":false,"kind":"bogus"}'),
+    });
+    const result = await classifyEntry("Some memory", env);
+    expect(result).toEqual({ importance: 3, canonical: false, kind: null });
+  });
+
+  it("falls back to { importance: 3, canonical: false, kind: null } when LLM returns unparseable text", async () => {
     const env = makeTestEnv(makeTestDb(), {
       AI: makeClassifyAI("sorry I cannot help with that"),
     });
     const result = await classifyEntry("Some memory", env);
-    expect(result).toEqual({ importance: 3, canonical: false });
+    expect(result).toEqual({ importance: 3, canonical: false, kind: null });
   });
 
-  it("falls back to { importance: 0, canonical: false } when env.AI.run throws", async () => {
+  it("falls back to { importance: 0, canonical: false, kind: null } when env.AI.run throws", async () => {
     const env = makeTestEnv(makeTestDb(), {
       AI: makeClassifyAI(null, true),
     });
     const result = await classifyEntry("Some memory", env);
-    expect(result).toEqual({ importance: 0, canonical: false });
+    expect(result).toEqual({ importance: 0, canonical: false, kind: null });
   });
 });

--- a/test/unit/classify-entry.test.ts
+++ b/test/unit/classify-entry.test.ts
@@ -72,4 +72,61 @@ describe("classifyEntry()", () => {
     const result = await classifyEntry("Some memory", env);
     expect(result).toEqual({ importance: 0, canonical: false, kind: null });
   });
+
+  // normalizeKind synonym/case/substring mapping tests
+  it('maps kind:"event" → "episodic"', async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance":2,"canonical":false,"kind":"event"}'),
+    });
+    const result = await classifyEntry("Attended a conference today", env);
+    expect(result).toEqual({ importance: 2, canonical: false, kind: "episodic" });
+  });
+
+  it('maps kind:"milestone" → "episodic"', async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance":2,"canonical":false,"kind":"milestone"}'),
+    });
+    const result = await classifyEntry("Shipped the first release", env);
+    expect(result).toEqual({ importance: 2, canonical: false, kind: "episodic" });
+  });
+
+  it('maps kind:"fact" → "semantic"', async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance":3,"canonical":false,"kind":"fact"}'),
+    });
+    const result = await classifyEntry("The office is in downtown", env);
+    expect(result).toEqual({ importance: 3, canonical: false, kind: "semantic" });
+  });
+
+  it('maps kind:"preference" → "semantic"', async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance":3,"canonical":false,"kind":"preference"}'),
+    });
+    const result = await classifyEntry("I prefer dark mode", env);
+    expect(result).toEqual({ importance: 3, canonical: false, kind: "semantic" });
+  });
+
+  it('maps kind:"Episodic" (mixed case) → "episodic"', async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance":3,"canonical":false,"kind":"Episodic"}'),
+    });
+    const result = await classifyEntry("Went for a run this morning", env);
+    expect(result).toEqual({ importance: 3, canonical: false, kind: "episodic" });
+  });
+
+  it('maps kind:"episodic event" (substring) → "episodic"', async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance":3,"canonical":false,"kind":"episodic event"}'),
+    });
+    const result = await classifyEntry("Had a team meeting", env);
+    expect(result).toEqual({ importance: 3, canonical: false, kind: "episodic" });
+  });
+
+  it('maps kind:"banana" (unknown synonym) → null', async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance":3,"canonical":false,"kind":"banana"}'),
+    });
+    const result = await classifyEntry("Some memory", env);
+    expect(result).toEqual({ importance: 3, canonical: false, kind: null });
+  });
 });

--- a/test/unit/classify-entry.test.ts
+++ b/test/unit/classify-entry.test.ts
@@ -129,4 +129,38 @@ describe("classifyEntry()", () => {
     const result = await classifyEntry("Some memory", env);
     expect(result).toEqual({ importance: 3, canonical: false, kind: null });
   });
+
+  // ── Malformed JSON / tolerant parsing ─────────────────────────────────────
+
+  it('salvages kind from real regression payload: {"importance": 3, "canonical":, "kind": "episodic"}', async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance": 3, "canonical":, "kind": "episodic"}'),
+    });
+    const result = await classifyEntry("Some memory", env);
+    expect(result).toEqual({ importance: 3, canonical: false, kind: "episodic" });
+  });
+
+  it('salvages canonical and kind when importance is malformed: {"importance":, "canonical": true, "kind": "semantic"}', async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('{"importance":, "canonical": true, "kind": "semantic"}'),
+    });
+    const result = await classifyEntry("Some memory", env);
+    expect(result).toEqual({ importance: 3, canonical: true, kind: "semantic" });
+  });
+
+  it('extracts kind from garbage-surrounding text: blah blah "kind": "episodic" blah', async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI('blah blah "kind": "episodic" blah'),
+    });
+    const result = await classifyEntry("Some memory", env);
+    expect(result).toEqual({ importance: 3, canonical: false, kind: "episodic" });
+  });
+
+  it("returns all defaults when no recoverable fields exist: 'not json at all'", async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeClassifyAI("not json at all"),
+    });
+    const result = await classifyEntry("Some memory", env);
+    expect(result).toEqual({ importance: 3, canonical: false, kind: null });
+  });
 });

--- a/test/unit/kind-tags.test.ts
+++ b/test/unit/kind-tags.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { getKind, withKind, KIND_VALUES } from "../../src/index";
+
+describe("kind tags", () => {
+  describe("getKind", () => {
+    it("returns null for empty tags array", () => {
+      expect(getKind([])).toBe(null);
+    });
+
+    it("extracts kind from mixed tags", () => {
+      expect(getKind(["work", "kind:episodic"])).toBe("episodic");
+    });
+
+    it("returns null for unknown kind values", () => {
+      expect(getKind(["kind:bogus"])).toBe(null);
+    });
+  });
+
+  describe("withKind", () => {
+    it("adds kind tag to tags array", () => {
+      expect(withKind(["work"], "semantic")).toEqual(["work", "kind:semantic"]);
+    });
+
+    it("replaces existing kind tag without duplicating", () => {
+      expect(withKind(["kind:episodic", "work"], "semantic")).toEqual([
+        "work",
+        "kind:semantic",
+      ]);
+    });
+  });
+
+  describe("KIND_VALUES", () => {
+    it("exports valid kind values", () => {
+      expect(KIND_VALUES).toEqual(["episodic", "semantic"]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Classifies every memory as **`episodic`** (events / decisions / milestones) or **`semantic`** (durable facts / preferences / knowledge), so recall can separate "what happened?" from "what do we know?". Stored as a reserved `kind:<value>` **tag** on `entries.tags` — **no schema change** (same tag-based approach as #119), and absent = unknown.

- **Classified for free at capture:** the existing per-capture `classifyEntry` LLM call (added in #119) now returns `{importance, canonical, kind}` from a single call — no new hot-path request. The capture writer applies the `kind:` tag alongside the status-gated `canonical` promotion in one read-modify-write. `kind:` and `status:` are fully orthogonal.
- **Type-aware recall:** optional `kind` filter on the `recall` MCP tool and `GET /recall`, applied at D1 hydration so it composes with semantic ranking and the existing `tag`/time filters (mirrors the `status:deprecated` exclusion). Enum-validated; no SQL-injection surface; the no-`kind` path is byte-identical to before.

## Design notes
- Web UI timeline / knowledge-base views (mentioned in the issue) are deferred to a later UI pass (pairs with the #16 dashboard work). This PR ships the data + recall filter those views will consume.
- Back-catalog backfill of existing (unclassified) entries is deferred to #145 (shared `/classify-pending` for status + kind).
- Like the existing `auto-pattern` / `status:deprecated` filters, the `kind` filter is applied after top-K selection — a kind-filtered recall can return fewer than `topK` if off-kind entries fill the top slots (consistent with current behavior, not a regression).

## Test plan
- [x] `npm test` — 352 passing (was 341 on v1.9 after #119), 34 files
- [x] `npm run typecheck` — clean
- [x] No change to `entries` schema / `db/schema.sql`
- [ ] Manual smoke on `wrangler dev --remote`: "We shipped v2 today" → `kind:episodic`; "Vectorize caps metadata at 5MB" → `kind:semantic`; `recall(query, kind:"episodic")` returns only events; existing kind-less entries still recall normally

Closes #12
