### PR TITLE
feat: contradiction-aware recall scoring (#152)

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7,8 +7,10 @@ CREATE TABLE IF NOT EXISTS entries (
   source           TEXT NOT NULL DEFAULT 'api',  -- 'phone', 'browser', 'voice', 'claude', 'api'
   created_at       INTEGER NOT NULL,             -- Unix ms timestamp
   vector_ids       TEXT NOT NULL DEFAULT '[]',   -- JSON array of Vectorize vector IDs
-  recall_count     INTEGER DEFAULT 0,
-  importance_score INTEGER DEFAULT 0
+  recall_count         INTEGER DEFAULT 0,
+  importance_score     INTEGER DEFAULT 0,
+  contradiction_wins   INTEGER DEFAULT 0,
+  contradiction_losses INTEGER DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_entries_created_at ON entries(created_at DESC);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1345,10 +1345,25 @@ export async function captureEntry(
       const draftTags = finalTags.filter(t => t !== "contradiction-resolved");
       await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`)
         .bind(JSON.stringify(withStatus(draftTags, "draft")), id).run();
+      // Record the outcome: canonical incumbent survived (win), new draft lost (loss).
+      // Non-fatal — a failed count update must not abort capture.
+      try {
+        await env.DB.prepare(`UPDATE entries SET contradiction_wins = contradiction_wins + 1 WHERE id = ?`).bind(conflictId).run();
+        await env.DB.prepare(`UPDATE entries SET contradiction_losses = contradiction_losses + 1 WHERE id = ?`).bind(id).run();
+      } catch (e) {
+        console.error("Contradiction count update failed (non-fatal):", e);
+      }
       return { status: "contradiction_protected", id, canonicalId: conflictId, reason: contradiction.reason };
     }
 
-    // Non-canonical loser: deprecate (keep row for audit) instead of hard-delete.
+    // Non-canonical loser: the new entry wins; the incumbent loses and is deprecated
+    // (row kept for audit). Record the outcome before deprecating. Non-fatal.
+    try {
+      await env.DB.prepare(`UPDATE entries SET contradiction_wins = contradiction_wins + 1 WHERE id = ?`).bind(id).run();
+      await env.DB.prepare(`UPDATE entries SET contradiction_losses = contradiction_losses + 1 WHERE id = ?`).bind(conflictId).run();
+    } catch (e) {
+      console.error("Contradiction count update failed (non-fatal):", e);
+    }
     try {
       await deprecateEntry(conflictId, env);
     } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,6 +226,8 @@ async function initializeDatabase(env: Env): Promise<void> {
   for (const alter of [
     `ALTER TABLE entries ADD COLUMN recall_count INTEGER DEFAULT 0`,
     `ALTER TABLE entries ADD COLUMN importance_score INTEGER DEFAULT 0`,
+    `ALTER TABLE entries ADD COLUMN contradiction_wins INTEGER DEFAULT 0`,
+    `ALTER TABLE entries ADD COLUMN contradiction_losses INTEGER DEFAULT 0`,
   ]) {
     try { await env.DB.exec(alter); } catch { /* column already exists — no-op */ }
   }
@@ -1131,19 +1133,21 @@ export async function recallEntries(
   // The tag path can produce far more than 100 candidates, so chunk the IN query
   // to stay under D1's bound-parameter limit.
   const candidateIds = [...new Set(results.matches.map(m => (m.metadata as any)?.parentId ?? m.id))] as string[];
-  const rcRows: { id: string; recall_count: number; importance_score: number }[] = [];
+  const rcRows: { id: string; recall_count: number; importance_score: number; contradiction_wins: number; contradiction_losses: number }[] = [];
   for (let i = 0; i < candidateIds.length; i += D1_MAX_BOUND_PARAMS) {
     const batch = candidateIds.slice(i, i + D1_MAX_BOUND_PARAMS);
     const rcPlaceholders = batch.map(() => "?").join(", ");
     const { results: rows } = await env.DB.prepare(
-      `SELECT id, recall_count, importance_score FROM entries WHERE id IN (${rcPlaceholders})`
-    ).bind(...batch).all() as { results: { id: string; recall_count: number; importance_score: number }[] };
+      `SELECT id, recall_count, importance_score, contradiction_wins, contradiction_losses FROM entries WHERE id IN (${rcPlaceholders})`
+    ).bind(...batch).all() as { results: { id: string; recall_count: number; importance_score: number; contradiction_wins: number; contradiction_losses: number }[] };
     rcRows.push(...rows);
   }
   const recallCounts = new Map(rcRows.map(r => [r.id, r.recall_count ?? 0]));
   const importanceScores = new Map(rcRows.map(r => [r.id, r.importance_score ?? 0]));
+  const contradictionWins = new Map(rcRows.map(r => [r.id, r.contradiction_wins ?? 0]));
+  const contradictionLosses = new Map(rcRows.map(r => [r.id, r.contradiction_losses ?? 0]));
 
-  const reranked = rerankWithTimeDecay(results.matches as VectorizeMatch[], recallCounts, importanceScores, queryTags);
+  const reranked = rerankWithTimeDecay(results.matches as VectorizeMatch[], recallCounts, importanceScores, queryTags, contradictionWins, contradictionLosses);
 
   const seen = new Set<string>();
   const deduped = reranked.filter((m) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,9 @@ const DUPLICATE_FLAG_THRESHOLD = 0.85;
 const CANDIDATE_SCORE_THRESHOLD = 0.45;
 const TAG_BOOST_STEP = 0.15;
 const TAG_BOOST_MAX = 1.5;
+// Each net contradiction (win or loss) shifts a memory's effective importance by
+// log1p(|net|) * this step, clamped to the [1,5] importance band. Tunable.
+const CONTRADICTION_IMPORTANCE_STEP = 1.0;
 
 // ─── Model constants ──────────────────────────────────────────────────────────
 
@@ -455,7 +458,9 @@ export function rerankWithTimeDecay(
   matches: VectorizeMatch[],
   recallCounts: Map<string, number> = new Map(),
   importanceScores: Map<string, number> = new Map(),
-  queryTags: string[] = []
+  queryTags: string[] = [],
+  contradictionWins: Map<string, number> = new Map(),
+  contradictionLosses: Map<string, number> = new Map()
 ): VectorizeMatch[] {
   const now = Date.now();
 
@@ -479,10 +484,23 @@ export function rerankWithTimeDecay(
       const appendPenalty = isShortAppend ? 0.2 : 1.0;
       const rolledUpPenalty = tags.includes("rolled-up") ? 0.4 : 1.0;
 
-      // importance_score 0 = unscored (neutral). 1–5 scales from 0.88 → 1.20.
-      // Lets high-importance memories surface above the recency cap without dominating.
+      // Effective importance = classifier score adjusted by net contradiction history.
+      // Survivors (net wins) rise toward 5; repeatedly-contradicted memories (net losses)
+      // fall toward 1. log1p gives diminishing returns; clamp keeps the effect inside the
+      // existing 0.88–1.20 importance band. The stored importance_score is never mutated.
       const imp = importanceScores.get(parentId) ?? 0;
-      const importanceMultiplier = imp === 0 ? 1.0 : 0.8 + (imp / 5) * 0.4;
+      const wins = contradictionWins.get(parentId) ?? 0;
+      const losses = contradictionLosses.get(parentId) ?? 0;
+      const net = wins - losses;
+      let importanceMultiplier: number;
+      if (imp === 0 && net === 0) {
+        importanceMultiplier = 1.0; // unscored and never contested — unchanged baseline
+      } else {
+        const base = imp === 0 ? 3 : imp; // unscored-but-contested → neutral midpoint
+        const adj = Math.sign(net) * Math.log1p(Math.abs(net)) * CONTRADICTION_IMPORTANCE_STEP;
+        const effectiveImp = Math.max(1, Math.min(5, base + adj));
+        importanceMultiplier = 0.8 + (effectiveImp / 5) * 0.4;
+      }
 
       // Tag boost: applied outside the recency ≤1.0 cap so a tag-relevant memory can
       // surface above a marginally-closer but irrelevant one.

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -69,6 +69,18 @@ export class D1Mock {
           }
           return { meta: { changes: row ? 1 : 0 } };
         }
+        if (s.startsWith("UPDATE entries SET contradiction_wins = contradiction_wins + 1")) {
+          const [id] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row) row.contradiction_wins = (row.contradiction_wins ?? 0) + 1;
+          return { meta: { changes: row ? 1 : 0 } };
+        }
+        if (s.startsWith("UPDATE entries SET contradiction_losses = contradiction_losses + 1")) {
+          const [id] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row) row.contradiction_losses = (row.contradiction_losses ?? 0) + 1;
+          return { meta: { changes: row ? 1 : 0 } };
+        }
         if (s.startsWith("UPDATE entries SET recall_count")) {
           const [id] = args;
           const row = db.entries.find((e: any) => e.id === id);

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -9,7 +9,7 @@ export class D1Mock {
       async run() {
         if (s.startsWith("INSERT INTO entries")) {
           const [id, content, tags, source, created_at, vector_ids] = args;
-          db.entries.push({ id, content, tags, source, created_at, vector_ids, recall_count: 0, importance_score: 0 });
+          db.entries.push({ id, content, tags, source, created_at, vector_ids, recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0 });
           return { meta: { changes: 1 } };
         }
         if (s.startsWith("UPDATE entries SET content = ?, vector_ids")) {
@@ -145,10 +145,10 @@ export class D1Mock {
             .map((e: any) => ({ id: e.id, vector_ids: e.vector_ids ?? "[]" }));
           return { results };
         }
-        if (s.includes("SELECT id, recall_count, importance_score FROM entries")) {
+        if (s.includes("SELECT id, recall_count, importance_score") && s.includes("WHERE id IN")) {
           const results = db.entries
             .filter((e: any) => args.includes(e.id))
-            .map((e: any) => ({ id: e.id, recall_count: e.recall_count ?? 0, importance_score: e.importance_score ?? 0 }));
+            .map((e: any) => ({ id: e.id, recall_count: e.recall_count ?? 0, importance_score: e.importance_score ?? 0, contradiction_wins: e.contradiction_wins ?? 0, contradiction_losses: e.contradiction_losses ?? 0 }));
           return { results };
         }
         if (s.includes("FROM entries WHERE id IN") && s.includes("tags NOT LIKE")) {

--- a/test/integration/recall.test.ts
+++ b/test/integration/recall.test.ts
@@ -1,9 +1,26 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import worker from "../../src/index";
+import worker, { captureEntry } from "../../src/index";
 import { makeTestEnv, makeTestDb, makeVectorizeMock } from "../helpers/make-env";
 import { req } from "../helpers/make-request";
 import type { Env } from "../../src/index";
 import { D1Mock } from "../helpers/d1-mock";
+
+// Returns an AI mock that always resolves a contradiction verdict (for captureEntry).
+function makeContradictionAI(response: string): Ai {
+  return {
+    run: vi.fn().mockImplementation(async (model: string) => {
+      if (model === "@cf/baai/bge-small-en-v1.5")
+        return { data: [new Array(384).fill(0.1)] };
+      return new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+          c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+          c.close();
+        },
+      });
+    }),
+  } as unknown as Ai;
+}
 
 const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
 
@@ -397,5 +414,96 @@ describe("GET /recall", () => {
     const data = await res.json() as any;
     expect(data.results[0].id).toBe("survivor");
     expect(data.results[1].id).toBe("shaky");
+  });
+
+  // ── End-to-end: captureEntry WRITES contradiction_wins → recallEntries READS and reranks ──
+
+  it("e2e: captureEntry writes contradiction_wins=1; subsequent recall ranks the winner above a peer with imp=3,wins=0 (real rerank, not seeded)", async () => {
+    // Phase 1 — CAPTURE: resolve a contradiction through production captureEntry.
+    //
+    // Seed the non-canonical incumbent "old-fact" that the new entry will beat.
+    // It needs vector_ids so the deprecation path has something to delete from Vectorize.
+    const now = Date.now();
+    db.entries.push({
+      id: "old-fact",
+      content: "I live in Boston",
+      tags: "[]",
+      source: "api",
+      created_at: now - 10000,
+      vector_ids: '["old-fact-vec"]',
+      recall_count: 0,
+      importance_score: 0,
+      contradiction_wins: 0,
+      contradiction_losses: 0,
+    });
+
+    // Seed an uncontested peer with importance_score=3, contradiction_wins=0.
+    // Rerank math (verified against src/index.ts rerankWithTimeDecay):
+    //   peer:   imp=3, net=0 → effectiveImp=3 → importanceMultiplier = 0.8+(3/5)*0.4 = 1.04
+    //   winner: imp=0 (unclassified), net=+1 (1 win 0 losses)
+    //           → base=3 (unscored-but-contested neutral midpoint)
+    //           → adj = sign(1)*log1p(1)*1.0 = ln(2) ≈ 0.693
+    //           → effectiveImp = 3+0.693 = 3.693
+    //           → importanceMultiplier = 0.8+(3.693/5)*0.4 = 1.0954
+    //   winner importanceMultiplier (1.0954) > peer (1.04), so winner ranks first.
+    //   Tie-breaker guard: peer is placed FIRST in the Vectorize matches array so that
+    //   without the win boost, the peer would be listed first — the win is the sole differentiator.
+    db.entries.push({
+      id: "peer",
+      content: "Uncontested peer fact",
+      tags: "[]",
+      source: "api",
+      created_at: now - 10000,
+      vector_ids: "[]",
+      recall_count: 0,
+      importance_score: 3,
+      contradiction_wins: 0,
+      contradiction_losses: 0,
+    });
+
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    const captureEnv = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        // captureEntry uses this query mock to find the near-match during capture
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "old-fact", score: 0.72, metadata: { parentId: "old-fact" } }],
+        }),
+        deleteByIds: deleteByIdsMock,
+      }),
+      AI: makeContradictionAI('{"contradicts": true, "conflicting_id": "old-fact", "reason": "different city"}'),
+    });
+
+    const captureCtx = { waitUntil: (_: Promise<any>) => {} } as any as ExecutionContext;
+    const captureResult = await captureEntry("I moved to Seattle", [], "api", captureEnv, captureCtx);
+
+    // Assert production code wrote contradiction_wins=1 on the new entry
+    expect(captureResult.status).toBe("contradiction");
+    if (captureResult.status !== "contradiction") return;
+    const winnerId = captureResult.id;
+
+    const winnerRow = db.entries.find(e => e.id === winnerId);
+    expect(winnerRow).toBeDefined();
+    expect(winnerRow!.contradiction_wins).toBe(1); // written by production, not seeded
+
+    // Phase 2 — RECALL: the shared db now has winner (wins=1, imp=0) and peer (wins=0, imp=3).
+    // Configure Vectorize to return [peer first, winner second] at equal score 0.9 —
+    // without the win boost the peer would appear first (it's listed first in matches).
+    // The real rerank formula must lift the winner above the peer.
+    const recallEnv = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [makeMatch("peer", 0.9), makeMatch(winnerId, 0.9)],
+        }),
+      }),
+    });
+
+    const res = await worker.fetch(req("GET", "/recall?query=where do I live"), recallEnv, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    // Winner (contradiction_wins=1, imp=0 → effectiveImp≈3.69) must rank above
+    // peer (contradiction_wins=0, imp=3 → effectiveImp=3.0) even though peer was listed first.
+    expect(data.results[0].id).toBe(winnerId);
+    expect(data.results[1].id).toBe("peer");
   });
 });

--- a/test/integration/recall.test.ts
+++ b/test/integration/recall.test.ts
@@ -378,4 +378,24 @@ describe("GET /recall", () => {
     const llmCalls = aiRun.mock.calls.filter((args: any[]) => args[0] !== "@cf/baai/bge-small-en-v1.5");
     expect(llmCalls.length).toBeGreaterThanOrEqual(1);
   });
+
+  it("a contradiction survivor outranks an equally-scored contested loser", async () => {
+    db.entries.push(
+      { id: "shaky", content: "Contested fact", tags: '["work"]', source: "api", created_at: 2000, vector_ids: "[]", recall_count: 0, importance_score: 4, contradiction_wins: 0, contradiction_losses: 3 },
+      { id: "survivor", content: "Battle-tested fact", tags: '["work"]', source: "api", created_at: 2000, vector_ids: "[]", recall_count: 0, importance_score: 4, contradiction_wins: 3, contradiction_losses: 0 },
+    );
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [makeMatch("shaky", 0.9), makeMatch("survivor", 0.9)],
+        }),
+      }),
+    });
+
+    const res = await worker.fetch(req("GET", "/recall?query=fact"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.results[0].id).toBe("survivor");
+    expect(data.results[1].id).toBe("shaky");
+  });
 });

--- a/test/unit/capture-entry.test.ts
+++ b/test/unit/capture-entry.test.ts
@@ -188,6 +188,9 @@ describe("captureEntry()", () => {
     expect(conflictRow!.vector_ids).toBe("[]");
     // Vectorize deleteByIds called with old vector ids
     expect(deleteByIdsMock).toHaveBeenCalledWith(["old-vec-1", "old-vec-2"]);
+    // New entry won the contradiction; deprecated incumbent recorded the loss.
+    expect(db.entries.find(e => e.id === result.id)!.contradiction_wins).toBe(1);
+    expect(conflictRow!.contradiction_losses).toBe(1);
   });
 
   it("returns status=contradiction_protected when conflicting entry is canonical — keeps canonical, demotes new to draft", async () => {
@@ -237,6 +240,9 @@ describe("captureEntry()", () => {
     const newTags: string[] = JSON.parse(newRow!.tags);
     expect(newTags).toContain("status:draft");
     expect(newTags).not.toContain("contradiction-resolved");
+    // Canonical incumbent survived (win); new draft entry recorded the loss.
+    expect(canonicalRow!.contradiction_wins).toBe(1);
+    expect(newRow!.contradiction_losses).toBe(1);
   });
 
   it("adds contradiction-resolved tag when contradiction detected", async () => {

--- a/test/unit/rerank.test.ts
+++ b/test/unit/rerank.test.ts
@@ -121,4 +121,80 @@ describe("rerankWithTimeDecay", () => {
     const [withDefault] = rerankWithTimeDecay([m]);
     expect(withEmpty.score).toBeCloseTo(withDefault.score, 6);
   });
+
+  it("canonical survivor (contradiction wins) ranks above an identical entry with no history", () => {
+    const a = match("survivor", 0.9, NOW - 5 * MS_DAY);
+    const b = match("plain", 0.9, NOW - 5 * MS_DAY);
+    const imp = new Map([["survivor", 4], ["plain", 4]]);
+    const wins = new Map([["survivor", 3]]);
+    const result = rerankWithTimeDecay([a, b], new Map(), imp, [], wins, new Map());
+    expect(result[0].id).toBe("survivor");
+  });
+
+  it("draft loser (contradiction losses) ranks below an identical entry with no history", () => {
+    const a = match("loser", 0.9, NOW - 5 * MS_DAY);
+    const b = match("plain", 0.9, NOW - 5 * MS_DAY);
+    const imp = new Map([["loser", 3], ["plain", 3]]);
+    const losses = new Map([["loser", 3]]);
+    const result = rerankWithTimeDecay([a, b], new Map(), imp, [], new Map(), losses);
+    expect(result[0].id).toBe("plain");
+  });
+
+  it("equal wins and losses produce no change vs no history", () => {
+    const [withHistory] = rerankWithTimeDecay(
+      [match("e", 0.9, NOW - 5 * MS_DAY)], new Map(), new Map([["e", 3]]), [],
+      new Map([["e", 2]]), new Map([["e", 2]]),
+    );
+    const [without] = rerankWithTimeDecay(
+      [match("e", 0.9, NOW - 5 * MS_DAY)], new Map(), new Map([["e", 3]]),
+    );
+    expect(withHistory.score).toBeCloseTo(without.score, 6);
+  });
+
+  it("unscored entry with contradiction wins is boosted (scored from neutral midpoint)", () => {
+    const contested = match("contested", 0.9, NOW - 5 * MS_DAY);
+    const unscored = match("unscored", 0.9, NOW - 5 * MS_DAY);
+    const result = rerankWithTimeDecay(
+      [contested, unscored], new Map(), new Map(), [], new Map([["contested", 2]]), new Map(),
+    );
+    expect(result[0].id).toBe("contested");
+  });
+
+  it("contradiction wins cannot push effective importance above the imp=5 ceiling", () => {
+    const [r] = rerankWithTimeDecay(
+      [match("max", 1.0, NOW)], new Map(), new Map([["max", 5]]), [], new Map([["max", 50]]), new Map(),
+    );
+    expect(r.score).toBeCloseTo(1.2, 2);
+  });
+
+  it("contradiction losses cannot push effective importance below the imp=1 floor", () => {
+    const [r] = rerankWithTimeDecay(
+      [match("min", 1.0, NOW)], new Map(), new Map([["min", 1]]), [], new Map(), new Map([["min", 50]]),
+    );
+    expect(r.score).toBeCloseTo(0.88, 2);
+  });
+
+  it("contradiction effect has diminishing returns (3 wins < 3x the boost of 1 win)", () => {
+    const [neutral] = rerankWithTimeDecay([match("b", 0.9, NOW - 5 * MS_DAY)], new Map(), new Map([["b", 3]]));
+    const [one] = rerankWithTimeDecay(
+      [match("b", 0.9, NOW - 5 * MS_DAY)], new Map(), new Map([["b", 3]]), [], new Map([["b", 1]]), new Map(),
+    );
+    const [three] = rerankWithTimeDecay(
+      [match("b", 0.9, NOW - 5 * MS_DAY)], new Map(), new Map([["b", 3]]), [], new Map([["b", 3]]), new Map(),
+    );
+    const boost1 = one.score - neutral.score;
+    const boost3 = three.score - neutral.score;
+    expect(boost3).toBeGreaterThan(boost1);
+    expect(boost3).toBeLessThan(boost1 * 3);
+  });
+
+  it("omitting contradiction maps behaves identically to passing empty maps", () => {
+    const withEmpty = rerankWithTimeDecay(
+      [match("a", 0.9, NOW - 10 * MS_DAY)], new Map(), new Map([["a", 4]]), [], new Map(), new Map(),
+    );
+    const withDefault = rerankWithTimeDecay(
+      [match("a", 0.9, NOW - 10 * MS_DAY)], new Map(), new Map([["a", 4]]),
+    );
+    expect(withDefault[0].score).toBeCloseTo(withEmpty[0].score, 6);
+  });
 });


### PR DESCRIPTION
Closes #152

## What

Feeds the outcome of every resolved contradiction back into a memory's **effective importance** at recall time, inspired by the Titans "surprise metric": memories that survive challenges rank higher; memories repeatedly contradicted rank lower.

## How

- **Two new columns** `contradiction_wins` / `contradiction_losses` on `entries`, added via the existing idempotent try-catch `ALTER` pattern (same as `recall_count` / `importance_score`) and mirrored into `db/schema.sql`. No managed-migration change — deliberately decoupled to a future PR.
- **Write path** — in `captureEntry`'s contradiction branch, every resolved contradiction credits exactly one win (to the survivor) and one loss (to the loser):
  - Canonical incumbent protected → incumbent +win, new draft +loss.
  - Non-canonical incumbent → new entry +win, incumbent +loss, then deprecated.
  - Increments are non-fatal (a failed count update never aborts capture). `deprecateEntry` is untouched (it's also used for user-initiated deprecation).
- **Read path** — `recallEntries` fetches the two columns and passes them to `rerankWithTimeDecay`, which derives an *effective importance* = stored `importance_score` adjusted by net contradiction history (`log1p` diminishing returns, clamped to `[1,5]`), then runs it through the existing importance curve. The stored `importance_score` is never mutated; the effect is bounded to the existing ~0.88–1.20× band. Tunable via `CONTRADICTION_IMPORTANCE_STEP`.

## Compatibility

Additive, backward-compatible: pre-existing rows backfill to `0` and score identically to before until they participate in a contradiction. Safe for self-hosted / one-click deployers — auto-upgrades on next `initializeDatabase`.

## Tests

375 passing (`tsc --noEmit` clean). Covers the rerank formula (boost, penalty, net-zero, clamps, diminishing returns, backward-compat), the schema/recall wiring, the capture write-path increments, and a full end-to-end test: a real contradiction writes the win, and recall reads it back to rank the winner above an equally-scored uncontested peer.