### PR TITLE
feat: recall-aware compression eligibility (adaptive forgetting gate)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1000,10 +1000,10 @@ export async function compressTag(
       AND tags NOT LIKE '%"synthesized"%'
       AND tags NOT LIKE '%"auto-pattern"%'
       AND tags NOT LIKE '%"rolled-up"%'
-      AND (importance_score IS NULL OR importance_score < 4)
+      AND ${compressionEligibilitySql()}
     ORDER BY created_at DESC
     LIMIT 50
-  `).bind(`%"${tag}"%`).all();
+  `).bind(`%"${tag}"%`, Date.now() - COMPRESSION_MIN_AGE_MS).all();
 
   if (rawEntries.length < 10) {
     return { synthesizedId: null, entriesUsed: 0, text: "" };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1043,11 +1043,11 @@ async function runNightlyCompression(env: Env, ctx: ExecutionContext): Promise<v
       AND entries.tags NOT LIKE '%"rolled-up"%'
       AND entries.tags NOT LIKE '%"synthesized"%'
       AND entries.tags NOT LIKE '%"auto-pattern"%'
-      AND (entries.importance_score IS NULL OR entries.importance_score < 4)
+      AND ${compressionEligibilitySql("entries.")}
     GROUP BY value
     HAVING count > 10
     ORDER BY count DESC
-  `).all();
+  `).bind(Date.now() - COMPRESSION_MIN_AGE_MS).all();
 
   for (const row of results) {
     const tag = row.tag as string;
@@ -1937,12 +1937,12 @@ const defaultHandler = {
             AND entries.tags NOT LIKE '%"rolled-up"%'
             AND entries.tags NOT LIKE '%"synthesized"%'
             AND entries.tags NOT LIKE '%"auto-pattern"%'
-            AND (entries.importance_score IS NULL OR entries.importance_score < 4)
+            AND ${compressionEligibilitySql("entries.")}
           GROUP BY value
           HAVING count > 10
           ORDER BY count DESC
           LIMIT 10
-        `).all(),
+        `).bind(Date.now() - COMPRESSION_MIN_AGE_MS).all(),
       ]);
 
       const cutoff = Date.now() - 86400000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -981,6 +981,14 @@ export async function compressTag(
   env: Env,
   ctx: ExecutionContext
 ): Promise<{ synthesizedId: string | null; entriesUsed: number; text: string }> {
+  // Reserved/namespaced tags (kind:*, status:*) describe a memory's type/lifecycle,
+  // not a topic — digesting them would blend unrelated memories (and could compress
+  // protected/canonical ones). Never compress by them. This also guards /digest and
+  // the web UI Compress button, not just the nightly cron.
+  if (tag.startsWith(STATUS_PREFIX) || tag.startsWith(KIND_PREFIX)) {
+    return { synthesizedId: null, entriesUsed: 0, text: "" };
+  }
+
   const recentSynth = await env.DB.prepare(`
     SELECT id FROM entries
     WHERE tags LIKE '%"synthesized"%'
@@ -1040,6 +1048,8 @@ async function runNightlyCompression(env: Env, ctx: ExecutionContext): Promise<v
     SELECT value as tag, COUNT(*) as count
     FROM entries, json_each(entries.tags)
     WHERE value NOT IN ('synthesized', 'auto-pattern', 'duplicate-candidate', 'contradiction-resolved', 'rolled-up')
+      AND value NOT LIKE 'status:%'
+      AND value NOT LIKE 'kind:%'
       AND entries.tags NOT LIKE '%"rolled-up"%'
       AND entries.tags NOT LIKE '%"synthesized"%'
       AND entries.tags NOT LIKE '%"auto-pattern"%'
@@ -1934,6 +1944,8 @@ const defaultHandler = {
           SELECT value as tag, COUNT(*) as count
           FROM entries, json_each(entries.tags)
           WHERE value NOT IN ('synthesized', 'auto-pattern', 'duplicate-candidate', 'contradiction-resolved', 'rolled-up')
+            AND value NOT LIKE 'status:%'
+            AND value NOT LIKE 'kind:%'
             AND entries.tags NOT LIKE '%"rolled-up"%'
             AND entries.tags NOT LIKE '%"synthesized"%'
             AND entries.tags NOT LIKE '%"auto-pattern"%'

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,24 @@ const TAG_BOOST_MAX = 1.5;
 // log1p(|net|) * this step, clamped to the [1,5] importance band. Tunable.
 const CONTRADICTION_IMPORTANCE_STEP = 1.0;
 
+// ─── Compression eligibility ──────────────────────────────────────────────────
+// An entry is eligible for nightly digest compression only if it's low-importance,
+// not proven-useful by recall, and not a contradiction survivor. Strictly more
+// protective than the old `importance_score < 4` filter — it can only exempt MORE.
+export const COMPRESSION_IMPORTANCE_THRESHOLD = 4;   // importance >= this → protected
+export const COMPRESSION_MIN_RECALL = 2;             // recalled >= this many times → protected
+export const COMPRESSION_MIN_AGE_MS = 60 * 86400000; // entries with fewer than COMPRESSION_MIN_RECALL recalls protected until this old (60 days)
+
+// Returns a SQL boolean fragment for "this entry is eligible for compression".
+// Contains exactly one `?` placeholder — bind `Date.now() - COMPRESSION_MIN_AGE_MS`.
+// columnPrefix: "" for bare columns (compressTag), "entries." for json_each-joined queries.
+export function compressionEligibilitySql(columnPrefix = ""): string {
+  const p = columnPrefix;
+  return `(${p}importance_score IS NULL OR ${p}importance_score < ${COMPRESSION_IMPORTANCE_THRESHOLD})
+      AND (${p}recall_count = 0 OR (${p}recall_count < ${COMPRESSION_MIN_RECALL} AND ${p}created_at < ?))
+      AND (${p}contradiction_wins IS NULL OR ${p}contradiction_wins = 0)`;
+}
+
 // ─── Model constants ──────────────────────────────────────────────────────────
 
 const EMBEDDING_MODEL = "@cf/baai/bge-small-en-v1.5";

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -1,3 +1,5 @@
+import { COMPRESSION_IMPORTANCE_THRESHOLD, COMPRESSION_MIN_RECALL } from "../../src/index";
+
 export class D1Mock {
   entries: any[] = [];
 
@@ -191,19 +193,21 @@ export class D1Mock {
           return { results };
         }
         if (s.includes("SELECT id, content FROM entries") && s.includes("WHERE tags LIKE") && s.includes("ORDER BY created_at DESC")) {
-          // compressTag raw entries query — filter by tag, exclude system tags and high importance
+          // compressTag raw entries query — tag match, system-tag exclusion, and the
+          // recall/age/contradiction eligibility predicate (cutoff is the 2nd bind param).
           const tagPattern = args[0] as string;
           const tag = tagPattern.replace(/%"/g, "").replace(/"%/g, "");
+          const cutoff = Number(args[1]);
           const results = [...db.entries]
             .filter((e: any) => {
               const tags: string[] = JSON.parse(e.tags ?? "[]");
-              return (
-                tags.includes(tag) &&
-                !tags.includes("synthesized") &&
-                !tags.includes("auto-pattern") &&
-                !tags.includes("rolled-up") &&
-                (e.importance_score == null || e.importance_score < 4)
-              );
+              if (!tags.includes(tag)) return false;
+              if (tags.includes("synthesized") || tags.includes("auto-pattern") || tags.includes("rolled-up")) return false;
+              if (!(e.importance_score == null || e.importance_score < COMPRESSION_IMPORTANCE_THRESHOLD)) return false;
+              const rc = e.recall_count ?? 0;
+              if (!(rc === 0 || (rc < COMPRESSION_MIN_RECALL && e.created_at < cutoff))) return false;
+              if (!(e.contradiction_wins == null || e.contradiction_wins === 0)) return false;
+              return true;
             })
             .sort((a: any, b: any) => b.created_at - a.created_at)
             .slice(0, 50)

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -235,6 +235,7 @@ export class D1Mock {
             if (!(e.contradiction_wins == null || e.contradiction_wins === 0)) continue;
             for (const t of tags) {
               if (SYSTEM.includes(t)) continue;
+              if (t.startsWith("status:") || t.startsWith("kind:")) continue;
               counts.set(t, (counts.get(t) ?? 0) + 1);
             }
           }

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -204,7 +204,7 @@ export class D1Mock {
               if (!tags.includes(tag)) return false;
               if (tags.includes("synthesized") || tags.includes("auto-pattern") || tags.includes("rolled-up")) return false;
               if (!(e.importance_score == null || e.importance_score < COMPRESSION_IMPORTANCE_THRESHOLD)) return false;
-              const rc = e.recall_count ?? 0;
+              const rc = e.recall_count; // NULL/undefined → recall clause is falsy → protected (matches SQL)
               if (!(rc === 0 || (rc < COMPRESSION_MIN_RECALL && e.created_at < cutoff))) return false;
               if (!(e.contradiction_wins == null || e.contradiction_wins === 0)) return false;
               return true;
@@ -230,7 +230,7 @@ export class D1Mock {
             const tags: string[] = JSON.parse(e.tags ?? "[]");
             if (tags.includes("rolled-up") || tags.includes("synthesized") || tags.includes("auto-pattern")) continue;
             if (!(e.importance_score == null || e.importance_score < COMPRESSION_IMPORTANCE_THRESHOLD)) continue;
-            const rc = e.recall_count ?? 0;
+            const rc = e.recall_count; // NULL/undefined → recall clause is falsy → protected (matches SQL)
             if (!(rc === 0 || (rc < COMPRESSION_MIN_RECALL && e.created_at < cutoff))) continue;
             if (!(e.contradiction_wins == null || e.contradiction_wins === 0)) continue;
             for (const t of tags) {

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -220,6 +220,30 @@ export class D1Mock {
             .map((e: any) => ({ id: e.id, content: e.content }));
           return { results };
         }
+        if (s.includes("json_each(entries.tags)") && s.includes("HAVING count > 10")) {
+          // Digest-candidate query (nightly compression + /stats): per-tag count of
+          // entries that pass the compression eligibility predicate. Cutoff is args[0].
+          const cutoff = Number(args[0]);
+          const SYSTEM = ["synthesized", "auto-pattern", "duplicate-candidate", "contradiction-resolved", "rolled-up"];
+          const counts = new Map<string, number>();
+          for (const e of db.entries as any[]) {
+            const tags: string[] = JSON.parse(e.tags ?? "[]");
+            if (tags.includes("rolled-up") || tags.includes("synthesized") || tags.includes("auto-pattern")) continue;
+            if (!(e.importance_score == null || e.importance_score < COMPRESSION_IMPORTANCE_THRESHOLD)) continue;
+            const rc = e.recall_count ?? 0;
+            if (!(rc === 0 || (rc < COMPRESSION_MIN_RECALL && e.created_at < cutoff))) continue;
+            if (!(e.contradiction_wins == null || e.contradiction_wins === 0)) continue;
+            for (const t of tags) {
+              if (SYSTEM.includes(t)) continue;
+              counts.set(t, (counts.get(t) ?? 0) + 1);
+            }
+          }
+          const results = [...counts.entries()]
+            .filter(([, c]) => c > 10)
+            .sort((a, b) => b[1] - a[1])
+            .map(([tag, count]) => ({ tag, count }));
+          return { results };
+        }
         if (s.includes("json_each(entries.tags)") && s.includes("GROUP BY value")) {
           // Top tags by frequency — for /stats
           const freq = new Map<string, number>();

--- a/test/integration/stats.test.ts
+++ b/test/integration/stats.test.ts
@@ -129,3 +129,38 @@ describe("GET /stats — vectorization fields", () => {
     expect(data.vectorize_grace_ms).toBe(60000);
   });
 });
+
+describe("GET /stats — digest candidates", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  function compressible(id: string, tag: string) {
+    return { id, content: `c ${id}`, tags: JSON.stringify([tag]), source: "api", created_at: Date.now(), vector_ids: "[]", recall_count: 0, importance_score: 0, contradiction_wins: 0 };
+  }
+
+  it("reports a tag with >10 eligible entries as a digest candidate", async () => {
+    for (let i = 0; i < 11; i++) db.entries.push(compressible(`e-${i}`, "work"));
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.digest_candidates.some((c: any) => c.tag === "work" && c.count === 11)).toBe(true);
+  });
+
+  it("does not report a tag whose entries are all recall-protected", async () => {
+    for (let i = 0; i < 11; i++) db.entries.push({ ...compressible(`e-${i}`, "work"), recall_count: 5 });
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.digest_candidates.some((c: any) => c.tag === "work")).toBe(false);
+  });
+
+  it("does not report a tag whose entries are all contradiction survivors", async () => {
+    for (let i = 0; i < 11; i++) db.entries.push({ ...compressible(`e-${i}`, "work"), contradiction_wins: 1 });
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.digest_candidates.some((c: any) => c.tag === "work")).toBe(false);
+  });
+});

--- a/test/integration/stats.test.ts
+++ b/test/integration/stats.test.ts
@@ -163,4 +163,19 @@ describe("GET /stats — digest candidates", () => {
     const data = await res.json() as any;
     expect(data.digest_candidates.some((c: any) => c.tag === "work")).toBe(false);
   });
+
+  it("excludes reserved namespaced tags (kind:* / status:*) from digest candidates", async () => {
+    for (let i = 0; i < 12; i++) {
+      db.entries.push({
+        ...compressible(`e-${i}`, "work"),
+        tags: JSON.stringify(["work", "kind:semantic", "status:canonical"]),
+      });
+    }
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    const data = await res.json() as any;
+    const tags = data.digest_candidates.map((c: any) => c.tag);
+    expect(tags).toContain("work");                  // topical tag still a candidate
+    expect(tags).not.toContain("kind:semantic");     // namespaced excluded
+    expect(tags).not.toContain("status:canonical");  // namespaced excluded
+  });
 });

--- a/test/unit/compress-tag.test.ts
+++ b/test/unit/compress-tag.test.ts
@@ -251,4 +251,22 @@ describe("compressTag()", () => {
       expect(JSON.parse(hot.tags)).not.toContain("rolled-up");
     }
   });
+
+  // ── Reserved namespace protection ────────────────────────────────────────────
+
+  it("refuses to compress a kind:* namespaced tag", async () => {
+    seedEntries(db, "kind:semantic", 15, { recall_count: 0 });
+    const { ctx } = makeCtx();
+    const result = await compressTag("kind:semantic", env, ctx);
+    expect(result.synthesizedId).toBeNull();
+    expect(env.AI.run).not.toHaveBeenCalled();
+  });
+
+  it("refuses to compress a status:* namespaced tag", async () => {
+    seedEntries(db, "status:canonical", 15, { recall_count: 0 });
+    const { ctx } = makeCtx();
+    const result = await compressTag("status:canonical", env, ctx);
+    expect(result.synthesizedId).toBeNull();
+    expect(env.AI.run).not.toHaveBeenCalled();
+  });
 });

--- a/test/unit/compress-tag.test.ts
+++ b/test/unit/compress-tag.test.ts
@@ -191,4 +191,64 @@ describe("compressTag()", () => {
     expect(JSON.parse(critical.tags)).not.toContain("rolled-up");
     expect(critical.content).not.toContain("[Digest:");
   });
+
+  // ── Recall- and contradiction-aware protection ───────────────────────────────
+
+  it("protects entries recalled >= 2 times from compression", async () => {
+    seedEntries(db, "work", 12, { recall_count: 5 });
+    const { ctx } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    expect(result.synthesizedId).toBeNull();
+  });
+
+  it("treats never-recalled entries as eligible", async () => {
+    seedEntries(db, "work", 12, { recall_count: 0 });
+    const { ctx, drain } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    await drain();
+    expect(result.synthesizedId).not.toBeNull();
+    expect(result.entriesUsed).toBe(12);
+  });
+
+  it("treats recall_count=1 entries older than 60 days as eligible", async () => {
+    seedEntries(db, "work", 12, { recall_count: 1, created_at: Date.now() - 61 * 86400000 });
+    const { ctx, drain } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    await drain();
+    expect(result.synthesizedId).not.toBeNull();
+    expect(result.entriesUsed).toBe(12);
+  });
+
+  it("protects recall_count=1 entries newer than 60 days", async () => {
+    seedEntries(db, "work", 12, { recall_count: 1, created_at: Date.now() - 5 * 86400000 });
+    const { ctx } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    expect(result.synthesizedId).toBeNull();
+  });
+
+  it("protects contradiction survivors (contradiction_wins > 0) from compression", async () => {
+    seedEntries(db, "work", 12, { contradiction_wins: 1 });
+    const { ctx } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    expect(result.synthesizedId).toBeNull();
+  });
+
+  it("only rolls up the eligible subset when a tag mixes protected and eligible entries", async () => {
+    seedEntries(db, "work", 11, { recall_count: 0 }); // 11 eligible (ids entry-0..entry-10)
+    for (let i = 0; i < 3; i++) {
+      db.entries.push({
+        id: `hot-${i}`, content: `hot ${i}`, tags: JSON.stringify(["work"]),
+        source: "api", created_at: Date.now(), vector_ids: "[]",
+        recall_count: 9, importance_score: 0, contradiction_wins: 0,
+      });
+    }
+    const { ctx, drain } = makeCtx();
+    const result = await compressTag("work", env, ctx);
+    await drain();
+    expect(result.entriesUsed).toBe(11);
+    for (let i = 0; i < 3; i++) {
+      const hot = db.entries.find(e => e.id === `hot-${i}`);
+      expect(JSON.parse(hot.tags)).not.toContain("rolled-up");
+    }
+  });
 });

--- a/test/unit/compression-eligibility.test.ts
+++ b/test/unit/compression-eligibility.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { compressionEligibilitySql, COMPRESSION_MIN_RECALL } from "../../src/index";
+
+describe("compressionEligibilitySql", () => {
+  it("includes the importance, recall+age, and contradiction-win clauses", () => {
+    const sql = compressionEligibilitySql();
+    expect(sql).toContain("importance_score < 4");
+    expect(sql).toContain(`recall_count < ${COMPRESSION_MIN_RECALL}`);
+    expect(sql).toContain("recall_count = 0");
+    expect(sql).toContain("contradiction_wins");
+    expect(sql).toContain("created_at < ?");
+  });
+
+  it("contains exactly one bind placeholder (the age cutoff)", () => {
+    expect(compressionEligibilitySql().match(/\?/g)?.length).toBe(1);
+  });
+
+  it("applies a column prefix to every column when given one", () => {
+    const sql = compressionEligibilitySql("entries.");
+    expect(sql).toContain("entries.importance_score");
+    expect(sql).toContain("entries.recall_count");
+    expect(sql).toContain("entries.contradiction_wins");
+    expect(sql).toContain("entries.created_at < ?");
+    for (const col of ["importance_score", "recall_count", "created_at", "contradiction_wins"]) {
+      expect(sql).not.toMatch(new RegExp(`(^|[^.])\\b${col}\\b`));
+    }
+  });
+
+  it("defaults to no prefix", () => {
+    const sql = compressionEligibilitySql();
+    expect(sql).not.toContain("entries.");
+  });
+});


### PR DESCRIPTION
Closes #153

## What

Makes nightly semantic compression *adaptive*: an entry is no longer compressible purely on its capture-time importance. It's now also protected if it's proven useful by recall, or has survived a contradiction. Inspired by the adaptive forgetting gate in Google's Titans research — forget by relevance, not an arbitrary threshold.

## Protection rules

An entry is exempt from compression when **any** hold:
- `importance_score >= 4` (existing)
- `recall_count >= 2` — proven useful
- `recall_count == 1` and younger than 60 days — give it time to prove out
- `contradiction_wins > 0` — battle-tested (survived a contradiction, from #152)

## How

- A single `compressionEligibilitySql(columnPrefix)` helper is the one source of truth for the eligibility predicate, applied at all three sites that decide what's compressible: `compressTag` (which entries roll up), `runNightlyCompression` (which tags are candidates), and the `/stats` digest-candidates query. So selection, execution, and the dashboard always agree.
- Two tunable constants: `COMPRESSION_MIN_RECALL` (2) and `COMPRESSION_MIN_AGE_MS` (60 days), plus `COMPRESSION_IMPORTANCE_THRESHOLD` (4).

## Properties

- **Strictly more protective.** The new predicate is a strict subset of the old `importance_score < 4` filter — it can only ever protect *more*, never compress something it wouldn't have before.
- **No schema change.** `recall_count` and `contradiction_wins` already exist; existing rows default to 0 and behave exactly as before until recalled or contradicted.
- Protection only — contradiction *losers* are not made more aggressively compressible.

## Tests

388 passing (`tsc --noEmit` clean). New coverage: the helper's SQL shape; compressTag protection for each rule (recall≥2, recall 0, recall 1 old/recent, contradiction survivor, mixed tag rolls up only the eligible subset); and `/stats` digest-candidates reflecting the filter (previously untested).