### PR TITLE
feat: hybrid recall — keyword retrieval fused with semantic search

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,16 @@ const VECTORIZE_GET_BY_IDS_BATCH = 20;
 // D1 allows at most 100 bound parameters per query
 const D1_MAX_BOUND_PARAMS = 100;
 
+// ─── Hybrid recall (keyword + semantic fusion) ─────────────────────────────────
+const RRF_K = 60;                    // Reciprocal Rank Fusion dampening constant
+const KEYWORD_CANDIDATE_LIMIT = 100; // max rows the LIKE keyword query scans
+const KEYWORD_MIN_TOKEN_LEN = 2;     // ignore 1-char tokens
+const KEYWORD_STOPWORDS = new Set([
+  "the", "a", "an", "and", "or", "of", "to", "in", "on", "for", "is", "are", "was", "were", "be", "been",
+  "i", "me", "my", "we", "you", "it", "this", "that", "these", "those", "with", "about", "from", "at", "as", "by",
+  "do", "did", "does", "what", "when", "where", "who", "whom", "how", "why", "which",
+]);
+
 // ─── Memory status layer (issue #119) ──────────────────────────────────────────
 // Status lives as a reserved tag (e.g. "status:canonical") on entries.tags — no
 // schema change. Absent status = unspecified = default behavior.
@@ -1089,6 +1099,85 @@ export interface RecallSearchResult {
   insight: string;
 }
 
+// ─── Hybrid recall: keyword search + Reciprocal Rank Fusion ────────────────────
+
+interface KeywordRow { id: string; content: string; tags: string; source: string; created_at: number; }
+
+// Split a query into lexical search tokens: lowercase, strip surrounding punctuation,
+// drop stopwords / 1-char tokens, and remove SQL LIKE wildcards so each token is a literal
+// substring. Identifier-shaped tokens (e.g. "v1.9", "#149") are preserved intact.
+export function tokenizeQuery(query: string): string[] {
+  return [...new Set(
+    query.toLowerCase().split(/\s+/)
+      .map(t => t.replace(/^[^\w#.]+|[^\w#.]+$/g, "").replace(/[%_]/g, ""))
+      .filter(t => t.length >= KEYWORD_MIN_TOKEN_LEN && !KEYWORD_STOPWORDS.has(t))
+  )];
+}
+
+// Keyword candidates: entries whose content contains any query token, bounded by
+// KEYWORD_CANDIDATE_LIMIT. Relevance ranking happens in fuseDenseAndKeyword.
+async function keywordSearch(tokens: string[], env: Env): Promise<KeywordRow[]> {
+  if (!tokens.length) return [];
+  const where = tokens.map(() => "content LIKE ?").join(" OR ");
+  const { results } = await env.DB.prepare(
+    `SELECT id, content, tags, source, created_at FROM entries WHERE ${where} ORDER BY created_at DESC LIMIT ?`
+  ).bind(...tokens.map(t => `%${t}%`), KEYWORD_CANDIDATE_LIMIT).all();
+  return results as unknown as KeywordRow[];
+}
+
+// Reciprocal Rank Fusion. Dense candidates contribute 1/(k+rank); keyword candidates
+// contribute weight/(k+rank), where weight = number of distinct query tokens the entry
+// matched — so an exact multi-token/identifier hit outweighs entries that merely share a
+// common word, and an entry present in BOTH lists accumulates from both.
+export function rrfFuse(
+  denseRanked: string[],
+  keywordRanked: { id: string; weight: number }[],
+  k = RRF_K
+): Map<string, number> {
+  const scores = new Map<string, number>();
+  denseRanked.forEach((id, i) => scores.set(id, (scores.get(id) ?? 0) + 1 / (k + i)));
+  keywordRanked.forEach((e, i) => scores.set(e.id, (scores.get(e.id) ?? 0) + e.weight / (k + i)));
+  return scores;
+}
+
+// Fuse a dense match list (Vectorize chunks, or tag-path cosine scores) with keyword rows
+// into one per-parent candidate list scored by RRF, ready for rerankWithTimeDecay. With
+// allowKeywordOnly=false (tag path) keyword is a re-ranking signal only — it never
+// introduces an entry the dense pass didn't already surface.
+function fuseDenseAndKeyword(
+  denseMatches: VectorizeMatch[],
+  keywordRows: KeywordRow[],
+  tokens: string[],
+  allowKeywordOnly: boolean
+): VectorizeMatch[] {
+  const denseByParent = new Map<string, VectorizeMatch>();
+  for (const m of [...denseMatches].sort((a, b) => b.score - a.score)) {
+    const pid = ((m.metadata as any)?.parentId ?? m.id) as string;
+    if (!denseByParent.has(pid)) denseByParent.set(pid, m);
+  }
+  const denseRanked = [...denseByParent.keys()];
+
+  const keywordRanked = keywordRows
+    .map(r => ({ row: r, weight: tokens.reduce((n, t) => n + (r.content.toLowerCase().includes(t) ? 1 : 0), 0) }))
+    .filter(x => x.weight > 0 && (allowKeywordOnly || denseByParent.has(x.row.id)))
+    .sort((a, b) => b.weight - a.weight || b.row.created_at - a.row.created_at || (a.row.id < b.row.id ? -1 : 1));
+
+  const fused = rrfFuse(denseRanked, keywordRanked.map(x => ({ id: x.row.id, weight: x.weight })));
+  const keywordRowById = new Map(keywordRows.map(r => [r.id, r]));
+
+  const out: VectorizeMatch[] = [];
+  for (const [pid, score] of fused) {
+    const dm = denseByParent.get(pid);
+    if (dm) {
+      out.push({ id: dm.id, score, metadata: dm.metadata });
+    } else {
+      const r = keywordRowById.get(pid)!;
+      out.push({ id: pid, score, metadata: { parentId: pid, created_at: r.created_at, tags: JSON.parse(r.tags ?? "[]"), content: r.content, source: r.source } });
+    }
+  }
+  return out;
+}
+
 export async function recallEntries(
   params: { query: string; topK: number; tag?: string; after?: number; before?: number; kind?: MemoryKind },
   env: Env,
@@ -1106,11 +1195,13 @@ export async function recallEntries(
     embedQuery = parsed.cleanQuery;
   }
 
+  const tokens = tokenizeQuery(embedQuery);
   const [values, queryTags] = await Promise.all([
     embed(embedQuery, env),
     inferQueryTags(embedQuery, env),
   ]);
 
+  let keywordRows: KeywordRow[] = [];
   let results: { matches: VectorizeMatch[] };
   if (tag) {
     // Tag path: score the tag's own vectors directly. An unconstrained Vectorize
@@ -1118,9 +1209,10 @@ export async function recallEntries(
     // semantic rank falls outside the top 50 (issue #141). D1 is the source of
     // truth for tags and already stores each entry's vector_ids.
     const { results: tagRows } = await env.DB.prepare(
-      `SELECT id, vector_ids FROM entries WHERE tags LIKE ?`
+      `SELECT id, vector_ids, content, tags, source, created_at FROM entries WHERE tags LIKE ?`
     ).bind(`%"${tag}"%`).all();
     if (!tagRows.length) return { matches: [], insight: "" };
+    keywordRows = tagRows as unknown as KeywordRow[];
 
     const vectorIds = [...new Set(
       (tagRows as any[]).flatMap(r => JSON.parse((r.vector_ids as string) ?? "[]") as string[])
@@ -1140,12 +1232,15 @@ export async function recallEntries(
       })) as VectorizeMatch[],
     };
   } else {
-    // Cloudflare Vectorize caps topK at 50 when returnMetadata="all" (error 40025)
+    // Cloudflare Vectorize caps topK at 50 when returnMetadata="all" (error 40025).
+    // Run the keyword search in parallel with the dense query.
     const vectorizeTopK = Math.min(topK * VECTORIZE_TOP_K_MULTIPLIER, 50);
-    results = await env.VECTORIZE.query(values, {
-      topK: vectorizeTopK,
-      returnMetadata: "all",
-    });
+    const [denseResults, kwRows] = await Promise.all([
+      env.VECTORIZE.query(values, { topK: vectorizeTopK, returnMetadata: "all" }),
+      keywordSearch(tokens, env),
+    ]);
+    results = denseResults;
+    keywordRows = kwRows;
 
     if (results.matches.length && results.matches[0].score < DUPLICATE_FLAG_THRESHOLD) {
       results = await env.VECTORIZE.query(values, {
@@ -1155,12 +1250,16 @@ export async function recallEntries(
     }
   }
 
-  if (!results.matches.length) return { matches: [], insight: "" };
+  // Always-on hybrid retrieval: fuse dense + keyword candidates via RRF. On the tag path
+  // keyword is a re-ranking signal only (allowKeywordOnly=false); on the default path it can
+  // also surface exact-identifier matches the dense top-K missed entirely.
+  const fusedMatches = fuseDenseAndKeyword(results.matches as VectorizeMatch[], keywordRows, tokens, !tag);
+  if (!fusedMatches.length) return { matches: [], insight: "" };
 
   // Fetch recall_count and importance_score for all candidates to use in scoring.
   // The tag path can produce far more than 100 candidates, so chunk the IN query
   // to stay under D1's bound-parameter limit.
-  const candidateIds = [...new Set(results.matches.map(m => (m.metadata as any)?.parentId ?? m.id))] as string[];
+  const candidateIds = [...new Set(fusedMatches.map(m => (m.metadata as any)?.parentId ?? m.id))] as string[];
   const rcRows: { id: string; recall_count: number; importance_score: number; contradiction_wins: number; contradiction_losses: number }[] = [];
   for (let i = 0; i < candidateIds.length; i += D1_MAX_BOUND_PARAMS) {
     const batch = candidateIds.slice(i, i + D1_MAX_BOUND_PARAMS);
@@ -1175,7 +1274,7 @@ export async function recallEntries(
   const contradictionWins = new Map(rcRows.map(r => [r.id, r.contradiction_wins ?? 0]));
   const contradictionLosses = new Map(rcRows.map(r => [r.id, r.contradiction_losses ?? 0]));
 
-  const reranked = rerankWithTimeDecay(results.matches as VectorizeMatch[], recallCounts, importanceScores, queryTags, contradictionWins, contradictionLosses);
+  const reranked = rerankWithTimeDecay(fusedMatches, recallCounts, importanceScores, queryTags, contradictionWins, contradictionLosses);
 
   const seen = new Set<string>();
   const deduped = reranked.filter((m) => {
@@ -1235,6 +1334,11 @@ export async function recallEntries(
       isUpdate,
     }];
   });
+
+  // Normalize fused scores to 0–1 (top match = 1.0) so the displayed match % is a clean,
+  // monotonically-decreasing scale rather than raw RRF values.
+  const maxScore = matches.reduce((mx, m) => Math.max(mx, m.score), 0);
+  if (maxScore > 0) for (const m of matches) m.score = m.score / maxScore;
 
   const insight = d1Rows.length > 1
     ? await synthesizeInsight(embedQuery, d1Rows as { id: string; content: string }[], env)

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -151,13 +151,28 @@ export class D1Mock {
         return null;
       },
       async all() {
-        if (s === "SELECT id FROM entries WHERE tags LIKE ?" || s === "SELECT id, vector_ids FROM entries WHERE tags LIKE ?") {
+        if (
+          s === "SELECT id FROM entries WHERE tags LIKE ?" ||
+          s === "SELECT id, vector_ids FROM entries WHERE tags LIKE ?" ||
+          s === "SELECT id, vector_ids, content, tags, source, created_at FROM entries WHERE tags LIKE ?"
+        ) {
           const pattern = String(args[0]);
           const tag = pattern.replace(/%"/g, "").replace(/"%/g, "");
           const results = db.entries
             .filter((e: any) => (JSON.parse(e.tags ?? "[]") as string[]).includes(tag))
-            .map((e: any) => ({ id: e.id, vector_ids: e.vector_ids ?? "[]" }));
+            .map((e: any) => ({ id: e.id, vector_ids: e.vector_ids ?? "[]", content: e.content, tags: e.tags, source: e.source, created_at: e.created_at }));
           return { results };
+        }
+        if (s.includes("WHERE content LIKE") && s.includes("ORDER BY created_at DESC LIMIT")) {
+          // Keyword (hybrid recall) query: content LIKE ? OR content LIKE ? ... LIMIT ?
+          const limit = Number(args[args.length - 1]);
+          const patterns = args.slice(0, -1).map((a: any) => String(a).replace(/^%/, "").replace(/%$/, "").toLowerCase());
+          const rows = [...db.entries]
+            .filter((e: any) => patterns.some((p: string) => String(e.content).toLowerCase().includes(p)))
+            .sort((a: any, b: any) => b.created_at - a.created_at)
+            .slice(0, limit)
+            .map((e: any) => ({ id: e.id, content: e.content, tags: e.tags, source: e.source, created_at: e.created_at }));
+          return { results: rows };
         }
         if (s.includes("SELECT id, recall_count, importance_score") && s.includes("WHERE id IN")) {
           const results = db.entries

--- a/test/integration/recall.test.ts
+++ b/test/integration/recall.test.ts
@@ -86,7 +86,9 @@ describe("GET /recall", () => {
     expect(data.ok).toBe(true);
     expect(data.results).toHaveLength(2);
     expect(data.results[0]).toMatchObject({ id: "entry-1", content: "First memory", tags: ["work"], source: "api" });
-    expect(data.results[0].score).toBeCloseTo(90, 0);
+    // Fused scores are normalized so the top match is 100% and the list descends.
+    expect(data.results[0].score).toBe(100);
+    expect(data.results[1].score).toBeLessThanOrEqual(data.results[0].score);
     expect(data.results[1]).toMatchObject({ id: "entry-2", content: "Second memory" });
     expect(typeof data.insight === "string" || data.insight === null).toBe(true);
   });
@@ -505,5 +507,67 @@ describe("GET /recall", () => {
     // peer (contradiction_wins=0, imp=3 → effectiveImp=3.0) even though peer was listed first.
     expect(data.results[0].id).toBe(winnerId);
     expect(data.results[1].id).toBe("peer");
+  });
+
+  // ── Hybrid recall: keyword fusion surfaces exact-identifier matches ──
+
+  it("surfaces an exact-identifier match the dense top-K missed, via keyword fusion", async () => {
+    const now = Date.now();
+    const seed: [string, string][] = [
+      ["v16", "Release notes for v1.6 — web UI polish"],
+      ["v17", "Release notes for v1.7 — added OAuth support"],
+      ["v18", "Release notes for v1.8 — fixed a re-embed bug"],
+      ["v19", "Release notes for v1.9 — added the memory status layer"],
+    ];
+    seed.forEach(([id, content], i) => db.entries.push({
+      id, content, tags: "[]", source: "api",
+      created_at: now - (seed.length - i) * 1000,
+      vector_ids: `["${id}"]`, recall_count: 0, importance_score: 0,
+      contradiction_wins: 0, contradiction_losses: 0,
+    }));
+
+    // Dense search returns the near-twins at high scores but misses v1.9 entirely —
+    // version tokens embed near-identically, so cosine can't single it out.
+    const queryMock = vi.fn().mockResolvedValue({
+      matches: [makeMatch("v16", 0.82), makeMatch("v17", 0.81), makeMatch("v18", 0.80)],
+    });
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ query: queryMock }) });
+    const prepareSpy = vi.spyOn(db, "prepare");
+
+    const res = await worker.fetch(req("GET", "/recall?query=release+v1.9"), env, ctx);
+    const data = await res.json() as any;
+
+    // Keyword search ran on this recall — it's always-on, not a fallback
+    expect(prepareSpy.mock.calls.some(([sql]) => sql.includes("content LIKE"))).toBe(true);
+    // The exact v1.9 entry is surfaced AND ranked first despite being absent from dense
+    const ids = data.results.map((r: any) => r.id);
+    expect(ids).toContain("v19");
+    expect(ids[0]).toBe("v19");
+    expect(data.results[0].score).toBe(100);
+  });
+
+  it("re-ranks an identifier hit to the top within a tag (hybrid on the tag path)", async () => {
+    const now = Date.now();
+    const seed: [string, string][] = [
+      ["v16", "Release notes for v1.6"],
+      ["v17", "Release notes for v1.7"],
+      ["v18", "Release notes for v1.8"],
+      ["v19", "Release notes for v1.9"],
+    ];
+    seed.forEach(([id, content], i) => db.entries.push({
+      id, content, tags: '["rel"]', source: "api",
+      created_at: now - (seed.length - i) * 1000,
+      vector_ids: `["${id}"]`, recall_count: 0, importance_score: 0,
+      contradiction_wins: 0, contradiction_losses: 0,
+    }));
+    // All tagged vectors score equally on cosine — only keyword fusion distinguishes them.
+    const getByIdsMock = vi.fn().mockResolvedValue(
+      seed.map(([id]) => ({ id, values: SIMILAR_VEC, metadata: { parentId: id, isUpdate: false } })),
+    );
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ getByIds: getByIdsMock }) });
+
+    const res = await worker.fetch(req("GET", "/recall?query=release+v1.9&tag=rel"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.results[0].id).toBe("v19");
   });
 });

--- a/test/unit/rrf-fuse.test.ts
+++ b/test/unit/rrf-fuse.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { rrfFuse } from "../../src/index";
+
+describe("rrfFuse()", () => {
+  it("ranks a dense-only list by position (earlier rank = higher score)", () => {
+    const scores = rrfFuse(["a", "b", "c"], []);
+    expect(scores.get("a")!).toBeGreaterThan(scores.get("b")!);
+    expect(scores.get("b")!).toBeGreaterThan(scores.get("c")!);
+  });
+
+  it("rewards an entry that appears in BOTH lists over one in a single list", () => {
+    // b is rank1 in dense AND rank0 in keyword; a is only in dense, c only in keyword.
+    const scores = rrfFuse(["a", "b"], [{ id: "b", weight: 1 }, { id: "c", weight: 1 }]);
+    expect(scores.get("b")!).toBeGreaterThan(scores.get("a")!);
+    expect(scores.get("b")!).toBeGreaterThan(scores.get("c")!);
+  });
+
+  it("scales a keyword contribution by its match weight", () => {
+    // x matches more distinct tokens than y, so even at a worse rank it must win.
+    const scores = rrfFuse([], [{ id: "x", weight: 2 }, { id: "y", weight: 1 }]);
+    expect(scores.get("x")!).toBeGreaterThan(scores.get("y")!);
+  });
+
+  it("lets a high-weight keyword-only hit beat near-twins present in both lists", () => {
+    // Mirrors the identifier case: twins t1/t2 are in both lists (weight 1); the exact
+    // match `hit` is keyword-only but matched 2 distinct tokens.
+    const scores = rrfFuse(
+      ["t1", "t2"],
+      [{ id: "hit", weight: 2 }, { id: "t1", weight: 1 }, { id: "t2", weight: 1 }],
+    );
+    expect(scores.get("hit")!).toBeGreaterThan(scores.get("t1")!);
+    expect(scores.get("hit")!).toBeGreaterThan(scores.get("t2")!);
+  });
+
+  it("returns an empty map when both lists are empty", () => {
+    expect(rrfFuse([], []).size).toBe(0);
+  });
+});

--- a/test/unit/tokenize-query.test.ts
+++ b/test/unit/tokenize-query.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { tokenizeQuery } from "../../src/index";
+
+describe("tokenizeQuery()", () => {
+  it("preserves identifier-shaped tokens like version strings", () => {
+    expect(tokenizeQuery("release v1.9")).toEqual(["release", "v1.9"]);
+  });
+
+  it("drops stopwords and 1-char tokens but keeps the meaningful ones", () => {
+    expect(tokenizeQuery("What is the v1.9 release?")).toEqual(["v1.9", "release"]);
+  });
+
+  it("strips SQL LIKE wildcards so a token is always a literal substring", () => {
+    expect(tokenizeQuery("foo_bar 100%")).toEqual(["foobar", "100"]);
+  });
+
+  it("deduplicates repeated tokens", () => {
+    expect(tokenizeQuery("test test")).toEqual(["test"]);
+  });
+
+  it("returns an empty array when the query is all stopwords", () => {
+    expect(tokenizeQuery("what is the")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #159.

## Why

`recall` relied **solely** on dense vector search. Dense embeddings can't distinguish exact identifiers — version strings (`v1.9`), PR numbers, error codes, acronyms — because they embed to nearly the same point as their neighbours. The failure mode isn't "no results", it's **confident wrong results**: near-twin entries crowd out the one the user named, and the top-50 cap can drop it entirely. A fallback gated on empty/low-score wouldn't help, because semantic returns full, high-confidence (but wrong) results.

## What

Always-on **hybrid retrieval** inside the shared `recallEntries()` pipeline (backs both the MCP `recall` tool and `GET /recall`, so they stay in parity):

- Run a keyword (`LIKE`) search in parallel with the dense Vectorize query.
- Fuse the two ranked lists with **Reciprocal Rank Fusion** before the existing `rerankWithTimeDecay()` (recency/importance/contradiction/tag-boost all still apply on top).
- Applies to **both** the default path and the tag-scoped path. On the tag path keyword is a re-ranking signal only — it never introduces an entry the dense pass didn't already surface.
- **No tertiary fallback.** If both dense and keyword come back empty, recall honestly returns nothing.
- Fused scores are **normalized** (top match = 100%) so the displayed match % descends cleanly.

## Design note: weighted keyword contribution

Pure rank-based RRF under-delivers on the motivating case: when the exact-identifier entry is missing from the dense list, it earns credit from only the keyword list while its near-twins earn from *both* — so the twins stay on top. To fix this, each keyword candidate's RRF contribution is **weighted by the number of distinct query tokens it matched**, so an entry matching the rare identifier token (e.g. `v1.9`) outranks entries that merely share a common word (e.g. `release`). Dense contributions remain pure rank-based.

## Engine choice: `LIKE`, not FTS5

`LIKE` substring matching needs zero schema/migration and is microseconds at personal scale. It's also *more predictable* than FTS5 here: FTS5's default tokenizer splits on punctuation (`v1.9` → `v1`, `9`), which would defeat the exact-identifier matching that's the whole point. FTS5/BM25 remains a documented future option if ranking quality demands it.

## Tests

- `test/unit/rrf-fuse.test.ts` — fusion ordering, dual-list reward, weight scaling, the identifier-beats-twins case.
- `test/unit/tokenize-query.test.ts` — stopword/short-token drop, identifier preservation, wildcard stripping.
- `test/integration/recall.test.ts` — an entry absent from the dense top-K is surfaced and ranked first via keyword (default path); an identifier hit is re-ranked to the top within a tag (tag path); keyword runs on every recall.
- Full suite: **403 passing**, `tsc --noEmit` clean. No schema change — existing deployments upgrade with a redeploy.