### PR TITLE
fix: ground the recall insight prompt to stop fabricating absent facts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -863,14 +863,19 @@ export async function synthesizeInsight(
     .map((r, i) => `[${i + 1}] ID: ${r.id}\n${r.content}`)
     .join("\n\n");
 
-  const prompt = `You are a second brain assistant. Given the user's query and their relevant stored memories, synthesize what they most need to know. Be specific and concise.
+  const prompt = `You are a second brain assistant. Summarize what the user's stored memories below say in relation to their query. Base the insight ONLY on these memories.
 
 Query: "${query}"
 
-Relevant memories:
+Memories:
 ${memoriesList}
 
-Provide a brief insight (2-4 sentences) focused on what's most relevant to this query.`;
+Rules:
+- Use ONLY the information in the memories above. Do not add, infer, guess, or speculate, and do not use hedging language like "might" or "it seems".
+- These memories are a retrieved subset, not the user's full memory store. Never say that information is missing, unavailable, or does not exist.
+- If the memories don't address the query, briefly state only what they do contain.
+
+Write a brief insight (2-4 sentences).`;
 
   let insight = "";
   try {

--- a/test/unit/synthesize-insight.test.ts
+++ b/test/unit/synthesize-insight.test.ts
@@ -71,4 +71,19 @@ describe("synthesizeInsight()", () => {
     expect(messages[0].content).toContain("JWT decision");
     expect(messages[0].content).toContain("switched to Postgres");
   });
+
+  it("grounds the prompt: only-these-memories, no absence claims, no speculation", async () => {
+    // The insight only ever sees the retrieved subset, so the prompt must forbid both
+    // claiming information is absent and speculating beyond the provided memories.
+    const env = makeTestEnv(undefined, { AI: aiMock("ok") });
+    await synthesizeInsight("release v1.9", [{ id: "1", content: "note" }], env);
+    const [, { messages }] = (env.AI.run as ReturnType<typeof vi.fn>).mock.calls[0];
+    const prompt = (messages[0].content as string).toLowerCase();
+    // grounding
+    expect(prompt).toContain("only");
+    // no absence claims
+    expect(prompt).toMatch(/missing|unavailable|does not exist/);
+    // no speculation
+    expect(prompt).toMatch(/speculate|guess|infer/);
+  });
 });


### PR DESCRIPTION
Closes #160.

## Why

The **Insight** line rendered above recall results (in both the MCP `recall` tool and `GET /recall`) is produced by `synthesizeInsight()`. Its prompt was **under-constrained** compared to the `/chat` prompt: it wasn't told to use only the provided memories, didn't forbid asserting absence, and didn't forbid speculation. Its framing — "synthesize what they most need to know" — invited the model to reason about the query and fill gaps rather than summarize what the retrieved memories actually say.

Because the function only ever sees the retrieved top-K subset (never the full store), this produced three failure modes: confidently asserting information "doesn't exist" (a negative claim it has no basis to make), speculating/hedging about facts not present, and even under-committing on facts that *were* present.

This is independent of retrieval quality — even with perfect retrieval, any query whose answer isn't in the top-K would still yield a fabricated insight. It's a prompt problem, fixed with a prompt change.

## What

Rewrite the `synthesizeInsight` prompt to mirror the grounding discipline `/chat` already uses:

- **Ground it** — base the insight only on the provided memories.
- **Forbid absence claims** — never say information is missing/unavailable/nonexistent; these are a retrieved subset, not the full store.
- **Forbid speculation** — no inferring, guessing, or hedging language ("might", "it seems").
- **Reframe the task** — summarize what the memories say in relation to the query, rather than "what they most need to know".

Behaviour is otherwise unchanged: same trigger (fires only when >1 result), same non-fatal error handling (returns `""` on failure), same token budget.

## Tests

- `test/unit/synthesize-insight.test.ts` — adds a deterministic assertion that the prompt carries the grounding / no-absence / no-speculation instructions (model behaviour isn't unit-testable, but the prompt content is). Existing plumbing tests still pass.
- Full suite: **392 passing**, `tsc --noEmit` clean. Prompt-only change — no schema or API change.