### PR TITLE
Add Notion integration with mirrored entry sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Memory is most useful when capturing information is easy. Second Brain connects 
   npm install -g second-brain-cf-cli
   ```
 
+* **Notion:** Connect your Notion workspace from **Settings → Integrations** in the web dashboard. Create an [internal integration](https://www.notion.so/profile/integrations), share the pages you want remembered with it, and paste its secret — shared pages sync into memory automatically (nightly, or on demand with **Sync now**) and stay updated as they change in Notion.
+
 * **Obsidian:** Automatically sync notes using the [Second Brain Sync plugin](https://github.com/rahilp/second-brain-obsidian-plugin), also available through [Obsidian Community Plugins](https://community.obsidian.md/plugins/second-brain-sync).
 
 * **Browser extension:** Capture a page or highlighted text using the [Chrome extension](https://github.com/rahilp/second-brain-browser-extension).

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Deploying takes about two minutes. See the [Quick Start](#quick-start) for the r
 >
 > <a href="https://www.producthunt.com/products/second-brain-cloudflare?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-second-brain-for-ai" target="_blank" rel="noopener noreferrer"><img alt="Second Brain for AI: Persistent memory for Claude, ChatGPT, and Cursor" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1151393&theme=light&period=daily&t=1780357463637"></a>
 
+## What's new in v2
+
+* **Memory graph.** Memories now connect to each other — automatically as you save, or explicitly with the new `link` and `connections` tools. Recall can follow those connections (the `hops` option) to surface related context that a plain search would miss, and the dashboard has a new **Graph** tab to explore your memory visually.
+
+* **Notion sync.** Connect your Notion workspace from **Settings → Integrations** in the dashboard. Pages you share with the connection sync into memory, stay updated as they change in Notion, and surface in recall alongside everything else. Nightly automatic sync, or on demand with **Sync now**.
+
+* **Graceful degradation.** If the Vectorize index is missing, recall now falls back to keyword search with a clear notice instead of failing, a new `/health` endpoint reports index status, and the dashboard shows a banner with the exact fix.
+
 ## See it in action
 
 [![Second Brain Demo](https://img.youtube.com/vi/h0JqRM0UxHE/hqdefault.jpg)](https://youtu.be/h0JqRM0UxHE)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Memory is most useful when capturing information is easy. Second Brain connects 
   npm install -g second-brain-cf-cli
   ```
 
-* **Notion:** Connect your Notion workspace from **Settings → Integrations** in the web dashboard. Create an [internal integration](https://www.notion.so/profile/integrations), share the pages you want remembered with it, and paste its secret — shared pages sync into memory automatically (nightly, or on demand with **Sync now**) and stay updated as they change in Notion.
+* **Notion:** Connect your Notion workspace from **Settings → Integrations** in the web dashboard. Create an internal **connection** in the [Notion developer portal](https://app.notion.com/developers) (a connection, not a personal access token — only connections appear in a page's Connections menu), share the pages you want remembered with it, and paste its secret — shared pages sync into memory automatically (nightly, or on demand with **Sync now**) and stay updated as they change in Notion.
 
 * **Obsidian:** Automatically sync notes using the [Second Brain Sync plugin](https://github.com/rahilp/second-brain-obsidian-plugin), also available through [Obsidian Community Plugins](https://community.obsidian.md/plugins/second-brain-sync).
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Memory is most useful when capturing information is easy. Second Brain connects 
   npm install -g second-brain-cf-cli
   ```
 
-* **Notion:** Connect your Notion workspace from **Settings → Integrations** in the web dashboard. Create an internal **connection** in the [Notion developer portal](https://app.notion.com/developers) (a connection, not a personal access token — only connections appear in a page's Connections menu), share the pages you want remembered with it, and paste its secret — shared pages sync into memory automatically (nightly, or on demand with **Sync now**) and stay updated as they change in Notion.
+* **Notion:** Connect your Notion workspace from **Settings → Integrations** in the web dashboard. Create an internal **connection** in the [Notion developer portal](https://app.notion.com/developers/connections) (a connection, not a personal access token — only connections appear in a page's Connections menu), share the pages you want remembered with it, and paste its secret — shared pages sync into memory automatically (nightly, or on demand with **Sync now**) and stay updated as they change in Notion.
 
 * **Obsidian:** Automatically sync notes using the [Second Brain Sync plugin](https://github.com/rahilp/second-brain-obsidian-plugin), also available through [Obsidian Community Plugins](https://community.obsidian.md/plugins/second-brain-sync).
 

--- a/public/index.html
+++ b/public/index.html
@@ -3516,8 +3516,9 @@
             <div class="integration-row">
               <div class="integration-head"><i class="ti ti-brand-notion"></i><span>Notion</span><span class="integration-state">Not connected</span></div>
               <p class="digest-note">
-                Create an internal integration at <b>notion.so/profile/integrations</b>, share the pages you want remembered with it
-                (page menu &rarr; Connections), then paste its secret here. Shared pages sync into your brain and stay updated.
+                Create an internal <b>connection</b> (not a personal access token) at <b>app.notion.com/developers</b>, share the pages
+                you want remembered with it (page menu &rarr; Connections), then paste its secret here. Shared pages sync into your
+                brain and stay updated.
               </p>
               <div class="integration-connect-row">
                 <input type="password" id="notion-token-input" placeholder="Integration secret (ntn_…)" autocomplete="off" />

--- a/public/index.html
+++ b/public/index.html
@@ -3566,7 +3566,7 @@
           return
         }
         const last = notionInfo.lastSyncedAt ? new Date(notionInfo.lastSyncedAt).toLocaleString() : 'never'
-        const pages = `${notionInfo.pageCount} page${notionInfo.pageCount === 1 ? '' : 's'} synced`
+        const pages = `${notionInfo.itemCount} page${notionInfo.itemCount === 1 ? '' : 's'} synced`
         const err = notionInfo.lastSyncError ? `<div class="integration-error">Last sync failed: ${escHtml(notionInfo.lastSyncError)}</div>` : ''
         el.innerHTML = `
           <div class="integration-row">
@@ -3652,9 +3652,9 @@
       async function disconnectNotion(btn) {
         if (!confirm('Disconnect Notion? Pages will stop syncing.')) return
         let purge = false
-        if (notionInfo && notionInfo.pageCount > 0) {
+        if (notionInfo && notionInfo.itemCount > 0) {
           purge = confirm(
-            `Also delete the ${notionInfo.pageCount} memor${notionInfo.pageCount === 1 ? 'y' : 'ies'} synced from Notion?\n\nOK = delete them\nCancel = keep them as regular memories`,
+            `Also delete the ${notionInfo.itemCount} memor${notionInfo.itemCount === 1 ? 'y' : 'ies'} synced from Notion?\n\nOK = delete them\nCancel = keep them as regular memories`,
           )
         }
         btn.disabled = true

--- a/public/index.html
+++ b/public/index.html
@@ -2010,6 +2010,74 @@
         margin-bottom: 10px;
       }
 
+      .integration-row {
+        padding: 2px 0;
+      }
+
+      .integration-head {
+        display: flex;
+        align-items: center;
+        gap: 7px;
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--text-primary);
+        margin-bottom: 6px;
+      }
+
+      .integration-head i {
+        color: var(--accent);
+        font-size: 15px;
+      }
+
+      .integration-state {
+        margin-left: auto;
+        font-size: 11px;
+        color: var(--text-tertiary);
+      }
+
+      .integration-state.connected {
+        color: var(--good);
+      }
+
+      .integration-connect-row {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 6px;
+      }
+
+      .integration-connect-row input {
+        flex: 1;
+        min-width: 0;
+        padding: 8px 10px;
+        background: transparent;
+        border: 0.5px solid var(--border-input);
+        border-radius: 9px;
+        font-size: 13px;
+        font-family: inherit;
+        color: var(--text-primary);
+        outline: none;
+      }
+
+      .integration-connect-row input:focus {
+        border-color: var(--accent);
+      }
+
+      .integration-actions {
+        display: flex;
+        gap: 8px;
+      }
+
+      .digest-btn.danger {
+        color: var(--danger);
+        background: rgba(179, 38, 30, 0.08);
+      }
+
+      .integration-error {
+        font-size: 12px;
+        color: var(--danger);
+        margin-bottom: 6px;
+      }
+
       .digest-result {
         font-size: 12px;
         color: var(--text-secondary);
@@ -2624,6 +2692,10 @@
         </div>
         <div class="digest-section" id="digest-section" style="display: none"></div>
         <div class="digest-section" id="vectorize-section" style="display: none"></div>
+        <div class="digest-section" id="integrations-section">
+          <div class="digest-section-label">Integrations</div>
+          <div id="integration-notion"><p class="digest-note">Loading&hellip;</p></div>
+        </div>
         <div class="theme-row">
           <span class="theme-row-label">Appearance</span>
           <div class="theme-toggle" id="theme-toggle">
@@ -3286,6 +3358,7 @@
       function openMenu() {
         document.getElementById('menu-sheet').classList.add('open')
         loadMenuStats()
+        loadIntegrations()
       }
       function closeMenu() {
         document.getElementById('menu-sheet').classList.remove('open')
@@ -3418,6 +3491,154 @@
             btn.innerHTML = 'Vectorize now →'
             btn.style.color = ''
           }, 3000)
+        }
+      }
+
+      // ── Integrations (Notion) ─────────────────────────────────────────────
+      let notionInfo = null
+
+      async function loadIntegrations() {
+        const el = document.getElementById('integration-notion')
+        try {
+          const res = await fetch(`${WORKER_URL}/integrations`, { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } })
+          const data = await res.json()
+          notionInfo = (data.integrations || []).find((i) => i.provider === 'notion') || null
+          renderNotionCard()
+        } catch {
+          el.innerHTML = '<p class="digest-note">Could not load integrations.</p>'
+        }
+      }
+
+      function renderNotionCard() {
+        const el = document.getElementById('integration-notion')
+        if (!notionInfo || !notionInfo.connected) {
+          el.innerHTML = `
+            <div class="integration-row">
+              <div class="integration-head"><i class="ti ti-brand-notion"></i><span>Notion</span><span class="integration-state">Not connected</span></div>
+              <p class="digest-note">
+                Create an internal integration at <b>notion.so/profile/integrations</b>, share the pages you want remembered with it
+                (page menu &rarr; Connections), then paste its secret here. Shared pages sync into your brain and stay updated.
+              </p>
+              <div class="integration-connect-row">
+                <input type="password" id="notion-token-input" placeholder="Integration secret (ntn_…)" autocomplete="off" />
+                <button class="digest-btn" onclick="connectNotion(this)">Connect</button>
+              </div>
+              <div class="integration-error" id="notion-error"></div>
+            </div>`
+          return
+        }
+        const last = notionInfo.lastSyncedAt ? new Date(notionInfo.lastSyncedAt).toLocaleString() : 'never'
+        const pages = `${notionInfo.pageCount} page${notionInfo.pageCount === 1 ? '' : 's'} synced`
+        const err = notionInfo.lastSyncError ? `<div class="integration-error">Last sync failed: ${escHtml(notionInfo.lastSyncError)}</div>` : ''
+        el.innerHTML = `
+          <div class="integration-row">
+            <div class="integration-head"><i class="ti ti-brand-notion"></i><span>Notion</span><span class="integration-state connected">${escHtml(notionInfo.workspaceName || 'Connected')}</span></div>
+            <p class="digest-note" id="notion-sync-note">${pages} &middot; Last sync: ${escHtml(last)}</p>
+            ${err}
+            <div class="integration-actions">
+              <button class="digest-btn" onclick="syncNotion(this)"><i class="ti ti-refresh"></i> Sync now</button>
+              <button class="digest-btn danger" onclick="disconnectNotion(this)">Disconnect</button>
+            </div>
+          </div>`
+      }
+
+      async function connectNotion(btn) {
+        const input = document.getElementById('notion-token-input')
+        const errEl = document.getElementById('notion-error')
+        const token = input.value.trim()
+        if (!token) {
+          errEl.textContent = 'Paste your integration secret first.'
+          return
+        }
+        btn.disabled = true
+        btn.textContent = 'Connecting…'
+        errEl.textContent = ''
+        try {
+          const res = await fetch(`${WORKER_URL}/integrations/notion/connect`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${AUTH_TOKEN}` },
+            body: JSON.stringify({ token }),
+          })
+          const data = await res.json()
+          if (!res.ok || !data.ok) throw new Error(data.error || 'Could not connect')
+          await loadIntegrations()
+        } catch (e) {
+          errEl.textContent = e.message || 'Could not connect.'
+          btn.disabled = false
+          btn.textContent = 'Connect'
+        }
+      }
+
+      async function syncNotion(btn) {
+        btn.disabled = true
+        btn.classList.add('digest-btn--loading')
+        btn.innerHTML = '<i class="ti ti-loader-2"></i> Syncing…'
+        const note = document.getElementById('notion-sync-note')
+        try {
+          // Each call processes a bounded batch (Workers subrequest limits) and
+          // reports what's left — loop until the backlog drains, like runVectorize.
+          let remaining = 1
+          let processed = 0
+          let guard = 0
+          while (remaining > 0 && guard < 40) {
+            guard++
+            const res = await fetch(`${WORKER_URL}/integrations/notion/sync`, {
+              method: 'POST',
+              headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+            })
+            const data = await res.json()
+            if (!res.ok || !data.ok) throw new Error(data.error || 'Sync failed')
+            processed += (data.created ?? 0) + (data.updated ?? 0)
+            remaining = data.remaining ?? 0
+            if (note) note.textContent = `Syncing… ${processed} page${processed === 1 ? '' : 's'} so far`
+            // A batch with zero progress means every page in it failed — stop looping.
+            if ((data.created ?? 0) + (data.updated ?? 0) + (data.deleted ?? 0) === 0 && remaining > 0) break
+          }
+          btn.classList.remove('digest-btn--loading')
+          btn.innerHTML = `<i class="ti ti-check"></i> ${processed} synced`
+          btn.style.color = 'var(--good)'
+          setTimeout(async () => {
+            await loadIntegrations()
+          }, 900)
+          loadRecent()
+          loadTags()
+          updateStatus()
+        } catch (e) {
+          btn.classList.remove('digest-btn--loading')
+          btn.innerHTML = '<i class="ti ti-alert-triangle"></i> Sync failed'
+          btn.style.color = 'var(--danger)'
+          setTimeout(() => loadIntegrations(), 3000)
+        }
+      }
+
+      async function disconnectNotion(btn) {
+        if (!confirm('Disconnect Notion? Pages will stop syncing.')) return
+        let purge = false
+        if (notionInfo && notionInfo.pageCount > 0) {
+          purge = confirm(
+            `Also delete the ${notionInfo.pageCount} memor${notionInfo.pageCount === 1 ? 'y' : 'ies'} synced from Notion?\n\nOK = delete them\nCancel = keep them as regular memories`,
+          )
+        }
+        btn.disabled = true
+        btn.textContent = 'Disconnecting…'
+        try {
+          const res = await fetch(`${WORKER_URL}/integrations/notion/disconnect`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${AUTH_TOKEN}` },
+            body: JSON.stringify({ purge }),
+          })
+          const data = await res.json()
+          if (!res.ok || !data.ok) throw new Error(data.error || 'Disconnect failed')
+          await loadIntegrations()
+          if (purge) {
+            loadRecent()
+            loadTags()
+            updateStatus()
+          }
+        } catch (e) {
+          btn.disabled = false
+          btn.textContent = 'Disconnect'
+          alert(e.message || 'Disconnect failed')
         }
       }
 

--- a/public/index.html
+++ b/public/index.html
@@ -2010,6 +2010,16 @@
         margin-bottom: 10px;
       }
 
+      .digest-note a {
+        color: var(--accent);
+        text-decoration: none;
+        border-bottom: 1px solid var(--accent-soft);
+      }
+
+      .digest-note a:hover {
+        border-bottom-color: var(--accent);
+      }
+
       .integration-row {
         padding: 2px 0;
       }
@@ -3516,9 +3526,10 @@
             <div class="integration-row">
               <div class="integration-head"><i class="ti ti-brand-notion"></i><span>Notion</span><span class="integration-state">Not connected</span></div>
               <p class="digest-note">
-                Create an internal <b>connection</b> (not a personal access token) at <b>app.notion.com/developers</b>, share the pages
-                you want remembered with it (page menu &rarr; Connections), then paste its secret here. Shared pages sync into your
-                brain and stay updated.
+                Create an internal <b>connection</b> (not a personal access token) at
+                <a href="https://app.notion.com/developers/connections" target="_blank" rel="noopener noreferrer">app.notion.com/developers/connections</a>,
+                share the pages you want remembered with it (page menu &rarr; Connections), then paste its secret here. Shared pages
+                sync into your brain and stay updated.
               </p>
               <div class="integration-connect-row">
                 <input type="password" id="notion-token-input" placeholder="Integration secret (ntn_…)" autocomplete="off" />

--- a/public/index.html
+++ b/public/index.html
@@ -1472,6 +1472,7 @@
       #append-sheet,
       #edit-sheet,
       #menu-sheet,
+      #integrations-sheet,
       #view-sheet {
         display: none;
         position: fixed;
@@ -1490,6 +1491,7 @@
       #append-sheet.open,
       #edit-sheet.open,
       #menu-sheet.open,
+      #integrations-sheet.open,
       #view-sheet.open {
         display: flex;
         opacity: 1;
@@ -2272,6 +2274,7 @@
         #append-sheet,
         #edit-sheet,
         #menu-sheet,
+        #integrations-sheet,
         #view-sheet {
           align-items: center;
           justify-content: center;
@@ -2702,10 +2705,6 @@
         </div>
         <div class="digest-section" id="digest-section" style="display: none"></div>
         <div class="digest-section" id="vectorize-section" style="display: none"></div>
-        <div class="digest-section" id="integrations-section">
-          <div class="digest-section-label">Integrations</div>
-          <div id="integration-notion"><p class="digest-note">Loading&hellip;</p></div>
-        </div>
         <div class="theme-row">
           <span class="theme-row-label">Appearance</span>
           <div class="theme-toggle" id="theme-toggle">
@@ -2723,9 +2722,24 @@
         >
           <i class="ti ti-clock"></i> View all memories
         </button>
+        <button class="menu-item" onclick="openIntegrations()"><i class="ti ti-plug"></i> Integrations</button>
         <button class="menu-item" onclick="exportMemories('json')"><i class="ti ti-download"></i> Export as JSON</button>
         <button class="menu-item" onclick="exportMemories('markdown')"><i class="ti ti-markdown"></i> Export as Markdown</button>
         <button class="menu-item danger" onclick="logout()"><i class="ti ti-logout"></i> Disconnect</button>
+      </div>
+    </div>
+
+    <div id="integrations-sheet">
+      <div class="menu-inner">
+        <div class="view-header">
+          <div style="display: flex; align-items: center; gap: 10px">
+            <button class="btn-close-icon" onclick="backToMenu()" title="Back to settings"><i class="ti ti-arrow-left"></i></button>
+            <h3 style="margin-bottom: 0">Integrations</h3>
+          </div>
+          <button class="btn-close-icon" onclick="closeIntegrations()"><i class="ti ti-x"></i></button>
+        </div>
+        <p class="digest-note">Connect the tools where your context already lives. Synced content stays up to date and surfaces in recall like any other memory.</p>
+        <div id="integration-notion"><p class="digest-note">Loading&hellip;</p></div>
       </div>
     </div>
 
@@ -3368,10 +3382,22 @@
       function openMenu() {
         document.getElementById('menu-sheet').classList.add('open')
         loadMenuStats()
-        loadIntegrations()
       }
       function closeMenu() {
         document.getElementById('menu-sheet').classList.remove('open')
+      }
+
+      function openIntegrations() {
+        closeMenu()
+        document.getElementById('integrations-sheet').classList.add('open')
+        loadIntegrations()
+      }
+      function closeIntegrations() {
+        document.getElementById('integrations-sheet').classList.remove('open')
+      }
+      function backToMenu() {
+        closeIntegrations()
+        openMenu()
       }
 
       async function loadMenuStats() {
@@ -4161,6 +4187,9 @@
       })
       document.getElementById('menu-sheet').addEventListener('click', (e) => {
         if (e.target === document.getElementById('menu-sheet')) closeMenu()
+      })
+      document.getElementById('integrations-sheet').addEventListener('click', (e) => {
+        if (e.target === document.getElementById('integrations-sheet')) closeIntegrations()
       })
       document.getElementById('view-sheet').addEventListener('click', (e) => {
         if (e.target === document.getElementById('view-sheet')) closeView()

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,12 @@ import { createMcpHandler } from "agents/mcp";
 import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
 import { z } from "zod";
 import {
+  INTEGRATION_PROVIDERS,
+  getProvider,
   loadIntegration,
   saveIntegration,
   deleteIntegration,
   integrationStatus,
-  notionValidateToken,
-  runNotionSync,
-  NOTION_SOURCE,
 } from "./integrations";
 import type { IntegrationRecord, MirrorStore } from "./integrations";
 
@@ -2184,11 +2183,11 @@ export async function applyStatus(id: string, status: MemoryStatus, env: Env): P
 }
 
 // ─── Integration mirror store ─────────────────────────────────────────────────
-// The narrow write surface the Notion sync uses to mirror pages into the memory
-// store (see src/integrations.ts). Mirrors bypass captureEntry's duplicate/
-// contradiction pipeline on purpose: Notion is the source of truth for its own
-// pages, dedupe is by page id (the KV pageMap), and every sync replaces content
-// wholesale.
+// The narrow write surface integration syncs use to mirror external items into
+// the memory store (see src/integrations/framework.ts). Mirrors bypass
+// captureEntry's duplicate/contradiction pipeline on purpose: the external tool
+// is the source of truth for its own items, dedupe is by item id (the KV
+// itemMap), and every sync replaces content wholesale.
 
 function makeMirrorStore(env: Env): MirrorStore {
   return {
@@ -2237,28 +2236,37 @@ function makeMirrorStore(env: Env): MirrorStore {
   };
 }
 
-// Notion-mirrored entries are replaced wholesale on every sync, so a manual
-// append/update would be silently clobbered by the page's next edit. While the
-// integration is connected, redirect edits to the source page. After
-// disconnect, mirrors become ordinary editable memories.
+// Mirrored entries are replaced wholesale on every sync, so a manual
+// append/update would be silently clobbered by the item's next upstream edit.
+// While the integration is connected, redirect edits to the source tool. After
+// disconnect, mirrors become ordinary editable memories. Provider ids double
+// as entry `source` values, so the registry is the lookup.
 async function isManagedMirror(source: string, env: Env): Promise<boolean> {
-  return source === NOTION_SOURCE && (await loadIntegration(env, "notion")) !== null;
+  return getProvider(source) !== null && (await loadIntegration(env, source)) !== null;
 }
 
-const MIRROR_EDIT_ERROR =
-  "This memory is synced from a Notion page. Edit the page in Notion (the change syncs automatically), or disconnect the Notion integration to make it editable.";
+function mirrorEditError(source: string): string {
+  const name = getProvider(source)?.name ?? source;
+  return `This memory is synced from ${name}. Edit it in ${name} (the change syncs automatically), or disconnect the ${name} integration to make it editable.`;
+}
 
-// Nightly sync: loop bounded batches so a backlog converges across runs without
-// betting the whole invocation's subrequest budget on one pass.
+// Nightly sync: loop bounded batches per provider so a backlog converges
+// across runs without betting the invocation's subrequest budget on one pass.
 const CRON_SYNC_MAX_BATCHES = 5;
 
 async function runScheduledIntegrationSync(env: Env): Promise<void> {
-  if (!(await loadIntegration(env, "notion"))) return;
-  await initializeDatabase(env);
-  const store = makeMirrorStore(env);
-  for (let i = 0; i < CRON_SYNC_MAX_BATCHES; i++) {
-    const result = await runNotionSync(env, store);
-    if (!result.ok || result.remaining === 0) break;
+  let initialized = false;
+  for (const provider of Object.values(INTEGRATION_PROVIDERS)) {
+    if (!(await loadIntegration(env, provider.id))) continue;
+    if (!initialized) {
+      await initializeDatabase(env);
+      initialized = true;
+    }
+    const store = makeMirrorStore(env);
+    for (let i = 0; i < CRON_SYNC_MAX_BATCHES; i++) {
+      const result = await provider.sync(env, store);
+      if (!result.ok || result.remaining === 0) break;
+    }
   }
 }
 
@@ -2335,7 +2343,7 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       }
 
       if (await isManagedMirror(source, env)) {
-        return { content: [{ type: "text", text: MIRROR_EDIT_ERROR }] };
+        return { content: [{ type: "text", text: mirrorEditError(source) }] };
       }
 
       try {
@@ -2382,7 +2390,7 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       }
 
       if (await isManagedMirror(row.source as string, env)) {
-        return { content: [{ type: "text", text: MIRROR_EDIT_ERROR }] };
+        return { content: [{ type: "text", text: mirrorEditError(row.source as string) }] };
       }
 
       const tags: string[] = JSON.parse(row.tags ?? "[]").filter((t: string) => t !== "rolled-up");
@@ -2686,7 +2694,7 @@ const defaultHandler = {
       const source = row.source as string;
 
       if (await isManagedMirror(source, env)) {
-        return json({ ok: false, error: MIRROR_EDIT_ERROR }, 409);
+        return json({ ok: false, error: mirrorEditError(source) }, 409);
       }
 
       try {
@@ -2722,7 +2730,7 @@ const defaultHandler = {
       if (!row) return json({ ok: false, error: `No entry found with ID: ${id}` }, 404);
 
       if (await isManagedMirror(row.source as string, env)) {
-        return json({ ok: false, error: MIRROR_EDIT_ERROR }, 409);
+        return json({ ok: false, error: mirrorEditError(row.source as string) }, 409);
       }
 
       const tags: string[] = JSON.parse(row.tags ?? "[]");
@@ -3060,84 +3068,89 @@ const defaultHandler = {
     }
 
     // ─── Integrations (settings UI) ─────────────────────────────────────────
-    // External sources mirrored into memory. State (token, workspace, page map)
-    // lives in OAUTH_KV under integrations:* — no schema change, and the
-    // namespace already exists in every deployment. See src/integrations.ts.
+    // External sources mirrored into memory, driven entirely by the provider
+    // registry — adding a provider requires no route changes. State (token,
+    // account, item map) lives in OAUTH_KV under integrations:* — no schema
+    // change, and the namespace already exists in every deployment. See
+    // src/integrations/.
 
     // GET /integrations — provider list + connection status (never the token)
     if (url.pathname === "/integrations" && request.method === "GET") {
       const authErr = requireAuth(request, env);
       if (authErr) return authErr;
-      const record = await loadIntegration(env, "notion");
-      return json({ ok: true, integrations: [integrationStatus(record)] });
+      const integrations = [];
+      for (const provider of Object.values(INTEGRATION_PROVIDERS)) {
+        integrations.push(integrationStatus(provider, await loadIntegration(env, provider.id)));
+      }
+      return json({ ok: true, integrations });
     }
 
-    // POST /integrations/notion/connect — validate an internal-integration
-    // token against Notion (server-side; the browser can't for CORS reasons)
-    // and store it only if it works.
-    if (url.pathname === "/integrations/notion/connect" && request.method === "POST") {
+    // POST /integrations/:provider/(connect|sync|disconnect)
+    const integrationRoute = url.pathname.match(/^\/integrations\/([a-z0-9-]+)\/(connect|sync|disconnect)$/);
+    if (integrationRoute && request.method === "POST") {
       const authErr = requireAuth(request, env);
       if (authErr) return authErr;
+      const provider = getProvider(integrationRoute[1]);
+      if (!provider) return json({ ok: false, error: `Unknown integration: ${integrationRoute[1]}` }, 404);
+      const action = integrationRoute[2];
 
-      let body: { token?: string };
-      try { body = await request.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
-      const token = body.token?.trim();
-      if (!token) return json({ ok: false, error: "token is required" }, 400);
+      // connect — validate the pasted token against the provider's API
+      // (server-side; the browser can't for CORS reasons) and store it only if
+      // it works.
+      if (action === "connect") {
+        let body: { token?: string };
+        try { body = await request.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
+        const token = body.token?.trim();
+        if (!token) return json({ ok: false, error: "token is required" }, 400);
 
-      let workspaceName: string;
-      try {
-        workspaceName = await notionValidateToken(token);
-      } catch (e) {
-        return json({ ok: false, error: e instanceof Error ? e.message : String(e) }, 400);
+        let workspaceName: string;
+        try {
+          workspaceName = await provider.validateToken(token);
+        } catch (e) {
+          return json({ ok: false, error: e instanceof Error ? e.message : String(e) }, 400);
+        }
+
+        // Preserve the item map across reconnects so already-mirrored items
+        // update in place instead of duplicating.
+        const existing = await loadIntegration(env, provider.id);
+        const now = Date.now();
+        const record: IntegrationRecord = {
+          provider: provider.id,
+          authKind: "token",
+          credentials: { token },
+          config: existing?.config ?? {},
+          status: "connected",
+          workspaceName,
+          lastSyncedAt: existing?.lastSyncedAt ?? null,
+          lastSyncError: null,
+          itemMap: existing?.itemMap ?? {},
+          createdAt: existing?.createdAt ?? now,
+          updatedAt: now,
+        };
+        await saveIntegration(env, record);
+        return json({ ok: true, provider: provider.id, workspaceName });
       }
 
-      // Preserve the page map across reconnects so already-mirrored pages
-      // update in place instead of duplicating.
-      const existing = await loadIntegration(env, "notion");
-      const now = Date.now();
-      const record: IntegrationRecord = {
-        provider: "notion",
-        authKind: "token",
-        credentials: { token },
-        config: existing?.config ?? {},
-        status: "connected",
-        workspaceName,
-        lastSyncedAt: existing?.lastSyncedAt ?? null,
-        lastSyncError: null,
-        pageMap: existing?.pageMap ?? {},
-        createdAt: existing?.createdAt ?? now,
-        updatedAt: now,
-      };
-      await saveIntegration(env, record);
-      return json({ ok: true, provider: "notion", workspaceName });
-    }
-
-    // POST /integrations/notion/sync — one bounded sync batch; callers loop
-    // while `remaining` > 0 (same pattern as POST /vectorize-pending).
-    if (url.pathname === "/integrations/notion/sync" && request.method === "POST") {
-      const authErr = requireAuth(request, env);
-      if (authErr) return authErr;
-      if (!(await loadIntegration(env, "notion"))) {
-        return json({ ok: false, error: "Notion is not connected" }, 404);
+      // sync — one bounded batch; callers loop while `remaining` > 0 (same
+      // pattern as POST /vectorize-pending).
+      if (action === "sync") {
+        if (!(await loadIntegration(env, provider.id))) {
+          return json({ ok: false, error: `${provider.name} is not connected` }, 404);
+        }
+        const result = await provider.sync(env, makeMirrorStore(env));
+        return json(result, result.ok ? 200 : 502);
       }
-      const result = await runNotionSync(env, makeMirrorStore(env));
-      return json(result, result.ok ? 200 : 502);
-    }
 
-    // POST /integrations/notion/disconnect — remove the connection. Mirrored
-    // memories are kept (they're the user's data) unless purge=true.
-    if (url.pathname === "/integrations/notion/disconnect" && request.method === "POST") {
-      const authErr = requireAuth(request, env);
-      if (authErr) return authErr;
-
+      // disconnect — remove the connection. Mirrored memories are kept
+      // (they're the user's data) unless purge=true.
       let body: { purge?: boolean } = {};
       try { body = await request.json(); } catch { /* empty body — keep memories */ }
-      const record = await loadIntegration(env, "notion");
-      if (!record) return json({ ok: false, error: "Notion is not connected" }, 404);
+      const record = await loadIntegration(env, provider.id);
+      if (!record) return json({ ok: false, error: `${provider.name} is not connected` }, 404);
 
       let purged = 0;
       if (body.purge) {
-        for (const mapped of Object.values(record.pageMap)) {
+        for (const mapped of Object.values(record.itemMap)) {
           try {
             const r = await forgetEntry(mapped.entryId, env);
             if (r.status === "deleted") purged++;
@@ -3146,8 +3159,8 @@ const defaultHandler = {
           }
         }
       }
-      await deleteIntegration(env, "notion");
-      return json({ ok: true, purged, kept: body.purge ? 0 : Object.keys(record.pageMap).length });
+      await deleteIntegration(env, provider.id);
+      return json({ ok: true, purged, kept: body.purge ? 0 : Object.keys(record.itemMap).length });
     }
 
     return new Response("Not found", { status: 404 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,16 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createMcpHandler } from "agents/mcp";
 import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
 import { z } from "zod";
+import {
+  loadIntegration,
+  saveIntegration,
+  deleteIntegration,
+  integrationStatus,
+  notionValidateToken,
+  runNotionSync,
+  NOTION_SOURCE,
+} from "./integrations";
+import type { IntegrationRecord, MirrorStore } from "./integrations";
 
 export interface Env {
   DB: D1Database;
@@ -2173,6 +2183,85 @@ export async function applyStatus(id: string, status: MemoryStatus, env: Env): P
   return true;
 }
 
+// ─── Integration mirror store ─────────────────────────────────────────────────
+// The narrow write surface the Notion sync uses to mirror pages into the memory
+// store (see src/integrations.ts). Mirrors bypass captureEntry's duplicate/
+// contradiction pipeline on purpose: Notion is the source of truth for its own
+// pages, dedupe is by page id (the KV pageMap), and every sync replaces content
+// wholesale.
+
+function makeMirrorStore(env: Env): MirrorStore {
+  return {
+    async createEntry(content, tags, source) {
+      const id = crypto.randomUUID();
+      const now = Date.now();
+      await env.DB.prepare(
+        `INSERT INTO entries (id, content, tags, source, created_at, vector_ids) VALUES (?, ?, ?, ?, ?, ?)`
+      ).bind(id, content, JSON.stringify(tags), source, now, "[]").run();
+      // Embed failure is non-fatal — the entry keeps vector_ids=[] and the
+      // vectorize-pending backstop re-embeds it later.
+      try {
+        await storeEntry(env, id, content, tags, source, now);
+      } catch (e) {
+        console.error("Vectorize insert failed (non-fatal):", e);
+      }
+      return id;
+    },
+    async updateEntry(id, content) {
+      const row = await env.DB.prepare(
+        `SELECT tags, source, vector_ids FROM entries WHERE id = ?`
+      ).bind(id).first() as Record<string, any> | null;
+      if (!row) return false;
+
+      const tags: string[] = JSON.parse(row.tags ?? "[]");
+      const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
+
+      // Same safe ordering as update/merge/replace: insert new → delete old.
+      await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`).bind(content, id).run();
+      let newVectorIds: string[] = [];
+      try {
+        newVectorIds = await storeEntry(env, id, content, tags, row.source as string, Date.now());
+      } catch (e) {
+        console.error("Vectorize re-embed failed (non-fatal):", e);
+      }
+      try {
+        await deleteStaleVectors(env, oldVectorIds, newVectorIds);
+      } catch (e) {
+        console.error("Old vector cleanup failed (non-fatal):", e);
+      }
+      return true;
+    },
+    async deleteEntry(id) {
+      await forgetEntry(id, env);
+    },
+  };
+}
+
+// Notion-mirrored entries are replaced wholesale on every sync, so a manual
+// append/update would be silently clobbered by the page's next edit. While the
+// integration is connected, redirect edits to the source page. After
+// disconnect, mirrors become ordinary editable memories.
+async function isManagedMirror(source: string, env: Env): Promise<boolean> {
+  return source === NOTION_SOURCE && (await loadIntegration(env, "notion")) !== null;
+}
+
+const MIRROR_EDIT_ERROR =
+  "This memory is synced from a Notion page. Edit the page in Notion (the change syncs automatically), or disconnect the Notion integration to make it editable.";
+
+// Nightly sync: loop bounded batches so a backlog converges across runs without
+// betting the whole invocation's subrequest budget on one pass.
+const CRON_SYNC_MAX_BATCHES = 5;
+
+async function runScheduledIntegrationSync(env: Env): Promise<void> {
+  if (!(await loadIntegration(env, "notion"))) return;
+  await initializeDatabase(env);
+  const store = makeMirrorStore(env);
+  for (let i = 0; i < CRON_SYNC_MAX_BATCHES; i++) {
+    const result = await runNotionSync(env, store);
+    if (!result.ok || result.remaining === 0) break;
+  }
+}
+
 // ─── MCP Server ───────────────────────────────────────────────────────────────
 
 function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
@@ -2245,6 +2334,10 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         };
       }
 
+      if (await isManagedMirror(source, env)) {
+        return { content: [{ type: "text", text: MIRROR_EDIT_ERROR }] };
+      }
+
       try {
         await appendToEntry(env, id, existingContent, a, tags, source);
       } catch (e) {
@@ -2286,6 +2379,10 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
 
       if (!row) {
         return { content: [{ type: "text", text: `No entry found with ID: ${id}` }] };
+      }
+
+      if (await isManagedMirror(row.source as string, env)) {
+        return { content: [{ type: "text", text: MIRROR_EDIT_ERROR }] };
       }
 
       const tags: string[] = JSON.parse(row.tags ?? "[]").filter((t: string) => t !== "rolled-up");
@@ -2588,6 +2685,10 @@ const defaultHandler = {
       const tags: string[] = JSON.parse(row.tags ?? "[]");
       const source = row.source as string;
 
+      if (await isManagedMirror(source, env)) {
+        return json({ ok: false, error: MIRROR_EDIT_ERROR }, 409);
+      }
+
       try {
         await appendToEntry(env, id, existingContent, addition, tags, source);
       } catch (e) {
@@ -2619,6 +2720,10 @@ const defaultHandler = {
       ).bind(id).first() as Record<string, any> | null;
 
       if (!row) return json({ ok: false, error: `No entry found with ID: ${id}` }, 404);
+
+      if (await isManagedMirror(row.source as string, env)) {
+        return json({ ok: false, error: MIRROR_EDIT_ERROR }, 409);
+      }
 
       const tags: string[] = JSON.parse(row.tags ?? "[]");
       const { cleanContent, hashtags: newHashtags } = extractHashtags(newContent);
@@ -2954,6 +3059,97 @@ const defaultHandler = {
       return json({ processed, failed, remaining: (remaining?.count as number) ?? 0 });
     }
 
+    // ─── Integrations (settings UI) ─────────────────────────────────────────
+    // External sources mirrored into memory. State (token, workspace, page map)
+    // lives in OAUTH_KV under integrations:* — no schema change, and the
+    // namespace already exists in every deployment. See src/integrations.ts.
+
+    // GET /integrations — provider list + connection status (never the token)
+    if (url.pathname === "/integrations" && request.method === "GET") {
+      const authErr = requireAuth(request, env);
+      if (authErr) return authErr;
+      const record = await loadIntegration(env, "notion");
+      return json({ ok: true, integrations: [integrationStatus(record)] });
+    }
+
+    // POST /integrations/notion/connect — validate an internal-integration
+    // token against Notion (server-side; the browser can't for CORS reasons)
+    // and store it only if it works.
+    if (url.pathname === "/integrations/notion/connect" && request.method === "POST") {
+      const authErr = requireAuth(request, env);
+      if (authErr) return authErr;
+
+      let body: { token?: string };
+      try { body = await request.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
+      const token = body.token?.trim();
+      if (!token) return json({ ok: false, error: "token is required" }, 400);
+
+      let workspaceName: string;
+      try {
+        workspaceName = await notionValidateToken(token);
+      } catch (e) {
+        return json({ ok: false, error: e instanceof Error ? e.message : String(e) }, 400);
+      }
+
+      // Preserve the page map across reconnects so already-mirrored pages
+      // update in place instead of duplicating.
+      const existing = await loadIntegration(env, "notion");
+      const now = Date.now();
+      const record: IntegrationRecord = {
+        provider: "notion",
+        authKind: "token",
+        credentials: { token },
+        config: existing?.config ?? {},
+        status: "connected",
+        workspaceName,
+        lastSyncedAt: existing?.lastSyncedAt ?? null,
+        lastSyncError: null,
+        pageMap: existing?.pageMap ?? {},
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+      };
+      await saveIntegration(env, record);
+      return json({ ok: true, provider: "notion", workspaceName });
+    }
+
+    // POST /integrations/notion/sync — one bounded sync batch; callers loop
+    // while `remaining` > 0 (same pattern as POST /vectorize-pending).
+    if (url.pathname === "/integrations/notion/sync" && request.method === "POST") {
+      const authErr = requireAuth(request, env);
+      if (authErr) return authErr;
+      if (!(await loadIntegration(env, "notion"))) {
+        return json({ ok: false, error: "Notion is not connected" }, 404);
+      }
+      const result = await runNotionSync(env, makeMirrorStore(env));
+      return json(result, result.ok ? 200 : 502);
+    }
+
+    // POST /integrations/notion/disconnect — remove the connection. Mirrored
+    // memories are kept (they're the user's data) unless purge=true.
+    if (url.pathname === "/integrations/notion/disconnect" && request.method === "POST") {
+      const authErr = requireAuth(request, env);
+      if (authErr) return authErr;
+
+      let body: { purge?: boolean } = {};
+      try { body = await request.json(); } catch { /* empty body — keep memories */ }
+      const record = await loadIntegration(env, "notion");
+      if (!record) return json({ ok: false, error: "Notion is not connected" }, 404);
+
+      let purged = 0;
+      if (body.purge) {
+        for (const mapped of Object.values(record.pageMap)) {
+          try {
+            const r = await forgetEntry(mapped.entryId, env);
+            if (r.status === "deleted") purged++;
+          } catch (e) {
+            console.error("Mirror purge failed (non-fatal):", e);
+          }
+        }
+      }
+      await deleteIntegration(env, "notion");
+      return json({ ok: true, purged, kept: body.purge ? 0 : Object.keys(record.pageMap).length });
+    }
+
     return new Response("Not found", { status: 404 });
   },
 };
@@ -2985,5 +3181,6 @@ export default {
   scheduled: async (_event: ScheduledEvent, env: Env, ctx: ExecutionContext) => {
     ctx.waitUntil(runNightlyCompression(env, ctx));
     ctx.waitUntil(runGraphPass(env, ctx));
+    ctx.waitUntil(runScheduledIntegrationSync(env));
   },
 };

--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -1,0 +1,387 @@
+/**
+ * Second Brain — external source integrations (Notion).
+ *
+ * Design notes:
+ * - All integration state (token, workspace info, page↔entry map) lives in
+ *   OAUTH_KV under `integrations:*` keys — one JSON blob per provider. KV is
+ *   deliberate: the namespace is already provisioned in every deployment, so
+ *   shipping this feature is a pure code deploy with no schema migration, and
+ *   the access pattern (read once at sync start, write once at the end) is
+ *   exactly what KV wants.
+ * - Synced pages are MIRRORS: the external tool is the source of truth for its
+ *   own pages. Every sync replaces a mirrored entry's content wholesale, dedupe
+ *   is by page id (not similarity), and an unshared/archived page deletes its
+ *   mirror. Mirrors therefore bypass captureEntry's duplicate/contradiction
+ *   pipeline — the MirrorStore interface below is the narrow write surface the
+ *   sync needs, wired up by index.ts.
+ * - Sync work per call is bounded (Workers subrequest limits, especially on the
+ *   free plan). The result reports `remaining` so callers loop until it hits 0 —
+ *   same pattern as POST /vectorize-pending.
+ */
+
+export interface IntegrationEnv {
+  OAUTH_KV: KVNamespace;
+}
+
+// ─── Integration record (the KV blob) ─────────────────────────────────────────
+
+export interface PageMapEntry {
+  entryId: string;    // the mirrored entry's id in D1
+  lastEdited: string; // the page's last_edited_time at the time it was mirrored
+}
+
+export interface IntegrationRecord {
+  provider: string;
+  authKind: "token"; // "oauth2" reserved for future providers that require it
+  credentials: { token: string };
+  config: Record<string, unknown>; // escape hatch for future per-provider options
+  status: "connected" | "error";
+  workspaceName: string | null;
+  lastSyncedAt: number | null;
+  lastSyncError: string | null;
+  pageMap: Record<string, PageMapEntry>;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// Prefixed so integration keys coexist with workers-oauth-provider's own
+// token:/grant:/client: keys in the same namespace.
+const INTEGRATIONS_KEY_PREFIX = "integrations:";
+
+export async function loadIntegration(env: IntegrationEnv, provider: string): Promise<IntegrationRecord | null> {
+  const raw = await env.OAUTH_KV.get(`${INTEGRATIONS_KEY_PREFIX}${provider}`);
+  if (!raw) return null;
+  try { return JSON.parse(raw) as IntegrationRecord; } catch { return null; }
+}
+
+export async function saveIntegration(env: IntegrationEnv, record: IntegrationRecord): Promise<void> {
+  await env.OAUTH_KV.put(`${INTEGRATIONS_KEY_PREFIX}${record.provider}`, JSON.stringify(record));
+}
+
+export async function deleteIntegration(env: IntegrationEnv, provider: string): Promise<void> {
+  await env.OAUTH_KV.delete(`${INTEGRATIONS_KEY_PREFIX}${provider}`);
+}
+
+// Connection status for the settings UI. Never exposes credentials — the token
+// is write-only from the dashboard's perspective.
+export function integrationStatus(record: IntegrationRecord | null) {
+  return {
+    provider: "notion",
+    name: "Notion",
+    connected: record !== null,
+    status: record?.status ?? null,
+    workspaceName: record?.workspaceName ?? null,
+    lastSyncedAt: record?.lastSyncedAt ?? null,
+    lastSyncError: record?.lastSyncError ?? null,
+    pageCount: record ? Object.keys(record.pageMap).length : 0,
+  };
+}
+
+// ─── Mirror store ─────────────────────────────────────────────────────────────
+// The write primitives the sync needs against the memory store. Implemented by
+// index.ts (which owns storeEntry/forgetEntry); injected here so this module
+// never imports from index.ts (no circular dependency).
+
+export interface MirrorStore {
+  // Insert a new entry (already-embedded content path) and return its id.
+  createEntry(content: string, tags: string[], source: string): Promise<string>;
+  // Replace an entry's content wholesale (re-embed). False if the entry no
+  // longer exists — the caller re-creates the mirror.
+  updateEntry(entryId: string, content: string): Promise<boolean>;
+  // Permanently delete an entry and its vectors.
+  deleteEntry(entryId: string): Promise<void>;
+}
+
+// ─── Notion API client ────────────────────────────────────────────────────────
+
+const NOTION_API_BASE = "https://api.notion.com/v1";
+const NOTION_VERSION = "2022-06-28";
+
+export const NOTION_SOURCE = "notion";
+export const NOTION_TAG = "notion";
+
+// Bounds tuned for the Workers free-plan budget of 50 external fetches per
+// invocation: a full sync batch costs ≤ MAX_LISTING_REQUESTS +
+// SYNC_PAGE_BATCH × (ROOT_BLOCK_REQUESTS + NESTED_BLOCK_REQUESTS) ≈ 35.
+const SEARCH_PAGE_SIZE = 100;
+const MAX_LISTING_REQUESTS = 5;    // ≤ 500 accessible pages listed per sync
+export const SYNC_PAGE_BATCH = 5;  // pages ingested per sync call; callers loop on `remaining`
+const BLOCK_PAGE_SIZE = 100;
+const ROOT_BLOCK_REQUESTS = 2;     // ≤ 200 top-level blocks per page
+const NESTED_BLOCK_REQUESTS = 4;   // one level of children for the first 4 nested blocks
+const MAX_PAGE_CONTENT_CHARS = 8000;
+
+async function notionFetch(token: string, path: string, init?: RequestInit): Promise<any> {
+  const res = await fetch(`${NOTION_API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Notion-Version": NOTION_VERSION,
+      ...(init?.body ? { "Content-Type": "application/json" } : {}),
+    },
+  });
+  if (!res.ok) {
+    let message = `Notion API error (${res.status})`;
+    try {
+      const body = await res.json() as any;
+      if (body?.message) message = `Notion: ${body.message}`;
+    } catch { /* non-JSON error body — keep the status message */ }
+    throw new Error(message);
+  }
+  return res.json();
+}
+
+// Validate an internal-integration token and return the workspace name for the
+// settings UI's "Connected to …" confirmation.
+export async function notionValidateToken(token: string): Promise<string> {
+  const me = await notionFetch(token, "/users/me");
+  return me?.bot?.workspace_name ?? me?.name ?? "Notion workspace";
+}
+
+export interface NotionPageMeta {
+  id: string;
+  lastEdited: string;
+  title: string;
+  url: string;
+  archived: boolean;
+}
+
+// List every page the integration can access. Notion's sharing model IS the
+// selection mechanism: users share pages (and their subtrees) with the
+// integration in Notion, and this listing returns exactly that set.
+export async function notionListPages(token: string): Promise<{ pages: NotionPageMeta[]; complete: boolean }> {
+  const pages: NotionPageMeta[] = [];
+  let cursor: string | undefined;
+  let complete = false;
+  for (let i = 0; i < MAX_LISTING_REQUESTS; i++) {
+    const body: Record<string, unknown> = {
+      filter: { property: "object", value: "page" },
+      page_size: SEARCH_PAGE_SIZE,
+    };
+    if (cursor) body.start_cursor = cursor;
+    const data = await notionFetch(token, "/search", { method: "POST", body: JSON.stringify(body) });
+    for (const p of (data.results ?? []) as any[]) {
+      if (p?.object !== "page") continue;
+      pages.push({
+        id: p.id as string,
+        lastEdited: (p.last_edited_time as string) ?? "",
+        title: extractPageTitle(p),
+        url: (p.url as string) ?? "",
+        archived: p.archived === true || p.in_trash === true,
+      });
+    }
+    if (!data.has_more) { complete = true; break; }
+    cursor = data.next_cursor as string;
+  }
+  return { pages, complete };
+}
+
+// A page's title lives in whichever property has type "title" (name varies by
+// parent database; standalone pages use "title").
+export function extractPageTitle(page: any): string {
+  const props = page?.properties ?? {};
+  for (const key of Object.keys(props)) {
+    const prop = props[key];
+    if (prop?.type === "title" && Array.isArray(prop.title)) {
+      const text = prop.title.map((t: any) => t?.plain_text ?? "").join("").trim();
+      if (text) return text;
+    }
+  }
+  return "Untitled";
+}
+
+function blockText(block: any): string {
+  const data = block?.[block?.type];
+  const rich = data?.rich_text;
+  if (!Array.isArray(rich)) return "";
+  return rich.map((t: any) => t?.plain_text ?? "").join("");
+}
+
+// Flatten Notion blocks to plain text for embedding. Nested children (attached
+// as `_children` by notionFetchPageText) indent one level per depth.
+export function flattenBlocks(blocks: any[], depth = 0): string {
+  const indent = "  ".repeat(depth);
+  const lines: string[] = [];
+  for (const block of blocks ?? []) {
+    const text = blockText(block);
+    let line = "";
+    switch (block?.type) {
+      case "heading_1": line = `# ${text}`; break;
+      case "heading_2": line = `## ${text}`; break;
+      case "heading_3": line = `### ${text}`; break;
+      case "bulleted_list_item":
+      case "numbered_list_item": line = `- ${text}`; break;
+      case "to_do": line = `[${block.to_do?.checked ? "x" : " "}] ${text}`; break;
+      case "quote":
+      case "callout": line = `> ${text}`; break;
+      case "code": line = "```" + (block.code?.language ?? "") + "\n" + text + "\n```"; break;
+      case "divider": line = "---"; break;
+      // Child pages sync as their own entries when shared — reference, don't inline.
+      case "child_page": line = `[Sub-page: ${block.child_page?.title ?? "Untitled"}]`; break;
+      case "child_database": line = `[Database: ${block.child_database?.title ?? "Untitled"}]`; break;
+      case "bookmark": line = block.bookmark?.url ?? ""; break;
+      default: line = text; // paragraph, toggle, and anything else with rich_text
+    }
+    if (line.trim()) lines.push(indent + line);
+    if (Array.isArray(block?._children) && block._children.length) {
+      const childText = flattenBlocks(block._children, depth + 1);
+      if (childText) lines.push(childText);
+    }
+  }
+  return lines.join("\n");
+}
+
+async function notionListChildren(token: string, blockId: string, maxRequests: number): Promise<any[]> {
+  const blocks: any[] = [];
+  let cursor: string | undefined;
+  for (let i = 0; i < maxRequests; i++) {
+    const qs = new URLSearchParams({ page_size: String(BLOCK_PAGE_SIZE) });
+    if (cursor) qs.set("start_cursor", cursor);
+    const data = await notionFetch(token, `/blocks/${blockId}/children?${qs}`);
+    blocks.push(...((data.results ?? []) as any[]));
+    if (!data.has_more) break;
+    cursor = data.next_cursor as string;
+  }
+  return blocks;
+}
+
+// Fetch a page's content as flattened text. One level of nesting only
+// (indented bullets, toggle bodies) under a bounded request budget — deep
+// trees truncate rather than risk the Worker's subrequest limit.
+export async function notionFetchPageText(token: string, pageId: string): Promise<string> {
+  const blocks = await notionListChildren(token, pageId, ROOT_BLOCK_REQUESTS);
+  let nestedBudget = NESTED_BLOCK_REQUESTS;
+  for (const block of blocks) {
+    if (nestedBudget <= 0) break;
+    if (block?.has_children && block.type !== "child_page" && block.type !== "child_database") {
+      nestedBudget--;
+      try {
+        block._children = await notionListChildren(token, block.id, 1);
+      } catch (e) {
+        console.error(`Notion nested block fetch failed for ${block.id} (non-fatal):`, e);
+      }
+    }
+  }
+  return flattenBlocks(blocks);
+}
+
+// Title + source URL lead the content: the title sharpens embedding quality,
+// and the URL lets recall results link back to the live page.
+export function buildPageContent(title: string, url: string, text: string): string {
+  const body = text.length > MAX_PAGE_CONTENT_CHARS ? `${text.slice(0, MAX_PAGE_CONTENT_CHARS)}\n…` : text;
+  return [`# ${title}`, url, "", body].join("\n").trim();
+}
+
+// ─── Sync planning ────────────────────────────────────────────────────────────
+// Per-page lastEdited comparison against the pageMap (not a global cursor):
+// robust to Notion's minute-granularity timestamps, and a partially-processed
+// batch simply leaves the unprocessed pages "changed" for the next run.
+
+export interface SyncPlan {
+  changed: NotionPageMeta[]; // new or edited, oldest first so partial batches converge
+  deleted: string[];         // page ids whose mirrors should be removed
+}
+
+export function computeSyncPlan(
+  pages: NotionPageMeta[],
+  pageMap: Record<string, PageMapEntry>,
+  listingComplete: boolean,
+): SyncPlan {
+  const changed = pages
+    .filter(p => !p.archived && pageMap[p.id]?.lastEdited !== p.lastEdited)
+    .sort((a, b) => (a.lastEdited < b.lastEdited ? -1 : 1));
+
+  const deleted: string[] = [];
+  // Archived/trashed pages are an explicit delete signal even on a truncated listing.
+  for (const p of pages) {
+    if (p.archived && pageMap[p.id]) deleted.push(p.id);
+  }
+  // Silent disappearance (page unshared or integration access revoked) is only
+  // trustworthy when the listing was complete — a truncated listing must never
+  // trigger deletions.
+  if (listingComplete) {
+    const listed = new Set(pages.map(p => p.id));
+    for (const id of Object.keys(pageMap)) {
+      if (!listed.has(id)) deleted.push(id);
+    }
+  }
+  return { changed, deleted };
+}
+
+// ─── Sync loop ────────────────────────────────────────────────────────────────
+
+export type NotionSyncOutcome =
+  | { ok: true; created: number; updated: number; deleted: number; failed: number; remaining: number; total: number }
+  | { ok: false; error: string };
+
+export async function runNotionSync(env: IntegrationEnv, store: MirrorStore): Promise<NotionSyncOutcome> {
+  const record = await loadIntegration(env, "notion");
+  if (!record) return { ok: false, error: "Notion is not connected" };
+
+  let pages: NotionPageMeta[];
+  let complete: boolean;
+  try {
+    ({ pages, complete } = await notionListPages(record.credentials.token));
+  } catch (e) {
+    record.status = "error";
+    record.lastSyncError = e instanceof Error ? e.message : String(e);
+    record.updatedAt = Date.now();
+    await saveIntegration(env, record);
+    return { ok: false, error: record.lastSyncError };
+  }
+
+  const plan = computeSyncPlan(pages, record.pageMap, complete);
+  const batch = plan.changed.slice(0, SYNC_PAGE_BATCH);
+
+  let created = 0, updated = 0, failed = 0;
+  for (const page of batch) {
+    try {
+      const text = await notionFetchPageText(record.credentials.token, page.id);
+      const content = buildPageContent(page.title, page.url, text);
+      const existing = record.pageMap[page.id];
+      if (existing && await store.updateEntry(existing.entryId, content)) {
+        record.pageMap[page.id] = { entryId: existing.entryId, lastEdited: page.lastEdited };
+        updated++;
+      } else {
+        // New page — or its mirror was deleted out-of-band; (re-)create it.
+        const entryId = await store.createEntry(content, [NOTION_TAG], NOTION_SOURCE);
+        record.pageMap[page.id] = { entryId, lastEdited: page.lastEdited };
+        created++;
+      }
+    } catch (e) {
+      // Per-page failure is non-fatal: the pageMap doesn't advance for this
+      // page, so the next sync retries it.
+      console.error(`Notion sync failed for page ${page.id} (non-fatal):`, e);
+      failed++;
+    }
+  }
+
+  let deleted = 0;
+  for (const pageId of plan.deleted) {
+    const mapped = record.pageMap[pageId];
+    if (!mapped) continue;
+    try {
+      await store.deleteEntry(mapped.entryId);
+      delete record.pageMap[pageId];
+      deleted++;
+    } catch (e) {
+      console.error(`Notion mirror delete failed for page ${pageId} (non-fatal):`, e);
+    }
+  }
+
+  record.status = "connected";
+  record.lastSyncedAt = Date.now();
+  record.lastSyncError = null;
+  record.updatedAt = Date.now();
+  await saveIntegration(env, record);
+
+  return {
+    ok: true,
+    created,
+    updated,
+    deleted,
+    failed,
+    remaining: plan.changed.length - batch.length,
+    total: pages.filter(p => !p.archived).length,
+  };
+}

--- a/src/integrations/framework.ts
+++ b/src/integrations/framework.ts
@@ -1,0 +1,139 @@
+/**
+ * Second Brain — integration framework.
+ *
+ * Provider-agnostic machinery for mirroring external sources into memory.
+ * Each provider (src/integrations/<provider>.ts) supplies an
+ * IntegrationProvider; the registry in src/integrations/index.ts wires them
+ * together so the Worker's routes, cron, and settings UI never hardcode a
+ * provider.
+ *
+ * Design notes:
+ * - All integration state (token, account info, item↔entry map) lives in
+ *   OAUTH_KV under `integrations:<provider>` — one JSON blob per provider. KV
+ *   is deliberate: the namespace is already provisioned in every deployment,
+ *   so shipping a provider is a pure code deploy with no schema migration, and
+ *   the access pattern (read once at sync start, write once at the end) is
+ *   exactly what KV wants.
+ * - Synced items are MIRRORS: the external tool is the source of truth. Every
+ *   sync replaces a mirrored entry's content wholesale, dedupe is by external
+ *   item id (the itemMap), and an item that disappears upstream deletes its
+ *   mirror. Mirrors therefore bypass captureEntry's duplicate/contradiction
+ *   pipeline — MirrorStore below is the narrow write surface a sync needs,
+ *   implemented by index.ts.
+ * - Sync work per call is bounded (Workers subrequest limits, especially on
+ *   the free plan). Outcomes report `remaining` so callers loop until it hits
+ *   0 — same pattern as POST /vectorize-pending.
+ */
+
+export interface IntegrationEnv {
+  OAUTH_KV: KVNamespace;
+}
+
+// ─── Provider interface ───────────────────────────────────────────────────────
+// The whole contract a new provider must implement. Deliberately thin: how a
+// provider lists changes, fetches content, and detects deletions is private to
+// it — sync semantics differ too much between APIs (Notion: full listing +
+// completeness-gated deletion sweep; cursor-native APIs: incremental exports)
+// to abstract further from one data point.
+
+export interface IntegrationProvider {
+  id: string;   // registry key, entry `source` value, and URL segment (/integrations/<id>/…)
+  name: string; // display name for the settings UI
+  // Validate a pasted token against the provider's API; returns an account /
+  // workspace label for the UI's "Connected to …" confirmation. Throws with a
+  // user-presentable message when the token is rejected.
+  validateToken(token: string): Promise<string>;
+  // Run one bounded sync batch against the stored record.
+  sync(env: IntegrationEnv, store: MirrorStore): Promise<SyncOutcome>;
+}
+
+export type SyncOutcome =
+  | { ok: true; created: number; updated: number; deleted: number; failed: number; remaining: number; total: number }
+  | { ok: false; error: string };
+
+// ─── Integration record (the KV blob) ─────────────────────────────────────────
+
+export interface ItemMapEntry {
+  entryId: string; // the mirrored entry's id in D1
+  version: string; // the item's change marker (e.g. Notion's last_edited_time) when mirrored
+}
+
+export interface IntegrationRecord {
+  provider: string;
+  authKind: "token"; // "oauth2" reserved for future providers that require it
+  credentials: { token: string };
+  config: Record<string, unknown>; // escape hatch for future per-provider options
+  status: "connected" | "error";
+  workspaceName: string | null;
+  lastSyncedAt: number | null;
+  lastSyncError: string | null;
+  itemMap: Record<string, ItemMapEntry>;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// Prefixed so integration keys coexist with workers-oauth-provider's own
+// token:/grant:/client: keys in the same namespace.
+const INTEGRATIONS_KEY_PREFIX = "integrations:";
+
+export async function loadIntegration(env: IntegrationEnv, provider: string): Promise<IntegrationRecord | null> {
+  const raw = await env.OAUTH_KV.get(`${INTEGRATIONS_KEY_PREFIX}${provider}`);
+  if (!raw) return null;
+  try {
+    const record = JSON.parse(raw) as any;
+    // Migrate pre-registry blobs (first Notion release): pageMap/lastEdited →
+    // itemMap/version. Persisted back on the next save; losing the map would
+    // duplicate every mirror on the following sync.
+    if (record.pageMap && !record.itemMap) {
+      record.itemMap = Object.fromEntries(
+        Object.entries(record.pageMap as Record<string, any>).map(([id, v]) => [
+          id,
+          { entryId: v.entryId, version: v.version ?? v.lastEdited ?? "" },
+        ])
+      );
+      delete record.pageMap;
+    }
+    record.itemMap ??= {};
+    return record as IntegrationRecord;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveIntegration(env: IntegrationEnv, record: IntegrationRecord): Promise<void> {
+  await env.OAUTH_KV.put(`${INTEGRATIONS_KEY_PREFIX}${record.provider}`, JSON.stringify(record));
+}
+
+export async function deleteIntegration(env: IntegrationEnv, provider: string): Promise<void> {
+  await env.OAUTH_KV.delete(`${INTEGRATIONS_KEY_PREFIX}${provider}`);
+}
+
+// Connection status for the settings UI. Never exposes credentials — the token
+// is write-only from the dashboard's perspective.
+export function integrationStatus(provider: Pick<IntegrationProvider, "id" | "name">, record: IntegrationRecord | null) {
+  return {
+    provider: provider.id,
+    name: provider.name,
+    connected: record !== null,
+    status: record?.status ?? null,
+    workspaceName: record?.workspaceName ?? null,
+    lastSyncedAt: record?.lastSyncedAt ?? null,
+    lastSyncError: record?.lastSyncError ?? null,
+    itemCount: record ? Object.keys(record.itemMap).length : 0,
+  };
+}
+
+// ─── Mirror store ─────────────────────────────────────────────────────────────
+// The write primitives a sync needs against the memory store. Implemented by
+// index.ts (which owns storeEntry/forgetEntry); injected so this module never
+// imports from index.ts (no circular dependency).
+
+export interface MirrorStore {
+  // Insert a new entry and return its id.
+  createEntry(content: string, tags: string[], source: string): Promise<string>;
+  // Replace an entry's content wholesale (re-embed). False if the entry no
+  // longer exists — the caller re-creates the mirror.
+  updateEntry(entryId: string, content: string): Promise<boolean>;
+  // Permanently delete an entry and its vectors.
+  deleteEntry(entryId: string): Promise<void>;
+}

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Second Brain — integration registry.
+ *
+ * Adding a provider: create src/integrations/<provider>.ts exporting an
+ * IntegrationProvider (see framework.ts for the contract), and register it
+ * here. The Worker's routes (/integrations/:provider/…), the nightly cron, the
+ * mirror edit guard, and the settings UI all iterate this registry — no other
+ * code changes needed.
+ */
+
+import type { IntegrationProvider } from "./framework";
+import { notionProvider } from "./notion";
+
+export const INTEGRATION_PROVIDERS: Record<string, IntegrationProvider> = {
+  [notionProvider.id]: notionProvider,
+};
+
+export function getProvider(id: string): IntegrationProvider | null {
+  return Object.prototype.hasOwnProperty.call(INTEGRATION_PROVIDERS, id)
+    ? INTEGRATION_PROVIDERS[id]
+    : null;
+}
+
+export * from "./framework";
+export {
+  notionProvider,
+  notionValidateToken,
+  notionListPages,
+  notionFetchPageText,
+  extractPageTitle,
+  flattenBlocks,
+  buildPageContent,
+  computeSyncPlan,
+  SYNC_PAGE_BATCH,
+} from "./notion";
+export type { NotionPageMeta, SyncPlan } from "./notion";

--- a/src/integrations/notion.ts
+++ b/src/integrations/notion.ts
@@ -1,104 +1,19 @@
 /**
- * Second Brain — external source integrations (Notion).
+ * Second Brain — Notion provider.
  *
- * Design notes:
- * - All integration state (token, workspace info, page↔entry map) lives in
- *   OAUTH_KV under `integrations:*` keys — one JSON blob per provider. KV is
- *   deliberate: the namespace is already provisioned in every deployment, so
- *   shipping this feature is a pure code deploy with no schema migration, and
- *   the access pattern (read once at sync start, write once at the end) is
- *   exactly what KV wants.
- * - Synced pages are MIRRORS: the external tool is the source of truth for its
- *   own pages. Every sync replaces a mirrored entry's content wholesale, dedupe
- *   is by page id (not similarity), and an unshared/archived page deletes its
- *   mirror. Mirrors therefore bypass captureEntry's duplicate/contradiction
- *   pipeline — the MirrorStore interface below is the narrow write surface the
- *   sync needs, wired up by index.ts.
- * - Sync work per call is bounded (Workers subrequest limits, especially on the
- *   free plan). The result reports `remaining` so callers loop until it hits 0 —
- *   same pattern as POST /vectorize-pending.
+ * Mirrors every page shared with the user's internal Notion connection into
+ * memory. Notion's sharing model IS the selection mechanism: users share pages
+ * (and their subtrees) with the connection in Notion, and the search listing
+ * returns exactly that set.
  */
 
-export interface IntegrationEnv {
-  OAUTH_KV: KVNamespace;
-}
+import type { IntegrationEnv, IntegrationProvider, ItemMapEntry, MirrorStore, SyncOutcome } from "./framework";
+import { loadIntegration, saveIntegration } from "./framework";
 
-// ─── Integration record (the KV blob) ─────────────────────────────────────────
-
-export interface PageMapEntry {
-  entryId: string;    // the mirrored entry's id in D1
-  lastEdited: string; // the page's last_edited_time at the time it was mirrored
-}
-
-export interface IntegrationRecord {
-  provider: string;
-  authKind: "token"; // "oauth2" reserved for future providers that require it
-  credentials: { token: string };
-  config: Record<string, unknown>; // escape hatch for future per-provider options
-  status: "connected" | "error";
-  workspaceName: string | null;
-  lastSyncedAt: number | null;
-  lastSyncError: string | null;
-  pageMap: Record<string, PageMapEntry>;
-  createdAt: number;
-  updatedAt: number;
-}
-
-// Prefixed so integration keys coexist with workers-oauth-provider's own
-// token:/grant:/client: keys in the same namespace.
-const INTEGRATIONS_KEY_PREFIX = "integrations:";
-
-export async function loadIntegration(env: IntegrationEnv, provider: string): Promise<IntegrationRecord | null> {
-  const raw = await env.OAUTH_KV.get(`${INTEGRATIONS_KEY_PREFIX}${provider}`);
-  if (!raw) return null;
-  try { return JSON.parse(raw) as IntegrationRecord; } catch { return null; }
-}
-
-export async function saveIntegration(env: IntegrationEnv, record: IntegrationRecord): Promise<void> {
-  await env.OAUTH_KV.put(`${INTEGRATIONS_KEY_PREFIX}${record.provider}`, JSON.stringify(record));
-}
-
-export async function deleteIntegration(env: IntegrationEnv, provider: string): Promise<void> {
-  await env.OAUTH_KV.delete(`${INTEGRATIONS_KEY_PREFIX}${provider}`);
-}
-
-// Connection status for the settings UI. Never exposes credentials — the token
-// is write-only from the dashboard's perspective.
-export function integrationStatus(record: IntegrationRecord | null) {
-  return {
-    provider: "notion",
-    name: "Notion",
-    connected: record !== null,
-    status: record?.status ?? null,
-    workspaceName: record?.workspaceName ?? null,
-    lastSyncedAt: record?.lastSyncedAt ?? null,
-    lastSyncError: record?.lastSyncError ?? null,
-    pageCount: record ? Object.keys(record.pageMap).length : 0,
-  };
-}
-
-// ─── Mirror store ─────────────────────────────────────────────────────────────
-// The write primitives the sync needs against the memory store. Implemented by
-// index.ts (which owns storeEntry/forgetEntry); injected here so this module
-// never imports from index.ts (no circular dependency).
-
-export interface MirrorStore {
-  // Insert a new entry (already-embedded content path) and return its id.
-  createEntry(content: string, tags: string[], source: string): Promise<string>;
-  // Replace an entry's content wholesale (re-embed). False if the entry no
-  // longer exists — the caller re-creates the mirror.
-  updateEntry(entryId: string, content: string): Promise<boolean>;
-  // Permanently delete an entry and its vectors.
-  deleteEntry(entryId: string): Promise<void>;
-}
-
-// ─── Notion API client ────────────────────────────────────────────────────────
+// ─── API client ───────────────────────────────────────────────────────────────
 
 const NOTION_API_BASE = "https://api.notion.com/v1";
 const NOTION_VERSION = "2022-06-28";
-
-export const NOTION_SOURCE = "notion";
-export const NOTION_TAG = "notion";
 
 // Bounds tuned for the Workers free-plan budget of 50 external fetches per
 // invocation: a full sync batch costs ≤ MAX_LISTING_REQUESTS +
@@ -131,7 +46,7 @@ async function notionFetch(token: string, path: string, init?: RequestInit): Pro
   return res.json();
 }
 
-// Validate an internal-integration token and return the workspace name for the
+// Validate an internal-connection token and return the workspace name for the
 // settings UI's "Connected to …" confirmation.
 export async function notionValidateToken(token: string): Promise<string> {
   const me = await notionFetch(token, "/users/me");
@@ -146,9 +61,7 @@ export interface NotionPageMeta {
   archived: boolean;
 }
 
-// List every page the integration can access. Notion's sharing model IS the
-// selection mechanism: users share pages (and their subtrees) with the
-// integration in Notion, and this listing returns exactly that set.
+// List every page the connection can access.
 export async function notionListPages(token: string): Promise<{ pages: NotionPageMeta[]; complete: boolean }> {
   const pages: NotionPageMeta[] = [];
   let cursor: string | undefined;
@@ -273,7 +186,7 @@ export function buildPageContent(title: string, url: string, text: string): stri
 }
 
 // ─── Sync planning ────────────────────────────────────────────────────────────
-// Per-page lastEdited comparison against the pageMap (not a global cursor):
+// Per-page version comparison against the itemMap (not a global cursor):
 // robust to Notion's minute-granularity timestamps, and a partially-processed
 // batch simply leaves the unprocessed pages "changed" for the next run.
 
@@ -284,24 +197,24 @@ export interface SyncPlan {
 
 export function computeSyncPlan(
   pages: NotionPageMeta[],
-  pageMap: Record<string, PageMapEntry>,
+  itemMap: Record<string, ItemMapEntry>,
   listingComplete: boolean,
 ): SyncPlan {
   const changed = pages
-    .filter(p => !p.archived && pageMap[p.id]?.lastEdited !== p.lastEdited)
+    .filter(p => !p.archived && itemMap[p.id]?.version !== p.lastEdited)
     .sort((a, b) => (a.lastEdited < b.lastEdited ? -1 : 1));
 
   const deleted: string[] = [];
   // Archived/trashed pages are an explicit delete signal even on a truncated listing.
   for (const p of pages) {
-    if (p.archived && pageMap[p.id]) deleted.push(p.id);
+    if (p.archived && itemMap[p.id]) deleted.push(p.id);
   }
-  // Silent disappearance (page unshared or integration access revoked) is only
+  // Silent disappearance (page unshared or connection access revoked) is only
   // trustworthy when the listing was complete — a truncated listing must never
   // trigger deletions.
   if (listingComplete) {
     const listed = new Set(pages.map(p => p.id));
-    for (const id of Object.keys(pageMap)) {
+    for (const id of Object.keys(itemMap)) {
       if (!listed.has(id)) deleted.push(id);
     }
   }
@@ -310,12 +223,8 @@ export function computeSyncPlan(
 
 // ─── Sync loop ────────────────────────────────────────────────────────────────
 
-export type NotionSyncOutcome =
-  | { ok: true; created: number; updated: number; deleted: number; failed: number; remaining: number; total: number }
-  | { ok: false; error: string };
-
-export async function runNotionSync(env: IntegrationEnv, store: MirrorStore): Promise<NotionSyncOutcome> {
-  const record = await loadIntegration(env, "notion");
+async function runNotionSync(env: IntegrationEnv, store: MirrorStore): Promise<SyncOutcome> {
+  const record = await loadIntegration(env, notionProvider.id);
   if (!record) return { ok: false, error: "Notion is not connected" };
 
   let pages: NotionPageMeta[];
@@ -330,7 +239,7 @@ export async function runNotionSync(env: IntegrationEnv, store: MirrorStore): Pr
     return { ok: false, error: record.lastSyncError };
   }
 
-  const plan = computeSyncPlan(pages, record.pageMap, complete);
+  const plan = computeSyncPlan(pages, record.itemMap, complete);
   const batch = plan.changed.slice(0, SYNC_PAGE_BATCH);
 
   let created = 0, updated = 0, failed = 0;
@@ -338,18 +247,18 @@ export async function runNotionSync(env: IntegrationEnv, store: MirrorStore): Pr
     try {
       const text = await notionFetchPageText(record.credentials.token, page.id);
       const content = buildPageContent(page.title, page.url, text);
-      const existing = record.pageMap[page.id];
+      const existing = record.itemMap[page.id];
       if (existing && await store.updateEntry(existing.entryId, content)) {
-        record.pageMap[page.id] = { entryId: existing.entryId, lastEdited: page.lastEdited };
+        record.itemMap[page.id] = { entryId: existing.entryId, version: page.lastEdited };
         updated++;
       } else {
         // New page — or its mirror was deleted out-of-band; (re-)create it.
-        const entryId = await store.createEntry(content, [NOTION_TAG], NOTION_SOURCE);
-        record.pageMap[page.id] = { entryId, lastEdited: page.lastEdited };
+        const entryId = await store.createEntry(content, [notionProvider.id], notionProvider.id);
+        record.itemMap[page.id] = { entryId, version: page.lastEdited };
         created++;
       }
     } catch (e) {
-      // Per-page failure is non-fatal: the pageMap doesn't advance for this
+      // Per-page failure is non-fatal: the itemMap doesn't advance for this
       // page, so the next sync retries it.
       console.error(`Notion sync failed for page ${page.id} (non-fatal):`, e);
       failed++;
@@ -358,11 +267,11 @@ export async function runNotionSync(env: IntegrationEnv, store: MirrorStore): Pr
 
   let deleted = 0;
   for (const pageId of plan.deleted) {
-    const mapped = record.pageMap[pageId];
+    const mapped = record.itemMap[pageId];
     if (!mapped) continue;
     try {
       await store.deleteEntry(mapped.entryId);
-      delete record.pageMap[pageId];
+      delete record.itemMap[pageId];
       deleted++;
     } catch (e) {
       console.error(`Notion mirror delete failed for page ${pageId} (non-fatal):`, e);
@@ -385,3 +294,10 @@ export async function runNotionSync(env: IntegrationEnv, store: MirrorStore): Pr
     total: pages.filter(p => !p.archived).length,
   };
 }
+
+export const notionProvider: IntegrationProvider = {
+  id: "notion",
+  name: "Notion",
+  validateToken: notionValidateToken,
+  sync: runNotionSync,
+};

--- a/test/helpers/make-env.ts
+++ b/test/helpers/make-env.ts
@@ -41,6 +41,24 @@ export function makeKVMock(): KVNamespace {
   } as unknown as KVNamespace;
 }
 
+// Stateful in-memory KV for tests where reads must see prior writes (the
+// integrations flow) — makeKVMock above always returns null.
+export function makeMemoryKV(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => { store.set(key, String(value)); },
+    delete: async (key: string) => { store.delete(key); },
+    list: async (opts: { prefix?: string } = {}) => ({
+      keys: [...store.keys()]
+        .filter(k => !opts.prefix || k.startsWith(opts.prefix))
+        .map(name => ({ name })),
+      list_complete: true,
+      cacheStatus: null,
+    }),
+  } as unknown as KVNamespace;
+}
+
 export function makeTestEnv(db?: D1Mock, overrides: Partial<Env> = {}): Env {
   return {
     DB: (db ?? new D1Mock()) as unknown as D1Database,

--- a/test/integration/integrations.test.ts
+++ b/test/integration/integrations.test.ts
@@ -86,7 +86,7 @@ describe("integrations routes", () => {
       expect(res.status).toBe(200);
       const data = await res.json() as any;
       expect(data.integrations).toEqual([
-        expect.objectContaining({ provider: "notion", connected: false, pageCount: 0 }),
+        expect.objectContaining({ provider: "notion", connected: false, itemCount: 0 }),
       ]);
     });
   });
@@ -146,7 +146,7 @@ describe("integrations routes", () => {
       expect(entry.content).toContain("Ship the beta in March");
 
       const status = await (await worker.fetch(req("GET", "/integrations"), env, ctx)).json() as any;
-      expect(status.integrations[0].pageCount).toBe(1);
+      expect(status.integrations[0].itemCount).toBe(1);
     });
 
     it("is a no-op when nothing changed", async () => {
@@ -192,7 +192,7 @@ describe("integrations routes", () => {
       expect(db.entries).toHaveLength(0);
 
       const status = await (await worker.fetch(req("GET", "/integrations"), env, ctx)).json() as any;
-      expect(status.integrations[0].pageCount).toBe(0);
+      expect(status.integrations[0].itemCount).toBe(0);
     });
 
     it("deletes the mirror when a page is archived", async () => {
@@ -249,7 +249,7 @@ describe("integrations routes", () => {
       const res = await worker.fetch(req("POST", "/update", { body: { id, content: "manual edit" } }), env, ctx);
       expect(res.status).toBe(409);
       const data = await res.json() as any;
-      expect(data.error).toContain("synced from a Notion page");
+      expect(data.error).toContain("synced from Notion");
       expect(db.entries[0].content).toContain("test");
     });
 

--- a/test/integration/integrations.test.ts
+++ b/test/integration/integrations.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb, makeMemoryKV } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+// ─── Notion API stub ────────────────────────────────────────────────────────
+// A mutable fixture the stubbed global fetch serves: /users/me validates the
+// token, /search returns `pages`, /blocks/:id/children returns `blocks[id]`.
+
+interface NotionFixture {
+  validToken: string;
+  pages: any[];
+  blocks: Record<string, any[]>;
+}
+
+function notionPage(id: string, title: string, lastEdited: string, archived = false) {
+  return {
+    object: "page",
+    id,
+    last_edited_time: lastEdited,
+    url: `https://notion.so/${id}`,
+    archived,
+    in_trash: false,
+    properties: { title: { type: "title", title: [{ plain_text: title }] } },
+  };
+}
+
+function paragraph(text: string) {
+  return { object: "block", id: `blk-${text}`, type: "paragraph", has_children: false, paragraph: { rich_text: [{ plain_text: text }] } };
+}
+
+function stubNotionApi(fixture: NotionFixture) {
+  vi.stubGlobal("fetch", vi.fn(async (input: any, init?: any) => {
+    const url = typeof input === "string" ? input : input.url;
+    const auth = init?.headers?.Authorization ?? "";
+    if (auth !== `Bearer ${fixture.validToken}`) {
+      return new Response(JSON.stringify({ message: "API token is invalid." }), { status: 401 });
+    }
+    if (url.endsWith("/users/me")) {
+      return new Response(JSON.stringify({ object: "user", type: "bot", name: "Second Brain", bot: { workspace_name: "Test Workspace" } }), { status: 200 });
+    }
+    if (url.endsWith("/search")) {
+      return new Response(JSON.stringify({ results: fixture.pages, has_more: false, next_cursor: null }), { status: 200 });
+    }
+    const m = url.match(/\/blocks\/([^/?]+)\/children/);
+    if (m) {
+      return new Response(JSON.stringify({ results: fixture.blocks[m[1]] ?? [], has_more: false, next_cursor: null }), { status: 200 });
+    }
+    return new Response("not found", { status: 404 });
+  }));
+}
+
+describe("integrations routes", () => {
+  let env: Env;
+  let db: D1Mock;
+  let fixture: NotionFixture;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db, { OAUTH_KV: makeMemoryKV() });
+    fixture = { validToken: "ntn_valid", pages: [], blocks: {} };
+    stubNotionApi(fixture);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const connect = () =>
+    worker.fetch(req("POST", "/integrations/notion/connect", { body: { token: "ntn_valid" } }), env, ctx);
+  const sync = () =>
+    worker.fetch(req("POST", "/integrations/notion/sync", { body: {} }), env, ctx);
+
+  describe("GET /integrations", () => {
+    it("requires auth", async () => {
+      const res = await worker.fetch(req("GET", "/integrations", { token: null }), env, ctx);
+      expect(res.status).toBe(401);
+    });
+
+    it("lists notion as disconnected by default", async () => {
+      const res = await worker.fetch(req("GET", "/integrations"), env, ctx);
+      expect(res.status).toBe(200);
+      const data = await res.json() as any;
+      expect(data.integrations).toEqual([
+        expect.objectContaining({ provider: "notion", connected: false, pageCount: 0 }),
+      ]);
+    });
+  });
+
+  describe("POST /integrations/notion/connect", () => {
+    it("requires a token", async () => {
+      const res = await worker.fetch(req("POST", "/integrations/notion/connect", { body: {} }), env, ctx);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects a token Notion does not accept, storing nothing", async () => {
+      const res = await worker.fetch(
+        req("POST", "/integrations/notion/connect", { body: { token: "ntn_wrong" } }), env, ctx
+      );
+      expect(res.status).toBe(400);
+      const data = await res.json() as any;
+      expect(data.error).toContain("API token is invalid");
+
+      const status = await (await worker.fetch(req("GET", "/integrations"), env, ctx)).json() as any;
+      expect(status.integrations[0].connected).toBe(false);
+    });
+
+    it("validates the token and stores the connection with the workspace name", async () => {
+      const res = await connect();
+      expect(res.status).toBe(200);
+      const data = await res.json() as any;
+      expect(data.ok).toBe(true);
+      expect(data.workspaceName).toBe("Test Workspace");
+
+      const status = await (await worker.fetch(req("GET", "/integrations"), env, ctx)).json() as any;
+      expect(status.integrations[0]).toMatchObject({ connected: true, workspaceName: "Test Workspace" });
+    });
+  });
+
+  describe("POST /integrations/notion/sync", () => {
+    it("404s when not connected", async () => {
+      const res = await sync();
+      expect(res.status).toBe(404);
+    });
+
+    it("mirrors accessible pages into entries with source notion", async () => {
+      fixture.pages = [notionPage("p1", "Project Plan", "2026-01-01T00:00:00.000Z")];
+      fixture.blocks["p1"] = [paragraph("Ship the beta in March")];
+      await connect();
+
+      const res = await sync();
+      expect(res.status).toBe(200);
+      const data = await res.json() as any;
+      expect(data).toMatchObject({ ok: true, created: 1, updated: 0, deleted: 0, remaining: 0, total: 1 });
+
+      expect(db.entries).toHaveLength(1);
+      const entry = db.entries[0];
+      expect(entry.source).toBe("notion");
+      expect(JSON.parse(entry.tags)).toEqual(["notion"]);
+      expect(entry.content).toContain("# Project Plan");
+      expect(entry.content).toContain("https://notion.so/p1");
+      expect(entry.content).toContain("Ship the beta in March");
+
+      const status = await (await worker.fetch(req("GET", "/integrations"), env, ctx)).json() as any;
+      expect(status.integrations[0].pageCount).toBe(1);
+    });
+
+    it("is a no-op when nothing changed", async () => {
+      fixture.pages = [notionPage("p1", "Note", "2026-01-01T00:00:00.000Z")];
+      fixture.blocks["p1"] = [paragraph("test")];
+      await connect();
+      await sync();
+
+      const data = await (await sync()).json() as any;
+      expect(data).toMatchObject({ created: 0, updated: 0, deleted: 0 });
+      expect(db.entries).toHaveLength(1);
+    });
+
+    it("replaces a mirrored entry in place when the page is edited", async () => {
+      fixture.pages = [notionPage("p1", "Note A", "2026-01-01T00:00:00.000Z")];
+      fixture.blocks["p1"] = [paragraph("test")];
+      await connect();
+      await sync();
+      const originalId = db.entries[0].id;
+
+      // The page changes: "test" → "test2", with a newer last_edited_time.
+      fixture.pages = [notionPage("p1", "Note A", "2026-01-08T00:00:00.000Z")];
+      fixture.blocks["p1"] = [paragraph("test2")];
+
+      const data = await (await sync()).json() as any;
+      expect(data).toMatchObject({ created: 0, updated: 1 });
+      expect(db.entries).toHaveLength(1);
+      expect(db.entries[0].id).toBe(originalId); // same entry — graph edges/recall counts survive
+      expect(db.entries[0].content).toContain("test2");
+      expect(db.entries[0].content).not.toContain("test\n");
+    });
+
+    it("deletes the mirror when a page disappears from the listing", async () => {
+      fixture.pages = [notionPage("p1", "Note", "2026-01-01T00:00:00.000Z")];
+      fixture.blocks["p1"] = [paragraph("test")];
+      await connect();
+      await sync();
+      expect(db.entries).toHaveLength(1);
+
+      fixture.pages = []; // page unshared
+      const data = await (await sync()).json() as any;
+      expect(data).toMatchObject({ deleted: 1 });
+      expect(db.entries).toHaveLength(0);
+
+      const status = await (await worker.fetch(req("GET", "/integrations"), env, ctx)).json() as any;
+      expect(status.integrations[0].pageCount).toBe(0);
+    });
+
+    it("deletes the mirror when a page is archived", async () => {
+      fixture.pages = [notionPage("p1", "Note", "2026-01-01T00:00:00.000Z")];
+      fixture.blocks["p1"] = [paragraph("test")];
+      await connect();
+      await sync();
+
+      fixture.pages = [notionPage("p1", "Note", "2026-01-02T00:00:00.000Z", true)];
+      const data = await (await sync()).json() as any;
+      expect(data).toMatchObject({ deleted: 1, created: 0 });
+      expect(db.entries).toHaveLength(0);
+    });
+
+    it("processes large backlogs in bounded batches and reports remaining", async () => {
+      fixture.pages = Array.from({ length: 7 }, (_, i) =>
+        notionPage(`p${i}`, `Note ${i}`, `2026-01-0${i + 1}T00:00:00.000Z`)
+      );
+      for (let i = 0; i < 7; i++) fixture.blocks[`p${i}`] = [paragraph(`body ${i}`)];
+      await connect();
+
+      const first = await (await sync()).json() as any;
+      expect(first).toMatchObject({ created: 5, remaining: 2 });
+      const second = await (await sync()).json() as any;
+      expect(second).toMatchObject({ created: 2, remaining: 0 });
+      expect(db.entries).toHaveLength(7);
+    });
+
+    it("records the error and returns 502 when the Notion API fails", async () => {
+      fixture.pages = [notionPage("p1", "Note", "2026-01-01T00:00:00.000Z")];
+      fixture.blocks["p1"] = [paragraph("test")];
+      await connect();
+      fixture.validToken = "ntn_rotated"; // stored token no longer works
+
+      const res = await sync();
+      expect(res.status).toBe(502);
+
+      const status = await (await worker.fetch(req("GET", "/integrations"), env, ctx)).json() as any;
+      expect(status.integrations[0].status).toBe("error");
+      expect(status.integrations[0].lastSyncError).toContain("API token is invalid");
+    });
+  });
+
+  describe("mirror edit protection", () => {
+    beforeEach(async () => {
+      fixture.pages = [notionPage("p1", "Note", "2026-01-01T00:00:00.000Z")];
+      fixture.blocks["p1"] = [paragraph("test")];
+      await connect();
+      await sync();
+    });
+
+    it("409s on POST /update for a mirrored entry while connected", async () => {
+      const id = db.entries[0].id;
+      const res = await worker.fetch(req("POST", "/update", { body: { id, content: "manual edit" } }), env, ctx);
+      expect(res.status).toBe(409);
+      const data = await res.json() as any;
+      expect(data.error).toContain("synced from a Notion page");
+      expect(db.entries[0].content).toContain("test");
+    });
+
+    it("409s on POST /append for a mirrored entry while connected", async () => {
+      const id = db.entries[0].id;
+      const res = await worker.fetch(req("POST", "/append", { body: { id, addition: "manual note" } }), env, ctx);
+      expect(res.status).toBe(409);
+    });
+
+    it("allows edits again after disconnect", async () => {
+      const id = db.entries[0].id;
+      await worker.fetch(req("POST", "/integrations/notion/disconnect", { body: {} }), env, ctx);
+      const res = await worker.fetch(req("POST", "/update", { body: { id, content: "manual edit" } }), env, ctx);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("POST /integrations/notion/disconnect", () => {
+    beforeEach(async () => {
+      fixture.pages = [
+        notionPage("p1", "Note 1", "2026-01-01T00:00:00.000Z"),
+        notionPage("p2", "Note 2", "2026-01-02T00:00:00.000Z"),
+      ];
+      fixture.blocks["p1"] = [paragraph("one")];
+      fixture.blocks["p2"] = [paragraph("two")];
+      await connect();
+      await sync();
+    });
+
+    it("404s when not connected", async () => {
+      await worker.fetch(req("POST", "/integrations/notion/disconnect", { body: {} }), env, ctx);
+      const res = await worker.fetch(req("POST", "/integrations/notion/disconnect", { body: {} }), env, ctx);
+      expect(res.status).toBe(404);
+    });
+
+    it("keeps mirrored memories by default", async () => {
+      const res = await worker.fetch(req("POST", "/integrations/notion/disconnect", { body: {} }), env, ctx);
+      const data = await res.json() as any;
+      expect(data).toMatchObject({ ok: true, purged: 0, kept: 2 });
+      expect(db.entries).toHaveLength(2);
+
+      const status = await (await worker.fetch(req("GET", "/integrations"), env, ctx)).json() as any;
+      expect(status.integrations[0].connected).toBe(false);
+    });
+
+    it("purges mirrored memories when asked", async () => {
+      const res = await worker.fetch(
+        req("POST", "/integrations/notion/disconnect", { body: { purge: true } }), env, ctx
+      );
+      const data = await res.json() as any;
+      expect(data).toMatchObject({ ok: true, purged: 2, kept: 0 });
+      expect(db.entries).toHaveLength(0);
+    });
+  });
+});

--- a/test/unit/notion.test.ts
+++ b/test/unit/notion.test.ts
@@ -5,8 +5,12 @@ import {
   buildPageContent,
   computeSyncPlan,
   integrationStatus,
+  loadIntegration,
+  notionProvider,
+  getProvider,
 } from "../../src/integrations";
-import type { NotionPageMeta, PageMapEntry, IntegrationRecord } from "../../src/integrations";
+import type { NotionPageMeta, ItemMapEntry, IntegrationRecord } from "../../src/integrations";
+import { makeMemoryKV } from "../helpers/make-env";
 
 function page(id: string, lastEdited: string, archived = false): NotionPageMeta {
   return { id, lastEdited, title: `Page ${id}`, url: `https://notion.so/${id}`, archived };
@@ -83,8 +87,8 @@ describe("buildPageContent", () => {
 });
 
 describe("computeSyncPlan", () => {
-  const map = (entries: Record<string, string>): Record<string, PageMapEntry> =>
-    Object.fromEntries(Object.entries(entries).map(([id, lastEdited]) => [id, { entryId: `e-${id}`, lastEdited }]));
+  const map = (entries: Record<string, string>): Record<string, ItemMapEntry> =>
+    Object.fromEntries(Object.entries(entries).map(([id, version]) => [id, { entryId: `e-${id}`, version }]));
 
   it("treats unseen pages as changed", () => {
     const plan = computeSyncPlan([page("a", "2026-01-01T00:00:00Z")], {}, true);
@@ -134,7 +138,7 @@ describe("computeSyncPlan", () => {
 
 describe("integrationStatus", () => {
   it("reports a disconnected provider", () => {
-    expect(integrationStatus(null)).toEqual({
+    expect(integrationStatus(notionProvider, null)).toEqual({
       provider: "notion",
       name: "Notion",
       connected: false,
@@ -142,7 +146,7 @@ describe("integrationStatus", () => {
       workspaceName: null,
       lastSyncedAt: null,
       lastSyncError: null,
-      pageCount: 0,
+      itemCount: 0,
     });
   });
 
@@ -156,14 +160,45 @@ describe("integrationStatus", () => {
       workspaceName: "Test Workspace",
       lastSyncedAt: 123,
       lastSyncError: null,
-      pageMap: { p1: { entryId: "e1", lastEdited: "t" } },
+      itemMap: { p1: { entryId: "e1", version: "t" } },
       createdAt: 1,
       updatedAt: 2,
     };
-    const status = integrationStatus(record);
+    const status = integrationStatus(notionProvider, record);
     expect(status.connected).toBe(true);
     expect(status.workspaceName).toBe("Test Workspace");
-    expect(status.pageCount).toBe(1);
+    expect(status.itemCount).toBe(1);
     expect(JSON.stringify(status)).not.toContain("ntn_secret");
+  });
+});
+
+describe("provider registry", () => {
+  it("resolves registered providers and rejects unknown ids", () => {
+    expect(getProvider("notion")).toBe(notionProvider);
+    expect(getProvider("nope")).toBeNull();
+    expect(getProvider("hasOwnProperty")).toBeNull(); // prototype names are not providers
+  });
+});
+
+describe("loadIntegration legacy migration", () => {
+  it("migrates first-release pageMap/lastEdited blobs to itemMap/version", async () => {
+    const kv = makeMemoryKV();
+    await kv.put("integrations:notion", JSON.stringify({
+      provider: "notion",
+      authKind: "token",
+      credentials: { token: "ntn_x" },
+      config: {},
+      status: "connected",
+      workspaceName: "W",
+      lastSyncedAt: 1,
+      lastSyncError: null,
+      pageMap: { p1: { entryId: "e1", lastEdited: "2026-01-01T00:00:00.000Z" } },
+      createdAt: 1,
+      updatedAt: 1,
+    }));
+
+    const record = await loadIntegration({ OAUTH_KV: kv }, "notion");
+    expect(record?.itemMap).toEqual({ p1: { entryId: "e1", version: "2026-01-01T00:00:00.000Z" } });
+    expect((record as any).pageMap).toBeUndefined();
   });
 });

--- a/test/unit/notion.test.ts
+++ b/test/unit/notion.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractPageTitle,
+  flattenBlocks,
+  buildPageContent,
+  computeSyncPlan,
+  integrationStatus,
+} from "../../src/integrations";
+import type { NotionPageMeta, PageMapEntry, IntegrationRecord } from "../../src/integrations";
+
+function page(id: string, lastEdited: string, archived = false): NotionPageMeta {
+  return { id, lastEdited, title: `Page ${id}`, url: `https://notion.so/${id}`, archived };
+}
+
+describe("extractPageTitle", () => {
+  it("reads the title property regardless of its name", () => {
+    const p = {
+      properties: {
+        Status: { type: "select", select: { name: "Done" } },
+        Name: { type: "title", title: [{ plain_text: "My " }, { plain_text: "Note" }] },
+      },
+    };
+    expect(extractPageTitle(p)).toBe("My Note");
+  });
+
+  it("falls back to Untitled when there is no title text", () => {
+    expect(extractPageTitle({ properties: { title: { type: "title", title: [] } } })).toBe("Untitled");
+    expect(extractPageTitle({})).toBe("Untitled");
+    expect(extractPageTitle(null)).toBe("Untitled");
+  });
+});
+
+describe("flattenBlocks", () => {
+  const rt = (text: string) => [{ plain_text: text }];
+
+  it("renders common block types", () => {
+    const blocks = [
+      { type: "heading_1", heading_1: { rich_text: rt("Title") } },
+      { type: "paragraph", paragraph: { rich_text: rt("Hello world") } },
+      { type: "bulleted_list_item", bulleted_list_item: { rich_text: rt("item") } },
+      { type: "to_do", to_do: { rich_text: rt("task"), checked: true } },
+      { type: "quote", quote: { rich_text: rt("wise words") } },
+      { type: "divider", divider: {} },
+      { type: "child_page", child_page: { title: "Sub" } },
+    ];
+    expect(flattenBlocks(blocks)).toBe(
+      "# Title\nHello world\n- item\n[x] task\n> wise words\n---\n[Sub-page: Sub]"
+    );
+  });
+
+  it("indents nested children attached as _children", () => {
+    const blocks = [
+      {
+        type: "bulleted_list_item",
+        bulleted_list_item: { rich_text: rt("parent") },
+        _children: [{ type: "bulleted_list_item", bulleted_list_item: { rich_text: rt("child") } }],
+      },
+    ];
+    expect(flattenBlocks(blocks)).toBe("- parent\n  - child");
+  });
+
+  it("skips empty blocks and unknown types without rich text", () => {
+    const blocks = [
+      { type: "paragraph", paragraph: { rich_text: [] } },
+      { type: "image", image: { file: { url: "x" } } },
+      { type: "paragraph", paragraph: { rich_text: rt("kept") } },
+    ];
+    expect(flattenBlocks(blocks)).toBe("kept");
+  });
+});
+
+describe("buildPageContent", () => {
+  it("leads with title and source URL", () => {
+    const content = buildPageContent("My Note", "https://notion.so/abc", "body text");
+    expect(content).toBe("# My Note\nhttps://notion.so/abc\n\nbody text");
+  });
+
+  it("truncates very long bodies", () => {
+    const content = buildPageContent("T", "u", "x".repeat(10000));
+    expect(content.length).toBeLessThan(9000);
+    expect(content.endsWith("…")).toBe(true);
+  });
+});
+
+describe("computeSyncPlan", () => {
+  const map = (entries: Record<string, string>): Record<string, PageMapEntry> =>
+    Object.fromEntries(Object.entries(entries).map(([id, lastEdited]) => [id, { entryId: `e-${id}`, lastEdited }]));
+
+  it("treats unseen pages as changed", () => {
+    const plan = computeSyncPlan([page("a", "2026-01-01T00:00:00Z")], {}, true);
+    expect(plan.changed.map(p => p.id)).toEqual(["a"]);
+    expect(plan.deleted).toEqual([]);
+  });
+
+  it("treats edited pages as changed and unchanged pages as no-ops", () => {
+    const pageMap = map({ a: "2026-01-01T00:00:00Z", b: "2026-01-01T00:00:00Z" });
+    const plan = computeSyncPlan(
+      [page("a", "2026-01-02T00:00:00Z"), page("b", "2026-01-01T00:00:00Z")],
+      pageMap,
+      true,
+    );
+    expect(plan.changed.map(p => p.id)).toEqual(["a"]);
+  });
+
+  it("orders changed pages oldest first so partial batches converge", () => {
+    const plan = computeSyncPlan(
+      [page("new", "2026-03-01T00:00:00Z"), page("old", "2026-01-01T00:00:00Z")],
+      {},
+      true,
+    );
+    expect(plan.changed.map(p => p.id)).toEqual(["old", "new"]);
+  });
+
+  it("deletes mirrors for pages missing from a COMPLETE listing", () => {
+    const plan = computeSyncPlan([], map({ gone: "2026-01-01T00:00:00Z" }), true);
+    expect(plan.deleted).toEqual(["gone"]);
+  });
+
+  it("never deletes from a truncated listing", () => {
+    const plan = computeSyncPlan([], map({ gone: "2026-01-01T00:00:00Z" }), false);
+    expect(plan.deleted).toEqual([]);
+  });
+
+  it("deletes archived pages even from a truncated listing", () => {
+    const plan = computeSyncPlan(
+      [page("a", "2026-01-02T00:00:00Z", true)],
+      map({ a: "2026-01-01T00:00:00Z" }),
+      false,
+    );
+    expect(plan.deleted).toEqual(["a"]);
+    expect(plan.changed).toEqual([]); // archived pages are never re-ingested
+  });
+});
+
+describe("integrationStatus", () => {
+  it("reports a disconnected provider", () => {
+    expect(integrationStatus(null)).toEqual({
+      provider: "notion",
+      name: "Notion",
+      connected: false,
+      status: null,
+      workspaceName: null,
+      lastSyncedAt: null,
+      lastSyncError: null,
+      pageCount: 0,
+    });
+  });
+
+  it("summarizes a connected record without exposing credentials", () => {
+    const record: IntegrationRecord = {
+      provider: "notion",
+      authKind: "token",
+      credentials: { token: "ntn_secret" },
+      config: {},
+      status: "connected",
+      workspaceName: "Test Workspace",
+      lastSyncedAt: 123,
+      lastSyncError: null,
+      pageMap: { p1: { entryId: "e1", lastEdited: "t" } },
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const status = integrationStatus(record);
+    expect(status.connected).toBe(true);
+    expect(status.workspaceName).toBe("Test Workspace");
+    expect(status.pageCount).toBe(1);
+    expect(JSON.stringify(status)).not.toContain("ntn_secret");
+  });
+});


### PR DESCRIPTION
## Summary
Adds a complete Notion integration framework that mirrors shared Notion pages into Second Brain as memories. Pages sync automatically, stay up-to-date, and are protected from manual edits while the integration is connected.

## Key Changes

**Integration Framework** (`src/integrations/`)
- New provider-agnostic framework (`framework.ts`) for mirroring external sources into memory
- Integration state (tokens, item maps, sync status) stored in OAUTH_KV with no schema changes
- Narrow `MirrorStore` interface for syncs to create/update/delete entries, bypassing duplicate detection
- Bounded sync batches with `remaining` counter so callers loop until complete

**Notion Provider** (`src/integrations/notion.ts`)
- Full Notion API client with token validation, page listing, and block fetching
- Sync planning that detects new/edited/deleted pages and handles archived pages
- Content flattening: converts Notion blocks to markdown with one level of nesting
- Batched processing (5 pages per sync call) within Workers' subrequest budget (~35 requests per batch)
- Robust error handling with user-facing error messages stored in integration record

**Worker Routes** (`src/index.ts`)
- `GET /integrations` — list all providers with connection status and item counts
- `POST /integrations/:provider/connect` — validate token and store connection
- `POST /integrations/:provider/sync` — run one bounded sync batch
- `POST /integrations/:provider/disconnect` — disconnect; keeps mirrored memories by default, `purge: true` deletes them
- Mirror edit protection: `/update` and `/append` (REST and MCP) on mirrored entries return 409 / an explanatory message redirecting edits to the source tool
- Nightly cron sync: loops bounded batches per provider to converge large backlogs

**Settings UI** (`public/index.html`)
- New Integrations sheet accessible from the settings menu
- Notion card shows connection status, item count, last sync time
- Token input with validation feedback
- Sync now button and disconnect option
- Error display for failed syncs

**Tests**
- Integration tests (`test/integration/integrations.test.ts`) covering full connect/sync/edit flows with stubbed Notion API
- Unit tests (`test/unit/notion.test.ts`) for content formatting, sync planning, provider registry, and legacy KV blob migration
- Test helpers: `makeMemoryKV()` for stateful KV mocking

## Implementation Details

- **Deduplication by external ID**: itemMap tracks `pageId → {entryId, version}` to detect changes and avoid duplicates
- **Deletion safety**: only deletes mirrors when listing is complete (prevents false positives on truncated results); archived pages always delete
- **Partial batch convergence**: pages ordered oldest-first so incomplete syncs resume from where they left off
- **Non-fatal embedding**: vectorize failures don't block sync; entries re-embed via the pending backstop
- **Provider registry**: single source of truth for all integration features (routes, cron, edit guards, UI); adding a provider is one file plus one registry entry
- **Legacy migration**: `loadIntegration` migrates first-release `pageMap/lastEdited` KV blobs to `itemMap/version` on read, so existing connections keep their mirrors across this upgrade

https://claude.ai/code/session_01U4qJqeRrSDNpeTUyguCC2z