### PR TITLE
Migrate from @cloudflare/workers-types to wrangler-generated types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/
 .claude/
 .dev.vars
 .env
+worker-configuration.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "zod": "^4.0.0"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20241022.0",
         "@types/node": "^25.9.1",
         "@vitest/coverage-v8": "^4.1.7",
         "typescript": "^5.5.0",
@@ -421,13 +420,6 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.7.1.tgz",
       "integrity": "sha512-zgjuZhSHH92IsxNMYcKIGGoFiQ9bSCFa7Y6tkmdnthGtAX+sKl8eL+ixXUEUlkpHAbEqXDBs6BSxGx2L5KJo5Q==",
       "license": "MIT"
-    },
-    "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260520.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260520.1.tgz",
-      "integrity": "sha512-wdmf9Fwabp06OgK9ZyCl8Q77GZ94k9J7OA9qA65FbgxZ/hd3hYRkVNiY7Bvsx4tKim+sWmKqGOblecZInAvoRg==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "typecheck": "tsc --noEmit"
+    "cf-typegen": "wrangler types",
+    "typecheck": "wrangler types && tsc --noEmit"
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.7.0",
@@ -21,7 +22,6 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20241022.0",
     "@types/node": "^25.9.1",
     "@vitest/coverage-v8": "^4.1.7",
     "typescript": "^5.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,10 @@ import {
 } from "./integrations";
 import type { IntegrationRecord, MirrorStore } from "./integrations";
 
-export interface Env {
-  DB: D1Database;
-  VECTORIZE: VectorizeIndex;
-  AI: Ai;
-  AUTH_TOKEN: string;
-  OAUTH_KV: KVNamespace;
+// Bindings come from the generated Cloudflare.Env (see `wrangler types`);
+// VECTORIZE_GRACE_MS is widened from its generated literal default so tests
+// and per-deploy vars can override it.
+export interface Env extends Omit<Cloudflare.Env, "VECTORIZE_GRACE_MS"> {
   VECTORIZE_GRACE_MS?: string;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,8 @@
     "noEmit": true,
     "allowJs": true,
     "skipLibCheck": true,
-    "types": ["@cloudflare/workers-types", "node"]
+    "types": ["node"]
   },
-  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.setup.ts"],
+  "include": ["worker-configuration.d.ts", "src/**/*.ts", "test/**/*.ts", "vitest.setup.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## What

Replaces the pinned `@cloudflare/workers-types` npm package with runtime types generated by `wrangler types`, following Cloudflare's recommendation now that v5 of the package only tracks the latest runtime.

- **`package.json`** — drops `@cloudflare/workers-types` from devDependencies; adds a `cf-typegen` script and makes `typecheck` regenerate types first (`wrangler types && tsc --noEmit`), so CI needs no workflow changes.
- **`src/index.ts`** — `Env` now extends the generated `Cloudflare.Env`, which is derived directly from `wrangler.jsonc` bindings, vars, and secrets — the interface can no longer drift from the config. Only `VECTORIZE_GRACE_MS` is declared manually, widened to optional `string` (the generator emits it as the required literal `"300000"`, but tests and per-deploy vars override it).
- **`tsconfig.json`** — swaps the package for the generated `worker-configuration.d.ts` in the type roots.
- **`.gitignore`** — ignores `worker-configuration.d.ts`; it's regenerated on demand.

## Why

The generated types match this project's exact `compatibility_date` (2026-06-17) and `compatibility_flags` (`nodejs_compat`) instead of whatever the npm package last published, and they eliminate a class of bugs where a binding is added to `wrangler.jsonc` but not to the hand-written `Env` interface (or vice versa).

## Verification

- Clean-state CI simulation (`npm ci --legacy-peer-deps` → `npm run typecheck` → `npm run test:coverage`): typecheck exits 0, all 535 tests pass, coverage unchanged (~87% statements).
- `wrangler deploy --dry-run` bundles cleanly with all bindings resolving. No runtime code changed — the `src/index.ts` diff is type-only.

## Notes

- After a fresh clone, run `npm run cf-typegen` (or `typecheck`/`dev`) once to generate `worker-configuration.d.ts`, otherwise the editor shows type errors.
- CI does not run on this PR: the workflow only triggers on PRs targeting `main`, not `v2`. The verification above was run manually against the exact CI steps.