### PR TITLE
feat: one-time classification backfill via POST /classify-pending

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2492,6 +2492,7 @@
         </div>
         <div class="digest-section" id="digest-section" style="display:none"></div>
         <div class="digest-section" id="vectorize-section" style="display:none"></div>
+        <div class="digest-section" id="classify-section" style="display:none"></div>
         <div class="theme-row">
           <span class="theme-row-label">Appearance</span>
           <div class="theme-toggle" id="theme-toggle">
@@ -3151,6 +3152,7 @@
           vectorizeGraceMs = data.vectorize_grace_ms ?? vectorizeGraceMs
           renderDigestSection(data.digest_candidates ?? [])
           renderVectorizeSection(data.unvectorized ?? 0)
+          renderClassifySection(data.unclassified ?? 0)
         } catch {}
       }
 
@@ -3253,6 +3255,52 @@
           setTimeout(() => {
             btn.disabled = false
             btn.innerHTML = 'Vectorize now →'
+            btn.style.color = ''
+          }, 3000)
+        }
+      }
+
+      function renderClassifySection(count) {
+        const el = document.getElementById('classify-section')
+        if (!count) { el.style.display = 'none'; return }
+        el.style.display = ''
+        el.innerHTML = `
+          <div class="digest-section-label">Not classified</div>
+          <p class="digest-note">${count} ${count === 1 ? 'memory has' : 'memories have'} no kind or status tag yet (captured before classification existed).</p>
+          <button class="digest-btn" id="classify-btn" onclick="runClassify(this)">Classify now →</button>
+        `
+      }
+
+      async function runClassify(btn) {
+        btn.disabled = true
+        btn.classList.add('digest-btn--loading')
+        btn.innerHTML = '<i class="ti ti-loader-2"></i> Working…'
+        try {
+          let remaining = 1
+          let totalProcessed = 0
+          while (remaining > 0) {
+            const res = await fetch(`${WORKER_URL}/classify-pending`, {
+              method: 'POST',
+              headers: { Authorization: `Bearer ${AUTH_TOKEN}` }
+            })
+            if (!res.ok) throw new Error(`Server error: ${res.status}`)
+            const data = await res.json()
+            remaining = data.remaining ?? 0
+            totalProcessed += data.processed ?? 0
+            if ((data.processed ?? 0) === 0 && remaining > 0) break
+          }
+          btn.classList.remove('digest-btn--loading')
+          btn.innerHTML = `<i class="ti ti-check"></i> Done — ${totalProcessed} classified`
+          btn.style.color = 'var(--good)'
+          await loadMenuStats()
+          loadRecent()
+        } catch {
+          btn.classList.remove('digest-btn--loading')
+          btn.innerHTML = '<i class="ti ti-wifi-off"></i> Request failed'
+          btn.style.color = 'var(--danger)'
+          setTimeout(() => {
+            btn.disabled = false
+            btn.innerHTML = 'Classify now →'
             btn.style.color = ''
           }, 3000)
         }

--- a/public/index.html
+++ b/public/index.html
@@ -3277,6 +3277,7 @@
         btn.innerHTML = '<i class="ti ti-loader-2"></i> Working…'
         try {
           let remaining = 1
+          let prevRemaining = Infinity
           let totalProcessed = 0
           while (remaining > 0) {
             const res = await fetch(`${WORKER_URL}/classify-pending`, {
@@ -3287,7 +3288,8 @@
             const data = await res.json()
             remaining = data.remaining ?? 0
             totalProcessed += data.processed ?? 0
-            if ((data.processed ?? 0) === 0 && remaining > 0) break
+            if (remaining >= prevRemaining) break
+            prevRemaining = remaining
           }
           btn.classList.remove('digest-btn--loading')
           btn.innerHTML = `<i class="ti ti-check"></i> Done — ${totalProcessed} classified`

--- a/src/index.ts
+++ b/src/index.ts
@@ -2045,7 +2045,8 @@ const defaultHandler = {
       const [summary, tagRows, candidateRows] = await Promise.all([
         env.DB.prepare(
           `SELECT COUNT(*) as count, AVG(importance_score) as avg_importance,
-           SUM(CASE WHEN vector_ids = '[]' AND created_at < ? THEN 1 ELSE 0 END) as unvectorized
+           SUM(CASE WHEN vector_ids = '[]' AND created_at < ? THEN 1 ELSE 0 END) as unvectorized,
+           SUM(CASE WHEN tags NOT LIKE '%"status:%' AND tags NOT LIKE '%"kind:%' THEN 1 ELSE 0 END) as unclassified
            FROM entries`
         ).bind(graceCutoff).first() as Promise<Record<string, any> | null>,
         env.DB.prepare(`SELECT value, COUNT(*) as n FROM entries, json_each(entries.tags) GROUP BY value ORDER BY n DESC LIMIT 5`).all(),
@@ -2082,6 +2083,7 @@ const defaultHandler = {
         digest_candidates: digestCandidates,
         unvectorized: (summary?.unvectorized as number) ?? 0,
         vectorize_grace_ms: graceMs(env),
+        unclassified: (summary?.unclassified as number) ?? 0,
       });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2260,6 +2260,47 @@ const defaultHandler = {
       return json({ processed, failed, remaining: (remaining?.count as number) ?? 0 });
     }
 
+    // POST /classify-pending
+    // One-time, opt-in backfill: runs classifyEntry over entries that predate the
+    // status (#119) and kind (#12) features and writes status:/kind: tags. Bounded
+    // batch per call, idempotent (skips entries that already carry either tag), and
+    // resumable (safe to stop/restart). No schema migration — only writes tags.
+    if (url.pathname === "/classify-pending" && request.method === "POST") {
+      const authErr = requireAuth(request, env);
+      if (authErr) return authErr;
+
+      const UNCLASSIFIED_WHERE = `tags NOT LIKE '%"status:%' AND tags NOT LIKE '%"kind:%'`;
+
+      const { results: toProcess } = await env.DB.prepare(
+        `SELECT id, content, tags FROM entries
+         WHERE ${UNCLASSIFIED_WHERE}
+         ORDER BY created_at ASC LIMIT 25`
+      ).all();
+
+      let processed = 0;
+      let failed = 0;
+
+      for (const row of toProcess as Record<string, any>[]) {
+        try {
+          const { canonical, kind } = await classifyEntry(row.content as string, env);
+          let tags: string[] = JSON.parse(row.tags as string);
+          if (kind) tags = withKind(tags, kind);
+          if (canonical && getStatus(tags) === null) tags = withStatus(tags, "canonical");
+          await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`).bind(JSON.stringify(tags), row.id).run();
+          processed++;
+        } catch (e) {
+          console.error("Classification backfill failed for entry", row.id, e);
+          failed++;
+        }
+      }
+
+      const remaining = await env.DB.prepare(
+        `SELECT COUNT(*) as count FROM entries WHERE ${UNCLASSIFIED_WHERE}`
+      ).first() as Record<string, any> | null;
+
+      return json({ processed, failed, remaining: (remaining?.count as number) ?? 0 });
+    }
+
     return new Response("Not found", { status: 404 });
   },
 };

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -118,7 +118,8 @@ export class D1Mock {
           const unvectorized = cutoff !== undefined
             ? db.entries.filter((e: any) => e.vector_ids === '[]' && e.created_at < cutoff).length
             : 0;
-          return { count, avg_importance, unvectorized };
+          const unclassified = db.entries.filter((e: any) => !String(e.tags).includes('"status:') && !String(e.tags).includes('"kind:')).length;
+          return { count, avg_importance, unvectorized, unclassified };
         }
         if (s.includes("COUNT(*) as count") && s.includes("vector_ids = '[]'") && s.includes("created_at <")) {
           const cutoff = Number(args[0]);

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -125,6 +125,10 @@ export class D1Mock {
           const count = db.entries.filter((e: any) => e.vector_ids === '[]' && e.created_at < cutoff).length;
           return { count };
         }
+        if (s.includes("COUNT(*) as count") && s.includes(`tags NOT LIKE '%"status:%'`) && s.includes(`tags NOT LIKE '%"kind:%'`)) {
+          const count = db.entries.filter((e: any) => !String(e.tags).includes('"status:') && !String(e.tags).includes('"kind:')).length;
+          return { count };
+        }
         if (s.includes("COUNT(*) as count")) {
           return { count: db.entries.length };
         }
@@ -276,6 +280,16 @@ export class D1Mock {
             (JSON.parse(e.tags ?? "[]") as string[]).forEach(t => tags.add(t));
           });
           return { results: [...tags].sort().map(t => ({ value: t })) };
+        }
+        if (s.includes(`tags NOT LIKE '%"status:%'`) && s.includes(`tags NOT LIKE '%"kind:%'`) && s.includes("ORDER BY created_at ASC LIMIT")) {
+          const limitMatch = s.match(/LIMIT\s+(\d+)/i);
+          const limit = limitMatch ? parseInt(limitMatch[1], 10) : 25;
+          const rows = [...db.entries]
+            .filter((e: any) => !String(e.tags).includes('"status:') && !String(e.tags).includes('"kind:'))
+            .sort((a: any, b: any) => a.created_at - b.created_at)
+            .slice(0, limit)
+            .map((e: any) => ({ id: e.id, content: e.content, tags: e.tags }));
+          return { results: rows };
         }
         if (s.includes("vector_ids = '[]' AND created_at <") && s.includes("ORDER BY created_at DESC LIMIT")) {
           const cutoff = Number(args[0]);

--- a/test/integration/classify-pending.test.ts
+++ b/test/integration/classify-pending.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+function unclassifiedEntry(id: string, tags: string[] = ["work"]) {
+  return {
+    id,
+    content: `Content for ${id}`,
+    tags: JSON.stringify(tags),
+    source: "api",
+    created_at: Date.now() - 600000,
+    vector_ids: '["v"]',
+    recall_count: 0,
+    importance_score: 0,
+  };
+}
+
+// The shared default AI mock (makeAIMock in make-env.ts) returns a bare "3" with
+// no parseable canonical/kind, so classifyEntry yields no signal and no tag gets
+// written. That's realistic (ambiguous content stays untagged and gets retried —
+// see the "still unclassified" test below) but most of these tests want a
+// classifier that actually resolves, so they supply one explicitly.
+function makeClassifyingAIMock(result: { importance: number; canonical: boolean; kind: "episodic" | "semantic" }) {
+  return {
+    run: vi.fn().mockImplementation(async (model: string) => {
+      if (model === "@cf/baai/bge-small-en-v1.5") return { data: [new Array(384).fill(0.1)] };
+      return new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(JSON.stringify(result))}}\n\n`));
+          c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+          c.close();
+        },
+      });
+    }),
+  } as any;
+}
+
+describe("POST /classify-pending", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await worker.fetch(req("POST", "/classify-pending", { token: null }), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns { processed: 0, failed: 0, remaining: 0 } when nothing is unclassified", async () => {
+    const res = await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.processed).toBe(0);
+    expect(data.failed).toBe(0);
+    expect(data.remaining).toBe(0);
+  });
+
+  it("processes unclassified entries, writes tags, and drains remaining to 0", async () => {
+    env = makeTestEnv(db, { AI: makeClassifyingAIMock({ importance: 4, canonical: true, kind: "semantic" }) });
+    db.entries.push(unclassifiedEntry("e1"), unclassifiedEntry("e2"));
+    const res = await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.processed).toBe(2);
+    expect(data.failed).toBe(0);
+    expect(data.remaining).toBe(0);
+    for (const id of ["e1", "e2"]) {
+      const tags: string[] = JSON.parse(db.entries.find((e: any) => e.id === id).tags);
+      expect(tags).toContain("kind:semantic");
+      expect(tags).toContain("status:canonical");
+    }
+  });
+
+  it("skips entries that already have a status: or kind: tag", async () => {
+    env = makeTestEnv(db, { AI: makeClassifyingAIMock({ importance: 4, canonical: true, kind: "semantic" }) });
+    db.entries.push(
+      unclassifiedEntry("has-status", ["work", "status:draft"]),
+      unclassifiedEntry("has-kind", ["work", "kind:episodic"]),
+    );
+    const res = await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.processed).toBe(0);
+    expect(data.remaining).toBe(0);
+    // untouched — still exactly the tags they started with
+    expect(JSON.parse(db.entries.find((e: any) => e.id === "has-status").tags)).toEqual(["work", "status:draft"]);
+    expect(JSON.parse(db.entries.find((e: any) => e.id === "has-kind").tags)).toEqual(["work", "kind:episodic"]);
+  });
+
+  it("is resumable: re-running after a full drain is a no-op", async () => {
+    env = makeTestEnv(db, { AI: makeClassifyingAIMock({ importance: 4, canonical: true, kind: "semantic" }) });
+    db.entries.push(unclassifiedEntry("only-one"));
+    await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const res2 = await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const data2 = await res2.json() as any;
+    expect(data2.processed).toBe(0);
+    expect(data2.remaining).toBe(0);
+  });
+
+  it("leaves an entry untagged and still 'remaining' when classification is inconclusive", async () => {
+    // Known, spec-accepted edge case: idempotency is defined by tag *presence*, not
+    // a separate "attempted" marker. If classifyEntry can't resolve a kind/canonical
+    // signal (default mock here returns neither), the row gets no tag and is
+    // reselected on the next call — this documents that behavior rather than hiding it.
+    db.entries.push(unclassifiedEntry("ambiguous"));
+    const res = await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.processed).toBe(1);
+    expect(data.remaining).toBe(1);
+    expect(JSON.parse(db.entries.find((e: any) => e.id === "ambiguous").tags)).toEqual(["work"]);
+  });
+
+  it("promotes canonical status and writes kind for a fully unclassified entry", async () => {
+    env = makeTestEnv(db, { AI: makeClassifyingAIMock({ importance: 5, canonical: true, kind: "episodic" }) });
+    // An entry that already carries kind: (but no status:) is excluded by the WHERE
+    // clause entirely — the "skips" test above covers that. This one has neither
+    // reserved tag, so it's selected and should get both written.
+    db.entries.push(unclassifiedEntry("neither", ["work"]));
+    await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const neither = JSON.parse(db.entries.find((e: any) => e.id === "neither").tags);
+    expect(neither).toContain("status:canonical");
+    expect(neither).toContain("kind:episodic");
+  });
+
+  it("does not touch importance_score (tags-only backfill)", async () => {
+    env = makeTestEnv(db, { AI: makeClassifyingAIMock({ importance: 5, canonical: true, kind: "semantic" }) });
+    db.entries.push(unclassifiedEntry("importance-check"));
+    await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const updated = db.entries.find((e: any) => e.id === "importance-check");
+    expect(updated.importance_score).toBe(0);
+  });
+
+  it("counts failed and continues when a row can't be updated (e.g. corrupt tags JSON)", async () => {
+    // classifyEntry swallows AI-level errors internally (returns a neutral,
+    // untagged result), so to exercise this endpoint's own try/catch we force a
+    // failure downstream of that call instead: malformed tags JSON blows up
+    // JSON.parse inside the handler.
+    env = makeTestEnv(db, { AI: makeClassifyingAIMock({ importance: 4, canonical: true, kind: "semantic" }) });
+    db.entries.push(
+      { ...unclassifiedEntry("bad"), tags: "not-json" },
+      unclassifiedEntry("good"),
+    );
+    const res = await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.processed).toBe(1);
+    expect(data.failed).toBe(1);
+    // "bad" is still malformed/untagged so it's still selected next time; "good"
+    // got tagged successfully and drops out of the unclassified set.
+    expect(data.remaining).toBe(1);
+  });
+});

--- a/test/integration/stats.test.ts
+++ b/test/integration/stats.test.ts
@@ -130,6 +130,34 @@ describe("GET /stats — vectorization fields", () => {
   });
 });
 
+describe("GET /stats — classification fields", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("returns unclassified: 0 when all entries have status/kind tags", async () => {
+    db.entries.push(entry("a", ["work", "status:canonical", "kind:semantic"], 5));
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.unclassified).toBe(0);
+  });
+
+  it("counts entries missing both status: and kind: tags as unclassified", async () => {
+    db.entries.push(
+      entry("a", ["work"], 5),
+      entry("b", ["work", "kind:episodic"], 5),
+      entry("c", ["work", "status:canonical", "kind:semantic"], 5),
+    );
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.unclassified).toBe(1);
+  });
+});
+
 describe("GET /stats — digest candidates", () => {
   let env: Env;
   let db: D1Mock;


### PR DESCRIPTION
Closes #145.

This adds a one-time, opt-in backfill for entries that were captured before the status (#119) and kind (#12) classification features existed, so they never got a status: or kind: tag.

POST /classify-pending picks up to 25 untagged entries, runs the existing classifyEntry on each, and writes back whatever tags it resolves (kind:episodic/kind:semantic, and status:canonical only if the entry doesn't already have a status). It only ever touches tags without making any schema changes or modifying any other fields

It mirrors /vectorize-pending's shape exactly: bounded batch per call, skips anything already tagged (idempotent), safe to call repeatedly until remaining hits 0 (resumable).

**And yeah:** 
if an entry's classification is genuinely ambiguous (no kind, not canonical), it won't get tagged and will show up as "remaining" again next call. That's intentional per the issue's own definition of idempotency (tag presence, not a separate "attempted" marker), expected.

Added test/integration/classify-pending.test.ts (9 tests: auth, empty state, tagging + full drain, skip-already-tagged, resumability, the ambiguous case above, status not clobbered, importance_score untouched, partial-batch failure). tsc --noEmit and the full suite pass (435/435).


* **Note:**
This PR was written with help from an AI agent (I reviewed it). Happy to walk through any of it. First time contributing here, I'd appreciate any feedback. If anything's off about the approach, the tests, or how it fits with the rest of the codebase, I'd love to hear it and redo.