### PR TITLE
fix: remove unsupported ${VAR} placeholders from Vectorize binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Enter the following values during setup:
 
 | FIELD      | VALUE                           |
 | ---------- | ------------------------------- |
+| Dimensions | `384`                           |
+| Metric     | `cosine`                        |
 | AUTH_TOKEN | The token you created in step 1 |
-| DIMENSION  | `384`                           |
-| METRIC     | `cosine`                        |
 
 Cloudflare will provision the required resources and deploy your Worker automatically.
 

--- a/package.json
+++ b/package.json
@@ -32,14 +32,6 @@
     "bindings": {
       "AUTH_TOKEN": {
         "description": "Your authentication token. Use a memorable phrase (like 'coffee-lover-2026') or generate a secure token with: openssl rand -base64 32. Save it - you'll need this for AI client connections!"
-      },
-      "VECTORIZE_DIMENSIONS": {
-        "description": "Number of dimensions for the Vectorize index = 384",
-        "default": "384"
-      },
-      "VECTORIZE_METRIC": {
-        "description": "Cosine is recommended for semantic search",
-        "default": "cosine"
       }
     }
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,9 +15,7 @@
 	"vectorize": [
 		{
 			"binding": "VECTORIZE",
-			"index_name": "second-brain-vectors",
-			"dimensions": "${VECTORIZE_DIMENSIONS}",
-			"metric": "${VECTORIZE_METRIC}"
+			"index_name": "second-brain-vectors"
 		}
 	],
 	"ai": {


### PR DESCRIPTION
The one-click Deploy to Cloudflare flow has been failing silently since the vectorize binding's dimensions/metric were replaced with `"${VECTORIZE_DIMENSIONS}"`/`"${VECTORIZE_METRIC}"` placeholders (#166, reintroduced in cloudflare/workers-sdk#173). Neither wrangler nor the deploy platform performs `${VAR}` interpolation, and the wrangler schema forbids dimensions/metric inside a vectorize binding entirely (cloudflare/cf-platform-issues#28 — the pre-fill feature is still in Cloudflare's backlog). The deploy form rendered fine but its submission bounced back with no worker created (#169, cloudflare/workers-sdk#171, cloudflare/workers-sdk#178).

Declare the binding with only binding + index_name (schema-valid), drop the dead VECTORIZE_DIMENSIONS/VECTORIZE_METRIC defaults from package.json cloudflare.bindings (only "description" is supported there), and align the README table with the form's actual field labels. Users still enter 384/cosine in the form's native Dimensions/Metric fields, which the README documents.

Verified locally: `wrangler deploy --dry-run` now parses with zero warnings and attaches all five bindings; typecheck and the 426-test suite pass.

Fixes cloudflare/workers-sdk#178