### PR TITLE
Classify-pending backfill + dashboard (v2 companion to #177)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2705,6 +2705,7 @@
         </div>
         <div class="digest-section" id="digest-section" style="display: none"></div>
         <div class="digest-section" id="vectorize-section" style="display: none"></div>
+        <div class="digest-section" id="classify-section" style="display: none"></div>
         <div class="theme-row">
           <span class="theme-row-label">Appearance</span>
           <div class="theme-toggle" id="theme-toggle">
@@ -3413,6 +3414,7 @@
           vectorizeGraceMs = data.vectorize_grace_ms ?? vectorizeGraceMs
           renderDigestSection(data.digest_candidates ?? [])
           renderVectorizeSection(data.unvectorized ?? 0)
+          renderClassifySection(data.unclassified ?? 0)
         } catch {}
       }
 
@@ -3677,6 +3679,52 @@
           btn.disabled = false
           btn.textContent = 'Disconnect'
           alert(e.message || 'Disconnect failed')
+        }
+      }
+
+      function renderClassifySection(count) {
+        const el = document.getElementById('classify-section')
+        if (!count) { el.style.display = 'none'; return }
+        el.style.display = ''
+        el.innerHTML = `
+          <div class="digest-section-label">Not classified</div>
+          <p class="digest-note">${count} ${count === 1 ? 'memory has' : 'memories have'} no kind or status tag yet (captured before classification existed).</p>
+          <button class="digest-btn" id="classify-btn" onclick="runClassify(this)">Classify now →</button>
+        `
+      }
+
+      async function runClassify(btn) {
+        btn.disabled = true
+        btn.classList.add('digest-btn--loading')
+        btn.innerHTML = '<i class="ti ti-loader-2"></i> Working…'
+        try {
+          let remaining = 1
+          let totalProcessed = 0
+          while (remaining > 0) {
+            const res = await fetch(`${WORKER_URL}/classify-pending`, {
+              method: 'POST',
+              headers: { Authorization: `Bearer ${AUTH_TOKEN}` }
+            })
+            if (!res.ok) throw new Error(`Server error: ${res.status}`)
+            const data = await res.json()
+            remaining = data.remaining ?? 0
+            totalProcessed += data.processed ?? 0
+            if ((data.processed ?? 0) === 0 && remaining > 0) break
+          }
+          btn.classList.remove('digest-btn--loading')
+          btn.innerHTML = `<i class="ti ti-check"></i> Done — ${totalProcessed} classified`
+          btn.style.color = 'var(--good)'
+          await loadMenuStats()
+          loadRecent()
+        } catch {
+          btn.classList.remove('digest-btn--loading')
+          btn.innerHTML = '<i class="ti ti-wifi-off"></i> Request failed'
+          btn.style.color = 'var(--danger)'
+          setTimeout(() => {
+            btn.disabled = false
+            btn.innerHTML = 'Classify now →'
+            btn.style.color = ''
+          }, 3000)
         }
       }
 

--- a/public/index.html
+++ b/public/index.html
@@ -3699,6 +3699,7 @@
         btn.innerHTML = '<i class="ti ti-loader-2"></i> Working…'
         try {
           let remaining = 1
+          let prevRemaining = Infinity
           let totalProcessed = 0
           while (remaining > 0) {
             const res = await fetch(`${WORKER_URL}/classify-pending`, {
@@ -3709,7 +3710,8 @@
             const data = await res.json()
             remaining = data.remaining ?? 0
             totalProcessed += data.processed ?? 0
-            if ((data.processed ?? 0) === 0 && remaining > 0) break
+            if (remaining >= prevRemaining) break
+            prevRemaining = remaining
           }
           btn.classList.remove('digest-btn--loading')
           btn.innerHTML = `<i class="ti ti-check"></i> Done — ${totalProcessed} classified`

--- a/src/index.ts
+++ b/src/index.ts
@@ -3161,6 +3161,47 @@ const defaultHandler = {
       return json({ ok: true, purged, kept: body.purge ? 0 : Object.keys(record.itemMap).length });
     }
 
+    // POST /classify-pending
+    // One-time, opt-in backfill: runs classifyEntry over entries that predate the
+    // status (#119) and kind (#12) features and writes status:/kind: tags. Bounded
+    // batch per call, idempotent (skips entries that already carry either tag), and
+    // resumable (safe to stop/restart). No schema migration — only writes tags.
+    if (url.pathname === "/classify-pending" && request.method === "POST") {
+      const authErr = requireAuth(request, env);
+      if (authErr) return authErr;
+
+      const UNCLASSIFIED_WHERE = `tags NOT LIKE '%"status:%' AND tags NOT LIKE '%"kind:%'`;
+
+      const { results: toProcess } = await env.DB.prepare(
+        `SELECT id, content, tags FROM entries
+         WHERE ${UNCLASSIFIED_WHERE}
+         ORDER BY created_at ASC LIMIT 25`
+      ).all();
+
+      let processed = 0;
+      let failed = 0;
+
+      for (const row of toProcess as Record<string, any>[]) {
+        try {
+          const { canonical, kind } = await classifyEntry(row.content as string, env);
+          let tags: string[] = JSON.parse(row.tags as string);
+          if (kind) tags = withKind(tags, kind);
+          if (canonical && getStatus(tags) === null) tags = withStatus(tags, "canonical");
+          await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`).bind(JSON.stringify(tags), row.id).run();
+          processed++;
+        } catch (e) {
+          console.error("Classification backfill failed for entry", row.id, e);
+          failed++;
+        }
+      }
+
+      const remaining = await env.DB.prepare(
+        `SELECT COUNT(*) as count FROM entries WHERE ${UNCLASSIFIED_WHERE}`
+      ).first() as Record<string, any> | null;
+
+      return json({ processed, failed, remaining: (remaining?.count as number) ?? 0 });
+    }
+
     return new Response("Not found", { status: 404 });
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2784,7 +2784,8 @@ const defaultHandler = {
       const [summary, tagRows, candidateRows] = await Promise.all([
         env.DB.prepare(
           `SELECT COUNT(*) as count, AVG(importance_score) as avg_importance,
-           SUM(CASE WHEN vector_ids = '[]' AND created_at < ? THEN 1 ELSE 0 END) as unvectorized
+           SUM(CASE WHEN vector_ids = '[]' AND created_at < ? THEN 1 ELSE 0 END) as unvectorized,
+           SUM(CASE WHEN tags NOT LIKE '%"status:%' AND tags NOT LIKE '%"kind:%' THEN 1 ELSE 0 END) as unclassified
            FROM entries`
         ).bind(graceCutoff).first() as Promise<Record<string, any> | null>,
         env.DB.prepare(`SELECT value, COUNT(*) as n FROM entries, json_each(entries.tags) GROUP BY value ORDER BY n DESC LIMIT 5`).all(),
@@ -2821,6 +2822,7 @@ const defaultHandler = {
         digest_candidates: digestCandidates,
         unvectorized: (summary?.unvectorized as number) ?? 0,
         vectorize_grace_ms: graceMs(env),
+        unclassified: (summary?.unclassified as number) ?? 0,
       });
     }
 

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -151,6 +151,10 @@ export class D1Mock {
           const count = db.entries.filter((e: any) => e.vector_ids === '[]' && e.created_at < cutoff).length;
           return { count };
         }
+        if (s.includes("COUNT(*) as count") && s.includes(`tags NOT LIKE '%"status:%'`) && s.includes(`tags NOT LIKE '%"kind:%'`)) {
+          const count = db.entries.filter((e: any) => !String(e.tags).includes('"status:') && !String(e.tags).includes('"kind:')).length;
+          return { count };
+        }
         if (s.includes("COUNT(*) as count")) {
           return { count: db.entries.length };
         }
@@ -361,6 +365,16 @@ export class D1Mock {
             (JSON.parse(e.tags ?? "[]") as string[]).forEach(t => tags.add(t));
           });
           return { results: [...tags].sort().map(t => ({ value: t })) };
+        }
+        if (s.includes(`tags NOT LIKE '%"status:%'`) && s.includes(`tags NOT LIKE '%"kind:%'`) && s.includes("ORDER BY created_at ASC LIMIT")) {
+          const limitMatch = s.match(/LIMIT\s+(\d+)/i);
+          const limit = limitMatch ? parseInt(limitMatch[1], 10) : 25;
+          const rows = [...db.entries]
+            .filter((e: any) => !String(e.tags).includes('"status:') && !String(e.tags).includes('"kind:'))
+            .sort((a: any, b: any) => a.created_at - b.created_at)
+            .slice(0, limit)
+            .map((e: any) => ({ id: e.id, content: e.content, tags: e.tags }));
+          return { results: rows };
         }
         if (s.includes("vector_ids = '[]' AND created_at <") && s.includes("ORDER BY created_at DESC LIMIT")) {
           const cutoff = Number(args[0]);

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -144,7 +144,8 @@ export class D1Mock {
           const unvectorized = cutoff !== undefined
             ? db.entries.filter((e: any) => e.vector_ids === '[]' && e.created_at < cutoff).length
             : 0;
-          return { count, avg_importance, unvectorized };
+          const unclassified = db.entries.filter((e: any) => !String(e.tags).includes('"status:') && !String(e.tags).includes('"kind:')).length;
+          return { count, avg_importance, unvectorized, unclassified };
         }
         if (s.includes("COUNT(*) as count") && s.includes("vector_ids = '[]'") && s.includes("created_at <")) {
           const cutoff = Number(args[0]);

--- a/test/integration/classify-pending.test.ts
+++ b/test/integration/classify-pending.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+function unclassifiedEntry(id: string, tags: string[] = ["work"]) {
+  return {
+    id,
+    content: `Content for ${id}`,
+    tags: JSON.stringify(tags),
+    source: "api",
+    created_at: Date.now() - 600000,
+    vector_ids: '["v"]',
+    recall_count: 0,
+    importance_score: 0,
+  };
+}
+
+// The shared default AI mock (makeAIMock in make-env.ts) returns a bare "3" with
+// no parseable canonical/kind, so classifyEntry yields no signal and no tag gets
+// written. That's realistic (ambiguous content stays untagged and gets retried —
+// see the "still unclassified" test below) but most of these tests want a
+// classifier that actually resolves, so they supply one explicitly.
+function makeClassifyingAIMock(result: { importance: number; canonical: boolean; kind: "episodic" | "semantic" }) {
+  return {
+    run: vi.fn().mockImplementation(async (model: string) => {
+      if (model === "@cf/baai/bge-small-en-v1.5") return { data: [new Array(384).fill(0.1)] };
+      return new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(JSON.stringify(result))}}\n\n`));
+          c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+          c.close();
+        },
+      });
+    }),
+  } as any;
+}
+
+describe("POST /classify-pending", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await worker.fetch(req("POST", "/classify-pending", { token: null }), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns { processed: 0, failed: 0, remaining: 0 } when nothing is unclassified", async () => {
+    const res = await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.processed).toBe(0);
+    expect(data.failed).toBe(0);
+    expect(data.remaining).toBe(0);
+  });
+
+  it("processes unclassified entries, writes tags, and drains remaining to 0", async () => {
+    env = makeTestEnv(db, { AI: makeClassifyingAIMock({ importance: 4, canonical: true, kind: "semantic" }) });
+    db.entries.push(unclassifiedEntry("e1"), unclassifiedEntry("e2"));
+    const res = await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.processed).toBe(2);
+    expect(data.failed).toBe(0);
+    expect(data.remaining).toBe(0);
+    for (const id of ["e1", "e2"]) {
+      const tags: string[] = JSON.parse(db.entries.find((e: any) => e.id === id).tags);
+      expect(tags).toContain("kind:semantic");
+      expect(tags).toContain("status:canonical");
+    }
+  });
+
+  it("skips entries that already have a status: or kind: tag", async () => {
+    env = makeTestEnv(db, { AI: makeClassifyingAIMock({ importance: 4, canonical: true, kind: "semantic" }) });
+    db.entries.push(
+      unclassifiedEntry("has-status", ["work", "status:draft"]),
+      unclassifiedEntry("has-kind", ["work", "kind:episodic"]),
+    );
+    const res = await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.processed).toBe(0);
+    expect(data.remaining).toBe(0);
+    // untouched — still exactly the tags they started with
+    expect(JSON.parse(db.entries.find((e: any) => e.id === "has-status").tags)).toEqual(["work", "status:draft"]);
+    expect(JSON.parse(db.entries.find((e: any) => e.id === "has-kind").tags)).toEqual(["work", "kind:episodic"]);
+  });
+
+  it("is resumable: re-running after a full drain is a no-op", async () => {
+    env = makeTestEnv(db, { AI: makeClassifyingAIMock({ importance: 4, canonical: true, kind: "semantic" }) });
+    db.entries.push(unclassifiedEntry("only-one"));
+    await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const res2 = await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const data2 = await res2.json() as any;
+    expect(data2.processed).toBe(0);
+    expect(data2.remaining).toBe(0);
+  });
+
+  it("leaves an entry untagged and still 'remaining' when classification is inconclusive", async () => {
+    // Known, spec-accepted edge case: idempotency is defined by tag *presence*, not
+    // a separate "attempted" marker. If classifyEntry can't resolve a kind/canonical
+    // signal (default mock here returns neither), the row gets no tag and is
+    // reselected on the next call — this documents that behavior rather than hiding it.
+    db.entries.push(unclassifiedEntry("ambiguous"));
+    const res = await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.processed).toBe(1);
+    expect(data.remaining).toBe(1);
+    expect(JSON.parse(db.entries.find((e: any) => e.id === "ambiguous").tags)).toEqual(["work"]);
+  });
+
+  it("promotes canonical status and writes kind for a fully unclassified entry", async () => {
+    env = makeTestEnv(db, { AI: makeClassifyingAIMock({ importance: 5, canonical: true, kind: "episodic" }) });
+    // An entry that already carries kind: (but no status:) is excluded by the WHERE
+    // clause entirely — the "skips" test above covers that. This one has neither
+    // reserved tag, so it's selected and should get both written.
+    db.entries.push(unclassifiedEntry("neither", ["work"]));
+    await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const neither = JSON.parse(db.entries.find((e: any) => e.id === "neither").tags);
+    expect(neither).toContain("status:canonical");
+    expect(neither).toContain("kind:episodic");
+  });
+
+  it("does not touch importance_score (tags-only backfill)", async () => {
+    env = makeTestEnv(db, { AI: makeClassifyingAIMock({ importance: 5, canonical: true, kind: "semantic" }) });
+    db.entries.push(unclassifiedEntry("importance-check"));
+    await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const updated = db.entries.find((e: any) => e.id === "importance-check");
+    expect(updated.importance_score).toBe(0);
+  });
+
+  it("counts failed and continues when a row can't be updated (e.g. corrupt tags JSON)", async () => {
+    // classifyEntry swallows AI-level errors internally (returns a neutral,
+    // untagged result), so to exercise this endpoint's own try/catch we force a
+    // failure downstream of that call instead: malformed tags JSON blows up
+    // JSON.parse inside the handler.
+    env = makeTestEnv(db, { AI: makeClassifyingAIMock({ importance: 4, canonical: true, kind: "semantic" }) });
+    db.entries.push(
+      { ...unclassifiedEntry("bad"), tags: "not-json" },
+      unclassifiedEntry("good"),
+    );
+    const res = await worker.fetch(req("POST", "/classify-pending"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.processed).toBe(1);
+    expect(data.failed).toBe(1);
+    // "bad" is still malformed/untagged so it's still selected next time; "good"
+    // got tagged successfully and drops out of the unclassified set.
+    expect(data.remaining).toBe(1);
+  });
+});

--- a/test/integration/stats.test.ts
+++ b/test/integration/stats.test.ts
@@ -130,6 +130,34 @@ describe("GET /stats — vectorization fields", () => {
   });
 });
 
+describe("GET /stats — classification fields", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("returns unclassified: 0 when all entries have status/kind tags", async () => {
+    db.entries.push(entry("a", ["work", "status:canonical", "kind:semantic"], 5));
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.unclassified).toBe(0);
+  });
+
+  it("counts entries missing both status: and kind: tags as unclassified", async () => {
+    db.entries.push(
+      entry("a", ["work"], 5),
+      entry("b", ["work", "kind:episodic"], 5),
+      entry("c", ["work", "status:canonical", "kind:semantic"], 5),
+    );
+    const res = await worker.fetch(req("GET", "/stats"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.unclassified).toBe(1);
+  });
+});
+
 describe("GET /stats — digest candidates", () => {
   let env: Env;
   let db: D1Mock;


### PR DESCRIPTION
Ports the classification backfill from #177 onto the v2 line so v2 has it ahead of the v2-to-main launch merge. Original work by @Aneesh-382005; the three commits are cherry-picked with authorship preserved.

## What this adds
- `POST /classify-pending`: one-time, opt-in backfill that runs `classifyEntry` over entries predating the kind (#12) and status (#119) tags and writes `kind:`/`status:` tags. Bounded batch of 25, idempotent, resumable, tags-only (no schema change).
- `/stats` now returns an `unclassified` count.
- A "Not classified" dashboard card that drains the backfill from the UI, with a progress-guarded loop that stops on stalled progress rather than only at zero.

## Conflicts resolved against v2
- `src/index.ts`: the classify-pending handler and the Notion integration routes both sit before the final 404; kept both.
- `public/index.html`: the classify dashboard section coexists with the Notion integration UI.

## Verification
- `npm run typecheck`: clean
- `npm test`: 546/546 passing (51 files)

Companion to #177, which targets main. Once both land, the feature is on both lines and the eventual v2-to-main merge reconciles the duplicate.