### PR TITLE
Pre-launch fixes: full export, graph tap-to-open, multi-hop recall UI, unlink, patterns panel

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2983,7 +2983,9 @@
         try {
           // Use the REST endpoint for structured results — parsing the MCP tool's
           // formatted text miscounts sources when memory content contains list items
-          const params = new URLSearchParams({ query, topK: '5' })
+          // hops=1 lets recall follow relationship edges one step out; direct matches
+          // always outrank expanded ones (worker applies a graph-distance penalty)
+          const params = new URLSearchParams({ query, topK: '5', hops: '1' })
           if (selectedTag) params.set('tag', selectedTag)
           const recallRes = await fetch(`${WORKER_URL}/recall?${params}`, { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } })
           const data = await recallRes.json()
@@ -2995,7 +2997,7 @@
           } else {
             // REST scores are already 0–100 (one decimal); map directly rather than via
             // normalizeEntry, whose 0–1 rescale heuristic would turn a 0.8% match into 80%
-            const entries = data.results.map((m) => ({ id: m.id, content: m.content, tags: m.tags || [], score: Math.min(100, Math.round(m.score)) }))
+            const entries = data.results.map((m) => ({ id: m.id, content: m.content, tags: m.tags || [], score: Math.min(100, Math.round(m.score)), hop: m.hop || 0 }))
             const answerBubble = document.createElement('div')
             answerBubble.className = 'ex-a-row'
             const answerEl = document.createElement('div')
@@ -3012,7 +3014,8 @@
                   const date = new Date(m.created_at).toLocaleDateString()
                   const tagList = m.tags && m.tags.length ? ` [${m.tags.join(', ')}]` : ''
                   const src = m.source ? ` · ${m.source}` : ''
-                  return `${i + 1}. [${date}${src}${tagList}] (${Math.min(100, Math.round(m.score))}% match)${m.updated ? ' [updated]' : ''}\n${m.content}`
+                  const related = m.hop > 0 ? ` [related, ${m.hop} hop${m.hop > 1 ? 's' : ''}]` : ''
+                  return `${i + 1}. [${date}${src}${tagList}] (${Math.min(100, Math.round(m.score))}% match)${m.updated ? ' [updated]' : ''}${related}\n${m.content}`
                 })
                 .join('\n\n')
             const res = await fetch(`${WORKER_URL}/chat`, {
@@ -3077,6 +3080,7 @@
         card.innerHTML = `
     <div class="match-line">
       <span class="match-pct">${entry.score}%</span>
+      ${entry.hop > 0 ? `<span class="tag-chip" style="background:var(--accent-soft);color:var(--accent);flex-shrink:0">related · ${entry.hop} hop${entry.hop > 1 ? 's' : ''}</span>` : ''}
       <div class="match-bar-bg"><div class="match-bar-fill" style="width:${entry.score}%"></div></div>
     </div>
     <div class="card-content" style="cursor: pointer;">${escHtml(entry.content)}</div>

--- a/public/index.html
+++ b/public/index.html
@@ -2724,6 +2724,7 @@
             <div class="stats-tags" id="stats-tags"></div>
           </div>
         </div>
+        <div class="digest-section" id="patterns-section" style="display: none"></div>
         <div class="digest-section" id="digest-section" style="display: none"></div>
         <div class="digest-section" id="vectorize-section" style="display: none"></div>
         <div class="digest-section" id="classify-section" style="display: none"></div>
@@ -3440,7 +3441,83 @@
           renderDigestSection(data.digest_candidates ?? [])
           renderVectorizeSection(data.unvectorized ?? 0)
           renderClassifySection(data.unclassified ?? 0)
+          loadPatterns()
         } catch {}
+      }
+
+      // ── Patterns panel: system proposes, human ratifies ───────────────────────
+      // Auto-derived patterns are excluded from recall until confirmed; confirming
+      // strips the auto-pattern tag (which is the exclusion), dismissing deprecates.
+      async function loadPatterns() {
+        const el = document.getElementById('patterns-section')
+        try {
+          const res = await fetch(`${WORKER_URL}/list?n=20&tag=auto-pattern`, { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } })
+          const rows = await res.json()
+          const patterns = (Array.isArray(rows) ? rows : []).filter((e) => {
+            let tags = []
+            try {
+              tags = JSON.parse(e.tags || '[]')
+            } catch {}
+            return !tags.includes('status:deprecated') // dismissed patterns linger in /list
+          })
+          if (!patterns.length) {
+            el.style.display = 'none'
+            el.innerHTML = ''
+            return
+          }
+          el.style.display = ''
+          el.innerHTML = `
+            <div class="digest-section-label">Patterns noticed</div>
+            <p class="digest-note">Your brain spotted these across multiple memories. Confirm to make one a trusted, recallable fact; dismiss to discard it.</p>
+            ${patterns
+              .map(
+                (p) => `
+              <div class="digest-result" id="pattern-row-${escAttr(p.id)}">
+                ${escHtml(p.content)}
+                <div style="display: flex; gap: 8px; margin-top: 10px">
+                  <button class="digest-btn" onclick="resolvePattern('${escAttr(p.id)}', 'confirm', this)">Confirm</button>
+                  <button class="digest-btn danger" onclick="resolvePattern('${escAttr(p.id)}', 'dismiss', this)">Dismiss</button>
+                </div>
+              </div>`,
+              )
+              .join('')}
+          `
+        } catch {}
+      }
+
+      async function resolvePattern(id, action, btn) {
+        const row = document.getElementById('pattern-row-' + id)
+        row.querySelectorAll('button').forEach((b) => (b.disabled = true))
+        btn.classList.add('digest-btn--loading')
+        btn.innerHTML = '<i class="ti ti-loader-2"></i> Working…'
+        try {
+          const res = await fetch(`${WORKER_URL}/patterns/resolve`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${AUTH_TOKEN}` },
+            body: JSON.stringify({ id, action }),
+          })
+          const data = await res.json()
+          if (!data.ok) throw new Error(data.error || 'failed')
+          if (action === 'dismiss') {
+            row.classList.add('explode-out')
+            setTimeout(() => {
+              row.innerHTML = `<div class="digest-result-meta">Dismissed</div>`
+              row.classList.remove('explode-out')
+              row.style.opacity = '1'
+            }, 400)
+          } else {
+            row.style.transition = 'opacity 0.4s'
+            row.style.opacity = '0'
+            setTimeout(() => {
+              row.innerHTML = `<div class="digest-result-meta"><i class="ti ti-check"></i> Saved as a trusted memory</div>`
+              row.style.opacity = '1'
+            }, 400)
+          }
+        } catch {
+          btn.classList.remove('digest-btn--loading')
+          btn.innerHTML = '<i class="ti ti-alert-triangle"></i> Failed'
+          setTimeout(() => loadPatterns(), 2000)
+        }
       }
 
       function renderDigestSection(candidates) {

--- a/public/index.html
+++ b/public/index.html
@@ -3733,24 +3733,25 @@
       async function exportMemories(format) {
         closeMenu()
         try {
-          const res = await fetch(`${WORKER_URL}/list?n=9999`, { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } })
+          // /export returns everything — entries AND edges — in one shot; /list caps
+          // at 100 rows, which used to silently truncate bigger brains
+          const res = await fetch(`${WORKER_URL}/export`, { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } })
           if (!res.ok) throw new Error(`Server error: ${res.status}`)
-          const entries = await res.json()
+          const data = await res.json()
+          const entries = data.entries || []
+          const edges = data.edges || []
 
           let content, filename, mime
           const ts = new Date().toISOString().slice(0, 10)
 
           if (format === 'json') {
-            content = JSON.stringify(entries, null, 2)
+            content = JSON.stringify(data, null, 2)
             filename = `second-brain-export-${ts}.json`
             mime = 'application/json'
           } else {
             const lines = [`# Second Brain Export`, `Exported: ${ts}`, '']
             entries.forEach((e, i) => {
-              let tags = []
-              try {
-                tags = JSON.parse(e.tags || '[]')
-              } catch {}
+              const tags = e.tags || []
               const date = new Date(e.created_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
               lines.push(`## Memory ${i + 1}`)
               lines.push(`**Date:** ${date}`)
@@ -3762,6 +3763,17 @@
               lines.push('---')
               lines.push('')
             })
+            if (edges.length) {
+              const labelById = new Map(entries.map((e) => [e.id, (e.content || '').slice(0, 60)]))
+              lines.push(`## Relationships`)
+              lines.push('')
+              edges.forEach((e) => {
+                const src = labelById.get(e.source_id) || e.source_id
+                const tgt = labelById.get(e.target_id) || e.target_id
+                lines.push(`- [${e.type}] ${src} -> ${tgt} (${e.weight})`)
+              })
+              lines.push('')
+            }
             content = lines.join('\n')
             filename = `second-brain-export-${ts}.md`
             mime = 'text/markdown'

--- a/public/index.html
+++ b/public/index.html
@@ -3406,7 +3406,7 @@
           const res = await fetch(`${WORKER_URL}/stats`, { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } })
           const data = await res.json()
           document.getElementById('stats-count').textContent = (data.count ?? 0).toLocaleString()
-          document.getElementById('stats-importance').textContent = data.avg_importance != null ? data.avg_importance.toFixed(1) + ' / 10' : '—'
+          document.getElementById('stats-importance').textContent = data.avg_importance != null ? data.avg_importance.toFixed(1) + ' / 5' : '—'
           const tagsEl = document.getElementById('stats-tags')
           tagsEl.innerHTML = data.top_tags?.length
             ? data.top_tags.map((t) => `<span class="tag-chip">${escHtml(t)}</span>`).join('')

--- a/public/index.html
+++ b/public/index.html
@@ -3869,6 +3869,23 @@
       // ── Force-directed graph view (issue #16) ─────────────────────────────────
       let graphState = null
 
+      // Graph nodes only carry an 80-char label; fetch the full memory on tap so the
+      // view sheet shows the whole thing. Falls back to the label if the fetch fails
+      // (offline etc.) so the graph never dead-ends.
+      async function openNodeView(node) {
+        try {
+          const res = await fetch(`${WORKER_URL}/entry?id=${encodeURIComponent(node.id)}`, { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } })
+          const data = await res.json()
+          if (data.ok && data.entry) {
+            openView({ id: data.entry.id, content: data.entry.content, tags: data.entry.tags }, null)
+            return
+          }
+          throw new Error('entry fetch failed')
+        } catch {
+          openView({ id: node.id, content: node.label, tags: node.tags }, null)
+        }
+      }
+
       async function loadGraph() {
         const canvas = document.getElementById('graph-canvas')
         const emptyEl = document.getElementById('graph-empty')
@@ -4175,7 +4192,7 @@
           } catch (e) {}
           if (state.pinch && pointers.size < 2) state.pinch = null
           if (ev.pointerId === state.downId) {
-            if (state.dragNode && !state.moved) openView({ id: state.dragNode.id, content: state.dragNode.label, tags: state.dragNode.tags }, null)
+            if (state.dragNode && !state.moved) openNodeView(state.dragNode)
             state.dragNode = null
             state.panning = false
             state.downId = null

--- a/public/index.html
+++ b/public/index.html
@@ -2643,19 +2643,40 @@
         margin-bottom: 8px;
       }
       .related-item {
-        display: block;
+        display: flex;
+        align-items: stretch;
         width: 100%;
-        text-align: left;
         background: var(--accent-soft);
-        border: none;
         border-radius: 8px;
-        padding: 8px 10px;
         margin-bottom: 6px;
-        cursor: pointer;
         font-size: 13px;
         line-height: 1.35;
         color: var(--text-primary);
+      }
+      .related-open {
+        flex: 1;
+        min-width: 0;
+        text-align: left;
+        background: none;
+        border: none;
+        padding: 8px 10px;
+        cursor: pointer;
+        font-size: inherit;
+        line-height: inherit;
+        color: inherit;
         font-family: inherit;
+      }
+      .related-unlink {
+        flex-shrink: 0;
+        background: none;
+        border: none;
+        padding: 0 10px;
+        cursor: pointer;
+        color: var(--text-tertiary);
+        font-size: 14px;
+      }
+      .related-unlink:hover {
+        color: var(--danger);
       }
       .related-item:hover {
         background: rgba(178, 102, 65, 0.16);
@@ -3851,20 +3872,36 @@
             headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
           })
           const data = await res.json()
-          if (!data.ok || !data.connections || !data.connections.length) return
+          if (!data.ok || !data.connections || !data.connections.length) {
+            // also handles the refresh after the last link is removed
+            el.style.display = 'none'
+            el.innerHTML = ''
+            return
+          }
           el.innerHTML =
             `<div class="view-related-label">Related</div>` +
             data.connections
               .map(
                 (c) =>
-                  `<button class="related-item" data-id="${escHtml(c.id)}"><span class="related-type">${escHtml(c.label)}</span>${escHtml((c.content || '').slice(0, 80))}</button>`,
+                  `<div class="related-item" data-id="${escHtml(c.id)}" data-type="${escHtml(c.type)}"><button class="related-open"><span class="related-type">${escHtml(c.label)}</span>${escHtml((c.content || '').slice(0, 80))}</button><button class="related-unlink" title="Remove link"><i class="ti ti-unlink"></i></button></div>`,
               )
               .join('')
           el.style.display = 'block'
-          el.querySelectorAll('.related-item').forEach((btn) => {
-            btn.onclick = () => {
-              const c = data.connections.find((x) => x.id === btn.dataset.id)
+          el.querySelectorAll('.related-item').forEach((row) => {
+            row.querySelector('.related-open').onclick = () => {
+              const c = data.connections.find((x) => x.id === row.dataset.id)
               if (c) openView({ id: c.id, content: c.content, tags: c.tags }, null)
+            }
+            row.querySelector('.related-unlink').onclick = async () => {
+              if (!confirm('Remove this link? The memories stay; only the connection is deleted.')) return
+              try {
+                await fetch(`${WORKER_URL}/unlink`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${AUTH_TOKEN}` },
+                  body: JSON.stringify({ source_id: id, target_id: row.dataset.id, type: row.dataset.type }),
+                })
+              } catch {}
+              loadRelated(id, el)
             }
           })
         } catch {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2987,6 +2987,33 @@ const defaultHandler = {
       return json({ ok: true, id, connections });
     }
 
+    // GET /entry — one full row by id, for the dashboard graph view's tap-to-open
+    // (/graph ships 80-char labels only; fattening it with full content would bloat
+    // every graph load to serve a per-tap need). Dashboard-only, no MCP twin.
+    if (url.pathname === "/entry" && request.method === "GET") {
+      const authErr = requireAuth(request, env);
+      if (authErr) return authErr;
+
+      const id = url.searchParams.get("id")?.trim();
+      if (!id) return json({ ok: false, error: "id is required" }, 400);
+
+      const row = await env.DB.prepare(
+        `SELECT id, content, tags, source, created_at FROM entries WHERE id = ?`
+      ).bind(id).first() as Record<string, any> | null;
+      if (!row) return json({ ok: false, error: `No entry found with ID: ${id}` }, 404);
+
+      return json({
+        ok: true,
+        entry: {
+          id: row.id,
+          content: row.content,
+          tags: JSON.parse(row.tags ?? "[]"),
+          source: row.source,
+          created_at: row.created_at,
+        },
+      });
+    }
+
     // GET /graph — node+edge subgraph for the dashboard graph view (dashboard-only;
     // no MCP twin — this is visualization data, not an agent capability)
     if (url.pathname === "/graph" && request.method === "GET") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2850,6 +2850,45 @@ const defaultHandler = {
       return json(results);
     }
 
+    // GET /export — complete backup: every entry plus the edges table. Single
+    // unbounded SELECTs are acceptable here: D1 handles tens of thousands of rows in
+    // one read and this route runs on explicit user action only. If response size
+    // ever becomes a problem, add ?after= cursor support then, not now.
+    if (url.pathname === "/export" && request.method === "GET") {
+      const authErr = requireAuth(request, env);
+      if (authErr) return authErr;
+
+      const { results: entryRows } = await env.DB.prepare(
+        `SELECT id, content, tags, source, created_at, recall_count, importance_score, contradiction_wins, contradiction_losses FROM entries ORDER BY created_at DESC`
+      ).all() as { results: Record<string, any>[] };
+      const { results: edgeRows } = await env.DB.prepare(
+        `SELECT source_id, target_id, type, weight, provenance, created_at FROM edges`
+      ).all() as { results: Record<string, any>[] };
+
+      // vector_ids are deliberately excluded — they're deployment-specific and an
+      // import tool re-embeds anyway. Tags are parsed so the file holds real arrays.
+      const entries = entryRows.map(r => ({
+        id: r.id,
+        content: r.content,
+        tags: JSON.parse(r.tags ?? "[]"),
+        source: r.source,
+        created_at: r.created_at,
+        recall_count: r.recall_count ?? 0,
+        importance_score: r.importance_score ?? 0,
+        contradiction_wins: r.contradiction_wins ?? 0,
+        contradiction_losses: r.contradiction_losses ?? 0,
+      }));
+      const edges = edgeRows.map(r => ({
+        source_id: r.source_id,
+        target_id: r.target_id,
+        type: r.type,
+        weight: r.weight,
+        provenance: r.provenance,
+        created_at: r.created_at,
+      }));
+      return json({ ok: true, exported_at: Date.now(), version: 2, entries, edges });
+    }
+
     // GET /recall — semantic search, mirrors the MCP `recall` tool
     if (url.pathname === "/recall" && request.method === "GET") {
       const authErr = requireAuth(request, env);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3112,6 +3112,43 @@ const defaultHandler = {
       return json({ ok: true, id, status });
     }
 
+    // POST /patterns/resolve — confirm or dismiss an auto-derived pattern.
+    // Dashboard-only, no MCP twin: pattern review is a human curation act, not an
+    // agent capability. Confirm promotes the pattern into a real recallable memory;
+    // dismiss deprecates it (audit row kept, vectors removed).
+    if (url.pathname === "/patterns/resolve" && request.method === "POST") {
+      const authErr = requireAuth(request, env);
+      if (authErr) return authErr;
+
+      let body: { id?: string; action?: string };
+      try { body = await request.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
+      const id = body.id?.trim();
+      if (!id) return json({ ok: false, error: "id is required" }, 400);
+      const action = body.action;
+      if (action !== "confirm" && action !== "dismiss") {
+        return json({ ok: false, error: `action must be "confirm" or "dismiss"` }, 400);
+      }
+
+      const row = await env.DB.prepare(`SELECT id, tags FROM entries WHERE id = ?`).bind(id).first() as Record<string, any> | null;
+      if (!row) return json({ ok: false, error: `No entry found with ID: ${id}` }, 404);
+      const tags: string[] = JSON.parse(row.tags ?? "[]");
+      if (!tags.includes("auto-pattern")) {
+        return json({ ok: false, error: "Entry is not an auto-derived pattern" }, 400);
+      }
+
+      if (action === "confirm") {
+        // Losing the auto-pattern tag is what exits the recall exclusion — it's
+        // enforced at D1 hydration, not vector metadata, so this tag update alone
+        // makes the entry recallable. No re-embed: content is unchanged and vectors
+        // already exist (the stale auto-pattern flag in vector metadata is harmless).
+        const promoted = withStatus(withKind(tags.filter(t => t !== "auto-pattern"), "semantic"), "canonical");
+        await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`).bind(JSON.stringify(promoted), id).run();
+      } else {
+        await deprecateEntry(id, env);
+      }
+      return json({ ok: true, id, action });
+    }
+
     // POST /chat
     if (url.pathname === "/chat" && request.method === "POST") {
       const authErr = requireAuth(request, env);

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,6 +220,28 @@ export async function createEdge(
   return { source_id: source, target_id: target, type };
 }
 
+// The single remover for edges. The WHERE is order-agnostic — it matches directed
+// edges stated in either direction AND symmetric pairs regardless of the smaller-id-
+// first normalization createEdge applied — so callers never re-derive that rule.
+// Optional type narrows the delete to one relationship type; omitted removes every
+// edge between the pair. Returns rows removed: 0 is not an error (idempotent delete,
+// the mirror of createEdge's idempotent upsert).
+export async function deleteEdge(
+  sourceId: string,
+  targetId: string,
+  type: string | undefined,
+  env: Env,
+): Promise<number> {
+  let sql = `DELETE FROM edges WHERE ((source_id = ? AND target_id = ?) OR (source_id = ? AND target_id = ?))`;
+  const bindings: string[] = [sourceId, targetId, targetId, sourceId];
+  if (type) {
+    sql += ` AND type = ?`;
+    bindings.push(type);
+  }
+  const result = await env.DB.prepare(sql).bind(...bindings).run();
+  return result.meta.changes ?? 0;
+}
+
 // ─── Graph traversal ────────────────────────────────────────────────────────────
 
 const GRAPH_MAX_HOPS = 3;
@@ -2536,6 +2558,24 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
     }
   );
 
+  // ── unlink ───────────────────────────────────────────────────────────────
+  server.registerTool(
+    "unlink",
+    {
+      description: "Remove a relationship link between two memories by ID. Use when a link is incorrect or no longer relevant. Get the IDs from recall or connections first.",
+      inputSchema: {
+        source_id: z.string().describe("Source entry ID"),
+        target_id: z.string().describe("Target entry ID"),
+        type: z.enum(Object.keys(EDGE_TYPES) as [string, ...string[]]).optional().describe("Only remove this relationship type; omit to remove all links between the pair"),
+      },
+    },
+    async ({ source_id, target_id, type }) => {
+      const deleted = await deleteEdge(source_id, target_id, type, env);
+      if (!deleted) return { content: [{ type: "text", text: "No link found between those entries." }] };
+      return { content: [{ type: "text", text: `Removed ${deleted} link(s) between ${source_id} and ${target_id}.` }] };
+    }
+  );
+
   // ── connections ──────────────────────────────────────────────────────────
   server.registerTool(
     "connections",
@@ -2972,6 +3012,27 @@ const defaultHandler = {
       const edge = await createEdge(sourceId, targetId, type, { provenance: "explicit", weight: 1.0 }, env);
       if (!edge) return json({ ok: false, error: "Cannot link an entry to itself" }, 400);
       return json({ ok: true, source_id: edge.source_id, target_id: edge.target_id, type: edge.type });
+    }
+
+    // POST /unlink — remove a relationship link, mirrors the MCP `unlink` tool.
+    // POST rather than DELETE /link: CORS_HEADERS allow only GET/POST/OPTIONS and
+    // every sibling mutation route is POST.
+    if (url.pathname === "/unlink" && request.method === "POST") {
+      const authErr = requireAuth(request, env);
+      if (authErr) return authErr;
+
+      let body: { source_id?: string; target_id?: string; type?: string };
+      try { body = await request.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
+      const sourceId = body.source_id?.trim();
+      const targetId = body.target_id?.trim();
+      if (!sourceId || !targetId) return json({ ok: false, error: "source_id and target_id are required" }, 400);
+      const type = body.type?.trim() || undefined;
+      if (type && !isValidEdgeType(type)) {
+        return json({ ok: false, error: `type must be one of: ${Object.keys(EDGE_TYPES).join(", ")}` }, 400);
+      }
+
+      const deleted = await deleteEdge(sourceId, targetId, type, env);
+      return json({ ok: true, deleted });
     }
 
     // GET /connections — 1-hop neighbors of an entry, mirrors the MCP `connections` tool

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -113,6 +113,18 @@ export class D1Mock {
           }
           return { meta: { changes: 1 } };
         }
+        if (s.startsWith("DELETE FROM edges WHERE ((source_id")) {
+          // deleteEdge: order-agnostic pair delete, optional trailing type filter.
+          const [a, b, c, d, type] = args;
+          const before = db.edges.length;
+          db.edges = db.edges.filter((e: any) => {
+            const pairMatch = (e.source_id === a && e.target_id === b) || (e.source_id === c && e.target_id === d);
+            if (!pairMatch) return true;
+            if (type && e.type !== type) return true;
+            return false;
+          });
+          return { meta: { changes: before - db.edges.length } };
+        }
         if (s.startsWith("DELETE FROM edges WHERE source_id")) {
           // Cascade delete on forget: source_id = ? OR target_id = ? (both bound to the same id).
           const [sid, tid] = args;

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -388,6 +388,25 @@ export class D1Mock {
             .map((e: any) => ({ id: e.id, content: e.content, tags: e.tags, source: e.source, created_at: e.created_at }));
           return { results: rows };
         }
+        if (s.startsWith("SELECT id, content, tags, source, created_at, recall_count, importance_score, contradiction_wins, contradiction_losses FROM entries ORDER BY created_at DESC")) {
+          // GET /export: every entry, newest first, no LIMIT.
+          const results = [...db.entries]
+            .sort((a: any, b: any) => b.created_at - a.created_at)
+            .map((e: any) => ({
+              id: e.id, content: e.content, tags: e.tags, source: e.source, created_at: e.created_at,
+              recall_count: e.recall_count ?? 0, importance_score: e.importance_score ?? 0,
+              contradiction_wins: e.contradiction_wins ?? 0, contradiction_losses: e.contradiction_losses ?? 0,
+            }));
+          return { results };
+        }
+        if (s.startsWith("SELECT source_id, target_id, type, weight, provenance, created_at FROM edges")) {
+          // GET /export: the whole edges table.
+          const results = db.edges.map((e: any) => ({
+            source_id: e.source_id, target_id: e.target_id, type: e.type,
+            weight: e.weight, provenance: e.provenance, created_at: e.created_at,
+          }));
+          return { results };
+        }
         if (s.includes("ORDER BY created_at DESC LIMIT")) {
           const limit = Number(args[args.length - 1]);
           const filterArgs = args.slice(0, -1);

--- a/test/integration/entry.test.ts
+++ b/test/integration/entry.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+describe("GET /entry", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("requires auth", async () => {
+    const res = await worker.fetch(req("GET", "/entry?id=a", { token: null }), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when id is missing", async () => {
+    const res = await worker.fetch(req("GET", "/entry"), env, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns the full row with tags parsed to an array", async () => {
+    const longContent = "A memory well past the eighty character graph label limit — ".repeat(4);
+    db.entries.push({ id: "a", content: longContent, tags: '["work","kind:semantic"]', source: "api", created_at: 1234, vector_ids: '["v"]', recall_count: 3, importance_score: 4 });
+
+    const res = await worker.fetch(req("GET", "/entry?id=a"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.entry).toEqual({
+      id: "a",
+      content: longContent, // full content, not an 80-char label
+      tags: ["work", "kind:semantic"],
+      source: "api",
+      created_at: 1234,
+    });
+  });
+
+  it("404s for an unknown id", async () => {
+    const res = await worker.fetch(req("GET", "/entry?id=ghost"), env, ctx);
+    expect(res.status).toBe(404);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(false);
+    expect(data.error).toContain("ghost");
+  });
+});

--- a/test/integration/export.test.ts
+++ b/test/integration/export.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+function seedEntry(db: D1Mock, id: string, content: string, tags: string[] = [], created_at = 1000) {
+  db.entries.push({ id, content, tags: JSON.stringify(tags), source: "api", created_at, vector_ids: '["v1"]', recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0 });
+}
+
+describe("GET /export", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("requires auth", async () => {
+    const res = await worker.fetch(req("GET", "/export", { token: null }), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns ALL entries when the count exceeds the /list cap of 100", async () => {
+    for (let i = 0; i < 150; i++) seedEntry(db, `e${i}`, `Memory ${i}`, [], 1000 + i);
+
+    const res = await worker.fetch(req("GET", "/export"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.version).toBe(2);
+    expect(typeof data.exported_at).toBe("number");
+    expect(data.entries).toHaveLength(150);
+    // newest first
+    expect(data.entries[0].id).toBe("e149");
+  });
+
+  it("includes edges and parses tags to real arrays", async () => {
+    seedEntry(db, "a", "Memory A", ["work", "kind:semantic"]);
+    seedEntry(db, "b", "Memory B", ["idea"]);
+    db.edges.push({ id: "edge-1", source_id: "a", target_id: "b", type: "relates_to", weight: 0.7, provenance: "inferred", metadata: "{}", created_at: 1, updated_at: 1 });
+
+    const res = await worker.fetch(req("GET", "/export"), env, ctx);
+    const data = await res.json() as any;
+    const a = data.entries.find((e: any) => e.id === "a");
+    expect(a.tags).toEqual(["work", "kind:semantic"]); // array, not a JSON string
+    expect(data.edges).toEqual([
+      { source_id: "a", target_id: "b", type: "relates_to", weight: 0.7, provenance: "inferred", created_at: 1 },
+    ]);
+  });
+
+  it("never includes vector_ids (deployment-specific, import re-embeds)", async () => {
+    seedEntry(db, "a", "Memory A");
+
+    const res = await worker.fetch(req("GET", "/export"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.entries[0]).not.toHaveProperty("vector_ids");
+  });
+
+  it("exports an empty brain as a valid structure with empty arrays", async () => {
+    const res = await worker.fetch(req("GET", "/export"), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.entries).toEqual([]);
+    expect(data.edges).toEqual([]);
+  });
+});

--- a/test/integration/patterns.test.ts
+++ b/test/integration/patterns.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb, makeVectorizeMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+function seedPattern(db: D1Mock, id: string, content: string) {
+  db.entries.push({ id, content, tags: '["auto-pattern"]', source: "system", created_at: 1000, vector_ids: `["${id}"]`, recall_count: 0, importance_score: 0 });
+}
+
+describe("POST /patterns/resolve", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("requires auth", async () => {
+    const res = await worker.fetch(req("POST", "/patterns/resolve", { body: { id: "p1", action: "confirm" }, token: null }), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("404s for an unknown id", async () => {
+    const res = await worker.fetch(req("POST", "/patterns/resolve", { body: { id: "ghost", action: "confirm" } }), env, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("400s for an entry that is not an auto-derived pattern", async () => {
+    db.entries.push({ id: "normal", content: "Just a memory", tags: '["work"]', source: "api", created_at: 1000, vector_ids: "[]" });
+
+    const res = await worker.fetch(req("POST", "/patterns/resolve", { body: { id: "normal", action: "confirm" } }), env, ctx);
+    expect(res.status).toBe(400);
+    const data = await res.json() as any;
+    expect(data.error).toContain("not an auto-derived pattern");
+  });
+
+  it("400s for an invalid action", async () => {
+    seedPattern(db, "p1", "You tend to test things");
+    const res = await worker.fetch(req("POST", "/patterns/resolve", { body: { id: "p1", action: "promote" } }), env, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("confirm strips auto-pattern, adds kind:semantic + status:canonical, and the entry becomes recallable", async () => {
+    seedPattern(db, "p1", "You tend to write tests before shipping");
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "p1", score: 0.9, metadata: { parentId: "p1", isUpdate: false } }],
+        }),
+      }),
+    });
+
+    // Before confirmation the pattern is excluded from recall at D1 hydration.
+    let recall = await worker.fetch(req("GET", "/recall?query=tests"), env, ctx);
+    let recallData = await recall.json() as any;
+    expect(recallData.results ?? []).toHaveLength(0);
+
+    const res = await worker.fetch(req("POST", "/patterns/resolve", { body: { id: "p1", action: "confirm" } }), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data).toMatchObject({ ok: true, id: "p1", action: "confirm" });
+
+    const tags = JSON.parse(db.entries.find((e: any) => e.id === "p1").tags);
+    expect(tags).not.toContain("auto-pattern");
+    expect(tags).toContain("kind:semantic");
+    expect(tags).toContain("status:canonical");
+
+    // After confirmation the same query returns it.
+    recall = await worker.fetch(req("GET", "/recall?query=tests"), env, ctx);
+    recallData = await recall.json() as any;
+    expect(recallData.results).toHaveLength(1);
+    expect(recallData.results[0].id).toBe("p1");
+  });
+
+  it("dismiss deprecates: vectors deleted, status:deprecated applied, row kept", async () => {
+    seedPattern(db, "p1", "You tend to dismiss patterns");
+    const deleteByIds = vi.fn().mockResolvedValue({ mutationId: "m" });
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ deleteByIds }) });
+
+    const res = await worker.fetch(req("POST", "/patterns/resolve", { body: { id: "p1", action: "dismiss" } }), env, ctx);
+    expect(res.status).toBe(200);
+
+    const row = db.entries.find((e: any) => e.id === "p1");
+    expect(row).toBeDefined(); // audit row kept
+    expect(JSON.parse(row.tags)).toContain("status:deprecated");
+    expect(row.vector_ids).toBe("[]");
+    expect(deleteByIds).toHaveBeenCalledWith(["p1"]);
+  });
+});

--- a/test/integration/unlink.test.ts
+++ b/test/integration/unlink.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import worker, { deleteEdge } from "../../src/index";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+function pushEdge(db: D1Mock, source_id: string, target_id: string, type = "relates_to", weight = 0.7) {
+  db.edges.push({ id: `${source_id}-${target_id}-${type}`, source_id, target_id, type, weight, provenance: "explicit", metadata: "{}", created_at: 1, updated_at: 1 });
+}
+
+describe("POST /unlink", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("requires auth", async () => {
+    const res = await worker.fetch(req("POST", "/unlink", { body: { source_id: "a", target_id: "b" }, token: null }), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when ids are missing", async () => {
+    const res = await worker.fetch(req("POST", "/unlink", { body: { source_id: "a" } }), env, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an unknown type", async () => {
+    const res = await worker.fetch(req("POST", "/unlink", { body: { source_id: "a", target_id: "b", type: "bogus" } }), env, ctx);
+    expect(res.status).toBe(400);
+    const data = await res.json() as any;
+    expect(data.error).toContain("type must be one of");
+  });
+
+  it("deletes a directed edge regardless of argument order", async () => {
+    pushEdge(db, "a", "b", "caused_by");
+
+    const res = await worker.fetch(req("POST", "/unlink", { body: { source_id: "b", target_id: "a" } }), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data).toMatchObject({ ok: true, deleted: 1 });
+    expect(db.edges).toHaveLength(0);
+  });
+
+  it("deletes a symmetric edge given in non-normalized order", async () => {
+    // createEdge stores relates_to smaller-id-first: linking z→a lands as (a, z)
+    pushEdge(db, "a", "z", "relates_to");
+
+    const res = await worker.fetch(req("POST", "/unlink", { body: { source_id: "z", target_id: "a" } }), env, ctx);
+    const data = await res.json() as any;
+    expect(data).toMatchObject({ ok: true, deleted: 1 });
+    expect(db.edges).toHaveLength(0);
+  });
+
+  it("type filter deletes only the matching edge when a pair has two edge types", async () => {
+    pushEdge(db, "a", "b", "relates_to");
+    pushEdge(db, "a", "b", "caused_by");
+
+    const res = await worker.fetch(req("POST", "/unlink", { body: { source_id: "a", target_id: "b", type: "caused_by" } }), env, ctx);
+    const data = await res.json() as any;
+    expect(data.deleted).toBe(1);
+    expect(db.edges).toHaveLength(1);
+    expect(db.edges[0].type).toBe("relates_to");
+  });
+
+  it("omitted type deletes all edges between the pair", async () => {
+    pushEdge(db, "a", "b", "relates_to");
+    pushEdge(db, "b", "a", "caused_by");
+    pushEdge(db, "a", "c", "relates_to"); // unrelated pair, must survive
+
+    const res = await worker.fetch(req("POST", "/unlink", { body: { source_id: "a", target_id: "b" } }), env, ctx);
+    const data = await res.json() as any;
+    expect(data.deleted).toBe(2);
+    expect(db.edges).toHaveLength(1);
+    expect(db.edges[0].target_id).toBe("c");
+  });
+
+  it("no match is still ok with deleted: 0 (idempotent delete)", async () => {
+    const res = await worker.fetch(req("POST", "/unlink", { body: { source_id: "a", target_id: "b" } }), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data).toMatchObject({ ok: true, deleted: 0 });
+  });
+});
+
+describe("deleteEdge (backs the MCP unlink tool)", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("returns the deleted count for the tool's happy-path message", async () => {
+    pushEdge(db, "a", "b", "relates_to");
+    expect(await deleteEdge("a", "b", undefined, env)).toBe(1);
+    expect(db.edges).toHaveLength(0);
+  });
+
+  it("returns 0 when nothing matches, for the 'No link found' message", async () => {
+    expect(await deleteEdge("a", "b", undefined, env)).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

The six pre-launch fixes from the July 5 spec, targeting `v2` ahead of the v2→main merge. One commit per task.

## Changes

**1. `GET /export` — no more silent truncation, edges included (P0)**
Export fetched `/list?n=9999` but the worker clamps `n` to 100, so bigger brains exported partial files with no warning — and edges (the v2 headline feature) were never in the backup. The new route returns every entry (tags parsed to real arrays, no deployment-specific `vector_ids`) plus the whole edges table. JSON export writes the body as-is; markdown gains a `## Relationships` section with 60-char labels. Unbounded SELECTs are intentional: D1 handles tens of thousands of rows in one read, and the route runs on explicit user action only — if size ever bites, add `?after=` cursor support then.

**2. `GET /entry` — graph node tap opens the full memory (P0)**
Tapping a node passed the 80-char `/graph` label to the view sheet as content. Taps now fetch the full row (Append/Edit/Forget operate on the real entry), falling back to the label offline so the graph never dead-ends. `/graph` stays lean rather than shipping full content for 200+ nodes per load.

**3. Importance scale (P0)** — stats read `X.X / 5` to match `classifyEntry()`'s 1–5 scoring, not `/ 10`.

**4. Multi-hop recall surfaced in the UI (P0)**
Recall now passes `hops=1`; graph-surfaced sources get a `related · N hop(s)` accent chip, and the `/chat` serialization appends `[related, N hop(s)]` so the answer model can tell direct evidence from graph context. Direct matches always outrank expanded ones by construction (worker-side decay), so this only adds labeled context. The optional "Connections: on" toggle is skipped — the default is the value; it can follow post-launch.

**5. Edge deletion (P0)**
`deleteEdge()` uses an order-agnostic WHERE (directed edges stated in either direction and smaller-id-first-normalized symmetric pairs covered by one query), optional `type` narrowing, `deleted: 0` still `ok` (idempotent, mirroring `createEdge`'s upsert). `POST /unlink` (POST, not DELETE — CORS allows GET/POST/OPTIONS and every sibling mutation is POST) plus a matching MCP `unlink` tool per the parity convention. UI: unlink icon per Related-list row with confirm dialog, type-scoped delete, refresh, hide-when-empty. **Out of scope by design:** tapping an edge on the graph canvas to delete it — line-segment hit-testing on mobile is fiddly and the Related-list path covers the job.

**6. Patterns panel with confirm gate (P1)**
`derivePattern()` output was write-only (recall excludes `auto-pattern`). `POST /patterns/resolve`: confirm strips the tag and applies `kind:semantic` + `status:canonical` — losing the tag is the exclusion exit, enforced at D1 hydration, so no re-embed; dismiss calls `deprecateEntry()` (audit row kept, vectors removed). Dashboard-only, no MCP tool, per the June 27 context-tax decision. The menu sheet's "Patterns noticed" section reuses digest styling wholesale (zero new CSS), hidden when empty, deprecated rows filtered client-side.

## Testing

- `npm test`: **573/573** passing (25 new tests across `export`, `entry`, `unlink`, `patterns` suites)
- `npm run typecheck`: clean
- Spec deviation: the MCP `unlink` happy-path/no-match cases are tested through the exported `deleteEdge()` (the code path the tool calls) — the repo has no MCP-protocol test harness; all existing tool coverage goes through REST twins.

## Follow-ups (not in this PR)

- Mirror the source changes (everything except `test/`) to `second-brain-worker` on the same branch name.
- Update the response bank answer for "incorrect relationship removal": bad links can now be removed one tap from any memory's Related list, via the `unlink` MCP tool from any AI client, or via `POST /unlink`.