### PR TITLE
feat: static nested topic-cluster graph view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4012,10 +4012,7 @@
           const res = await fetch(`${WORKER_URL}/graph`, { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } })
           const data = await res.json()
           if (!data.ok || !data.nodes || !data.nodes.length) {
-            if (graphState) {
-              cancelAnimationFrame(graphState.raf)
-              graphState = null
-            }
+            graphState = null
             canvas.style.display = 'none'
             emptyEl.style.display = 'block'
             return
@@ -4030,13 +4027,10 @@
       }
 
       function graphNodeColor(n) {
-        if (n.kind === 'semantic') return '#b26641'
-        if (n.kind === 'episodic') return '#4a7c8c'
-        return '#9a958a'
+        return n.clusterColor || '#9a958a'
       }
 
       function initGraphSim(canvas, nodes, edges) {
-        if (graphState) cancelAnimationFrame(graphState.raf)
         const dpr = window.devicePixelRatio || 1
         const rect = canvas.getBoundingClientRect()
         const W = rect.width || 600
@@ -4047,112 +4041,131 @@
 
         const byId = {}
         nodes.forEach((n) => {
-          n.vx = 0
-          n.vy = 0
           byId[n.id] = n
         })
         const links = edges.map((e) => ({ s: byId[e.source], t: byId[e.target], w: e.weight })).filter((l) => l.s && l.t)
 
-        // Weighted adjacency — drives spawn order, communities, and per-component forces.
-        const adj = new Map(nodes.map((n) => [n.id, []]))
-        for (const l of links) {
-          adj.get(l.s.id).push({ m: l.t, w: l.w })
-          adj.get(l.t.id).push({ m: l.s, w: l.w })
-        }
+        // No physics: node positions are computed deterministically below (static packed
+        // clusters), after topic clustering.
 
-        // Degree-normalized springs (d3-force scheme). Springs are linear in distance
-        // and sum per node, so an unnormalized hub's effective stiffness grows with its
-        // degree until explicit-Euler integration diverges: strength 1/min(deg) plus a
-        // bias that moves each endpoint in proportion to the OTHER end's degree, so a
-        // hub is nearly immobile and its leaves do the moving. Rest length shrinks as
-        // edge weight grows, so strongly-linked clusters visibly contract.
-        for (const l of links) {
-          const ds = adj.get(l.s.id).length
-          const dt = adj.get(l.t.id).length
-          l.k = 1 / Math.min(ds, dt)
-          l.bias = ds / (ds + dt)
-          l.rest = 130 - 85 * Math.min(1, l.w || 0.5)
-        }
+        // Topic clusters (reagraph-style clusterAttribute): assignGraphClusters (utils.js, unit
+        // tested) tags each node with n.cluster (its broad category) and n.sub (a shared
+        // sub-topic within that category, or null). The clusters drive the static packed
+        // layout, the outline rings, the cluster labels, and the legend below.
+        assignGraphClusters(nodes)
 
-        // Spawn on the phyllotaxis spiral in BFS order from each component's
-        // highest-degree node: cluster members start adjacent, so the settled layout
-        // keeps them together instead of freezing mid-migration. Near-uniform density
-        // at any node count means the sim starts close to equilibrium. Also tags each
-        // node with its connected component for per-component centering.
-        let compCount = 0
+        // Order clusters (largest first, sentinels last), assign palette colors + dense index.
+        const CLUSTER_PALETTE = ['#b26641', '#4a7c8c', '#7a9a5b', '#a9739e', '#c99a3f', '#5b8a8f', '#8c6f5b', '#6a7bb0', '#b0685f', '#5f8c6a', '#9a7bb0', '#7d8c4f']
+        const SENTINEL_COLOR = { __other__: '#9a958a', __untagged__: '#b8b3a8', __autopattern__: '#9aa7ad' }
+        const SENTINEL_CLUSTER = new Set(['__other__', '__untagged__', '__autopattern__'])
+        const clusterLabelOf = (id) =>
+          id === '__other__' ? 'Other' : id === '__untagged__' ? 'Untagged' : id === '__autopattern__' ? 'Auto-patterns' : id
+        const clusterHue = (s) => {
+          let h = 0
+          for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0
+          return `hsl(${h % 360}, 45%, 52%)`
+        }
+        const clusterColor = new Map()
+        const clusterLegend = []
         {
-          const roots = [...nodes].sort((a, b) => adj.get(b.id).length - adj.get(a.id).length)
-          const seen = new Set()
-          let idx = 0
-          for (const root of roots) {
-            if (seen.has(root.id)) continue
-            seen.add(root.id)
-            const queue = [root]
-            while (queue.length) {
-              const n = queue.shift()
-              n.comp = compCount
-              const sr = 26 * Math.sqrt(idx + 1)
-              const sth = idx * 2.39996323 // golden angle
-              n.x = W / 2 + Math.cos(sth) * sr
-              n.y = H / 2 + Math.sin(sth) * sr
-              idx++
-              for (const { m } of adj.get(n.id)) {
-                if (!seen.has(m.id)) {
-                  seen.add(m.id)
-                  queue.push(m)
-                }
-              }
-            }
-            compCount++
-          }
+          const sz = new Map()
+          for (const n of nodes) sz.set(n.cluster, (sz.get(n.cluster) || 0) + 1)
+          const ordered = [...sz.keys()].sort((a, b) => {
+            const sa = SENTINEL_CLUSTER.has(a),
+              sb = SENTINEL_CLUSTER.has(b)
+            if (sa !== sb) return sa ? 1 : -1
+            return sz.get(b) - sz.get(a) || (a < b ? -1 : 1)
+          })
+          let pi = 0
+          ordered.forEach((id) => {
+            const color = SENTINEL_CLUSTER.has(id) ? SENTINEL_COLOR[id] : pi < CLUSTER_PALETTE.length ? CLUSTER_PALETTE[pi++] : clusterHue(id)
+            clusterColor.set(id, color)
+            clusterLegend.push({ label: clusterLabelOf(id), color, count: sz.get(id) })
+          })
         }
+        for (const n of nodes) n.clusterColor = clusterColor.get(n.cluster)
 
-        // Communities via label propagation: every node repeatedly adopts the label
-        // its neighbors vote for hardest (weighted by edge weight) until stable.
-        // Cheap, dependency-free, and only used to tint the cluster halos.
-        {
-          for (const n of nodes) n.community = n.id
-          for (let pass = 0; pass < 10; pass++) {
-            let changed = 0
-            for (const n of nodes) {
-              const votes = new Map()
-              for (const { m, w } of adj.get(n.id)) votes.set(m.community, (votes.get(m.community) || 0) + w)
-              let best = n.community
-              let bestV = votes.get(n.community) || 0
-              for (const [c, v] of votes) {
-                if (v > bestV) {
-                  bestV = v
-                  best = c
-                }
-              }
-              if (best !== n.community) {
-                n.community = best
-                changed++
-              }
-            }
-            if (!changed) break
-          }
-        }
-        // Per-community index for the cluster-gravity force in tick().
-        const commIndex = new Map()
-        for (const n of nodes) {
-          if (!commIndex.has(n.community)) commIndex.set(n.community, commIndex.size)
-          n.commIdx = commIndex.get(n.community)
-        }
-        const commCount = commIndex.size
+        // Nested packed layout (static, no physics). Two levels: pack each sub-topic's nodes into
+        // a small disc, pack those sub-discs plus the category's loose nodes inside the category's
+        // outer disc, then pack the outer discs on the canvas. Everything is final; nothing
+        // animates. clusterList drives the outer rings/labels, subList the inner ones.
+        const NODE_PACK_R = 9 // representative node radius used for packing spacing
+        const GAP_SUB = 7 // gap between sub-discs / loose nodes inside a category
+        const GAP_OUT = 24 // gap between category discs
+        // packGraphNodes / packGraphCircles (utils.js, unit tested) do the geometry: phyllotaxis
+        // node offsets within a disc, and non-overlapping closest-to-center circle packing.
 
-        const commGroups = []
+        const clusterList = [] // outer category discs: { color, label, cx, cy, R }
+        const subList = [] // inner sub-topic discs: { color, label, cx, cy, R }
         {
-          const byComm = new Map()
+          const byOuter = new Map()
           for (const n of nodes) {
-            if (!byComm.has(n.community)) byComm.set(n.community, [])
-            byComm.get(n.community).push(n)
+            if (!byOuter.has(n.cluster)) byOuter.set(n.cluster, [])
+            byOuter.get(n.cluster).push(n)
           }
-          let hue = 90
-          for (const members of byComm.values()) {
-            if (members.length < 3) continue // halos only where there's a real cluster
-            commGroups.push({ members, tint: `hsla(${hue}, 42%, 50%, 0.08)` })
-            hue = (hue + 137.5) % 360
+          const outerObjs = []
+          for (const [id, members] of byOuter) {
+            const color = clusterColor.get(id)
+            // split members into sub-topic groups + loose members
+            const bySub = new Map()
+            const loose = []
+            for (const n of members) {
+              if (!n.sub) {
+                loose.push(n)
+                continue
+              }
+              if (!bySub.has(n.sub)) bySub.set(n.sub, [])
+              bySub.get(n.sub).push(n)
+            }
+            const subs = []
+            for (const [tag, subMembers] of bySub) {
+              const spread = subMembers.length <= 1 ? 0 : 7 + 8 * Math.sqrt(subMembers.length)
+              const local = packGraphNodes(subMembers.length, spread)
+              subMembers.forEach((n, i) => {
+                n.slx = local[i].x
+                n.sly = local[i].y
+              })
+              subs.push({ tag, members: subMembers, ringR: spread + NODE_PACK_R + 3 })
+            }
+            // pack sub-discs (radius ringR) + loose nodes (radius NODE_PACK_R+3) inside the category
+            const items = [...subs.map((s) => s.ringR), ...loose.map(() => NODE_PACK_R + 4)]
+            const packed = packGraphCircles(items, GAP_SUB)
+            subs.forEach((s, i) => {
+              s.cx = packed.centers[i].x
+              s.cy = packed.centers[i].y
+            })
+            loose.forEach((n, i) => {
+              const c = packed.centers[subs.length + i]
+              n.olx = c.x
+              n.oly = c.y
+            })
+            outerObjs.push({ id, color, label: clusterLabelOf(id), subs, loose, R: packed.R + 9 })
+          }
+          // pack the category discs on the canvas (largest first)
+          const outerPacked = packGraphCircles(
+            outerObjs.map((o) => o.R),
+            GAP_OUT,
+          )
+          outerObjs.forEach((o, i) => {
+            o.cx = outerPacked.centers[i].x
+            o.cy = outerPacked.centers[i].y
+          })
+          // resolve absolute node positions and build the draw lists
+          for (const o of outerObjs) {
+            clusterList.push({ color: o.color, label: o.label, cx: o.cx, cy: o.cy, R: o.R })
+            for (const s of o.subs) {
+              const scx = o.cx + s.cx
+              const scy = o.cy + s.cy
+              subList.push({ color: o.color, label: s.tag, cx: scx, cy: scy, R: s.ringR })
+              for (const n of s.members) {
+                n.x = scx + n.slx
+                n.y = scy + n.sly
+              }
+            }
+            for (const n of o.loose) {
+              n.x = o.cx + n.olx
+              n.y = o.cy + n.oly
+            }
           }
         }
 
@@ -4160,17 +4173,13 @@
         const cam = { x: 0, y: 0, scale: 1 }
         const pointers = new Map()
         const state = {
-          raf: 0,
-          running: false,
           hover: null,
-          dragNode: null,
+          pressNode: null,
           panning: false,
           panStart: null,
           moved: false,
           downId: null,
           pinch: null,
-          didFit: false,
-          ticks: 0,
           cam,
         }
         graphState = state
@@ -4229,7 +4238,7 @@
           cam.y = H / 2 - ((minY + maxY) / 2) * cam.scale
           requestDraw()
         }
-        state.api = { zoomBy: (f) => zoomAround(W / 2, H / 2, f), fit }
+        state.api = { zoomBy: (f) => zoomAround(W / 2, H / 2, f), fit, redraw: () => requestDraw() }
 
         // ── input: wheel zoom, pointer drag/pan, two-pointer pinch ──
         canvas.addEventListener(
@@ -4245,7 +4254,7 @@
         const twoPointers = () => [...pointers.values()]
         function startPinch() {
           const [a, b] = twoPointers()
-          state.dragNode = null
+          state.pressNode = null
           state.panning = false
           state.pinch = { dist: Math.hypot(a.x - b.x, a.y - b.y) || 1, scale: cam.scale }
         }
@@ -4266,12 +4275,9 @@
           }
           state.moved = false
           state.downId = ev.pointerId
-          const hit = nodeAt(p.x, p.y)
-          if (hit) state.dragNode = hit
-          else {
-            state.panning = true
-            state.panStart = { x: ev.clientX - cam.x, y: ev.clientY - cam.y }
-          }
+          state.pressNode = nodeAt(p.x, p.y) // remembered for tap-to-open; any drag pans the canvas
+          state.panning = true
+          state.panStart = { x: ev.clientX - cam.x, y: ev.clientY - cam.y }
           canvas.style.cursor = 'grabbing'
         })
 
@@ -4282,15 +4288,7 @@
             movePinch()
             return
           }
-          if (state.dragNode) {
-            const w = screenToWorld(p.x, p.y)
-            state.dragNode.x = w.x
-            state.dragNode.y = w.y
-            state.dragNode.vx = 0
-            state.dragNode.vy = 0
-            state.moved = true
-            energize() // reheat so the rest of the graph re-settles around the dragged node
-          } else if (state.panning) {
+          if (state.panning) {
             cam.x = ev.clientX - state.panStart.x
             cam.y = ev.clientY - state.panStart.y
             state.moved = true
@@ -4299,7 +4297,7 @@
             const prev = state.hover
             state.hover = nodeAt(p.x, p.y)
             canvas.style.cursor = state.hover ? 'pointer' : 'grab'
-            if (!state.running && prev !== state.hover) draw()
+            if (prev !== state.hover) draw()
           }
         })
 
@@ -4310,20 +4308,20 @@
           } catch (e) {}
           if (state.pinch && pointers.size < 2) state.pinch = null
           if (ev.pointerId === state.downId) {
-            if (state.dragNode && !state.moved) openNodeView(state.dragNode)
-            state.dragNode = null
+            if (state.pressNode && !state.moved) openNodeView(state.pressNode)
+            state.pressNode = null
             state.panning = false
             state.downId = null
             canvas.style.cursor = 'grab'
-            energize()
+            requestDraw()
           }
         }
         canvas.addEventListener('pointerup', endPointer)
         canvas.addEventListener('pointercancel', endPointer)
         canvas.addEventListener('pointerleave', () => {
-          if (!state.dragNode && !state.panning && state.hover) {
+          if (!state.panning && state.hover) {
             state.hover = null
-            if (!state.running) draw()
+            draw()
           }
         })
 
@@ -4356,175 +4354,8 @@
           ctx.globalAlpha = 1
         }
 
-        const GRID_CELL = 176 // 2× link rest length — radius of exact near-field repulsion
-        const EXACT_MAX = 300 // ≤ this many nodes: exact all-pairs repulsion (continuous forces settle naturally)
-        const MAX_SPEED = 40 // px/frame velocity cap — keeps the integrator unconditionally stable
-        const MAX_TICKS = 800 // hard stop so the animation loop always terminates
-
-        function tick() {
-          if (nodes.length <= EXACT_MAX) {
-            // Exact all-pairs repulsion: O(n²) but trivial at this size, and its
-            // continuous forces let small graphs settle naturally and fast.
-            for (let i = 0; i < nodes.length; i++) {
-              const a = nodes[i]
-              for (let j = i + 1; j < nodes.length; j++) {
-                const b = nodes[j]
-                let dx = a.x - b.x
-                let dy = a.y - b.y
-                let d2 = dx * dx + dy * dy || 0.01
-                const d = Math.sqrt(d2)
-                const f = 2000 / d2
-                const fx = (dx / d) * f,
-                  fy = (dy / d) * f
-                a.vx += fx
-                a.vy += fy
-                b.vx -= fx
-                b.vy -= fy
-              }
-            }
-          } else {
-            // Big graphs: repulsion via a spatial grid — exact pair forces inside the
-            // 3×3 cell neighborhood, one aggregated force per far cell (centroid ×
-            // node count). O(n × cells) per frame instead of all-pairs O(n²).
-            const grid = new Map()
-            for (const n of nodes) {
-              n.gx = Math.floor(n.x / GRID_CELL)
-              n.gy = Math.floor(n.y / GRID_CELL)
-              const key = n.gx + ':' + n.gy
-              let c = grid.get(key)
-              if (!c) grid.set(key, (c = { gx: n.gx, gy: n.gy, sx: 0, sy: 0, members: [] }))
-              c.sx += n.x
-              c.sy += n.y
-              c.members.push(n)
-            }
-            const cells = [...grid.values()]
-            for (const a of nodes) {
-              for (const c of cells) {
-                if (Math.abs(c.gx - a.gx) <= 1 && Math.abs(c.gy - a.gy) <= 1) {
-                  for (const b of c.members) {
-                    if (b === a) continue
-                    let dx = a.x - b.x
-                    let dy = a.y - b.y
-                    let d2 = dx * dx + dy * dy || 0.01
-                    const d = Math.sqrt(d2)
-                    const f = 2000 / d2
-                    a.vx += (dx / d) * f
-                    a.vy += (dy / d) * f
-                  }
-                } else {
-                  const m = c.members.length
-                  let dx = a.x - c.sx / m
-                  let dy = a.y - c.sy / m
-                  let d2 = dx * dx + dy * dy || 0.01
-                  const d = Math.sqrt(d2)
-                  const f = (2000 * m) / d2
-                  a.vx += (dx / d) * f
-                  a.vy += (dy / d) * f
-                }
-              }
-            }
-          }
-          for (const l of links) {
-            let dx = l.t.x - l.s.x
-            let dy = l.t.y - l.s.y
-            const d = Math.sqrt(dx * dx + dy * dy) || 0.01
-            const f = (d - l.rest) * 0.02 * (0.5 + l.w) * l.k
-            const fx = (dx / d) * f,
-              fy = (dy / d) * f
-            l.s.vx += fx * (1 - l.bias)
-            l.s.vy += fy * (1 - l.bias)
-            l.t.vx -= fx * l.bias
-            l.t.vy -= fy * l.bias
-          }
-          // Cooling (Fruchterman–Reingold): full speed for the first 150 ticks, then
-          // the speed cap decays 1.5%/tick — below the settle threshold by ~tick 680,
-          // so the sim is guaranteed to freeze even when hub oscillations or the
-          // grid's force discontinuities would otherwise sustain jitter forever.
-          const temp = state.dragNode ? MAX_SPEED : MAX_SPEED * Math.min(1, Math.pow(0.985, state.ticks - 150))
-          // Per-component centering: each island coheres around its own centroid (an
-          // internal force — net-zero per component) with only a weak global pull to
-          // keep everything on screen, so disconnected clusters drift apart into
-          // distinct islands instead of being packed into one disc.
-          const csx = new Float64Array(compCount)
-          const csy = new Float64Array(compCount)
-          const cn = new Float64Array(compCount)
-          // Cluster gravity: each node is also pulled toward its community's centroid,
-          // so communities contract into tight balls and repulsion pushes the balls
-          // apart — this is what makes clusters legible inside one big component.
-          const qsx = new Float64Array(commCount)
-          const qsy = new Float64Array(commCount)
-          const qn = new Float64Array(commCount)
-          for (const n of nodes) {
-            csx[n.comp] += n.x
-            csy[n.comp] += n.y
-            cn[n.comp]++
-            qsx[n.commIdx] += n.x
-            qsy[n.commIdx] += n.y
-            qn[n.commIdx]++
-          }
-          let energy = 0
-          for (const n of nodes) {
-            if (n === state.dragNode) {
-              n.vx = 0
-              n.vy = 0
-              continue
-            } // pinned under the cursor
-            n.vx += (csx[n.comp] / cn[n.comp] - n.x) * 0.0015 + (W / 2 - n.x) * 0.0004 + (qsx[n.commIdx] / qn[n.commIdx] - n.x) * 0.004
-            n.vy += (csy[n.comp] / cn[n.comp] - n.y) * 0.0015 + (H / 2 - n.y) * 0.0004 + (qsy[n.commIdx] / qn[n.commIdx] - n.y) * 0.004
-            n.vx *= 0.85
-            n.vy *= 0.85
-            const sp = Math.hypot(n.vx, n.vy)
-            if (sp > temp) {
-              n.vx *= temp / sp
-              n.vy *= temp / sp
-            }
-            n.x += n.vx
-            n.y += n.vy
-            energy += n.vx * n.vx + n.vy * n.vy
-          }
-          draw()
-          if (!state.dragNode) state.ticks++
-          // Settle threshold scales with node count past the old 200-node design point
-          // (0.04 total ≈ 0.0002/node); the tick cap ends the loop no matter what.
-          if (state.dragNode || (energy > Math.max(0.04, 0.0002 * nodes.length) && state.ticks < MAX_TICKS)) {
-            state.raf = requestAnimationFrame(tick)
-          } else {
-            state.running = false
-            if (!state.didFit) {
-              state.didFit = true
-              fit()
-            } // frame the graph once it first settles
-          }
-        }
-        function energize() {
-          state.ticks = 0 // reheat: back to full temperature with a fresh settle budget
-          if (!state.running) {
-            state.running = true
-            state.raf = requestAnimationFrame(tick)
-          }
-        }
         function requestDraw() {
-          if (!state.running) draw()
-        }
-
-        // Andrew's monotone-chain convex hull; pts must be sorted by (x, y).
-        function hull(pts) {
-          if (pts.length < 3) return pts
-          const cross = (o, a, b) => (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x)
-          const lower = []
-          for (const p of pts) {
-            while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) lower.pop()
-            lower.push(p)
-          }
-          const upper = []
-          for (let i = pts.length - 1; i >= 0; i--) {
-            const p = pts[i]
-            while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) upper.pop()
-            upper.push(p)
-          }
-          lower.pop()
-          upper.pop()
-          return lower.concat(upper)
+          draw()
         }
 
         function draw() {
@@ -4532,29 +4363,45 @@
           ctx.clearRect(0, 0, W, H)
           ctx.setTransform(dpr * cam.scale, 0, 0, dpr * cam.scale, dpr * cam.x, dpr * cam.y)
           const hover = state.hover
-          // Soft tinted halo behind each detected community — draws the clusters the
-          // layout alone can only hint at. Thick round-joined stroke + fill = a
-          // rounded, padded hull around the members.
-          for (const g of commGroups) {
-            const h = hull([...g.members].sort((a, b) => a.x - b.x || a.y - b.y))
-            if (!h.length) continue
+          // Theme-aware ink: dark strokes on the light theme, light strokes on the dark theme,
+          // so edges and the hover ring stay visible in both. Slightly more alpha in dark mode
+          // since light lines read fainter on a dark background.
+          const darkTheme = document.documentElement.getAttribute('data-theme') === 'dark'
+          const inkRGB = darkTheme ? '224,221,213' : '38,36,31'
+          const inkHex = darkTheme ? '#e0ddd5' : '#26241f'
+          const edgeA = darkTheme ? 0.15 : 0.06
+          const edgeDimA = darkTheme ? 0.07 : 0.03
+          // Outer category rings: a barely-there fill plus a screen-constant stroke (a boundary,
+          // not a shaded blob). c.R already includes the ring padding.
+          for (const c of clusterList) {
             ctx.beginPath()
-            ctx.moveTo(h[0].x, h[0].y)
-            for (let i = 1; i < h.length; i++) ctx.lineTo(h[i].x, h[i].y)
-            ctx.closePath()
-            ctx.fillStyle = g.tint
-            ctx.strokeStyle = g.tint
-            ctx.lineWidth = 56
-            ctx.lineJoin = 'round'
-            ctx.lineCap = 'round'
-            ctx.stroke()
+            ctx.arc(c.cx, c.cy, c.R, 0, Math.PI * 2)
+            ctx.globalAlpha = 0.045
+            ctx.fillStyle = c.color
             ctx.fill()
+            ctx.globalAlpha = 0.5
+            ctx.strokeStyle = c.color
+            ctx.lineWidth = 1.25 / cam.scale
+            ctx.stroke()
+            ctx.globalAlpha = 1
           }
+          // Inner sub-topic rings: same hue, thinner and dashed, no fill.
+          ctx.setLineDash([4 / cam.scale, 4 / cam.scale])
+          for (const s of subList) {
+            ctx.beginPath()
+            ctx.arc(s.cx, s.cy, s.R, 0, Math.PI * 2)
+            ctx.globalAlpha = 0.4
+            ctx.strokeStyle = s.color
+            ctx.lineWidth = 1 / cam.scale
+            ctx.stroke()
+            ctx.globalAlpha = 1
+          }
+          ctx.setLineDash([])
           for (const l of links) {
             const dim = l.s.status === 'deprecated' || l.t.status === 'deprecated'
             const lit = hover && (l.s === hover || l.t === hover)
-            ctx.strokeStyle = lit ? 'rgba(178,102,65,0.55)' : dim ? 'rgba(38,36,31,0.05)' : 'rgba(38,36,31,0.13)'
-            ctx.lineWidth = lit ? Math.max(1.5, l.w * 2.5) : Math.max(0.5, l.w * 2)
+            ctx.strokeStyle = lit ? 'rgba(178,102,65,0.55)' : dim ? `rgba(${inkRGB}, ${edgeDimA})` : `rgba(${inkRGB}, ${edgeA})`
+            ctx.lineWidth = lit ? Math.max(1.5, l.w * 2.5) : Math.max(0.4, l.w * 1.5)
             ctx.beginPath()
             ctx.moveTo(l.s.x, l.s.y)
             ctx.lineTo(l.t.x, l.t.y)
@@ -4569,7 +4416,7 @@
             ctx.fill()
             if (n === hover) {
               ctx.globalAlpha = 1
-              ctx.strokeStyle = '#26241f'
+              ctx.strokeStyle = inkHex
               ctx.lineWidth = 2
               ctx.beginPath()
               ctx.arc(n.x, n.y, r + 3, 0, Math.PI * 2)
@@ -4584,14 +4431,108 @@
               labelPill(shortLabel(n), n.x, n.y + nodeRadius(n) + 4, false, n.status === 'deprecated' ? 0.5 : 1)
             }
           }
+          // Cluster labels: a bold, cluster-colored pill above each cluster's top edge.
+          if (cam.scale >= 0.4) {
+            for (const c of clusterList) {
+              const cx = c.cx
+              const cy = c.cy - c.R - 16
+              ctx.font = '700 13px "DM Sans", system-ui, sans-serif'
+              const tw = ctx.measureText(c.label).width
+              const padX = 7
+              const h = 20
+              const rr = 6
+              const x = cx - tw / 2 - padX
+              const w = tw + padX * 2
+              const topY = cy - h / 2
+              ctx.globalAlpha = 0.92
+              ctx.fillStyle = 'rgba(252,251,247,0.9)'
+              ctx.beginPath()
+              ctx.moveTo(x + rr, topY)
+              ctx.arcTo(x + w, topY, x + w, topY + h, rr)
+              ctx.arcTo(x + w, topY + h, x, topY + h, rr)
+              ctx.arcTo(x, topY + h, x, topY, rr)
+              ctx.arcTo(x, topY, x + w, topY, rr)
+              ctx.fill()
+              ctx.fillStyle = c.color
+              ctx.textAlign = 'center'
+              ctx.textBaseline = 'middle'
+              ctx.fillText(c.label, cx, cy)
+              ctx.globalAlpha = 1
+            }
+          }
+          // Inner sub-topic labels (smaller; shown only when zoomed in enough to read them).
+          if (cam.scale >= 0.7) {
+            for (const s of subList) {
+              const cx = s.cx
+              const cy = s.cy - s.R - 9
+              ctx.font = '600 10px "DM Sans", system-ui, sans-serif'
+              const tw = ctx.measureText(s.label).width
+              const padX = 5
+              const h = 15
+              const rr = 5
+              const x = cx - tw / 2 - padX
+              const w = tw + padX * 2
+              const topY = cy - h / 2
+              ctx.globalAlpha = 0.9
+              ctx.fillStyle = 'rgba(252,251,247,0.88)'
+              ctx.beginPath()
+              ctx.moveTo(x + rr, topY)
+              ctx.arcTo(x + w, topY, x + w, topY + h, rr)
+              ctx.arcTo(x + w, topY + h, x, topY + h, rr)
+              ctx.arcTo(x, topY + h, x, topY, rr)
+              ctx.arcTo(x, topY, x + w, topY, rr)
+              ctx.fill()
+              ctx.fillStyle = s.color
+              ctx.textAlign = 'center'
+              ctx.textBaseline = 'middle'
+              ctx.fillText(s.label, cx, cy)
+              ctx.globalAlpha = 1
+            }
+          }
           if (hover) {
             const full = (hover.label || '').replace(/\s+/g, ' ').trim()
             const text = full.length > 48 ? full.slice(0, 48).trimEnd() + '…' : full
-            labelPill(text, hover.x, hover.y + nodeRadius(hover) + 4, true, 1)
+            const withKind = hover.kind ? `${hover.kind} · ${text}` : text
+            labelPill(withKind, hover.x, hover.y + nodeRadius(hover) + 4, true, 1)
+          }
+          // Legend (screen space): color swatch + label + count per cluster, top-left,
+          // fixed while the graph pans/zooms. Ivory pill + dark text reads on both themes.
+          ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+          if (clusterLegend.length) {
+            const rows = clusterLegend.slice(0, 10)
+            ctx.font = '600 11px "DM Sans", system-ui, sans-serif'
+            let maxW = 0
+            for (const r of rows) maxW = Math.max(maxW, ctx.measureText(r.label).width + ctx.measureText(String(r.count)).width)
+            const padX = 8
+            const rowH = 17
+            const sw = 10
+            const gap = 24
+            const boxW = padX * 2 + sw + 6 + maxW + gap
+            const boxH = padX + rows.length * rowH
+            ctx.globalAlpha = 0.92
+            ctx.fillStyle = 'rgba(252,251,247,0.9)'
+            ctx.beginPath()
+            ctx.rect(10, 10, boxW, boxH)
+            ctx.fill()
+            ctx.globalAlpha = 1
+            ctx.textBaseline = 'middle'
+            rows.forEach((r, i) => {
+              const y = 10 + padX + i * rowH + rowH / 2 - 4
+              ctx.fillStyle = r.color
+              ctx.beginPath()
+              ctx.arc(10 + padX + sw / 2, y, sw / 2, 0, Math.PI * 2)
+              ctx.fill()
+              ctx.textAlign = 'left'
+              ctx.fillStyle = '#26241f'
+              ctx.fillText(r.label, 10 + padX + sw + 6, y)
+              ctx.textAlign = 'right'
+              ctx.fillStyle = '#6e6b62'
+              ctx.fillText(String(r.count), 10 + boxW - padX, y)
+            })
           }
         }
 
-        energize()
+        fit()
       }
 
       function graphZoom(factor) {
@@ -4730,6 +4671,7 @@
         const tc = document.querySelector('meta[name="theme-color"]')
         if (tc) tc.setAttribute('content', dark ? '#18160F' : '#F4F1EA')
         document.querySelectorAll('#theme-toggle [data-theme-val]').forEach((b) => b.classList.toggle('active', b.dataset.themeVal === mode))
+        if (graphState && graphState.api) graphState.api.redraw() // repaint the graph in the new theme's ink
       }
       _prefersDark.addEventListener('change', applyTheme)
 

--- a/public/utils.js
+++ b/public/utils.js
@@ -154,6 +154,203 @@ function syncVectorizeBanner(doc, banner) {
   return el;
 }
 
+/* ---- Graph view: topic clustering + static packed layout ------------------------------
+ *
+ * The dashboard graph groups memories into topic clusters derived from their tags, at two
+ * levels: a broad outer category per node (n.cluster) and an optional shared sub-topic
+ * within that category (n.sub). The layout is deterministic circle packing; nothing is
+ * force-simulated or animated.
+ */
+
+/* Group graph nodes into topic clusters by tag. Mutates each node, setting:
+ *   n.cluster - the node's broad category: a tag, or one of the reserved sentinel ids
+ *               '__other__' | '__untagged__' | '__autopattern__'
+ *   n.sub     - a sub-topic tag shared with other members of the same category, or null
+ *
+ * Rules (all thresholds scale with the store, so this works for small and large stores):
+ * - Reserved (kind:/status:) and system tags never define clusters; entries tagged
+ *   'auto-pattern' get their own bucket instead of polluting Untagged.
+ * - A tag must be shared by >= 2 nodes to define a cluster (no lone-tag singletons).
+ * - Nodes join the broadest of their tags that still distinguishes them: a near-universal
+ *   tag (on >= half the store) does not distinguish anything, so it is skipped in favor of
+ *   more focused tags. This keeps one dominant tag from swallowing the whole graph. Only
+ *   when every eligible tag is near-universal does the node fall back to the least
+ *   universal one.
+ * - Tiny categories (fewer than ~1% of nodes, floor 3) fold into the node's largest
+ *   surviving alternative category, or Other, so the graph does not scatter into dozens
+ *   of one- and two-node circles.
+ * - Sub-topics: within a category, a non-category tag shared by >= 2 members that lives
+ *   mostly inside the category (>= half its global uses) becomes a sub-group. A 'japan'
+ *   tag concentrated in a 'travel' category qualifies; a cross-cutting 'urgent' tag
+ *   spread across many categories does not. Each member takes the dominant such tag.
+ * - Ties break deterministically (higher share, then more specific, then alphabetical).
+ */
+function assignGraphClusters(nodes) {
+  const RESERVED_TAG = /^(kind|status):/;
+  const SYSTEM_TAGS = new Set(['duplicate-candidate', 'synthesized', 'auto-pattern']);
+  const SENTINELS = new Set(['__other__', '__untagged__', '__autopattern__']);
+  const MIN_CLUSTER_SIZE = 2;
+  const MIN_SUB = 2;
+  const candidateTags = (n) => (n.tags || []).filter((t) => !RESERVED_TAG.test(t) && !SYSTEM_TAGS.has(t) && !SENTINELS.has(t));
+
+  const df = new Map();
+  for (const n of nodes) for (const t of new Set(candidateTags(n))) df.set(t, (df.get(t) || 0) + 1);
+  const GENERIC_CEIL = Math.max(MIN_CLUSTER_SIZE + 1, Math.round(nodes.length * 0.5));
+
+  // Outer category per node.
+  for (const n of nodes) {
+    if ((n.tags || []).includes('auto-pattern')) {
+      n.cluster = '__autopattern__';
+      continue;
+    }
+    const cands = [...new Set(candidateTags(n))];
+    const eligible = cands.filter((t) => df.get(t) >= MIN_CLUSTER_SIZE);
+    if (!eligible.length) {
+      n.cluster = cands.length ? '__other__' : '__untagged__';
+      continue;
+    }
+    const focused = eligible.filter((t) => df.get(t) < GENERIC_CEIL);
+    if (focused.length) {
+      let best = focused[0];
+      let bestDf = -1;
+      for (const t of focused) {
+        const d = df.get(t);
+        if (d > bestDf || (d === bestDf && t < best)) {
+          bestDf = d;
+          best = t;
+        }
+      }
+      n.cluster = best;
+    } else {
+      let best = eligible[0];
+      let bestDf = Infinity;
+      for (const t of eligible) {
+        const d = df.get(t);
+        if (d < bestDf || (d === bestDf && t < best)) {
+          bestDf = d;
+          best = t;
+        }
+      }
+      n.cluster = best;
+    }
+  }
+
+  // Fold tiny categories into a larger alternative, or Other.
+  const MIN_OUTER = Math.max(3, Math.round(nodes.length / 100));
+  const csz = new Map();
+  for (const n of nodes) csz.set(n.cluster, (csz.get(n.cluster) || 0) + 1);
+  for (const n of nodes) {
+    if (SENTINELS.has(n.cluster) || csz.get(n.cluster) >= MIN_OUTER) continue;
+    let alt = null;
+    let altSz = MIN_OUTER - 1;
+    for (const t of new Set(candidateTags(n))) {
+      if (t === n.cluster) continue;
+      const s = csz.get(t) || 0;
+      if (s > altSz) {
+        altSz = s;
+        alt = t;
+      }
+    }
+    n.cluster = alt || '__other__';
+  }
+
+  // Sub-topic within each category.
+  const groups = new Map();
+  for (const n of nodes) {
+    n.sub = null;
+    if (SENTINELS.has(n.cluster)) continue;
+    if (!groups.has(n.cluster)) groups.set(n.cluster, []);
+    groups.get(n.cluster).push(n);
+  }
+  for (const [outer, members] of groups) {
+    const wdf = new Map();
+    for (const n of members) for (const t of new Set(candidateTags(n))) if (t !== outer) wdf.set(t, (wdf.get(t) || 0) + 1);
+    for (const n of members) {
+      let best = null;
+      let bestW = -1;
+      let bestDf = Infinity;
+      for (const t of new Set(candidateTags(n))) {
+        if (t === outer) continue;
+        const w = wdf.get(t) || 0;
+        if (w < MIN_SUB || w < 0.5 * df.get(t)) continue;
+        const d = df.get(t);
+        if (w > bestW || (w === bestW && d < bestDf) || (w === bestW && d === bestDf && t < best)) {
+          bestW = w;
+          bestDf = d;
+          best = t;
+        }
+      }
+      n.sub = best;
+    }
+  }
+  return nodes;
+}
+
+/* Phyllotaxis (sunflower) offsets for k node centers inside a disc of radius R.
+ * A single node sits at the exact center. Returns [{x, y}] relative to the disc center. */
+function packGraphNodes(k, R) {
+  const pts = [];
+  for (let i = 0; i < k; i++) {
+    const rr = k <= 1 ? 0 : R * Math.sqrt((i + 0.5) / k);
+    const th = i * 2.399963229; // golden angle
+    pts.push({ x: Math.cos(th) * rr, y: Math.sin(th) * rr });
+  }
+  return pts;
+}
+
+/* Pack circles of the given radii with no overlap (largest first, closest-to-center free
+ * spot, at least `gap` between edges). Returns { centers, R }: each circle's center in
+ * input order, and the bounding radius of the whole packing. Scale-invariant: the ring
+ * step and angular resolution scale with each circle's size, so it packs tightly whether
+ * the circles are tiny nodes or huge category discs. Deterministic. */
+function packGraphCircles(radii, gap) {
+  if (radii.length <= 1) return { centers: radii.length ? [{ x: 0, y: 0 }] : [], R: radii[0] || 0 };
+  const order = radii.map((r, i) => ({ r, i })).sort((a, b) => b.r - a.r);
+  const placed = [];
+  for (const it of order) {
+    if (!placed.length) {
+      placed.push({ x: 0, y: 0, r: it.r, i: it.i });
+      continue;
+    }
+    // Scan concentric rings outward and take the first free spot, so each circle sits as
+    // close to the center as it can without overlapping the ones already placed.
+    let maxd = 0;
+    for (const p of placed) maxd = Math.max(maxd, Math.hypot(p.x, p.y) + p.r);
+    const reach = maxd + it.r + gap; // radius that provably clears every placed circle
+    const step = Math.max(3, it.r * 0.5);
+    let best = null;
+    for (let rad = step; rad <= reach && !best; rad += step) {
+      const samples = Math.max(8, Math.round((2 * Math.PI * rad) / Math.max(6, it.r)));
+      for (let k = 0; k < samples && !best; k++) {
+        const ang = (k / samples) * 2 * Math.PI + rad * 0.618; // rotate each ring to avoid seams
+        const x = Math.cos(ang) * rad;
+        const y = Math.sin(ang) * rad;
+        let ok = true;
+        for (const p of placed) {
+          const need = it.r + p.r + gap;
+          if ((x - p.x) ** 2 + (y - p.y) ** 2 < need * need) {
+            ok = false;
+            break;
+          }
+        }
+        if (ok) best = { x, y };
+      }
+    }
+    if (!best) {
+      const ang = placed.length * 2.399963229;
+      best = { x: Math.cos(ang) * reach, y: Math.sin(ang) * reach };
+    }
+    placed.push({ x: best.x, y: best.y, r: it.r, i: it.i });
+  }
+  const centers = [];
+  let R = 0;
+  for (const p of placed) {
+    centers[p.i] = { x: p.x, y: p.y };
+    R = Math.max(R, Math.hypot(p.x, p.y) + p.r);
+  }
+  return { centers, R };
+}
+
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { escHtml, escAttr, toDateStr, parseRecallResult, normalizeEntry, vectorizeHealthBanner, vectorizeBannerHtml, syncVectorizeBanner };
+  module.exports = { escHtml, escAttr, toDateStr, parseRecallResult, normalizeEntry, vectorizeHealthBanner, vectorizeBannerHtml, syncVectorizeBanner, assignGraphClusters, packGraphNodes, packGraphCircles };
 }

--- a/test/ui/graph-clusters.test.ts
+++ b/test/ui/graph-clusters.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "vitest";
+
+const { assignGraphClusters, packGraphNodes, packGraphCircles } = require("../../public/utils.js");
+
+type N = { id: string; tags: string[]; cluster?: string; sub?: string | null };
+
+const node = (id: string, tags: string[]): N => ({ id, tags });
+const byId = (nodes: N[], id: string) => nodes.find((n) => n.id === id)!;
+
+describe("assignGraphClusters — outer category", () => {
+  it("groups a memory under the broadest shared tag, not a rare one", () => {
+    // 8 memories all tagged travel; a couple carry extra, more specific tags.
+    const nodes = [
+      ...Array.from({ length: 5 }, (_, i) => node(`t${i}`, ["travel"])),
+      node("j1", ["travel", "japan"]),
+      node("j2", ["travel", "japan"]),
+      node("jr", ["travel", "japan", "ryokan"]), // ryokan is unique -> must not strand
+    ];
+    assignGraphClusters(nodes);
+    // travel is on the whole store (near-universal), so japan-tagged memories surface
+    // as their own focused category; the unique ryokan tag never forms a cluster.
+    expect(byId(nodes, "j1").cluster).toBe("japan");
+    expect(byId(nodes, "jr").cluster).toBe("japan");
+    // memories with only the near-universal tag still group under it
+    expect(byId(nodes, "t0").cluster).toBe("travel");
+  });
+
+  it("demotes a dominant tag so it cannot swallow the whole graph", () => {
+    // 'inbox' is on 9 of 10 memories; focused topics must win for those that have them.
+    const nodes = [
+      ...Array.from({ length: 3 }, (_, i) => node(`g${i}`, ["inbox", "gardening"])),
+      node("g3", ["gardening"]),
+      ...Array.from({ length: 3 }, (_, i) => node(`c${i}`, ["inbox", "cooking"])),
+      ...Array.from({ length: 3 }, (_, i) => node(`p${i}`, ["inbox"])),
+    ];
+    assignGraphClusters(nodes);
+    expect(byId(nodes, "g0").cluster).toBe("gardening");
+    expect(byId(nodes, "g3").cluster).toBe("gardening");
+    expect(byId(nodes, "c0").cluster).toBe("cooking");
+    // inbox-only memories fall back to inbox rather than Other
+    expect(byId(nodes, "p0").cluster).toBe("inbox");
+  });
+
+  it("buckets auto-pattern entries separately, regardless of other tags", () => {
+    const nodes = [
+      node("a", ["auto-pattern"]),
+      node("b", ["auto-pattern", "status:canonical"]),
+      node("c", ["auto-pattern", "travel"]),
+      node("d", ["travel"]),
+      node("e", ["travel"]),
+      node("f", ["travel"]), // 3 direct travel members so the category survives the tiny-fold
+    ];
+    assignGraphClusters(nodes);
+    expect(byId(nodes, "a").cluster).toBe("__autopattern__");
+    expect(byId(nodes, "b").cluster).toBe("__autopattern__");
+    expect(byId(nodes, "c").cluster).toBe("__autopattern__");
+    expect(byId(nodes, "d").cluster).toBe("travel");
+  });
+
+  it("sends reserved/system-only memories to Untagged and unique-only ones to Other", () => {
+    const nodes = [
+      node("res", ["kind:episodic", "status:canonical", "synthesized"]),
+      node("uni", ["one-of-a-kind"]),
+      node("t1", ["travel"]),
+      node("t2", ["travel"]),
+    ];
+    assignGraphClusters(nodes);
+    expect(byId(nodes, "res").cluster).toBe("__untagged__");
+    expect(byId(nodes, "uni").cluster).toBe("__other__");
+  });
+
+  it("never lets a literal sentinel-named tag define or hijack a cluster", () => {
+    const nodes = [node("x", ["__other__"]), node("y", ["__untagged__"]), node("z", ["__autopattern__"])];
+    assignGraphClusters(nodes);
+    // sentinel-named tags are filtered out, so these have no candidate tags at all
+    expect(byId(nodes, "x").cluster).toBe("__untagged__");
+    expect(byId(nodes, "y").cluster).toBe("__untagged__");
+    expect(byId(nodes, "z").cluster).toBe("__untagged__");
+  });
+
+  it("folds tiny categories into a larger alternative, or Other", () => {
+    const nodes = [
+      ...Array.from({ length: 10 }, (_, i) => node(`a${i}`, ["alpha"])),
+      ...Array.from({ length: 8 }, (_, i) => node(`b${i}`, ["beta"])),
+      // gamma is shared by only 2 memories; both also carry alpha -> re-home to alpha
+      node("g0", ["gamma", "alpha"]),
+      node("g1", ["gamma", "alpha"]),
+      // epsilon is shared by only 2 memories with no alternative -> Other
+      node("e0", ["epsilon"]),
+      node("e1", ["epsilon"]),
+    ];
+    assignGraphClusters(nodes);
+    expect(byId(nodes, "g0").cluster).toBe("alpha");
+    expect(byId(nodes, "g1").cluster).toBe("alpha");
+    expect(byId(nodes, "e0").cluster).toBe("__other__");
+    expect(byId(nodes, "e1").cluster).toBe("__other__");
+  });
+
+  it("is deterministic", () => {
+    const make = () => [
+      ...Array.from({ length: 6 }, (_, i) => node(`a${i}`, ["alpha", i % 2 ? "x" : "y"])),
+      ...Array.from({ length: 5 }, (_, i) => node(`b${i}`, ["beta"])),
+      node("m", ["alpha", "beta", "x"]),
+    ];
+    const one = assignGraphClusters(make());
+    const two = assignGraphClusters(make());
+    expect(one.map((n: N) => [n.id, n.cluster, n.sub])).toEqual(two.map((n: N) => [n.id, n.cluster, n.sub]));
+  });
+});
+
+describe("assignGraphClusters — sub-topics", () => {
+  // travel and cooking categories, each well under half the store; 'sync' is a
+  // cross-cutting tag that lives mostly in cooking.
+  const makeStore = () => [
+    ...Array.from({ length: 8 }, (_, i) => node(`t${i}`, ["travel"])),
+    node("j0", ["travel", "japan"]),
+    node("j1", ["travel", "japan"]),
+    node("j2", ["travel", "japan"]),
+    node("j3", ["travel", "japan", "tokyo"]),
+    node("i0", ["travel", "italy"]),
+    node("i1", ["travel", "italy"]),
+    node("i2", ["travel", "italy"]),
+    node("solo", ["travel", "one-off"]),
+    node("ts0", ["travel", "sync"]),
+    node("ts1", ["travel", "sync"]),
+    ...Array.from({ length: 13 }, (_, i) => node(`c${i}`, ["cooking"])),
+    ...Array.from({ length: 5 }, (_, i) => node(`cs${i}`, ["cooking", "sync"])),
+    ...Array.from({ length: 8 }, (_, i) => node(`g${i}`, ["garden"])),
+  ];
+
+  it("forms sub-groups from shared, category-contained tags", () => {
+    const nodes = assignGraphClusters(makeStore());
+    expect(byId(nodes, "j0").cluster).toBe("travel");
+    expect(byId(nodes, "j0").sub).toBe("japan");
+    expect(byId(nodes, "j3").sub).toBe("japan"); // dominant shared tag beats its unique tokyo
+    expect(byId(nodes, "i0").sub).toBe("italy");
+  });
+
+  it("rejects cross-cutting tags that mostly live in other categories", () => {
+    const nodes = assignGraphClusters(makeStore());
+    // sync: 2 of 7 uses are in travel (under half) -> not a travel sub-topic...
+    expect(byId(nodes, "ts0").sub).toBeNull();
+    // ...but 5 of 7 uses are in cooking -> a genuine cooking sub-topic
+    expect(byId(nodes, "cs0").sub).toBe("sync");
+  });
+
+  it("leaves members without a shared sub-topic loose", () => {
+    const nodes = assignGraphClusters(makeStore());
+    expect(byId(nodes, "solo").sub).toBeNull(); // its extra tag is unique
+    expect(byId(nodes, "t0").sub).toBeNull(); // no extra tags at all
+    expect(byId(nodes, "g0").sub).toBeNull(); // category with no sub-topics
+  });
+});
+
+describe("packGraphNodes", () => {
+  it("centers a single node and returns empty for zero", () => {
+    expect(packGraphNodes(0, 50)).toEqual([]);
+    expect(packGraphNodes(1, 50)).toEqual([{ x: 0, y: 0 }]);
+  });
+
+  it("keeps k nodes inside the disc radius", () => {
+    const R = 40;
+    const pts = packGraphNodes(25, R);
+    expect(pts).toHaveLength(25);
+    for (const p of pts) expect(Math.hypot(p.x, p.y)).toBeLessThanOrEqual(R + 1e-9);
+    // points are distinct
+    const uniq = new Set(pts.map((p: { x: number; y: number }) => `${p.x.toFixed(6)},${p.y.toFixed(6)}`));
+    expect(uniq.size).toBe(25);
+  });
+});
+
+describe("packGraphCircles", () => {
+  const assertNoOverlap = (radii: number[], gap: number) => {
+    const { centers, R } = packGraphCircles(radii, gap);
+    expect(centers).toHaveLength(radii.length);
+    let maxEdge = 0;
+    for (let i = 0; i < radii.length; i++) {
+      expect(Number.isFinite(centers[i].x)).toBe(true);
+      expect(Number.isFinite(centers[i].y)).toBe(true);
+      maxEdge = Math.max(maxEdge, Math.hypot(centers[i].x, centers[i].y) + radii[i]);
+      for (let j = i + 1; j < radii.length; j++) {
+        const d = Math.hypot(centers[i].x - centers[j].x, centers[i].y - centers[j].y);
+        expect(d + 1e-6).toBeGreaterThanOrEqual(radii[i] + radii[j] + gap);
+      }
+    }
+    // the reported bounding radius covers every circle
+    expect(R + 1e-6).toBeGreaterThanOrEqual(maxEdge);
+    return { centers, R };
+  };
+
+  it("handles empty and single inputs", () => {
+    expect(packGraphCircles([], 10)).toEqual({ centers: [], R: 0 });
+    expect(packGraphCircles([42], 10)).toEqual({ centers: [{ x: 0, y: 0 }], R: 42 });
+  });
+
+  it("packs mixed sizes with no overlap and honors input order", () => {
+    const radii = [80, 15, 40, 200, 22, 60, 9, 120];
+    assertNoOverlap(radii, 24);
+  });
+
+  it("packs a huge circle among small ones without overlap", () => {
+    assertNoOverlap([600, 20, 30, 25, 40, 18, 22], 24);
+  });
+
+  it("stays tight and finite for many circles", () => {
+    const radii = Array.from({ length: 200 }, (_, i) => 10 + (i % 17) * 3);
+    const { R } = assertNoOverlap(radii, 7);
+    // tight-ish: the bounding circle should be far smaller than laying circles in a line
+    const worst = radii.reduce((a, r) => a + 2 * r, 0);
+    expect(R).toBeLessThan(worst / 4);
+  });
+
+  it("is deterministic", () => {
+    const radii = [30, 55, 10, 80, 44, 12, 66];
+    const a = packGraphCircles(radii, 12);
+    const b = packGraphCircles(radii, 12);
+    expect(a).toEqual(b);
+  });
+});


### PR DESCRIPTION
## What this does

Replaces the force-directed graph view with a static, deterministic clustered layout. Memories now group into broad category circles derived from their tags, with shared sub-topic circles nested inside each category. Nodes are colored by category, categories get outline rings and labels, and a legend sits in the corner. Positions are computed once when the graph loads; nothing animates.

## Why

The force layout got noisy as stores grew: memories scattered into dozens of tiny one-node islands, a single dominant tag swallowed everything into one giant blob, and the simulation spun before settling. A static clustered view reads at a glance, matches how people actually think about their memories (topics containing sub-topics), and behaves the same for a 40-memory store and a 4,000-memory one.

## How the clustering works

All thresholds scale with store size so this generalizes across users:

- Each memory joins the broadest of its tags that still distinguishes it. A near-universal tag (on half the store or more) does not distinguish anything, so it is skipped in favor of the memory's more focused tags. Memories whose only tags are near-universal still group under them.
- A tag needs at least 2 memories to define a cluster, and tiny categories (under ~1% of the store, floor 3) fold into the memory's largest alternative category or Other, so the graph never scatters into single-node circles.
- Within each category, a tag shared by 2+ members that lives mostly inside that category becomes a nested sub-circle (a japan tag concentrated in travel qualifies; a cross-cutting urgent tag spread across many categories does not).
- Auto-pattern entries get their own bucket instead of polluting Untagged.
- Assignment is fully deterministic (ties break by share, then specificity, then alphabetically).

## Layout

Scale-invariant circle packing, no physics: phyllotaxis for nodes within a disc, and a closest-to-center ring scan to pack sub-discs inside categories and categories on the canvas, with no overlap at any size. Pan, zoom, pinch, hover, and tap-to-open still work; node dragging is gone along with the simulation. Edges and the hover ring use theme-aware ink so they are visible in dark mode, and the graph repaints when the theme toggles.

## Code layout and tests

The pure logic is extracted into `public/utils.js` following the existing pattern there:

- `assignGraphClusters(nodes)` sets `n.cluster` and `n.sub` per the rules above
- `packGraphNodes(k, R)` phyllotaxis offsets
- `packGraphCircles(radii, gap)` non-overlapping packing

Covered by `test/ui/graph-clusters.test.ts` with 17 tests: grouping rules, dominant-tag demotion, folds to alternative/Other, sentinel guards, sub-topic formation and cross-cutting rejection, packing invariants (no overlap, finite, bounded, tight), and determinism.

Full suite: 590 passed. `npm run typecheck` clean. Single-file dashboard stays dependency-free (no build step, no external libraries).