### PR TITLE
Strip execution metadata from MCP tools/list responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2601,6 +2601,91 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
   return server;
 }
 
+// ─── MCP tools/list sanitization ──────────────────────────────────────────────
+// Newer @modelcontextprotocol/sdk releases attach an `execution` (task-support)
+// field to each tool definition in tools/list responses. Strict MCP clients —
+// OpenAI Codex at the time of writing — reject the entire tool list when they
+// see the unknown field, which breaks the connection outright. Strip it so any
+// client can connect; the server doesn't use MCP task execution, so nothing is
+// lost. Remove this shim if we ever adopt task execution or once strict clients
+// tolerate unknown fields.
+//
+// Bug discovered, and fix originally authored, in the
+// guoyingwei6/second-brain-cloudflare fork (commit a3fa15f).
+
+export async function isMcpToolsListRequest(request: Request): Promise<boolean> {
+  if (request.method !== "POST") return false;
+  try {
+    const payload = await request.clone().json();
+    return isRecord(payload) && payload.method === "tools/list";
+  } catch {
+    return false;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function removeToolExecutionMetadata(payload: unknown): unknown {
+  if (!isRecord(payload) || !isRecord(payload.result) || !Array.isArray(payload.result.tools)) {
+    return payload;
+  }
+
+  const tools = payload.result.tools.map(tool => {
+    if (!isRecord(tool) || !("execution" in tool)) return tool;
+    const { execution: _execution, ...toolWithoutExecution } = tool;
+    return toolWithoutExecution;
+  });
+
+  return {
+    ...payload,
+    result: {
+      ...payload.result,
+      tools,
+    },
+  };
+}
+
+export async function sanitizeToolsListResponse(response: Response): Promise<Response> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json") && !contentType.includes("text/event-stream")) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+
+  if (contentType.includes("text/event-stream")) {
+    const body = await response.text();
+    const sanitized = body.split("\n").map(line => {
+      if (!line.startsWith("data: ")) return line;
+      try {
+        return `data: ${JSON.stringify(removeToolExecutionMetadata(JSON.parse(line.slice(6))))}`;
+      } catch {
+        return line;
+      }
+    }).join("\n");
+
+    return new Response(sanitized, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+
+  try {
+    const payload = await response.json();
+    return new Response(JSON.stringify(removeToolExecutionMetadata(payload)), {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  } catch {
+    return response;
+  }
+}
+
 // ─── OAuth API handler — /mcp only ────────────────────────────────────────────
 // OAuthProvider validates the token (OAuth grant, or the static AUTH_TOKEN via
 // resolveExternalToken) before delegating to this handler.
@@ -2611,7 +2696,9 @@ const apiHandler = {
       ctx.waitUntil(initializeDatabase(env).then(() => { dbReady = true; }));
     }
     const server = buildMcpServer(env, ctx);
-    return createMcpHandler(server)(request, env, ctx);
+    const isToolsList = await isMcpToolsListRequest(request);
+    const response = await createMcpHandler(server)(request, env, ctx);
+    return isToolsList ? sanitizeToolsListResponse(response) : response;
   },
 };
 

--- a/test/unit/sanitize-tools-list.test.ts
+++ b/test/unit/sanitize-tools-list.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+  isMcpToolsListRequest,
+  removeToolExecutionMetadata,
+  sanitizeToolsListResponse,
+} from "../../src/index";
+
+const toolsListPayload = (tools: unknown[]) => ({
+  jsonrpc: "2.0",
+  id: 1,
+  result: { tools },
+});
+
+const TOOL_WITH_EXECUTION = {
+  name: "remember",
+  description: "Store a memory",
+  inputSchema: { type: "object" },
+  execution: { taskSupport: "optional" },
+};
+
+describe("isMcpToolsListRequest()", () => {
+  const post = (body: string) =>
+    new Request("https://example.com/mcp", { method: "POST", body });
+
+  it("detects a JSON-RPC tools/list POST", async () => {
+    expect(await isMcpToolsListRequest(post(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" })))).toBe(true);
+  });
+
+  it("rejects other methods, non-POSTs, and unparseable bodies", async () => {
+    expect(await isMcpToolsListRequest(post(JSON.stringify({ method: "tools/call" })))).toBe(false);
+    expect(await isMcpToolsListRequest(new Request("https://example.com/mcp", { method: "GET" }))).toBe(false);
+    expect(await isMcpToolsListRequest(post("not json")).catch(() => false)).toBe(false);
+    expect(await isMcpToolsListRequest(post(JSON.stringify(["tools/list"])))).toBe(false);
+  });
+
+  it("leaves the request body readable for the downstream handler", async () => {
+    const body = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+    const request = post(body);
+    await isMcpToolsListRequest(request);
+    expect(await request.text()).toBe(body);
+  });
+});
+
+describe("removeToolExecutionMetadata()", () => {
+  it("strips execution from each tool and preserves everything else", () => {
+    const out = removeToolExecutionMetadata(toolsListPayload([TOOL_WITH_EXECUTION])) as any;
+    expect(out.result.tools[0]).toEqual({
+      name: "remember",
+      description: "Store a memory",
+      inputSchema: { type: "object" },
+    });
+    expect(out.jsonrpc).toBe("2.0");
+    expect(out.id).toBe(1);
+  });
+
+  it("leaves tools without an execution field untouched", () => {
+    const tool = { name: "recall", inputSchema: { type: "object" } };
+    const out = removeToolExecutionMetadata(toolsListPayload([tool])) as any;
+    expect(out.result.tools[0]).toEqual(tool);
+  });
+
+  it("returns non-tools/list payloads unchanged", () => {
+    const error = { jsonrpc: "2.0", id: 1, error: { code: -32600 } };
+    expect(removeToolExecutionMetadata(error)).toBe(error);
+    expect(removeToolExecutionMetadata(null)).toBe(null);
+    expect(removeToolExecutionMetadata("text")).toBe("text");
+  });
+});
+
+describe("sanitizeToolsListResponse()", () => {
+  it("sanitizes a plain JSON response and drops content-length", async () => {
+    const body = JSON.stringify(toolsListPayload([TOOL_WITH_EXECUTION]));
+    const response = new Response(body, {
+      headers: { "content-type": "application/json", "content-length": String(body.length), "mcp-session-id": "abc" },
+    });
+
+    const sanitized = await sanitizeToolsListResponse(response);
+    const payload = await sanitized.json() as any;
+
+    expect(payload.result.tools[0].execution).toBeUndefined();
+    expect(payload.result.tools[0].name).toBe("remember");
+    expect(sanitized.headers.get("content-length")).toBeNull();
+    expect(sanitized.headers.get("mcp-session-id")).toBe("abc");
+  });
+
+  it("sanitizes data: lines in an SSE response and preserves other lines", async () => {
+    const sse = [
+      "event: message",
+      `data: ${JSON.stringify(toolsListPayload([TOOL_WITH_EXECUTION]))}`,
+      "",
+    ].join("\n");
+    const response = new Response(sse, { headers: { "content-type": "text/event-stream" } });
+
+    const sanitized = await sanitizeToolsListResponse(response);
+    const lines = (await sanitized.text()).split("\n");
+
+    expect(lines[0]).toBe("event: message");
+    const payload = JSON.parse(lines[1].slice("data: ".length));
+    expect(payload.result.tools[0].execution).toBeUndefined();
+    expect(payload.result.tools[0].name).toBe("remember");
+  });
+
+  it("passes through non-JSON/SSE responses and unparseable bodies unchanged", async () => {
+    const html = new Response("<html></html>", { headers: { "content-type": "text/html" } });
+    expect(await sanitizeToolsListResponse(html)).toBe(html);
+
+    const broken = new Response("not json", { headers: { "content-type": "application/json" } });
+    const out = await sanitizeToolsListResponse(broken);
+    expect(out).toBe(broken);
+  });
+});


### PR DESCRIPTION
## Problem

Newer `@modelcontextprotocol/sdk` releases (which we pull in via `^1.0.0`) attach an `execution` (task-support) field to each tool definition in `tools/list` responses. Strict MCP clients — OpenAI Codex at the time of writing — reject the entire tool list when they encounter the unknown field, which breaks the connection outright. Since this server is meant to work with any MCP client, that's a compatibility bug for anyone deploying fresh and connecting Codex.

Bug discovered, and fix originally authored, in the [guoyingwei6/second-brain-cloudflare](https://github.com/guoyingwei6/second-brain-cloudflare) fork (commit a3fa15f).

## Fix

Sanitize `tools/list` responses before they reach the client:

- `isMcpToolsListRequest()` — detects JSON-RPC `tools/list` POSTs (clones the request, so the body stays readable downstream)
- `removeToolExecutionMetadata()` — strips the `execution` field from each tool, preserving everything else
- `sanitizeToolsListResponse()` — applies the strip to both plain JSON and SSE response bodies, dropping the stale `content-length` header; fails open (any parse failure returns the response unchanged)

Wired into `apiHandler` so only `tools/list` responses are touched — all other MCP traffic passes through untouched. The server doesn't use MCP task execution, so nothing is lost. The shim should be removed if we ever adopt task execution, or once strict clients tolerate unknown fields.

## Testing

- New unit suite `test/unit/sanitize-tools-list.test.ts` (9 tests): request detection, body readability after sniffing, metadata stripping, JSON + SSE sanitization, and fail-open passthrough
- Full suite on the v2 base: 599 tests across 57 files, all passing

---
_Generated by [Claude Code](https://claude.ai/code/session_016CTmMMpofKNkboteUNukvs)_