### PR TITLE
fix(installer): notarize and staple the macOS DMG

### DIFF
--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -125,6 +125,22 @@ jobs:
           releaseDraft: true
           uploadWorkflowArtifacts: ${{ !startsWith(github.ref, 'refs/tags/installer-v') }}
 
+      # tauri-action notarizes and staples the .app but not the .dmg that wraps
+      # it — a signed-but-un-notarized DMG still trips Gatekeeper on download.
+      # Notarize + staple the DMG itself so the downloaded file is clean too.
+      - name: Notarize macOS DMG
+        if: matrix.platform == 'macos-latest' && env.MAC_SIGNED == '1'
+        shell: bash
+        run: |
+          DMG=$(find src-tauri/target/universal-apple-darwin/release/bundle/dmg -name "*.dmg" | head -1)
+          echo "Notarizing $DMG"
+          xcrun notarytool submit "$DMG" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          xcrun stapler staple "$DMG"
+
       # ── Post-build signature verification (signed builds fail CI if bad) ───
       - name: Verify macOS signature
         if: matrix.platform == 'macos-latest' && env.MAC_SIGNED == '1'
@@ -133,7 +149,12 @@ jobs:
           APP=$(find src-tauri/target/universal-apple-darwin/release/bundle/macos -name "*.app" | head -1)
           DMG=$(find src-tauri/target/universal-apple-darwin/release/bundle/dmg -name "*.dmg" | head -1)
           echo "Verifying $APP and $DMG"
+          # App: valid Developer ID signature + notarized & stapled
           codesign --verify --deep --strict --verbose=2 "$APP"
+          xcrun stapler validate "$APP"
+          spctl -a -t exec -vv "$APP"
+          # DMG: notarized & stapled (the artifact users actually download)
+          xcrun stapler validate "$DMG"
           spctl -a -t open --context context:primary-signature -v "$DMG"
 
       - name: Verify Windows signature


### PR DESCRIPTION
The signed build run showed notarization of the `.app` succeeding (`status: Accepted`), but the release job still failed at signature verification with `source=Unnotarized Developer ID` on the **`.dmg`**.

`tauri-action` notarizes and staples the `.app` bundle but not the `.dmg` container that wraps it. A Developer-ID-signed but un-notarized DMG still triggers Gatekeeper's "cannot be checked for malicious software" warning on download — exactly what this app exists to avoid for non-technical users.

This adds a step (signed builds only) that submits the DMG to `notarytool` and staples it, and tightens the verification step to confirm both the `.app` and the `.dmg` are notarized and stapled (`stapler validate` + `spctl`).

No effect on unsigned builds — the new step is gated on `MAC_SIGNED`.