### PR TITLE
chore(installer): bump version to 0.1.1 for first signed release

### DIFF
--- a/installer/package.json
+++ b/installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "second-brain-installer",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -3348,7 +3348,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "second-brain-desktop"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain-desktop"
-version = "0.1.0"
+version = "0.1.1"
 description = "Second Brain desktop app — one-click setup and a native shell for your own memory dashboard"
 edition = "2021"
 rust-version = "1.82"

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Second Brain",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.secondbrain.desktop",
   "build": {
     "beforeDevCommand": "npm run bundle-worker && npm run dev",


### PR DESCRIPTION
Bumps the desktop app version to `0.1.1` across `tauri.conf.json`, `Cargo.toml`, `package.json`, and `Cargo.lock`.

This is the version that will be tagged `installer-v0.1.1` to produce the first **signed and notarized** macOS release. Signing + notarization of both the `.app` and `.dmg` are verified passing in CI (run 29382648782). The Windows build remains unsigned pending SignPath Foundation approval.

No code changes — version metadata only.