### PR TITLE
feat(installer): app self-update (check for updates from within the app)

### DIFF
--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -110,10 +110,33 @@ jobs:
             Write-Host "::notice::WINDOWS_CERTIFICATE not configured - producing an UNSIGNED Windows build (testing only)."
           }
 
+      # ── Updater artifacts (skipped cleanly when the signing key is absent) ──
+      # When TAURI_SIGNING_PRIVATE_KEY is set, enable createUpdaterArtifacts so
+      # the build emits the signed update package + latest.json (uploaded to the
+      # release by tauri-action). Guards against shipping the placeholder pubkey.
+      - name: Enable updater artifacts
+        shell: bash
+        env:
+          UPDATER_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: |
+          if [ -n "$UPDATER_KEY" ]; then
+            if grep -q "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDJFNjgxMENBRTVCRENEOTQK" src-tauri/tauri.conf.json; then
+              echo "::error::The updater pubkey in tauri.conf.json is still the development placeholder. Generate your own key and replace plugins.updater.pubkey before shipping updates (see installer/README.md)."
+              exit 1
+            fi
+            node -e "const f='src-tauri/tauri.conf.json';const fs=require('fs');const c=JSON.parse(fs.readFileSync(f));c.bundle.createUpdaterArtifacts=true;fs.writeFileSync(f,JSON.stringify(c,null,2))"
+            echo "UPDATER_ENABLED=1" >> "$GITHUB_ENV"
+            echo "Updater artifacts enabled."
+          else
+            echo "::notice::TAURI_SIGNING_PRIVATE_KEY not set — building without in-app updates."
+          fi
+
       - name: Build (and release on tag)
         uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: installer
           args: ${{ matrix.args }}

--- a/installer/README.md
+++ b/installer/README.md
@@ -120,6 +120,37 @@ The Windows job imports the `.pfx`, points Tauri at its thumbprint, timestamps a
 
 For the EV/cloud route: skip those two secrets, store the provider's API credentials as secrets instead, and replace the "Enable Windows signing" step with the provider's CLI plus a `signCommand` config (e.g. `"signCommand": "artifact-signing-cli -e https://…azure.net -a Account -c Profile -d SecondBrain %1"`). Document which route is active here when you set it up.
 
+### In-app updates — updater signing key (one-time)
+
+The app updates itself via `tauri-plugin-updater`. Updates are verified against a **minisign key** that is separate from the Apple/Windows code-signing certs above. Until you set this up, releases build without update artifacts and the in-app updater simply finds nothing — everything else still works.
+
+1. Generate the keypair once (from `installer/`):
+
+   ```bash
+   npm run tauri signer generate -- -w ~/.tauri/second-brain-updater.key
+   ```
+
+   Choose a password when prompted (it protects the private key). This writes:
+   - `~/.tauri/second-brain-updater.key` — **private key**, never commit or share.
+   - `~/.tauri/second-brain-updater.key.pub` — **public key**, safe to commit.
+
+2. Replace the `pubkey` value in `src-tauri/tauri.conf.json` (`plugins.updater.pubkey`) with the **full contents** of `second-brain-updater.key.pub`. The repo currently ships a development placeholder; CI **fails on purpose** if you enable updates without replacing it.
+
+   ```bash
+   cat ~/.tauri/second-brain-updater.key.pub
+   ```
+
+3. Add two GitHub Secrets:
+
+   | Secret | Value |
+   | --- | --- |
+   | `TAURI_SIGNING_PRIVATE_KEY` | the full contents of `second-brain-updater.key` |
+   | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | the password from step 1 |
+
+4. Back up the private key + password (a password manager). **If you lose them, you can never ship another auto-update** — users would have to re-download manually.
+
+The release workflow enables `createUpdaterArtifacts` and uploads `latest.json` automatically whenever `TAURI_SIGNING_PRIVATE_KEY` is present. The app's update endpoint is the repo's `releases/latest/download/latest.json`. In-app updates become functional starting from the **first release built with the key in place** — users on an earlier build download that one manually once, and every release after updates in-app.
+
 ### Cut a release
 
 The version does **not** auto-increment. Bump it first in `src-tauri/tauri.conf.json` (`"version"`) — that value names the artifacts (`Second Brain_X.Y.Z_….dmg`) and fills the release title. Keep `src-tauri/Cargo.toml` and `package.json` in step with it for tidiness (they don't drive the release, but drift is confusing). Then commit, and tag **matching that version** — the tag itself is what triggers the workflow, and a tag that disagrees with the config produces a release whose title and filenames don't match its tag:

--- a/installer/package-lock.json
+++ b/installer/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "second-brain-installer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "second-brain-installer",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@tauri-apps/api": "^2.9.0"
+        "@tauri-apps/api": "^2.9.0",
+        "@tauri-apps/plugin-process": "^2.3.0",
+        "@tauri-apps/plugin-updater": "^2.9.0"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2.9.0",
@@ -1034,6 +1036,24 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@types/estree": {

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +770,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1080,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1977,6 +2007,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2254,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2464,6 +2530,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,6 +2616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +2645,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3147,15 +3245,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3248,6 +3351,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,6 +3371,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3287,6 +3429,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3366,6 +3517,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "thiserror 2.0.18",
  "tiny_http",
@@ -3642,6 +3794,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3842,7 +4010,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3876,6 +4044,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3898,7 +4077,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -4106,6 +4285,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-plugin-window-state"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4130,7 +4342,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -4153,7 +4365,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -5059,6 +5271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5625,7 +5846,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5688,6 +5909,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"
@@ -5851,6 +6082,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-plugin-window-state = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "multipart"] }

--- a/installer/src-tauri/src/app_update.rs
+++ b/installer/src-tauri/src/app_update.rs
@@ -1,0 +1,87 @@
+//! App self-update, driven entirely from Rust so it works in every window
+//! (including the remote wrapper window, which has no IPC). Checks GitHub
+//! Releases for a newer signed build, asks the user with a native dialog, then
+//! downloads, verifies (minisign), installs, and relaunches.
+
+use tauri::AppHandle;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+use tauri_plugin_updater::UpdaterExt;
+
+/// Entry point. `silent` = true for the on-launch check (say nothing unless an
+/// update exists); false for the menu item (also confirm "up to date" / errors).
+pub fn check_for_updates(app: &AppHandle, silent: bool) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        match run_check(&app).await {
+            Ok(Some(update)) => prompt_and_install(&app, update).await,
+            Ok(None) => {
+                if !silent {
+                    info_dialog(&app, "You're up to date", "You have the latest version of Second Brain.");
+                }
+            }
+            Err(e) => {
+                log::warn!("update check failed: {e}");
+                if !silent {
+                    info_dialog(
+                        &app,
+                        "Couldn't check for updates",
+                        "We couldn't check for updates right now. Please try again later.",
+                    );
+                }
+            }
+        }
+    });
+}
+
+async fn run_check(app: &AppHandle) -> Result<Option<tauri_plugin_updater::Update>, String> {
+    let updater = app.updater().map_err(|e| e.to_string())?;
+    updater.check().await.map_err(|e| e.to_string())
+}
+
+async fn prompt_and_install(app: &AppHandle, update: tauri_plugin_updater::Update) {
+    let version = update.version.clone();
+    let notes = update
+        .body
+        .clone()
+        .filter(|b| !b.trim().is_empty())
+        .map(|b| format!("\n\nWhat's new:\n{}", b.trim()))
+        .unwrap_or_default();
+    let message = format!(
+        "Second Brain {version} is available.\n\nUpdate now? The app will download it and restart.{notes}"
+    );
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.dialog()
+        .message(message)
+        .title("Update available")
+        .kind(MessageDialogKind::Info)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Update now".to_string(),
+            "Later".to_string(),
+        ))
+        .show(move |accepted| {
+            let _ = tx.send(accepted);
+        });
+
+    if rx.await.unwrap_or(false) {
+        match update.download_and_install(|_downloaded, _total| {}, || {}).await {
+            Ok(()) => app.restart(),
+            Err(e) => {
+                log::error!("update install failed: {e}");
+                info_dialog(
+                    app,
+                    "Update didn't finish",
+                    "Something went wrong installing the update. Your app is unchanged — please try again later.",
+                );
+            }
+        }
+    }
+}
+
+fn info_dialog(app: &AppHandle, title: &str, message: &str) {
+    app.dialog()
+        .message(message)
+        .title(title)
+        .kind(MessageDialogKind::Info)
+        .blocking_show();
+}

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@
 //!   * afterwards → a native shell around the user's own Worker dashboard
 //! Mode is decided by whether OS-secure storage holds a completed setup.
 
+mod app_update;
 mod cf;
 mod commands;
 mod mcp_config;
@@ -62,6 +63,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(SetupSession::new(dry_run))
         .invoke_handler(tauri::generate_handler![
             commands::get_app_state,
@@ -90,11 +92,14 @@ pub fn run() {
                 true,
                 Some("CmdOrCtrl+D"),
             )?;
+            let update_item =
+                MenuItem::with_id(app, "menu-update", "Check for updates…", true, None::<&str>)?;
             let logout_item =
                 MenuItem::with_id(app, "menu-logout", "Log out…", true, None::<&str>)?;
             let menu = Menu::default(&handle)?;
             let connections = SubmenuBuilder::new(app, "Connections")
                 .item(&details_item)
+                .item(&update_item)
                 .separator()
                 .item(&logout_item)
                 .build()?;
@@ -102,6 +107,7 @@ pub fn run() {
             app.set_menu(menu)?;
             app.on_menu_event(|app, event| match event.id().as_ref() {
                 "menu-details" => windows::open_details_window(app),
+                "menu-update" => app_update::check_for_updates(app, false),
                 "menu-logout" => confirm_logout(app),
                 _ => {}
             });
@@ -139,6 +145,12 @@ pub fn run() {
                     windows::open_wrapper_window(&handle, &info.worker_url, &info.auth_token)?
                 }
                 _ => windows::open_setup_window(&handle)?,
+            }
+
+            // Quiet check for an app update on launch (says nothing unless one
+            // exists). Skipped in dry-run so demos don't hit the network.
+            if !dry_run {
+                app_update::check_for_updates(&handle, true);
             }
             Ok(())
         })

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -17,7 +17,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDJFNjgxMENBRTVCRENEOTQKUldTVXpiM2x5aEJvTHBmcndNbGw5OWo3SGhhTjdBazBMUTd0L2kvdE0zQVgveThJcXRCMTFQYnoK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZEQzBDMjBCQjBDRDdBRTEKUldUaGVzMndDOExBYmQ5SW5DUk50K2h2MjlIR1A1b0dCT2ZkNm9sOGpmYnlvVWF6dndLaVNpRC8K",
       "endpoints": [
         "https://github.com/rahilp/second-brain-cloudflare/releases/latest/download/latest.json"
       ],

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -15,9 +15,21 @@
       "csp": null
     }
   },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDJFNjgxMENBRTVCRENEOTQKUldTVXpiM2x5aEJvTHBmcndNbGw5OWo3SGhhTjdBazBMUTd0L2kvdE0zQVgveThJcXRCMTFQYnoK",
+      "endpoints": [
+        "https://github.com/rahilp/second-brain-cloudflare/releases/latest/download/latest.json"
+      ],
+      "windows": {
+        "installMode": "passive"
+      }
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": false,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Unit A of the in-app updates design (`docs/superpowers/specs/2026-07-15-in-app-updates-design.md`).

The desktop app can now check for and install its own updates:

- **`tauri-plugin-updater`** drives a check against the repo's `releases/latest/download/latest.json`. Runs quietly on launch (says nothing unless an update exists) and on demand via a new **Connections → Check for updates…** menu item.
- The whole flow is **Rust-side** (check → native dialog with release notes → download → minisign-verify → install → relaunch), so it works in the remote wrapper window, which has no IPC.
- **CI**: when `TAURI_SIGNING_PRIVATE_KEY` is present, the build enables `createUpdaterArtifacts` and `tauri-action` uploads the signed update package + `latest.json`. Absent → builds without update artifacts (graceful, same pattern as code signing). A guard fails the build if updates are enabled while the pubkey is still the dev placeholder.
- **Docs**: `installer/README.md` gains the one-time updater-key runbook (`tauri signer generate` → replace `pubkey` → add two secrets).

Verified locally: the build emits `Second Brain.app.tar.gz` + `.sig` with a dev key; 27 Rust tests pass; workflow YAML lints.

### Maintainer step before this ships updates
Generate the real updater key and replace the placeholder `pubkey` in `tauri.conf.json`, then add `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` secrets (runbook in `installer/README.md`). In-app updates activate from the first release built with the key in place.

Worker update (Unit B) follows in a separate PR.