### PR TITLE
feat(installer): update the deployed Worker from within the app

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -135,6 +135,21 @@ Two jobs build in parallel (macOS universal binary; Windows NSIS installer), eac
 
 ---
 
+## Worker versioning
+
+The app can update a user's deployed Worker in place (preserving their memories, password, and connections). It decides whether an update is available by comparing the version the deployed Worker reports at `GET /health` against the version this app bundles.
+
+The source of truth is a single constant, **`SB_VERSION`** in `src/index.ts` (currently `2.0.0`), echoed by `/health`. The installer's bundle step reads that same constant into its manifest, so both sides always agree.
+
+To ship a Worker change:
+
+1. Make the change in `src/index.ts`.
+2. Bump `SB_VERSION` (semver: patch / minor / major).
+3. PR → squash-merge to `main`.
+4. Tag `worker-v<version>` (e.g. `worker-v2.1.0`) to mark the release — a marker for history, not a trigger.
+
+**How each audience receives it:** Cloudflare-button and manual deployers get the change when they redeploy from `main`. **Desktop-app users get it only when a new `installer-v*` release repackages it** — the app bundles the Worker at build time and never fetches it from the repo. So a Worker change intended for app users needs both the `SB_VERSION` bump *and* a following installer release; bump the installer version too so they travel together. Once a user's app updates and thus bundles the newer Worker, the app offers to redeploy it into their Cloudflare account.
+
 ## Security model
 
 - **The user's password (`AUTH_TOKEN`)** — typed on screen 2, held in Rust memory during setup, sent once to Cloudflare as the Worker secret, then stored only in the OS keychain (macOS Keychain / Windows Credential Manager) as `com.secondbrain.desktop`. Never written to disk in plaintext, never displayed again by the app.

--- a/installer/scripts/bundle-worker.mjs
+++ b/installer/scripts/bundle-worker.mjs
@@ -86,8 +86,21 @@ if (!d1 || !vectorize || !kv || !wrangler.ai?.binding) {
   throw new Error("wrangler.jsonc is missing an expected binding (d1/vectorize/kv/ai)");
 }
 
+// The bundled Worker's version — the app compares this against a deployed
+// Worker's /health version to offer updates. Read from the same SB_VERSION
+// constant the Worker echoes, so both sides always agree.
+const workerSource = readFileSync(resolve(repoRoot, wrangler.main), "utf8");
+const versionMatch = workerSource.match(
+  /export\s+const\s+SB_VERSION\s*=\s*["']([^"']+)["']/,
+);
+if (!versionMatch) {
+  throw new Error("could not find `export const SB_VERSION = \"...\"` in the Worker source");
+}
+const workerVersion = versionMatch[1];
+
 const manifest = {
   scriptName: wrangler.name,
+  workerVersion,
   compatibilityDate: wrangler.compatibility_date,
   compatibilityFlags: wrangler.compatibility_flags ?? [],
   vars: wrangler.vars ?? {},

--- a/installer/src-tauri/src/cf/api.rs
+++ b/installer/src-tauri/src/cf/api.rs
@@ -279,6 +279,21 @@ impl CfClient {
         Ok(())
     }
 
+    /// Reads a deployed script's current bindings (from its settings), so an
+    /// update can reuse the *actual* database/namespace/index IDs already
+    /// bound rather than guessing by name.
+    pub async fn get_script_bindings(
+        &self,
+        script: &str,
+    ) -> Result<Vec<serde_json::Value>, CfApiError> {
+        let url = self.url(&self.account_path(&format!("/workers/scripts/{script}/settings")));
+        let settings: Option<serde_json::Value> = self.send(|h| h.get(&url)).await?;
+        Ok(settings
+            .and_then(|s| s.get("bindings").cloned())
+            .and_then(|b| b.as_array().cloned())
+            .unwrap_or_default())
+    }
+
     pub async fn set_cron(&self, script: &str, crons: &[String]) -> Result<(), CfApiError> {
         let url = self.url(&self.account_path(&format!("/workers/scripts/{script}/schedules")));
         // Body is a bare array, not an object.
@@ -384,6 +399,32 @@ pub async fn worker_health_ok(worker_url: &str, auth_token: &str) -> Result<bool
     }
     let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
     Ok(body["ok"] == true && body["vectorize"]["ok"] == true)
+}
+
+/// GET /health and return the Worker's reported `version` (None if the field
+/// is absent — e.g. a deployment predating the version echo).
+pub async fn worker_version(
+    worker_url: &str,
+    auth_token: &str,
+) -> Result<Option<String>, CfApiError> {
+    let http = reqwest::Client::new();
+    let resp = http
+        .get(format!("{worker_url}/health"))
+        .bearer_auth(auth_token)
+        .timeout(Duration::from_secs(20))
+        .send()
+        .await?;
+    if resp.status().as_u16() == 401 {
+        return Err(CfApiError::Unauthorized);
+    }
+    if !resp.status().is_success() {
+        return Ok(None);
+    }
+    let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+    Ok(body
+        .get("version")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string()))
 }
 
 /// POST /capture — end-to-end write test. A `duplicate` response counts as a

--- a/installer/src-tauri/src/cf/backend.rs
+++ b/installer/src-tauri/src/cf/backend.rs
@@ -67,6 +67,12 @@ impl Backend for LiveBackend {
     async fn capture_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError> {
         api::worker_capture_ok(worker_url, auth_token).await
     }
+    async fn get_script_bindings(
+        &self,
+        script: &str,
+    ) -> Result<Vec<serde_json::Value>, CfApiError> {
+        self.client.get_script_bindings(script).await
+    }
     async fn sleep(&self, duration: Duration) {
         tokio::time::sleep(duration).await;
     }
@@ -143,6 +149,16 @@ impl Backend for DryRunBackend {
     }
     async fn capture_ok(&self, _worker_url: &str, _auth_token: &str) -> Result<bool, CfApiError> {
         Ok(true)
+    }
+    async fn get_script_bindings(
+        &self,
+        _script: &str,
+    ) -> Result<Vec<serde_json::Value>, CfApiError> {
+        self.pause().await;
+        Ok(vec![
+            serde_json::json!({ "type": "d1", "name": "DB", "database_id": "dryrun-d1" }),
+            serde_json::json!({ "type": "kv_namespace", "name": "OAUTH_KV", "namespace_id": "dryrun-kv" }),
+        ])
     }
     async fn sleep(&self, _duration: Duration) {}
 }

--- a/installer/src-tauri/src/cf/provision.rs
+++ b/installer/src-tauri/src/cf/provision.rs
@@ -92,6 +92,9 @@ pub trait Backend {
     async fn enable_script_subdomain(&self, script: &str) -> Result<(), CfApiError>;
     async fn health_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError>;
     async fn capture_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError>;
+    /// The deployed script's current bindings (for a preserve-everything update).
+    async fn get_script_bindings(&self, script: &str)
+        -> Result<Vec<serde_json::Value>, CfApiError>;
     async fn sleep(&self, duration: Duration);
 }
 
@@ -144,6 +147,56 @@ pub fn build_worker_metadata(
         "compatibility_date": manifest.compatibility_date,
         "compatibility_flags": manifest.compatibility_flags,
         "bindings": bindings,
+        "assets": {
+            "jwt": assets_jwt,
+            "config": {
+                "html_handling": "auto-trailing-slash",
+                "not_found_handling": "none",
+                "run_worker_first": false
+            }
+        },
+        "observability": { "enabled": true }
+    })
+}
+
+/// Pulls a binding's id/name field out of a deployed script's bindings array
+/// (as returned by the settings endpoint), matched by binding type + field.
+pub fn binding_field<'a>(
+    bindings: &'a [serde_json::Value],
+    binding_type: &str,
+    field: &str,
+) -> Option<&'a str> {
+    bindings
+        .iter()
+        .find(|b| b.get("type").and_then(|t| t.as_str()) == Some(binding_type))
+        .and_then(|b| b.get(field))
+        .and_then(|v| v.as_str())
+}
+
+/// Update metadata: same bindings as a fresh deploy, but the `AUTH_TOKEN`
+/// secret is *preserved* from the previous deployment via `keep_bindings`
+/// rather than re-sent (the app never knows the password on an update).
+pub fn build_update_metadata(
+    manifest: &WorkerManifest,
+    d1_id: &str,
+    kv_id: &str,
+    assets_jwt: &str,
+) -> serde_json::Value {
+    let mut bindings = vec![
+        serde_json::json!({ "type": "d1", "name": manifest.d1_binding, "database_id": d1_id }),
+        serde_json::json!({ "type": "vectorize", "name": manifest.vectorize_binding, "index_name": manifest.vectorize_name }),
+        serde_json::json!({ "type": "kv_namespace", "name": manifest.kv_binding, "namespace_id": kv_id }),
+        serde_json::json!({ "type": "ai", "name": manifest.ai_binding }),
+    ];
+    for (name, value) in &manifest.vars {
+        bindings.push(serde_json::json!({ "type": "plain_text", "name": name, "text": value }));
+    }
+    serde_json::json!({
+        "main_module": "worker.js",
+        "compatibility_date": manifest.compatibility_date,
+        "compatibility_flags": manifest.compatibility_flags,
+        "bindings": bindings,
+        "keep_bindings": ["secret_text", "secret_key"],
         "assets": {
             "jwt": assets_jwt,
             "config": {
@@ -280,6 +333,105 @@ pub async fn provision<B: Backend>(
     })
 }
 
+/// Redeploys the bundled (newer) Worker over an existing one, preserving the
+/// user's data, password, and connections. Reuses the deployed script's real
+/// binding IDs; the password rides along via `keep_bindings`. Idempotent and
+/// safe to retry. Reports progress through the Memory/Recall/Finish steps
+/// (Space is skipped — the account already has its address).
+pub async fn update_worker<B: Backend>(
+    backend: &B,
+    manifest: &WorkerManifest,
+    worker_url: &str,
+    auth_token: &str,
+    progress: impl Fn(StepEvent),
+) -> Result<(), ProvisionError> {
+    let emit = |step: Step, status: StepStatus| progress(StepEvent { step, status });
+    let script = manifest.script_name.as_str();
+
+    macro_rules! step {
+        ($step:expr, $body:expr) => {{
+            emit($step, StepStatus::Running);
+            match $body.await {
+                Ok(value) => {
+                    emit($step, StepStatus::Done);
+                    value
+                }
+                Err(e) => {
+                    emit($step, StepStatus::Error);
+                    return Err(e);
+                }
+            }
+        }};
+    }
+
+    // Memory — reuse the database + key-value namespace already bound to the
+    // deployed script; fall back to find-or-create only if a binding is absent.
+    let (d1_id, kv_id) = step!(Step::Memory, async {
+        let bindings = backend.get_script_bindings(script).await?;
+        let d1_id = match binding_field(&bindings, "d1", "database_id") {
+            Some(id) => id.to_string(),
+            None => match backend.find_d1(&manifest.d1_name).await? {
+                Some(id) => id,
+                None => backend.create_d1(&manifest.d1_name).await?,
+            },
+        };
+        let kv_id = match binding_field(&bindings, "kv_namespace", "namespace_id") {
+            Some(id) => id.to_string(),
+            None => match backend.find_kv(KV_TITLE).await? {
+                Some(id) => id,
+                None => backend.create_kv(KV_TITLE).await?,
+            },
+        };
+        Ok::<_, ProvisionError>((d1_id, kv_id))
+    });
+
+    // Recall — make sure the vector index exists (unchanged across updates).
+    step!(Step::Recall, async {
+        if !backend.vectorize_exists(&manifest.vectorize_name).await? {
+            backend
+                .create_vectorize(
+                    &manifest.vectorize_name,
+                    manifest.vectorize_dimensions,
+                    &manifest.vectorize_metric,
+                )
+                .await?;
+        }
+        Ok::<_, ProvisionError>(())
+    });
+
+    // Finish — upload the newer assets + Worker (password preserved), then verify.
+    step!(Step::Finish, async {
+        let assets_jwt = backend.upload_assets(script).await?;
+        let metadata = build_update_metadata(manifest, &d1_id, &kv_id, &assets_jwt);
+        backend.deploy_worker(script, &metadata).await?;
+        backend.set_cron(script, &manifest.cron).await?;
+        backend.enable_script_subdomain(script).await?;
+
+        let mut healthy = false;
+        for attempt in 0..HEALTH_ATTEMPTS {
+            match backend.health_ok(worker_url, auth_token).await {
+                Ok(true) => {
+                    healthy = true;
+                    break;
+                }
+                // A wrong token here means the secret was NOT preserved — fail
+                // rather than silently locking the user out.
+                Err(CfApiError::Unauthorized) => return Err(ProvisionError::HealthCheckFailed),
+                Ok(false) | Err(_) => {}
+            }
+            if attempt + 1 < HEALTH_ATTEMPTS {
+                backend.sleep(HEALTH_WAIT).await;
+            }
+        }
+        if !healthy {
+            return Err(ProvisionError::HealthCheckFailed);
+        }
+        Ok::<_, ProvisionError>(())
+    });
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -288,6 +440,7 @@ mod tests {
     fn test_manifest() -> WorkerManifest {
         serde_json::from_value(serde_json::json!({
             "scriptName": "second-brain",
+            "workerVersion": "2.0.0",
             "compatibilityDate": "2026-06-17",
             "compatibilityFlags": ["nodejs_compat"],
             "vars": { "VECTORIZE_GRACE_MS": "300000" },
@@ -313,6 +466,8 @@ mod tests {
         existing_vectorize: bool,
         subdomain_rejections: Mutex<u32>,
         health_failures: Mutex<u32>,
+        script_bindings: Vec<serde_json::Value>,
+        last_deploy_metadata: Mutex<Option<serde_json::Value>>,
     }
 
     impl Fake {
@@ -381,7 +536,15 @@ mod tests {
                 "deploy:{script}:{}",
                 metadata["bindings"].as_array().unwrap().len()
             ));
+            *self.last_deploy_metadata.lock().unwrap() = Some(metadata.clone());
             Ok(())
+        }
+        async fn get_script_bindings(
+            &self,
+            _script: &str,
+        ) -> Result<Vec<serde_json::Value>, CfApiError> {
+            self.log("get_script_bindings");
+            Ok(self.script_bindings.clone())
         }
         async fn set_cron(&self, _script: &str, crons: &[String]) -> Result<(), CfApiError> {
             self.log(format!("set_cron:{}", crons.join(",")));
@@ -513,6 +676,64 @@ mod tests {
         assert_eq!(find("secret_text")["text"], "secret-pw");
         assert_eq!(find("plain_text")["name"], "VECTORIZE_GRACE_MS");
         assert_eq!(meta["assets"]["jwt"], "jwt-1");
+    }
+
+    #[tokio::test]
+    async fn update_reuses_deployed_bindings_and_preserves_secret() {
+        let fake = Fake {
+            script_bindings: vec![
+                serde_json::json!({ "type": "d1", "name": "DB", "database_id": "real-d1-id" }),
+                serde_json::json!({ "type": "kv_namespace", "name": "OAUTH_KV", "namespace_id": "real-kv-id" }),
+                serde_json::json!({ "type": "vectorize", "name": "VECTORIZE", "index_name": "second-brain-vectors" }),
+                serde_json::json!({ "type": "secret_text", "name": "AUTH_TOKEN" }),
+            ],
+            existing_vectorize: true,
+            ..Default::default()
+        };
+        update_worker(
+            &&fake,
+            &test_manifest(),
+            "https://second-brain.acme.workers.dev",
+            "stored-token",
+            |_| {},
+        )
+        .await
+        .unwrap();
+
+        let log = fake.entries();
+        assert!(log.contains(&"get_script_bindings".to_string()));
+        // Never re-created the resources that already exist.
+        assert!(!log.iter().any(|l| l.starts_with("create_")));
+
+        let meta = fake.last_deploy_metadata.lock().unwrap().clone().unwrap();
+        // Reused the real binding IDs from the deployed script.
+        let bindings = meta["bindings"].as_array().unwrap();
+        let find = |ty: &str| bindings.iter().find(|b| b["type"] == ty).unwrap();
+        assert_eq!(find("d1")["database_id"], "real-d1-id");
+        assert_eq!(find("kv_namespace")["namespace_id"], "real-kv-id");
+        // Password preserved, not re-sent.
+        assert!(!bindings.iter().any(|b| b["type"] == "secret_text"));
+        assert_eq!(meta["keep_bindings"], serde_json::json!(["secret_text", "secret_key"]));
+    }
+
+    #[tokio::test]
+    async fn update_falls_back_when_bindings_absent() {
+        // An older deployment whose settings don't expose the ids → find-or-create.
+        let fake = Fake {
+            script_bindings: vec![],
+            existing_d1: Some("found-d1".into()),
+            existing_kv: Some("found-kv".into()),
+            existing_vectorize: true,
+            ..Default::default()
+        };
+        update_worker(&&fake, &test_manifest(), "https://x.acme.workers.dev", "tok", |_| {})
+            .await
+            .unwrap();
+        let meta = fake.last_deploy_metadata.lock().unwrap().clone().unwrap();
+        let bindings = meta["bindings"].as_array().unwrap();
+        let find = |ty: &str| bindings.iter().find(|b| b["type"] == ty).unwrap();
+        assert_eq!(find("d1")["database_id"], "found-d1");
+        assert_eq!(find("kv_namespace")["namespace_id"], "found-kv");
     }
 
     #[test]

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -12,6 +12,7 @@ use crate::{mcp_config, secure_store, windows, worker_bundle};
 use std::sync::Mutex;
 use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_clipboard_manager::ClipboardExt;
+use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_opener::OpenerExt;
 
 /// In-memory state for the setup flow. Dropped when the process exits;
@@ -22,6 +23,9 @@ pub struct SetupSession {
     tokens: Mutex<Option<Tokens>>,
     accounts: Mutex<Vec<Account>>,
     outcome: Mutex<Option<ProvisionOutcome>>,
+    /// Set when the main window should boot straight into the Worker-update
+    /// flow instead of the normal setup flow.
+    pending_worker_update: Mutex<bool>,
 }
 
 impl SetupSession {
@@ -32,6 +36,7 @@ impl SetupSession {
             tokens: Mutex::new(None),
             accounts: Mutex::new(Vec::new()),
             outcome: Mutex::new(None),
+            pending_worker_update: Mutex::new(false),
         }
     }
 
@@ -40,6 +45,7 @@ impl SetupSession {
         *self.tokens.lock().unwrap() = None;
         self.accounts.lock().unwrap().clear();
         *self.outcome.lock().unwrap() = None;
+        *self.pending_worker_update.lock().unwrap() = false;
     }
 }
 
@@ -56,7 +62,9 @@ pub struct AppState {
 
 #[tauri::command]
 pub fn get_app_state(session: State<'_, SetupSession>) -> AppState {
-    let mode = if secure_store::load_setup().is_some() && !session.dry_run {
+    let mode = if *session.pending_worker_update.lock().unwrap() {
+        "worker-update"
+    } else if secure_store::load_setup().is_some() && !session.dry_run {
         "wrapper"
     } else {
         "setup"
@@ -379,6 +387,173 @@ pub fn open_dashboard(app: AppHandle, session: State<'_, SetupSession>) -> Resul
 #[tauri::command]
 pub fn open_details_window(app: AppHandle) {
     windows::open_details_window(&app);
+}
+
+// ── Worker update ────────────────────────────────────────────────────────────
+
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerUpdateInfo {
+    pub deployed_version: Option<String>,
+    pub available_version: String,
+}
+
+/// The workers.dev subdomain in a Worker URL is the second dotted label:
+/// `second-brain.acme.workers.dev` → `acme`.
+fn subdomain_of(worker_url: &str) -> Option<String> {
+    let host = url::Url::parse(worker_url).ok()?.host_str()?.to_string();
+    if !host.ends_with(".workers.dev") {
+        return None; // custom domain — can't auto-resolve the account
+    }
+    host.split('.').nth(1).map(|s| s.to_string())
+}
+
+/// Core check, usable outside a command context (the launch-time offer). None
+/// when up to date, unknown, on a custom domain, in dry-run, or not set up.
+async fn compute_worker_update(dry_run: bool) -> Option<WorkerUpdateInfo> {
+    if dry_run {
+        return None;
+    }
+    let info = secure_store::load_setup()?;
+    subdomain_of(&info.worker_url)?;
+    let bundled = worker_bundle::manifest().worker_version.clone();
+    let deployed = crate::cf::api::worker_version(&info.worker_url, &info.auth_token)
+        .await
+        .unwrap_or(None);
+    crate::version::is_behind(deployed.as_deref(), &bundled).then_some(WorkerUpdateInfo {
+        deployed_version: deployed,
+        available_version: bundled,
+    })
+}
+
+/// Checks whether the deployed Worker is behind the version this app bundles.
+#[tauri::command]
+pub async fn worker_update_available(
+    session: State<'_, SetupSession>,
+) -> Result<Option<WorkerUpdateInfo>, String> {
+    Ok(compute_worker_update(session.dry_run).await)
+}
+
+/// Launch-time offer: quietly check, and if the Worker is behind, ask with a
+/// native dialog. On accept, drop into the Worker-update flow.
+pub fn maybe_offer_worker_update(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let dry_run = app.state::<SetupSession>().dry_run;
+        let Some(update) = compute_worker_update(dry_run).await else {
+            return;
+        };
+        let message = format!(
+            "A newer version of your Second Brain is available (version {}).\n\n\
+             Update now? You'll sign in to Cloudflare once. Your memories, password, \
+             and connected tools are kept.",
+            update.available_version
+        );
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        app.dialog()
+            .message(message)
+            .title("Update your Second Brain")
+            .kind(tauri_plugin_dialog::MessageDialogKind::Info)
+            .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
+                "Update now".to_string(),
+                "Later".to_string(),
+            ))
+            .show(move |accepted| {
+                let _ = tx.send(accepted);
+            });
+        if rx.await.unwrap_or(false) {
+            *app.state::<SetupSession>().pending_worker_update.lock().unwrap() = true;
+            let _ = windows::open_setup_window(&app);
+        }
+    });
+}
+
+/// Puts the main window into Worker-update mode and shows it. Called from the
+/// launch-time prompt and the Connection details button.
+#[tauri::command]
+pub fn begin_worker_update(app: AppHandle, session: State<'_, SetupSession>) -> Result<(), String> {
+    *session.pending_worker_update.lock().unwrap() = true;
+    windows::open_setup_window(&app).map_err(|_| "Couldn't open the update window.".to_string())
+}
+
+/// Runs the preserve-everything redeploy. Requires a prior `connect_cloudflare`
+/// (so the session holds a Cloudflare token + account list). Resolves the
+/// account that hosts the Worker by matching its workers.dev subdomain.
+#[tauri::command]
+pub async fn start_worker_update(
+    app: AppHandle,
+    session: State<'_, SetupSession>,
+) -> Result<ProvisionOutcome, String> {
+    let manifest = worker_bundle::manifest();
+
+    let progress_app = app.clone();
+    let progress = move |event: provision::StepEvent| {
+        let _ = progress_app.emit("setup-progress", &event);
+    };
+
+    if session.dry_run {
+        let outcome = ProvisionOutcome {
+            worker_url: "https://second-brain.demo.workers.dev".into(),
+            mcp_url: "https://second-brain.demo.workers.dev/mcp".into(),
+        };
+        provision::update_worker(&DryRunBackend, manifest, &outcome.worker_url, "demo", progress)
+            .await
+            .map_err(|e| {
+                log::warn!("dry-run worker update failed: {e}");
+                FRIENDLY_RETRY.to_string()
+            })?;
+        *session.pending_worker_update.lock().unwrap() = false;
+        return Ok(outcome);
+    }
+
+    let info = secure_store::load_setup().ok_or("This computer isn't set up yet.")?;
+    let expected_sub = subdomain_of(&info.worker_url)
+        .ok_or("Your Second Brain is on a custom address — update it from your dashboard.")?;
+    let mut tokens = session
+        .tokens
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or("Please sign in to Cloudflare first.")?;
+    if tokens.expires_at <= std::time::Instant::now() {
+        tokens = oauth::refresh(&tokens).await.map_err(|e| {
+            log::warn!("token refresh failed: {e}");
+            "Your Cloudflare sign-in expired. Please sign in again.".to_string()
+        })?;
+        *session.tokens.lock().unwrap() = Some(tokens.clone());
+    }
+    let accounts = session.accounts.lock().unwrap().clone();
+
+    // Find the account whose workers.dev subdomain matches the Worker's URL.
+    let mut matched: Option<String> = None;
+    for account in &accounts {
+        let client = CfClient::new(tokens.access_token.clone(), account.id.clone());
+        if let Ok(Some(sub)) = client.get_account_subdomain().await {
+            if sub == expected_sub {
+                matched = Some(account.id.clone());
+                break;
+            }
+        }
+    }
+    let account_id = matched.ok_or(
+        "That Cloudflare account doesn't host this Second Brain. Sign in with the account you set it up in.",
+    )?;
+
+    let backend = LiveBackend {
+        client: CfClient::new(tokens.access_token.clone(), account_id),
+    };
+    provision::update_worker(&backend, manifest, &info.worker_url, &info.auth_token, progress)
+        .await
+        .map_err(|e| {
+            log::warn!("worker update failed: {e}");
+            FRIENDLY_RETRY.to_string()
+        })?;
+
+    *session.pending_worker_update.lock().unwrap() = false;
+    Ok(ProvisionOutcome {
+        mcp_url: format!("{}/mcp", info.worker_url.trim_end_matches('/')),
+        worker_url: info.worker_url,
+    })
 }
 
 /// Signs this computer out: forgets the saved address + password and returns

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod cf;
 mod commands;
 mod mcp_config;
 mod secure_store;
+mod version;
 mod windows;
 mod worker_bundle;
 
@@ -77,6 +78,9 @@ pub fn run() {
             commands::open_dashboard,
             commands::open_details_window,
             commands::logout,
+            commands::worker_update_available,
+            commands::begin_worker_update,
+            commands::start_worker_update,
         ])
         .setup(move |app| {
             let handle = app.handle().clone();
@@ -136,7 +140,10 @@ pub fn run() {
             // demoed even on a machine that already has a Second Brain.
             match secure_store::load_setup() {
                 Some(info) if !dry_run => {
-                    windows::open_wrapper_window(&handle, &info.worker_url, &info.auth_token)?
+                    windows::open_wrapper_window(&handle, &info.worker_url, &info.auth_token)?;
+                    // In wrapper mode, quietly check whether the deployed Worker
+                    // is behind what this app bundles and offer to update it.
+                    commands::maybe_offer_worker_update(&handle);
                 }
                 _ => windows::open_setup_window(&handle)?,
             }

--- a/installer/src-tauri/src/version.rs
+++ b/installer/src-tauri/src/version.rs
@@ -1,0 +1,57 @@
+//! Minimal semver comparison for Worker update detection. Only needs to answer
+//! "is the deployed version behind the bundled one?" — a full semver crate
+//! would be overkill for `MAJOR.MINOR.PATCH` strings.
+
+/// Parses `MAJOR.MINOR.PATCH` (ignoring any pre-release/build suffix). Returns
+/// `None` if it doesn't look like a version at all.
+fn parse(v: &str) -> Option<(u64, u64, u64)> {
+    let core = v.trim().split(['-', '+']).next()?;
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().unwrap_or("0").parse().ok()?;
+    let patch = parts.next().unwrap_or("0").parse().ok()?;
+    Some((major, minor, patch))
+}
+
+/// True when `deployed` is a valid version strictly older than `bundled`.
+/// An unparseable or absent `deployed` version returns `false` — we never nag
+/// about a Worker whose version we can't read (e.g. a pre-version deployment).
+pub fn is_behind(deployed: Option<&str>, bundled: &str) -> bool {
+    match (deployed.and_then(parse), parse(bundled)) {
+        (Some(d), Some(b)) => d < b,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn behind_is_detected() {
+        assert!(is_behind(Some("2.0.0"), "2.1.0"));
+        assert!(is_behind(Some("2.0.0"), "2.0.1"));
+        assert!(is_behind(Some("1.9.9"), "2.0.0"));
+        assert!(is_behind(Some("2.0"), "2.0.1")); // missing patch treated as .0
+    }
+
+    #[test]
+    fn equal_or_ahead_is_not_behind() {
+        assert!(!is_behind(Some("2.0.0"), "2.0.0"));
+        assert!(!is_behind(Some("2.1.0"), "2.0.0"));
+        assert!(!is_behind(Some("3.0.0"), "2.9.9"));
+    }
+
+    #[test]
+    fn unknown_deployed_version_never_nags() {
+        assert!(!is_behind(None, "2.0.0"));
+        assert!(!is_behind(Some(""), "2.0.0"));
+        assert!(!is_behind(Some("not-a-version"), "2.0.0"));
+    }
+
+    #[test]
+    fn tolerates_prerelease_and_build_suffixes() {
+        assert!(is_behind(Some("2.0.0-beta"), "2.0.1"));
+        assert!(!is_behind(Some("2.0.0+build7"), "2.0.0"));
+    }
+}

--- a/installer/src-tauri/src/worker_bundle.rs
+++ b/installer/src-tauri/src/worker_bundle.rs
@@ -18,6 +18,8 @@ static WORKER_DIST: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/worker-dist");
 #[serde(rename_all = "camelCase")]
 pub struct WorkerManifest {
     pub script_name: String,
+    /// Version of the bundled Worker (its `SB_VERSION`), for update detection.
+    pub worker_version: String,
     pub compatibility_date: String,
     pub compatibility_flags: Vec<String>,
     pub vars: BTreeMap<String, String>,
@@ -132,6 +134,11 @@ mod tests {
     fn manifest_matches_worker_expectations() {
         let m = manifest();
         assert_eq!(m.script_name, "second-brain");
+        assert!(
+            m.worker_version.chars().next().is_some_and(|c| c.is_ascii_digit()),
+            "worker_version should be a semver string, got {:?}",
+            m.worker_version
+        );
         assert_eq!(m.d1_binding, "DB");
         assert_eq!(m.vectorize_binding, "VECTORIZE");
         assert_eq!(m.vectorize_name, "second-brain-vectors");

--- a/installer/src/details.ts
+++ b/installer/src/details.ts
@@ -31,11 +31,15 @@ async function boot() {
     return;
   }
   const tools = await invoke<ToolStatus>("detect_tools");
+  const update = await invoke<{ availableVersion: string } | null>(
+    "worker_update_available",
+  ).catch(() => null);
 
   app.replaceChildren(
     h("div", { class: "screen" }, [
       h("h1", {}, ["Connection details"]),
       h("p", { class: "lede" }, ["Everything you need to connect a tool or another computer."]),
+      ...(update ? [updateCard(update.availableVersion)] : []),
       ...detailCards(details),
       h("div", { class: "actions-spread" }, [copyBothButton(details), emailButton(details)]),
       h("div", { style: "height:18px" }),
@@ -49,6 +53,18 @@ async function boot() {
       logoutSection(),
     ]),
   );
+}
+
+function updateCard(availableVersion: string): HTMLElement {
+  const button = h("button", { class: "btn-primary" }, ["Update my Second Brain"]);
+  button.addEventListener("click", () => void invoke("begin_worker_update"));
+  return h("div", { class: "card", style: "border-color: var(--accent);" }, [
+    h("div", { class: "url-label" }, [`A newer Second Brain is available (${availableVersion})`]),
+    h("div", { class: "url-desc" }, [
+      "Update to get the latest improvements. Your memories, password, and connected tools are kept.",
+    ]),
+    button,
+  ]);
 }
 
 function logoutSection(): HTMLElement {

--- a/installer/src/main.ts
+++ b/installer/src/main.ts
@@ -357,12 +357,142 @@ function detailsScreen() {
   );
 }
 
+// ── Worker update flow (main window in "worker-update" mode) ──────────────────
+
+interface WorkerUpdateInfo {
+  deployedVersion: string | null;
+  availableVersion: string;
+}
+
+const UPDATE_STEPS: { id: StepId; label: string }[] = [
+  { id: "memory", label: "Updating your memory store" },
+  { id: "recall", label: "Refreshing smart recall" },
+  { id: "finish", label: "Finishing up" },
+];
+
+async function workerUpdateScreen() {
+  const info = await invoke<WorkerUpdateInfo | null>("worker_update_available").catch(() => null);
+  const versionLine = info
+    ? `A newer version of your Second Brain (version ${info.availableVersion}) is ready to install.`
+    : "A newer version of your Second Brain is ready to install.";
+  const start = h("button", { class: "btn-primary" }, ["Sign in and update"]);
+  start.addEventListener("click", () => void runWorkerUpdate());
+  const notNow = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    "Not now",
+  ]);
+  notNow.addEventListener("click", () => void invoke("open_dashboard"));
+  show(
+    brand(),
+    h("h1", {}, ["Update your Second Brain"]),
+    h("p", { class: "lede" }, [
+      versionLine +
+        " Your memories, password, and connected tools are all kept — nothing is reset.",
+    ]),
+    h("div", { class: "notice" }, [
+      "🔒",
+      h("span", {}, [
+        "You'll sign in to Cloudflare once to authorize the update. It takes about a minute.",
+      ]),
+    ]),
+    start,
+    notNow,
+  );
+}
+
+async function runWorkerUpdate(errorMsg?: string) {
+  if (errorMsg) {
+    const retry = h("button", { class: "btn-primary" }, ["Try again"]);
+    retry.addEventListener("click", () => void runWorkerUpdate());
+    const back = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+      "Not now",
+    ]);
+    back.addEventListener("click", () => void invoke("open_dashboard"));
+    show(
+      brand(),
+      h("h1", {}, ["Update your Second Brain"]),
+      h("div", { class: "notice error" }, ["⚠️", h("span", {}, [errorMsg])]),
+      retry,
+      back,
+    );
+    return;
+  }
+
+  // Sign in to Cloudflare (the app doesn't keep that login after setup).
+  show(
+    brand(),
+    h("h1", {}, ["Waiting for your browser…"]),
+    h("p", { class: "lede" }, [
+      "Finish signing in to Cloudflare in the browser window that just opened, then come back here.",
+    ]),
+    h("div", { class: "checklist" }, [
+      h("li", { class: "running" }, [
+        h("span", { class: "check-icon" }, [h("span", { class: "spinner" })]),
+        "Watching for you to finish signing in",
+      ]),
+    ]),
+  );
+  try {
+    await invoke<Account[]>("connect_cloudflare");
+  } catch (e) {
+    return void runWorkerUpdate(String(e));
+  }
+
+  // Redeploy with a progress checklist.
+  const rows = new Map<StepId, HTMLLIElement>();
+  const list = h("ul", { class: "checklist" });
+  for (const step of UPDATE_STEPS) {
+    const li = h("li", {}, [h("span", { class: "check-icon" }, ["•"]), step.label]);
+    rows.set(step.id, li);
+    list.append(li);
+  }
+  show(
+    brand(),
+    h("h1", {}, ["Updating your Second Brain"]),
+    h("p", { class: "lede" }, ["This usually takes a minute. Your memories are safe."]),
+    h("div", { class: "card" }, [list]),
+  );
+  const unlisten = await listen<StepEvent>("setup-progress", (e) => {
+    const li = rows.get(e.payload.step);
+    if (!li) return;
+    li.className = e.payload.status;
+    const icon = li.querySelector<HTMLSpanElement>(".check-icon")!;
+    if (e.payload.status === "running") icon.replaceChildren(h("span", { class: "spinner" }));
+    if (e.payload.status === "done") icon.replaceChildren("✓");
+    if (e.payload.status === "error") icon.replaceChildren("!");
+  });
+  try {
+    details = await invoke<ConnectionDetails>("start_worker_update");
+    unlisten();
+    workerUpdateDoneScreen();
+  } catch (e) {
+    unlisten();
+    runWorkerUpdate(String(e));
+  }
+}
+
+function workerUpdateDoneScreen() {
+  const done = h("button", { class: "btn-primary" }, ["Open my Second Brain"]);
+  done.addEventListener("click", () => void invoke("open_dashboard"));
+  show(
+    brand(),
+    h("h1", {}, ["Your Second Brain is up to date"]),
+    h("p", { class: "lede" }, [
+      "Everything's on the latest version — your memories, password, and connected tools are unchanged.",
+    ]),
+    done,
+  );
+}
+
 // ── Boot ──────────────────────────────────────────────────────────────────────
 
 async function boot() {
   const state = await invoke<{ mode: string; dryRun: boolean }>("get_app_state");
   if (state.dryRun) {
     document.body.append(h("div", { class: "dry-run-badge" }, ["Demo mode"]));
+  }
+  if (state.mode === "worker-update") {
+    void workerUpdateScreen();
+    return;
   }
   welcomeScreen();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,11 @@ export interface Env extends Omit<Cloudflare.Env, "VECTORIZE_GRACE_MS"> {
 
 const LLM_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 
+// Worker version, echoed by GET /health. The desktop app compares this against
+// the version it bundles to offer a one-click "update your Second Brain".
+// Bump (semver) when the Worker changes; see installer/README "Worker versioning".
+export const SB_VERSION = "2.0.0";
+
 // ─── CORS ─────────────────────────────────────────────────────────────────────
 
 const CORS_HEADERS = {
@@ -2960,7 +2965,7 @@ const defaultHandler = {
       const authErr = requireAuth(request, env);
       if (authErr) return authErr;
       const vectorize = await checkVectorizeHealth(env);
-      return json({ ok: vectorize.ok, vectorize });
+      return json({ ok: vectorize.ok, version: SB_VERSION, vectorize });
     }
 
     // GET /list

--- a/test/integration/health.test.ts
+++ b/test/integration/health.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import worker from "../../src/index";
+import worker, { SB_VERSION } from "../../src/index";
 import { makeTestEnv, makeTestDb, makeVectorizeMock } from "../helpers/make-env";
 import { req } from "../helpers/make-request";
 import { D1Mock } from "../helpers/d1-mock";
@@ -26,6 +26,16 @@ describe("GET /health", () => {
     expect(data.ok).toBe(true);
     expect(data.vectorize.ok).toBe(true);
     expect(data.vectorize.indexName).toBe("second-brain-vectors");
+  });
+
+  it("echoes the Worker version (used by the desktop app's update check)", async () => {
+    const env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({ describe: vi.fn().mockResolvedValue({ dimensions: 384 }) }),
+    });
+    const res = await worker.fetch(req("GET", "/health"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.version).toBe(SB_VERSION);
+    expect(SB_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
   it("reports vectorize not-ok when the index is missing", async () => {


### PR DESCRIPTION
Unit B of the in-app updates design (`docs/superpowers/specs/2026-07-15-in-app-updates-design.md`). Depends conceptually on Unit A (PR #195) but is independent code.

The app can now keep the user's **deployed Second Brain (Worker)** current, not just itself.

### Worker version awareness (the one Worker-source change)
- `src/index.ts` gains `export const SB_VERSION = "2.0.0"`, echoed by `GET /health` (`{ ok, version, vectorize }`). Additive — the smoke test still only asserts `ok`/`vectorize.ok`.
- `bundle-worker.mjs` extracts `SB_VERSION` into the manifest as `workerVersion`, so the app knows the version it *would* deploy. Both sides read the same constant.

### Detection & UX
- On launch (wrapper mode), the app compares the deployed Worker's `/health` version to its bundled version. If behind, a **native prompt** offers to update; an **"Update my Second Brain"** card also appears in Connection details.
- Accept → the main window enters a compact **worker-update flow**: one Cloudflare sign-in → progress → done. Unknown/absent versions and custom domains never nag.

### The update — preserve-everything redeploy
- Reads the deployed script's **real bindings** (`GET /workers/scripts/{name}/settings`) and reuses the actual D1/KV/Vectorize IDs (also fixes the git-era KV-title mismatch).
- Preserves the password via `keep_bindings: ["secret_text"]` — never re-sent, never seen.
- Resolves the hosting account by matching the Worker URL's `workers.dev` subdomain; refuses to deploy into a non-matching account.
- Reuses the existing provisioning pipeline; idempotent and safe to retry; re-runs `/health` to confirm.

### Tests
6 new Rust tests (version comparison incl. no-nag on unknown; update reuses deployed binding IDs + preserves secret + `keep_bindings`; fallback when settings lack bindings). Worker suite gains a `/health` version-echo test. **33 Rust + 600 Worker tests pass; frontend typechecks.**

### Note
Worker updates reach app users via a new `installer-v*` release that repackages the Worker (documented in `installer/README.md` → "Worker versioning") — the app never fetches the Worker from the repo.