### PR TITLE
chore(installer): drop the redundant Windows MSI + clearer release notes

### DIFF
--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -144,8 +144,18 @@ jobs:
           # action just builds and uploads workflow artifacts below.
           tagName: ${{ startsWith(github.ref, 'refs/tags/installer-v') && github.ref_name || '' }}
           releaseName: ${{ startsWith(github.ref, 'refs/tags/installer-v') && 'Second Brain Desktop __VERSION__' || '' }}
-          releaseBody: "${{ startsWith(github.ref, 'refs/tags/installer-v') && 'Download the installer for your computer below — the `.dmg` for Mac, the `.exe` for Windows.' || '' }}"
+          # Only used on tag builds (a release is created only when tagName is set).
+          # Names the two real downloads and explains the auto-update plumbing.
+          releaseBody: |
+            **Download for your computer:**
+
+            - **Mac** — the `.dmg` (works on Apple Silicon and Intel)
+            - **Windows** — the `.exe`
+
+            The other files (`latest.json`, `.app.tar.gz`, and the `.sig` files) are how the app updates itself — you can ignore them.
           releaseDraft: true
+          # Windows updates use the NSIS .exe (we no longer build the .msi).
+          updaterJsonPreferNsis: true
           uploadWorkflowArtifacts: ${{ !startsWith(github.ref, 'refs/tags/installer-v') }}
 
       # tauri-action notarizes and staples the .app but not the .dmg that wraps

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "second-brain-installer",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -3499,7 +3499,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "second-brain-desktop"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain-desktop"
-version = "0.2.0"
+version = "0.2.1"
 description = "Second Brain desktop app — one-click setup and a native shell for your own memory dashboard"
 edition = "2021"
 rust-version = "1.82"

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Second Brain",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.secondbrain.desktop",
   "build": {
     "beforeDevCommand": "npm run bundle-worker && npm run dev",
@@ -28,7 +28,11 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["app", "dmg", "nsis"],
+    "targets": [
+      "app",
+      "dmg",
+      "nsis"
+    ],
     "createUpdaterArtifacts": false,
     "icon": [
       "icons/32x32.png",

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["app", "dmg", "nsis"],
     "createUpdaterArtifacts": false,
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
Simplifies what a user sees on the GitHub releases page.

- **Drops the Windows `.msi`** (`targets: "all"` → `["app", "dmg", "nsis"]`). The `.msi` was a redundant second Windows installer; the `.exe` is the one users want, and the Windows auto-updater uses it. `updaterJsonPreferNsis: true` makes `latest.json` reference the `.exe` for Windows updates now that no `.msi` is built.
- **Clearer auto-generated release notes** — names the two real downloads (Mac → `.dmg`, Windows → `.exe`) and explains that `latest.json` / `.app.tar.gz` / `.sig` are auto-update plumbing to ignore.

Net effect from the next release: two obvious installers instead of two Mac + two Windows files, with notes that point at them. The Mac side is unchanged (the `.dmg` is the install, the `.app.tar.gz` stays as required updater plumbing). The Windows verify step already tolerates a missing `.msi`.

Takes effect on the next `installer-v*` release; the current 0.2.0 assets are left as-is (its `latest.json` still references the `.msi` for existing Windows users).