### PR TITLE
fix(release): push/PR steps no longer throw after succeeding

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -45,7 +45,10 @@ function run(cmd, opts = {}) {
     console.log(`  [dry-run] ${cmd}`);
     return "";
   }
-  return execSync(cmd, { cwd: ROOT, stdio: opts.stdio ?? "pipe", encoding: "utf8" }).trim();
+  // With stdio "inherit" execSync returns null (output isn't captured), so
+  // guard before trimming — otherwise a successful push/PR still throws.
+  const out = execSync(cmd, { cwd: ROOT, stdio: opts.stdio ?? "pipe", encoding: "utf8" });
+  return out ? out.trim() : "";
 }
 
 function step(msg) {


### PR DESCRIPTION
The `run()` helper called `.trim()` on `execSync`'s result even for `stdio: "inherit"` commands (git push, gh pr create), which return `null` — so the command **succeeded** but the script then crashed on `null.trim()`.

Surfaced on the first real use: `deploy:tag 0.2.1` pushed the tag and triggered CI correctly, then threw. This fix guards the trim so `deploy:app` / `deploy:worker` / `deploy:tag` complete cleanly (and reach their "✓ CI is building" message).

One-line fix; no behavior change beyond not throwing.