### PR TITLE
fix(installer): fresh Cloudflare provisioning (v0.2.2)

### DIFF
--- a/installer/package.json
+++ b/installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "second-brain-installer",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -3661,7 +3661,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "second-brain-desktop"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +590,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +814,37 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -995,6 +1082,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1962,6 +2072,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2104,31 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2605,6 +2746,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "open"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,6 +3006,21 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -3503,6 +3665,7 @@ version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "dirs",
+ "env_logger",
  "include_dir",
  "keyring",
  "log",
@@ -4977,6 +5140,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ url = "2"
 dirs = "6"
 thiserror = "2"
 log = "0.4"
+env_logger = "0.11"
 
 [profile.release]
 codegen-units = 1

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain-desktop"
-version = "0.2.1"
+version = "0.2.2"
 description = "Second Brain desktop app — one-click setup and a native shell for your own memory dashboard"
 edition = "2021"
 rust-version = "1.82"

--- a/installer/src-tauri/src/cf/api.rs
+++ b/installer/src-tauri/src/cf/api.rs
@@ -72,17 +72,24 @@ impl CfClient {
                     let retryable = status == 429 || status >= 500;
                     let body = resp.text().await.unwrap_or_default();
                     match serde_json::from_str::<Envelope<T>>(&body) {
-                        Ok(env) if env.success => return Ok(env.result),
+                        // Success = no errors reported. `success` defaults true
+                        // for endpoints that omit it (Workers assets).
+                        Ok(env) if env.success && env.errors.is_empty() => {
+                            return Ok(env.result)
+                        }
                         Ok(env) => {
                             if !retryable || attempt >= MAX_ATTEMPTS {
                                 return Err(CfApiError::from_errors(&env.errors));
                             }
                         }
-                        Err(_) => {
+                        Err(parse_err) => {
                             if !retryable || attempt >= MAX_ATTEMPTS {
                                 let mut short = body;
-                                short.truncate(300);
-                                return Err(CfApiError::Http { status, body: short });
+                                short.truncate(600);
+                                return Err(CfApiError::Http {
+                                    status,
+                                    body: format!("[unparseable response: {parse_err}] {short}"),
+                                });
                             }
                         }
                     }
@@ -482,6 +489,26 @@ mod tests {
             }
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    #[test]
+    fn envelope_parses_assets_response_without_success_field() {
+        // The Workers assets-upload-session endpoint returns `{ "result": … }`
+        // with no top-level `success` — this used to fail parsing and abort the
+        // whole deploy. It must now parse and be treated as a success.
+        let body = r#"{"result":{"jwt":"cfwau_abc","buckets":[["hash1","hash2"]],"manifest_id":"m-1"}}"#;
+        let env: Envelope<UploadSession> = serde_json::from_str(body).unwrap();
+        assert!(env.success, "missing `success` must default to true");
+        assert!(env.errors.is_empty());
+        let session = env.result.unwrap();
+        assert_eq!(session.jwt.as_deref(), Some("cfwau_abc"));
+        assert_eq!(session.buckets, vec![vec!["hash1".to_string(), "hash2".to_string()]]);
+
+        // The completion response (no buckets) must also parse.
+        let done: Envelope<UploadSession> =
+            serde_json::from_str(r#"{"result":{"jwt":"cfwau_done"}}"#).unwrap();
+        assert!(done.success);
+        assert!(done.result.unwrap().buckets.is_empty());
     }
 
     #[tokio::test]

--- a/installer/src-tauri/src/cf/api.rs
+++ b/installer/src-tauri/src/cf/api.rs
@@ -509,6 +509,16 @@ mod tests {
             serde_json::from_str(r#"{"result":{"jwt":"cfwau_done"}}"#).unwrap();
         assert!(done.success);
         assert!(done.result.unwrap().buckets.is_empty());
+
+        // Cloudflare sends `null` (not `[]` or missing) for empty collections;
+        // both `errors: null` and `buckets: null` must be tolerated.
+        let nulls: Envelope<UploadSession> = serde_json::from_str(
+            r#"{"result":{"jwt":"cfwau_x","buckets":null},"success":true,"errors":null,"messages":null}"#,
+        )
+        .unwrap();
+        assert!(nulls.success);
+        assert!(nulls.errors.is_empty());
+        assert!(nulls.result.unwrap().buckets.is_empty());
     }
 
     #[tokio::test]

--- a/installer/src-tauri/src/cf/api.rs
+++ b/installer/src-tauri/src/cf/api.rs
@@ -258,6 +258,12 @@ impl CfClient {
     ) -> Result<(), CfApiError> {
         let url = self.url(&self.account_path(&format!("/workers/scripts/{script}")));
         let metadata_str = metadata.to_string();
+        log::info!(
+            "deploy_worker: {} bytes of code, {} bytes of metadata, {} bindings",
+            worker_js.len(),
+            metadata_str.len(),
+            metadata.get("bindings").and_then(|b| b.as_array()).map_or(0, |a| a.len()),
+        );
         self.send::<serde_json::Value>(move |h| {
             let form = Form::new()
                 .part(

--- a/installer/src-tauri/src/cf/api.rs
+++ b/installer/src-tauri/src/cf/api.rs
@@ -44,19 +44,40 @@ impl CfClient {
 
     /// Sends a request (rebuilt per attempt so multipart bodies can retry) and
     /// parses the Cloudflare envelope. Returns the envelope `result`, which
-    /// some endpoints legitimately leave null.
+    /// some endpoints legitimately leave null. The account token is attached as
+    /// the bearer.
     async fn send<T: DeserializeOwned>(
         &self,
         build: impl Fn(&reqwest::Client) -> reqwest::RequestBuilder,
     ) -> Result<Option<T>, CfApiError> {
+        self.send_impl(build, true).await
+    }
+
+    /// Like [`send`], but does not attach the account token — the closure must
+    /// supply its own `Authorization`. Used for the asset upload, which
+    /// authenticates with the upload-session JWT; attaching the account token
+    /// too would send two `Authorization` headers and Cloudflare's edge rejects
+    /// that with a 400.
+    async fn send_no_auth<T: DeserializeOwned>(
+        &self,
+        build: impl Fn(&reqwest::Client) -> reqwest::RequestBuilder,
+    ) -> Result<Option<T>, CfApiError> {
+        self.send_impl(build, false).await
+    }
+
+    async fn send_impl<T: DeserializeOwned>(
+        &self,
+        build: impl Fn(&reqwest::Client) -> reqwest::RequestBuilder,
+        account_auth: bool,
+    ) -> Result<Option<T>, CfApiError> {
         let mut attempt = 0;
         loop {
             attempt += 1;
-            let sent = build(&self.http)
-                .bearer_auth(&self.token)
-                .timeout(Duration::from_secs(60))
-                .send()
-                .await;
+            let mut req = build(&self.http);
+            if account_auth {
+                req = req.bearer_auth(&self.token);
+            }
+            let sent = req.timeout(Duration::from_secs(60)).send().await;
             let retry_wait = Duration::from_millis(800 * (attempt as u64) * (attempt as u64));
             match sent {
                 Err(e) => {
@@ -233,7 +254,7 @@ impl CfClient {
             let jwt = session_jwt.clone();
             let upload_url = upload_url.clone();
             let uploaded: Option<UploadedBucket> = self
-                .send(move |h| {
+                .send_no_auth(move |h| {
                     let mut form = Form::new();
                     for (hash, b64, mime) in &parts {
                         let part = Part::text(b64.clone())

--- a/installer/src-tauri/src/cf/types.rs
+++ b/installer/src-tauri/src/cf/types.rs
@@ -5,10 +5,19 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct Envelope<T> {
+    // The classic v4 envelope always includes `success`, but some newer
+    // endpoints (Workers assets: assets-upload-session, /assets/upload) return
+    // `{ "result": … }` with no `success`. Default to true when absent — a real
+    // error still carries `success: false` and/or a non-empty `errors` array.
+    #[serde(default = "default_true")]
     pub success: bool,
     #[serde(default)]
     pub errors: Vec<CfError>,
     pub result: Option<T>,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/installer/src-tauri/src/cf/types.rs
+++ b/installer/src-tauri/src/cf/types.rs
@@ -1,7 +1,7 @@
 //! Serde types for the Cloudflare v4 API envelope and the handful of
 //! resources the installer provisions.
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 #[derive(Debug, Deserialize)]
 pub struct Envelope<T> {
@@ -11,13 +11,25 @@ pub struct Envelope<T> {
     // error still carries `success: false` and/or a non-empty `errors` array.
     #[serde(default = "default_true")]
     pub success: bool,
-    #[serde(default)]
+    // Cloudflare sometimes sends `"errors": null` rather than omitting it or
+    // sending `[]`; treat null the same as missing/empty.
+    #[serde(default, deserialize_with = "null_default")]
     pub errors: Vec<CfError>,
     pub result: Option<T>,
 }
 
 fn default_true() -> bool {
     true
+}
+
+/// Deserializes a value that may be `null` into its `Default` — for fields
+/// Cloudflare sends as `null` instead of an empty collection.
+pub fn null_default<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    Ok(Option::<T>::deserialize(d)?.unwrap_or_default())
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -60,7 +72,8 @@ pub struct SubdomainResult {
 #[derive(Debug, Clone, Deserialize)]
 pub struct UploadSession {
     pub jwt: Option<String>,
-    #[serde(default)]
+    // Cloudflare returns `"buckets": null` when there's nothing to upload.
+    #[serde(default, deserialize_with = "null_default")]
     pub buckets: Vec<Vec<String>>,
 }
 

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -203,7 +203,7 @@ pub async fn start_provisioning(
                 }
                 Err(e) => {
                     log::warn!("provisioning failed: {e}");
-                    return Err(FRIENDLY_RETRY.to_string());
+                    return Err(format!("{FRIENDLY_RETRY}\n\nWhat went wrong: {e}"));
                 }
             }
         }

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -48,6 +48,13 @@ fn confirm_logout(app: &AppHandle) {
 }
 
 pub fn run() {
+    // Errors from provisioning etc. print to stderr (visible under `tauri dev`
+    // or when launched from a terminal). Override with RUST_LOG.
+    let _ = env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or("info,second_brain_desktop_lib=debug"),
+    )
+    .try_init();
+
     let dry_run = std::env::var("SECOND_BRAIN_DRY_RUN").is_ok();
 
     tauri::Builder::default()

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Second Brain",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.secondbrain.desktop",
   "build": {
     "beforeDevCommand": "npm run bundle-worker && npm run dev",


### PR DESCRIPTION
Fresh-account provisioning was failing at "Finishing up." Three bugs in the Workers-assets upload pipeline, all only exercised by fresh provisioning (connect-existing never reached them), plus the reason they were invisible.

## Fixes
- **Logging + surfaced errors** — the app initialized no logger, so every `log::warn!/error!` was a silent no-op. Added `env_logger` and surfaced the real provisioning error into the UI. This made the rest debuggable.
- **Missing `success` field** — the assets-upload-session endpoint returns `{ "result": … }` with no `success` field, which broke required-field parsing. `Envelope.success` now defaults true and success is inferred from an empty `errors` array.
- **`null` collections** — Cloudflare sends `"errors": null` / `"buckets": null` instead of `[]`; `#[serde(default)]` only covers missing fields. Added a `null_default` deserializer for both.
- **Double `Authorization` header** — the asset file upload authenticates with the upload-session JWT, but `send()` also attached the account token, so the request went out with two `Authorization` headers and Cloudflare's edge returned a 400. Added `send_no_auth`; the bucket upload now sends only the JWT.

## Version
Bumped to `0.2.2` (Cargo.toml, tauri.conf.json, package.json, Cargo.lock).

## Testing
- `cargo test` — 34 pass, including new cases for the missing-`success` and `null`-collection responses.
- Verified live: a full fresh-account provision now completes end to end (Worker code uploads, health check passes, lands in the dashboard).