### PR TITLE
feat(installer): breached-password check + generator on the setup screen

### DIFF
--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -569,8 +569,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -773,12 +775,36 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -796,11 +822,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.118",
 ]
@@ -864,6 +901,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.118",
 ]
 
@@ -1038,6 +1106,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1233,17 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2078,6 +2163,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2262,6 +2356,12 @@ dependencies = [
  "windows-sys 0.60.2",
  "zeroize",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libappindicator"
@@ -3673,6 +3773,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "tauri",
  "tauri-build",
@@ -3686,6 +3787,7 @@ dependencies = [
  "tiny_http",
  "tokio",
  "url",
+ "zxcvbn",
 ]
 
 [[package]]
@@ -3886,7 +3988,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3921,6 +4023,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -6324,4 +6437,21 @@ dependencies = [
  "serde",
  "syn 2.0.118",
  "winnow 1.0.4",
+]
+
+[[package]]
+name = "zxcvbn"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9eaee90f4a795d1eb4ba6c51e1c1721d4784d550e8efa7b2600f29c867365e0"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "fancy-regex",
+ "itertools",
+ "lazy_static",
+ "regex",
+ "time",
+ "wasm-bindgen",
+ "web-sys",
 ]

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -27,9 +27,11 @@ serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "multipart"] }
 tokio = { version = "1", features = ["macros", "time"] }
 keyring = { version = "3", features = ["apple-native", "windows-native"] }
+sha1 = "0.10"
 sha2 = "0.10"
 base64 = "0.22"
 rand = "0.8"
+zxcvbn = "3"
 tiny_http = "0.12"
 include_dir = "0.7"
 url = "2"

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -62,9 +62,12 @@ pub struct AppState {
 
 #[tauri::command]
 pub fn get_app_state(session: State<'_, SetupSession>) -> AppState {
+    // Dry-run is checked before the keychain read so demo mode never touches
+    // secure storage (each read can raise a macOS permission prompt for
+    // unsigned dev builds, which would block the setup UI's first paint).
     let mode = if *session.pending_worker_update.lock().unwrap() {
         "worker-update"
-    } else if secure_store::load_setup().is_some() && !session.dry_run {
+    } else if !session.dry_run && secure_store::load_setup().is_some() {
         "wrapper"
     } else {
         "setup"
@@ -79,11 +82,8 @@ pub fn get_app_state(session: State<'_, SetupSession>) -> AppState {
 /// the password only crosses the IPC boundary the same way submit does; the
 /// breach lookup sends a 5-character hash prefix and nothing else.
 #[tauri::command]
-pub async fn check_password(
-    password: String,
-    session: State<'_, SetupSession>,
-) -> Result<password_check::PasswordCheck, String> {
-    Ok(password_check::check(password.trim(), session.dry_run).await)
+pub async fn check_password(password: String) -> Result<password_check::PasswordCheck, String> {
+    Ok(password_check::check(password.trim()).await)
 }
 
 /// A fresh strong password for the "generate one for me" button.

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -8,7 +8,7 @@ use crate::cf::backend::{DryRunBackend, LiveBackend};
 use crate::cf::oauth::{self, Tokens};
 use crate::cf::provision::{self, ProvisionError, ProvisionOutcome};
 use crate::cf::types::{Account, CfApiError};
-use crate::{mcp_config, secure_store, windows, worker_bundle};
+use crate::{mcp_config, password_check, secure_store, windows, worker_bundle};
 use std::sync::Mutex;
 use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_clipboard_manager::ClipboardExt;
@@ -73,6 +73,23 @@ pub fn get_app_state(session: State<'_, SetupSession>) -> AppState {
         mode,
         dry_run: session.dry_run,
     }
+}
+
+/// Strength + breach check for the password screen. Runs entirely in Rust so
+/// the password only crosses the IPC boundary the same way submit does; the
+/// breach lookup sends a 5-character hash prefix and nothing else.
+#[tauri::command]
+pub async fn check_password(
+    password: String,
+    session: State<'_, SetupSession>,
+) -> Result<password_check::PasswordCheck, String> {
+    Ok(password_check::check(password.trim(), session.dry_run).await)
+}
+
+/// A fresh strong password for the "generate one for me" button.
+#[tauri::command]
+pub fn generate_password() -> String {
+    password_check::generate()
 }
 
 #[tauri::command]

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod app_update;
 mod cf;
 mod commands;
 mod mcp_config;
+mod password_check;
 mod secure_store;
 mod version;
 mod windows;
@@ -75,6 +76,8 @@ pub fn run() {
         .manage(SetupSession::new(dry_run))
         .invoke_handler(tauri::generate_handler![
             commands::get_app_state,
+            commands::check_password,
+            commands::generate_password,
             commands::submit_password,
             commands::connect_cloudflare,
             commands::connect_existing,

--- a/installer/src-tauri/src/password_check.rs
+++ b/installer/src-tauri/src/password_check.rs
@@ -80,15 +80,12 @@ async fn pwned_count(password: &str) -> Option<u64> {
     Some(count_in_range_response(&body, suffix))
 }
 
-/// Full check: offline strength always; breach lookup unless `skip_network`
-/// (dry-run mode makes no network calls).
-pub async fn check(password: &str, skip_network: bool) -> PasswordCheck {
+/// Full check: offline strength estimate plus the breach lookup. Runs the
+/// lookup in dry-run too — it's anonymous and touches no account — and fails
+/// open when the network is unavailable.
+pub async fn check(password: &str) -> PasswordCheck {
     let score = strength_score(password);
-    let looked_up = if skip_network {
-        None
-    } else {
-        pwned_count(password).await
-    };
+    let looked_up = pwned_count(password).await;
     let count = looked_up.unwrap_or(0);
     PasswordCheck {
         breached: count > 0,
@@ -162,12 +159,12 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn live_breach_check_flags_password_and_passes_generated() {
-        let bad = check("password", false).await;
+        let bad = check("password").await;
         assert!(bad.online, "HIBP should be reachable");
         assert!(bad.breached);
         assert!(bad.count > 1_000_000);
 
-        let good = check(&generate(), false).await;
+        let good = check(&generate()).await;
         assert!(good.online);
         assert!(!good.breached);
         assert!(good.score >= 3);

--- a/installer/src-tauri/src/password_check.rs
+++ b/installer/src-tauri/src/password_check.rs
@@ -1,0 +1,194 @@
+//! Password safety checks for the setup flow.
+//!
+//! Two layers, both run in Rust so the password never leaves this process
+//! except as a 5-character hash prefix:
+//!   * zxcvbn — offline strength estimate (catches guessable passwords)
+//!   * Have I Been Pwned range API — k-anonymity breach lookup: we SHA-1 the
+//!     password locally and send only the first 5 hex characters of the hash;
+//!     the full password (and even its full hash) never leaves the machine.
+//!
+//! The breach check fails open: if the network is unavailable the caller gets
+//! `online: false` and setup continues on the offline estimate alone.
+
+use serde::Serialize;
+use sha1::{Digest, Sha1};
+use std::time::Duration;
+
+const HIBP_RANGE_URL: &str = "https://api.pwnedpasswords.com/range";
+const HIBP_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PasswordCheck {
+    /// Password appeared in known breaches (only meaningful when `online`).
+    pub breached: bool,
+    /// How many breaches it appeared in.
+    pub count: u64,
+    /// zxcvbn strength score, 0 (guessable) ..= 4 (strong).
+    pub score: u8,
+    /// Whether the breach lookup actually reached the service.
+    pub online: bool,
+}
+
+/// Uppercase hex SHA-1 of the password — the format HIBP's dataset uses.
+fn sha1_hex_upper(password: &str) -> String {
+    let mut hasher = Sha1::new();
+    hasher.update(password.as_bytes());
+    let digest = hasher.finalize();
+    digest.iter().map(|b| format!("{b:02X}")).collect()
+}
+
+/// Finds our hash suffix in a range response (`SUFFIX:COUNT` per line) and
+/// returns its breach count. Lines that don't parse are skipped.
+fn count_in_range_response(body: &str, suffix: &str) -> u64 {
+    body.lines()
+        .filter_map(|line| {
+            let (candidate, count) = line.trim().split_once(':')?;
+            if candidate.eq_ignore_ascii_case(suffix) {
+                count.trim().parse::<u64>().ok()
+            } else {
+                None
+            }
+        })
+        .next()
+        .unwrap_or(0)
+}
+
+/// zxcvbn offline strength estimate, 0..=4.
+fn strength_score(password: &str) -> u8 {
+    zxcvbn::zxcvbn(password, &[]).score() as u8
+}
+
+/// Breach count via the HIBP k-anonymity range API. `Ok(None)` means the
+/// service couldn't be reached (offline / timeout) — the caller fails open.
+async fn pwned_count(password: &str) -> Option<u64> {
+    let hash = sha1_hex_upper(password);
+    let (prefix, suffix) = hash.split_at(5);
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("{HIBP_RANGE_URL}/{prefix}"))
+        // Pads the response set so even its size can't fingerprint the query.
+        .header("Add-Padding", "true")
+        .timeout(HIBP_TIMEOUT)
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let body = response.text().await.ok()?;
+    Some(count_in_range_response(&body, suffix))
+}
+
+/// Full check: offline strength always; breach lookup unless `skip_network`
+/// (dry-run mode makes no network calls).
+pub async fn check(password: &str, skip_network: bool) -> PasswordCheck {
+    let score = strength_score(password);
+    let looked_up = if skip_network {
+        None
+    } else {
+        pwned_count(password).await
+    };
+    let count = looked_up.unwrap_or(0);
+    PasswordCheck {
+        breached: count > 0,
+        count,
+        score,
+        online: looked_up.is_some(),
+    }
+}
+
+// ── Password generation ─────────────────────────────────────────────────────
+
+/// Readable, unambiguous alphabet (no 0/o/1/l/i): 31 symbols ≈ 5 bits each.
+const ALPHABET: &[u8] = b"abcdefghjkmnpqrstuvwxyz23456789";
+const GROUPS: usize = 4;
+const GROUP_LEN: usize = 5;
+
+/// Generates a `xxxxx-xxxxx-xxxxx-xxxxx` password: 20 random symbols from a
+/// 31-symbol alphabet (~99 bits), grouped for easy reading and retyping on a
+/// second computer.
+pub fn generate() -> String {
+    use rand::Rng;
+    let mut rng = rand::thread_rng();
+    (0..GROUPS)
+        .map(|_| {
+            (0..GROUP_LEN)
+                .map(|_| ALPHABET[rng.gen_range(0..ALPHABET.len())] as char)
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha1_matches_known_vector() {
+        // Standard test vector — also the most-breached password there is.
+        assert_eq!(
+            sha1_hex_upper("password"),
+            "5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8"
+        );
+    }
+
+    #[test]
+    fn range_response_finds_suffix_case_insensitively() {
+        let body = "0018A45C4D1DEF81644B54AB7F969B88D65:3\r\n\
+                    1E4C9B93F3F0682250B6CF8331B7EE68FD8:52372427\r\n\
+                    011053FD0102E94D6AE2F8B83D76FAF94F6:1";
+        assert_eq!(
+            count_in_range_response(body, "1e4c9b93f3f0682250b6cf8331b7ee68fd8"),
+            52372427
+        );
+    }
+
+    #[test]
+    fn range_response_without_match_is_zero() {
+        let body = "0018A45C4D1DEF81644B54AB7F969B88D65:3\nBAD-LINE\n:\n";
+        assert_eq!(count_in_range_response(body, "FFFFFFFFFFFFFFFFFFFFF"), 0);
+    }
+
+    #[test]
+    fn weak_passwords_score_low_and_strong_ones_high() {
+        assert!(strength_score("password") <= 1);
+        assert!(strength_score("qwerty12345") <= 2);
+        assert!(strength_score("mqkw3-vt8nj-p5xrd-h29fs") >= 3);
+    }
+
+    /// Hits the real HIBP API — run explicitly with `cargo test -- --ignored`.
+    #[tokio::test]
+    #[ignore]
+    async fn live_breach_check_flags_password_and_passes_generated() {
+        let bad = check("password", false).await;
+        assert!(bad.online, "HIBP should be reachable");
+        assert!(bad.breached);
+        assert!(bad.count > 1_000_000);
+
+        let good = check(&generate(), false).await;
+        assert!(good.online);
+        assert!(!good.breached);
+        assert!(good.score >= 3);
+    }
+
+    #[test]
+    fn generated_passwords_are_well_formed_and_unique() {
+        let a = generate();
+        let b = generate();
+        assert_ne!(a, b);
+        for pw in [&a, &b] {
+            let groups: Vec<&str> = pw.split('-').collect();
+            assert_eq!(groups.len(), GROUPS);
+            for g in &groups {
+                assert_eq!(g.len(), GROUP_LEN);
+                assert!(g.bytes().all(|c| ALPHABET.contains(&c)));
+            }
+            // Comfortably clears the 12-character minimum.
+            assert!(pw.len() >= 12);
+            // And rates as strong offline.
+            assert!(strength_score(pw) >= 3);
+        }
+    }
+}

--- a/installer/src/main.ts
+++ b/installer/src/main.ts
@@ -147,7 +147,17 @@ function passwordScreen() {
   const fill = h("div", { class: "strength-fill" });
   const label = h("span", { class: "strength-label" });
   const hint = h("p", { class: "hint" }, [""]);
-  const generate = h("button", { class: "btn-secondary" }, ["Generate a strong password for me"]);
+  const generate = h("button", {
+    class: "input-action",
+    title: "Generate a strong password for me",
+    "aria-label": "Generate a strong password for me",
+  });
+  // Flat sparkle mark, drawn inline so it picks up the accent color.
+  generate.innerHTML =
+    '<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">' +
+    '<path d="M11 2 C11.7 6.8 13.2 8.3 18 9 C13.2 9.7 11.7 11.2 11 16 C10.3 11.2 8.8 9.7 4 9 C8.8 8.3 10.3 6.8 11 2 Z"/>' +
+    '<path d="M18 13 C18.35 15.4 19.1 16.15 21.5 16.5 C19.1 16.85 18.35 17.6 18 20 C17.65 17.6 16.9 16.85 14.5 16.5 C16.9 16.15 17.65 15.4 18 13 Z"/>' +
+    "</svg>";
   const next = h("button", { class: "btn-primary", disabled: "" }, ["Continue"]);
 
   // Latest completed check for the current password value (null = pending).
@@ -237,12 +247,11 @@ function passwordScreen() {
         "new tools and to sign in from other computers.",
     ]),
     h("div", { class: "field-stack" }, [
-      pw,
+      h("div", { class: "input-wrap" }, [pw, generate]),
       h("div", { class: "strength" }, [h("div", { class: "strength-track" }, [fill]), label]),
       confirm,
       hint,
     ]),
-    generate,
     h("div", { class: "notice" }, [
       "🔑",
       h("span", {}, [
@@ -250,12 +259,12 @@ function passwordScreen() {
           "You'll need it to connect new tools later, and it can't be recovered for you.",
       ]),
     ]),
+    next,
     h("p", { class: "footnote" }, [
       "We check new passwords against known data breaches without ever " +
         "sending your password anywhere — only a fragment of a fingerprint " +
         "leaves this computer.",
     ]),
-    next,
   );
   pw.focus();
 }
@@ -557,13 +566,18 @@ function workerUpdateDoneScreen() {
 // ── Boot ──────────────────────────────────────────────────────────────────────
 
 async function boot() {
-  const state = await invoke<{ mode: string; dryRun: boolean }>("get_app_state");
-  if (state.dryRun) {
-    document.body.append(h("div", { class: "dry-run-badge" }, ["Demo mode"]));
-  }
-  if (state.mode === "worker-update") {
-    void workerUpdateScreen();
-    return;
+  try {
+    const state = await invoke<{ mode: string; dryRun: boolean }>("get_app_state");
+    if (state.dryRun) {
+      document.body.append(h("div", { class: "dry-run-badge" }, ["Demo mode"]));
+    }
+    if (state.mode === "worker-update") {
+      void workerUpdateScreen();
+      return;
+    }
+  } catch {
+    // If state can't be read the safe default is the welcome screen —
+    // never leave the window blank.
   }
   welcomeScreen();
 }

--- a/installer/src/main.ts
+++ b/installer/src/main.ts
@@ -117,18 +117,28 @@ function connectExistingScreen(errorMsg?: string, prefillAddress?: string) {
 
 // ── Screen 2: Password ────────────────────────────────────────────────────────
 
-function strengthOf(pw: string): { pct: number; label: string; color: string } {
+interface PasswordCheck {
+  breached: boolean;
+  count: number;
+  score: number; // zxcvbn 0 (guessable) ..= 4 (strong)
+  online: boolean;
+}
+
+/** Meter position + label for a checked password. Breached always wins. */
+function meterFor(pw: string, check: PasswordCheck | null): {
+  pct: number;
+  label: string;
+  color: string;
+} {
   if (pw.length === 0) return { pct: 0, label: "", color: "var(--danger)" };
-  if (pw.length < 12) return { pct: 20, label: "Too short", color: "var(--danger)" };
-  let variety = 0;
-  if (/[a-z]/.test(pw)) variety++;
-  if (/[A-Z]/.test(pw)) variety++;
-  if (/[0-9]/.test(pw)) variety++;
-  if (/[^a-zA-Z0-9]/.test(pw)) variety++;
-  const score = pw.length + variety * 4;
-  if (score >= 32) return { pct: 100, label: "Strong", color: "var(--ok)" };
-  if (score >= 24) return { pct: 70, label: "Good", color: "var(--ok)" };
-  return { pct: 45, label: "Okay", color: "var(--accent)" };
+  if (pw.trim().length < 12)
+    return { pct: 20, label: "Too short", color: "var(--danger)" };
+  if (check === null) return { pct: 45, label: "Checking…", color: "var(--accent)" };
+  if (check.breached)
+    return { pct: 30, label: "Found in breaches", color: "var(--danger)" };
+  if (check.score >= 4) return { pct: 100, label: "Strong", color: "var(--ok)" };
+  if (check.score === 3) return { pct: 70, label: "Good", color: "var(--ok)" };
+  return { pct: 45, label: "Easy to guess", color: "var(--accent)" };
 }
 
 function passwordScreen() {
@@ -137,23 +147,77 @@ function passwordScreen() {
   const fill = h("div", { class: "strength-fill" });
   const label = h("span", { class: "strength-label" });
   const hint = h("p", { class: "hint" }, [""]);
+  const generate = h("button", { class: "btn-secondary" }, ["Generate a strong password for me"]);
   const next = h("button", { class: "btn-primary", disabled: "" }, ["Continue"]);
 
-  const update = () => {
-    const s = strengthOf(pw.value);
+  // Latest completed check for the current password value (null = pending).
+  let check: PasswordCheck | null = null;
+  let debounce: number | undefined;
+
+  const render = () => {
+    const s = meterFor(pw.value, check);
     fill.style.width = `${s.pct}%`;
     fill.style.background = s.color;
     label.textContent = s.label;
     const longEnough = pw.value.trim().length >= 12;
     const match = pw.value === confirm.value;
-    hint.textContent =
-      pw.value && confirm.value && !match ? "Those don't match yet." : "";
-    hint.className = "hint error";
-    if (longEnough && match) next.removeAttribute("disabled");
-    else next.setAttribute("disabled", "");
+    const breached = check?.breached ?? false;
+    if (breached) {
+      hint.textContent =
+        "This password has appeared in data breaches, so it isn't safe " +
+        "to use here. Try another, or let us generate one.";
+      hint.className = "hint error";
+    } else if (pw.value && confirm.value && !match) {
+      hint.textContent = "Those don't match yet.";
+      hint.className = "hint error";
+    } else {
+      hint.textContent = "";
+      hint.className = "hint";
+    }
+    // Blocked: too short, mismatch, known-breached, or check still pending.
+    // Merely-weak is allowed — the meter warns but doesn't stop you.
+    if (longEnough && match && check !== null && !breached) {
+      next.removeAttribute("disabled");
+    } else {
+      next.setAttribute("disabled", "");
+    }
   };
-  pw.addEventListener("input", update);
-  confirm.addEventListener("input", update);
+
+  const runCheck = () => {
+    const value = pw.value.trim();
+    if (value.length < 12) return; // nothing to check yet
+    invoke<PasswordCheck>("check_password", { password: pw.value })
+      .then((result) => {
+        if (pw.value.trim() !== value) return; // stale — user kept typing
+        check = result;
+        render();
+      })
+      .catch(() => {
+        // Treat a failed check like an offline one: don't block setup.
+        check = { breached: false, count: 0, score: 3, online: false };
+        render();
+      });
+  };
+
+  pw.addEventListener("input", () => {
+    check = null;
+    render();
+    window.clearTimeout(debounce);
+    debounce = window.setTimeout(runCheck, 450);
+  });
+  confirm.addEventListener("input", render);
+
+  generate.addEventListener("click", async () => {
+    const generated = await invoke<string>("generate_password");
+    pw.value = generated;
+    confirm.value = generated;
+    // Show what they got — they need to save it somewhere.
+    pw.setAttribute("type", "text");
+    confirm.setAttribute("type", "text");
+    check = null;
+    render();
+    runCheck();
+  });
 
   next.addEventListener("click", async () => {
     try {
@@ -161,6 +225,7 @@ function passwordScreen() {
       connectScreen();
     } catch (e) {
       hint.textContent = String(e);
+      hint.className = "hint error";
     }
   });
 
@@ -177,12 +242,18 @@ function passwordScreen() {
       confirm,
       hint,
     ]),
+    generate,
     h("div", { class: "notice" }, [
       "🔑",
       h("span", {}, [
         "Save this somewhere safe — a password manager is perfect. " +
           "You'll need it to connect new tools later, and it can't be recovered for you.",
       ]),
+    ]),
+    h("p", { class: "footnote" }, [
+      "We check new passwords against known data breaches without ever " +
+        "sending your password anywhere — only a fragment of a fingerprint " +
+        "leaves this computer.",
     ]),
     next,
   );

--- a/installer/src/style.css
+++ b/installer/src/style.css
@@ -221,6 +221,35 @@ input:focus {
   margin-bottom: 14px;
 }
 
+/* A text input with a small action button tucked into its right edge. */
+.input-wrap {
+  position: relative;
+}
+
+.input-wrap input {
+  padding-right: 48px;
+}
+
+.input-action {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  padding: 7px;
+  border-radius: 9px;
+  cursor: pointer;
+  color: var(--accent);
+}
+
+.input-action:hover {
+  background: var(--accent-soft);
+}
+
 .hint {
   font-size: 13px;
   color: var(--text-secondary);


### PR DESCRIPTION
The setup password is the sole key to the brain, so the password screen now runs two safety checks. Both run in Rust; the password never leaves the process.

## What this adds

- **Breach check (Have I Been Pwned, k-anonymity)** — the password is SHA-1 hashed locally and only the first 5 hex characters of the hash are sent (with `Add-Padding` to defeat traffic-size analysis). A match turns the meter red ("Found in breaches"), explains in plain language, and blocks Continue. Fails open on any network problem so setup is never walled off.
- **Real strength estimate (zxcvbn)** — replaces the naive length+variety meter. Merely-weak passwords warn ("Easy to guess") but are allowed; only known-breached ones block.
- **Password generator** — a flat sparkle button inside the password field generates a `xxxxx-xxxxx-xxxxx-xxxxx` password (~99 bits, unambiguous alphabet), fills both fields, and reveals it so it can be saved to a password manager.
- Trust footnote under Continue: the check never sends the password anywhere, only a fragment of a fingerprint.

## Fixes along the way

- `get_app_state` checked the keychain before the dry-run flag, so demo mode could hang on a macOS keychain prompt hidden behind the window (blank white setup screen on dev builds). Dry-run now short-circuits first.
- `boot()` falls back to the welcome screen on any state error — the window can never stay blank.

## Testing

- 39 Rust unit tests pass (SHA-1 known vectors, range-response parsing incl. malformed lines, generator shape/uniqueness/strength, zxcvbn thresholds)
- Live integration test (ignored by default, run with `--ignored`): `password` flagged breached with 52M+ count via the real HIBP API; a generated password comes back clean
- Frontend typechecks and builds; full flow exercised in the dev app: breach block, weak-warn, generator, mismatch handling