### PR TITLE
fix(worker): update re-embed must upsert, not insert (stale vectors) — v0.2.5

### DIFF
--- a/installer/package.json
+++ b/installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "second-brain-installer",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -3761,7 +3761,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "second-brain-desktop"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain-desktop"
-version = "0.2.4"
+version = "0.2.5"
 description = "Second Brain desktop app — one-click setup and a native shell for your own memory dashboard"
 edition = "2021"
 rust-version = "1.82"

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Second Brain",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "com.secondbrain.desktop",
   "build": {
     "beforeDevCommand": "npm run bundle-worker && npm run dev",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ const LLM_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 // Worker version, echoed by GET /health. The desktop app compares this against
 // the version it bundles to offer a one-click "update your Second Brain".
 // Bump (semver) when the Worker changes; see installer/README "Worker versioning".
-export const SB_VERSION = "2.0.0";
+export const SB_VERSION = "2.0.1";
 
 // ─── CORS ─────────────────────────────────────────────────────────────────────
 
@@ -1210,7 +1210,10 @@ async function storeEntry(
     })
   );
 
-  await env.VECTORIZE.insert(vectors);
+  // upsert (not insert): on update the re-embed of a single-chunk entry reuses
+  // the entry id, and Vectorize insert() silently skips ids that already exist —
+  // so insert would leave the stale embedding in place. upsert overwrites it.
+  await env.VECTORIZE.upsert(vectors);
 
   const vectorIds = vectors.map(v => v.id);
 

--- a/test/integration/append.test.ts
+++ b/test/integration/append.test.ts
@@ -158,11 +158,11 @@ describe("POST /append", () => {
     expect(deleteByIdsMock).toHaveBeenCalledWith(["entry-1", "entry-1-update-111"]);
   });
 
-  it("oversized append: new vectors inserted before old ones are deleted (safe ordering)", async () => {
+  it("oversized append: new vectors written before old ones are deleted (safe ordering)", async () => {
     const callOrder: string[] = [];
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({
-        insert: vi.fn().mockImplementation(async () => { callOrder.push("insert"); return { mutationId: "m" }; }),
+        upsert: vi.fn().mockImplementation(async () => { callOrder.push("upsert"); return { mutationId: "m" }; }),
         deleteByIds: vi.fn().mockImplementation(async () => { callOrder.push("delete"); return { mutationId: "m" }; }),
       }),
     });
@@ -181,13 +181,13 @@ describe("POST /append", () => {
       ctx
     );
 
-    expect(callOrder.indexOf("insert")).toBeLessThan(callOrder.indexOf("delete"));
+    expect(callOrder.indexOf("upsert")).toBeLessThan(callOrder.indexOf("delete"));
   });
 
   it("oversized append: Vectorize re-embed failure is non-fatal — D1 still updated", async () => {
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({
-        insert: vi.fn().mockRejectedValue(new Error("Vectorize down")),
+        upsert: vi.fn().mockRejectedValue(new Error("Vectorize down")),
       }),
     });
     db.entries.push({

--- a/test/integration/smart-merge.test.ts
+++ b/test/integration/smart-merge.test.ts
@@ -122,7 +122,7 @@ describe("POST /capture — smart merge (flagged band 0.85–0.95)", () => {
         query: vi.fn().mockResolvedValue({
           matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
         }),
-        insert: insertMock,
+        upsert: insertMock,
         deleteByIds: deleteByIdsMock,
       }),
       AI: makeMergeAI('{"action":"replace","target_id":"existing-id"}'),
@@ -146,14 +146,14 @@ describe("POST /capture — smart merge (flagged band 0.85–0.95)", () => {
         query: vi.fn().mockResolvedValue({
           matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
         }),
-        insert: vi.fn().mockImplementation(async () => { callOrder.push("insert"); return { mutationId: "m" }; }),
+        upsert: vi.fn().mockImplementation(async () => { callOrder.push("upsert"); return { mutationId: "m" }; }),
         deleteByIds: vi.fn().mockImplementation(async () => { callOrder.push("delete"); return { mutationId: "m" }; }),
       }),
       AI: makeMergeAI('{"action":"replace","target_id":"existing-id"}'),
     });
 
     await worker.fetch(req("POST", "/capture", { body: { content: "Cursor IDE" } }), env, ctx);
-    expect(callOrder.indexOf("insert")).toBeLessThan(callOrder.indexOf("delete"));
+    expect(callOrder.indexOf("upsert")).toBeLessThan(callOrder.indexOf("delete"));
   });
 
   // ── Merge ───────────────────────────────────────────────────────────────────
@@ -192,7 +192,7 @@ describe("POST /capture — smart merge (flagged band 0.85–0.95)", () => {
         query: vi.fn().mockResolvedValue({
           matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
         }),
-        insert: insertMock,
+        upsert: insertMock,
       }),
       AI: makeMergeAI('{"action":"merge","target_id":"existing-id","merged_content":"THE MERGED RESULT"}'),
     });
@@ -298,7 +298,7 @@ describe("POST /capture — smart merge (flagged band 0.85–0.95)", () => {
         query: vi.fn().mockResolvedValue({
           matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
         }),
-        insert: vi.fn().mockRejectedValue(new Error("Vectorize down")),
+        upsert: vi.fn().mockRejectedValue(new Error("Vectorize down")),
       }),
       AI: makeMergeAI('{"action":"replace","target_id":"existing-id"}'),
     });

--- a/test/integration/update.test.ts
+++ b/test/integration/update.test.ts
@@ -7,6 +7,33 @@ import { D1Mock } from "../helpers/d1-mock";
 
 const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
 
+// A stateful Vectorize mock that faithfully models Cloudflare's semantics:
+// insert() SKIPS ids that already exist, upsert() OVERWRITES them. The default
+// mock's insert/upsert are indistinguishable no-op spies, which is exactly why
+// the stale-vector bug (#208) went unnoticed — this reproduces it behaviorally.
+function makeStatefulVectorize(seed: any[] = []) {
+  const store = new Map<string, any>();
+  for (const v of seed) store.set(v.id, v);
+  const mock = makeVectorizeMock({
+    insert: vi.fn(async (vectors: any[]): Promise<any> => {
+      for (const v of vectors) if (!store.has(v.id)) store.set(v.id, v);
+      return { mutationId: "m" };
+    }),
+    upsert: vi.fn(async (vectors: any[]): Promise<any> => {
+      for (const v of vectors) store.set(v.id, v);
+      return { mutationId: "m" };
+    }),
+    deleteByIds: vi.fn(async (ids: string[]): Promise<any> => {
+      for (const id of ids) store.delete(id);
+      return { mutationId: "m" };
+    }),
+    getByIds: vi.fn(async (ids: string[]): Promise<any> =>
+      ids.map(id => store.get(id)).filter(Boolean)),
+    query: vi.fn(async (): Promise<any> => ({ matches: [] })),
+  });
+  return { store, mock };
+}
+
 function seedEntry(db: D1Mock, overrides: Partial<ReturnType<typeof makeEntry>> = {}) {
   const entry = makeEntry(overrides);
   db.entries.push(entry);
@@ -142,19 +169,49 @@ describe("POST /update", () => {
     expect(tags.filter((t: string) => t === "work")).toHaveLength(1);
   });
 
-  it("calls Vectorize insert (re-embed) with new content", async () => {
+  it("re-embeds on update via upsert (overwrites the reused vector id)", async () => {
+    // The re-embed must use upsert, not insert: a single-chunk entry's vector
+    // id equals the entry id, and Vectorize insert() skips ids that already
+    // exist, so insert would leave the old embedding in place.
+    const upsertMock = vi.fn().mockResolvedValue({ mutationId: "m" });
     const insertMock = vi.fn().mockResolvedValue({ mutationId: "m" });
     env = makeTestEnv(db, {
-      VECTORIZE: makeVectorizeMock({ insert: insertMock }),
+      VECTORIZE: makeVectorizeMock({ upsert: upsertMock, insert: insertMock }),
     });
     seedEntry(db);
     await worker.fetch(
       req("POST", "/update", { body: { id: "entry-abc", content: "Brand new content" } }),
       env, ctx
     );
-    expect(insertMock).toHaveBeenCalledOnce();
-    const insertedVectors = insertMock.mock.calls[0][0] as any[];
-    expect(insertedVectors[0].id).toBe("entry-abc");
+    expect(upsertMock).toHaveBeenCalledOnce();
+    const upsertedVectors = upsertMock.mock.calls[0][0] as any[];
+    expect(upsertedVectors[0].id).toBe("entry-abc");
+    expect(upsertedVectors[0].metadata.content).toBe("Brand new content");
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the stored single-chunk vector on update (regression #208)", async () => {
+    // Reproduces the reported bug end-to-end against a store with real
+    // insert/upsert semantics. The entry already has a vector keyed by its id
+    // (as `remember` would have created); updating must overwrite it. With the
+    // old insert() call the write is skipped and the stale content survives.
+    const { store, mock } = makeStatefulVectorize([
+      {
+        id: "entry-abc",
+        values: new Array(384).fill(0.1),
+        metadata: { content: "Original content", parentId: "entry-abc", chunkIndex: 0, totalChunks: 1 },
+      },
+    ]);
+    env = makeTestEnv(db, { VECTORIZE: mock });
+    seedEntry(db, { content: "Original content", vector_ids: '["entry-abc"]' });
+
+    await worker.fetch(
+      req("POST", "/update", { body: { id: "entry-abc", content: "Brand new content" } }),
+      env, ctx
+    );
+
+    // The vector the entry is keyed by must now hold the new content.
+    expect(store.get("entry-abc")?.metadata.content).toBe("Brand new content");
   });
 
   // ── Vector orphan prevention ────────────────────────────────────────────────
@@ -212,10 +269,10 @@ describe("POST /update", () => {
 
   // ── Non-fatal error handling ────────────────────────────────────────────────
 
-  it("returns ok:true even when Vectorize insert throws", async () => {
+  it("returns ok:true even when the Vectorize re-embed throws", async () => {
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({
-        insert: vi.fn().mockRejectedValue(new Error("Vectorize down")),
+        upsert: vi.fn().mockRejectedValue(new Error("Vectorize down")),
       }),
     });
     seedEntry(db);
@@ -257,13 +314,13 @@ describe("POST /update", () => {
       callOrder.push(`delete:${ids.join(",")}`);
       return { mutationId: "m" };
     });
-    const insertMock = vi.fn().mockImplementation(async () => {
-      callOrder.push("insert");
+    const upsertMock = vi.fn().mockImplementation(async () => {
+      callOrder.push("upsert");
       return { mutationId: "m" };
     });
 
     env = makeTestEnv(db, {
-      VECTORIZE: makeVectorizeMock({ insert: insertMock, deleteByIds: deleteByIdsMock }),
+      VECTORIZE: makeVectorizeMock({ upsert: upsertMock, deleteByIds: deleteByIdsMock }),
     });
 
     await worker.fetch(
@@ -271,8 +328,8 @@ describe("POST /update", () => {
       env, ctx
     );
 
-    // insert must happen before delete — new vectors before old ones removed
-    const insertIdx = callOrder.indexOf("insert");
+    // re-embed must happen before delete — new vectors before old ones removed
+    const insertIdx = callOrder.indexOf("upsert");
     const deleteIdx = callOrder.findIndex(s => s.startsWith("delete:"));
     expect(insertIdx).toBeLessThan(deleteIdx);
     expect(callOrder[deleteIdx]).toContain("old-vec-1");

--- a/test/integration/vectorize-pending.test.ts
+++ b/test/integration/vectorize-pending.test.ts
@@ -98,7 +98,7 @@ describe("POST /vectorize-pending", () => {
     let callCount = 0;
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({
-        insert: vi.fn().mockImplementation(() => {
+        upsert: vi.fn().mockImplementation(() => {
           callCount++;
           if (callCount === 1) throw new Error("Vectorize error");
           return Promise.resolve({ mutationId: "m" });

--- a/test/unit/capture-entry.test.ts
+++ b/test/unit/capture-entry.test.ts
@@ -365,21 +365,21 @@ describe("captureEntry()", () => {
       id: "existing", content: "I prefer dark mode", tags: "[]", source: "api",
       created_at: Date.now(), vector_ids: '["existing"]', recall_count: 0, importance_score: 0,
     });
-    const insertMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    const upsertMock = vi.fn().mockResolvedValue({ mutationId: "m" });
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({
         query: vi.fn().mockResolvedValue({
           matches: [{ id: "existing", score: 0.88, metadata: { parentId: "existing" } }],
         }),
-        insert: insertMock,
+        upsert: upsertMock,
       }),
       AI: makeContradictionAI('{"action":"merge","target_id":"existing","merged_content":"Combined merged memory"}'),
     });
     const { ctx } = makeCtx();
     await captureEntry("I like dark mode at night", [], "api", env, ctx);
-    // The inserted vector metadata should contain the merged content
-    const insertedVectors = insertMock.mock.calls[0][0] as any[];
-    expect(insertedVectors[0].metadata.content).toBe("Combined merged memory");
+    // The re-embedded vector metadata should contain the merged content
+    const upsertedVectors = upsertMock.mock.calls[0][0] as any[];
+    expect(upsertedVectors[0].metadata.content).toBe("Combined merged memory");
   });
 
   it("merge: deletes old vectors after re-embedding", async () => {
@@ -613,10 +613,10 @@ describe("captureEntry()", () => {
 
   // ── Non-fatal error handling ────────────────────────────────────────────────
 
-  it("stores to D1 and returns stored even when Vectorize insert throws", async () => {
+  it("stores to D1 and returns stored even when the Vectorize re-embed throws", async () => {
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({
-        insert: vi.fn().mockRejectedValue(new Error("Vectorize unavailable")),
+        upsert: vi.fn().mockRejectedValue(new Error("Vectorize unavailable")),
       }),
     });
     const { ctx } = makeCtx();


### PR DESCRIPTION
Closes #208

## The bug

Updating an entry changed the D1 content but never refreshed the embedding for **single-chunk entries**. Recall by the new content missed the entry; recall by the old content still returned it, showing the new (mismatched) text.

`storeEntry` keys a single-chunk entry's vector by the entry id. On update the re-embed reuses that id, but the write was `VECTORIZE.insert()`, which **silently skips ids that already exist** — only `upsert()` overwrites. `deleteStaleVectors` then correctly keeps the reused id, so the stale vector was neither overwritten nor deleted. The comment above `deleteStaleVectors` already assumed upsert semantics; the code called the wrong method.

## The fix

One line: `insert → upsert` at the `storeEntry` embed write. This is the single embed chokepoint, so it fixes every re-embed path at once (update, smart-merge replace/merge, deprecate, oversized append, vectorize-pending). The append-only path keeps `insert()` — it writes a fresh `-update-<ts>` id, so there is no collision.

## Why it shipped (and the test gap it closes)

The `VECTORIZE` mock was stateless — `insert`/`upsert` were indistinguishable no-op spies — and the existing update test literally asserted `insert` was called on the re-embed. So the suite codified the bug rather than catching it.

This PR adds a **stateful Vectorize mock** that models Cloudflare's real semantics (insert skips existing ids, upsert overwrites) and a behavioural regression test proving a single-chunk update overwrites its vector (fails on `insert`, passes on `upsert`). It also switches every `storeEntry` re-embed assertion across the suite from `insert` to `upsert`; several of those previously passed **vacuously** because the `insert` spy never fired.

## Release

Carries the version bumps so the fix reaches desktop-app users:
- `SB_VERSION` 2.0.0 → 2.0.1 (drives the app's "your Second Brain is behind" prompt)
- installer 0.2.4 → 0.2.5 (tauri.conf.json, Cargo.toml, package.json, Cargo.lock)

After merge: tag `installer-v0.2.5`.

## Testing
- `npm run typecheck` — clean
- `npm test` — 601 passed
- Reproduction verified locally: the two new tests fail on `insert`, pass on `upsert`