### PR TITLE
fix(worker): tag containing '.' or '"' silently blocked embedding — v0.2.6

### DIFF
--- a/installer/package.json
+++ b/installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "second-brain-installer",
   "private": true,
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -3761,7 +3761,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "second-brain-desktop"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain-desktop"
-version = "0.2.5"
+version = "0.2.6"
 description = "Second Brain desktop app — one-click setup and a native shell for your own memory dashboard"
 edition = "2021"
 rust-version = "1.82"

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Second Brain",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "com.secondbrain.desktop",
   "build": {
     "beforeDevCommand": "npm run bundle-worker && npm run dev",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ const LLM_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 // Worker version, echoed by GET /health. The desktop app compares this against
 // the version it bundles to offer a one-click "update your Second Brain".
 // Bump (semver) when the Worker changes; see installer/README "Worker versioning".
-export const SB_VERSION = "2.0.1";
+export const SB_VERSION = "2.0.2";
 
 // ─── CORS ─────────────────────────────────────────────────────────────────────
 
@@ -1199,7 +1199,7 @@ async function storeEntry(
       };
 
       tags.forEach(t => {
-        metadata[`tag_${t}`] = true;
+        metadata[`tag_${t.replace(/[."]/g, "_")}`] = true;
       });
 
       return {
@@ -1310,7 +1310,7 @@ async function appendToEntry(
   };
 
   tags.forEach(t => {
-    metadata[`tag_${t}`] = true;
+    metadata[`tag_${t.replace(/[."]/g, "_")}`] = true;
   });
 
   await env.VECTORIZE.insert([{

--- a/test/integration/capture.test.ts
+++ b/test/integration/capture.test.ts
@@ -108,6 +108,36 @@ describe("POST /capture", () => {
     expect(tags).toEqual(["work"]);
   });
 
+  it("embeds an entry whose tag contains '.' or '\"' — metadata keys are sanitized (regression #210)", async () => {
+    // Cloudflare Vectorize rejects metadata property names containing '.' or '"'.
+    // Model that: the write throws if any tag_ key is left unsanitized, which is
+    // how a tag like "v3.9 notes" silently prevented the entry from embedding.
+    const upsertMock = vi.fn(async (vectors: any[]): Promise<any> => {
+      for (const v of vectors)
+        for (const key of Object.keys(v.metadata ?? {}))
+          if (/[."]/.test(key)) throw new Error(`invalid Vectorize metadata key: ${key}`);
+      return { mutationId: "m" };
+    });
+    const { ctx, drain } = makeCtx();
+    env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ upsert: upsertMock }) });
+
+    const res = await worker.fetch(
+      req("POST", "/capture", { body: { content: "Django compat notes", tags: ['v3.9 notes', 'a"b'] } }),
+      env, ctx
+    );
+    await drain();
+
+    expect(res.status).toBe(200);
+    // The write succeeded rather than being swallowed: a vector was upserted...
+    expect(upsertMock).toHaveBeenCalledOnce();
+    const vector = upsertMock.mock.calls[0][0][0];
+    // ...with every metadata key free of '.' and '"'...
+    expect(Object.keys(vector.metadata).some(k => /[."]/.test(k))).toBe(false);
+    expect(vector.metadata["tag_v3_9 notes"]).toBe(true);
+    // ...while the canonical tags array keeps the originals verbatim.
+    expect(vector.metadata.tags).toEqual(['v3.9 notes', 'a"b']);
+  });
+
   it("falls back to original content when input is only hashtags", async () => {
     const { ctx, drain } = makeCtx();
     const res = await worker.fetch(req("POST", "/capture", { body: { content: "#task" } }), env, ctx);


### PR DESCRIPTION
Closes #210

## The bug

`storeEntry` builds a boolean metadata key per tag (`metadata[\`tag_${t}\`] = true`). Cloudflare Vectorize rejects metadata property names containing `.` or `"`, so any entry carrying a tag like `v3.9 notes` made the **entire** `upsert`/`insert` throw. `storeEntry` runs inside a non-fatal try/catch, so the entry persisted in D1 with `vector_ids = '[]'` and was **silently unrecallable** by semantic search — the caller even saw success (`Re-embedded as 0 vector(s)`). Version numbers, filenames, and imported tags with spaces make this common.

## The fix

Sanitize the per-tag key, keeping `metadata.tags` verbatim:

```ts
metadata[`tag_${t.replace(/[."]/g, "_")}`] = true;
```

Applied to **both** write sites — `storeEntry` and the append path (the report only showed the first). I traced every `VECTORIZE.query(...)` call: none filter on `tag_` keys, so these keys are **write-only** and sanitizing the write is complete — no read-side change needed.

## Test

Adds a **validating Vectorize mock** that rejects metadata keys containing `.`/`"` (as Cloudflare does), and asserts a capture whose tags include `v3.9 notes` and `a"b` still upserts a vector, with sanitized keys and the canonical `tags` array preserved verbatim. Fails on the unsanitized key, passes after the fix — the stateless default mock couldn't have caught this (same blind spot as #208).

## Release

- `SB_VERSION` 2.0.1 → 2.0.2 (drives the app's "your Second Brain is behind" prompt)
- installer 0.2.5 → 0.2.6

After merge: tag `installer-v0.2.6`.

## Testing
- `npm run typecheck` — clean
- `npm test` — 602 passed
- Reproduction verified: the new test fails on the unsanitized key, passes after the fix

## Follow-up (not in this PR)
The reporter's related suggestion — surface `storeEntry` failures to the update caller instead of reporting success with 0 vectors — is a worthwhile observability improvement but a broader contract change, better as its own PR.