### PR TITLE
feat(recall): smarter ranking — recency floor, MMR diversity, data-driven query distillation (v0.2.7)

### DIFF
--- a/installer/package.json
+++ b/installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "second-brain-installer",
   "private": true,
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -3761,7 +3761,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "second-brain-desktop"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain-desktop"
-version = "0.2.6"
+version = "0.2.7"
 description = "Second Brain desktop app — one-click setup and a native shell for your own memory dashboard"
 edition = "2021"
 rust-version = "1.82"

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Second Brain",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "identifier": "com.secondbrain.desktop",
   "build": {
     "beforeDevCommand": "npm run bundle-worker && npm run dev",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ const LLM_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 // Worker version, echoed by GET /health. The desktop app compares this against
 // the version it bundles to offer a one-click "update your Second Brain".
 // Bump (semver) when the Worker changes; see installer/README "Worker versioning".
-export const SB_VERSION = "2.0.2";
+export const SB_VERSION = "2.0.3";
 
 // ─── CORS ─────────────────────────────────────────────────────────────────────
 
@@ -106,6 +106,8 @@ const D1_MAX_BOUND_PARAMS = 100;
 const RRF_K = 60;                    // Reciprocal Rank Fusion dampening constant
 const KEYWORD_CANDIDATE_LIMIT = 100; // max rows the LIKE keyword query scans
 const KEYWORD_MIN_TOKEN_LEN = 2;     // ignore 1-char tokens
+const QUERY_SATURATION_FRACTION = 0.3; // a query term in >30% of memories is non-discriminative for THIS brain → dropped before embedding
+const MAX_QUERY_TERMS = 3;             // embed at most the rarest N content terms so common words can't dilute the query
 const KEYWORD_STOPWORDS = new Set([
   "the", "a", "an", "and", "or", "of", "to", "in", "on", "for", "is", "are", "was", "were", "be", "been",
   "i", "me", "my", "we", "you", "it", "this", "that", "these", "those", "with", "about", "from", "at", "as", "by",
@@ -916,7 +918,24 @@ interface VectorizeMatch {
   id: string;
   score: number;
   metadata?: Record<string, unknown>;
+  values?: number[] | Float32Array | Float64Array; // present when the query/getByIds returned vectors (used by MMR)
 }
+
+// Recency-decay floors: the minimum fraction of its semantic relevance a memory
+// keeps regardless of age (applied in rerankWithTimeDecay). Because decay now
+// bottoms out at a floor instead of exp()-ing toward zero, recency becomes a
+// tie-breaker rather than a gate — a strong old match can no longer be buried
+// under a fresh weak one. Durability sets the floor: settled/important memories
+// barely fade, volatile tasks still do. Staleness is handled by status +
+// contradiction, not by making old memories invisible.
+export const RECENCY_FLOOR = 0.6;            // ordinary memories keep >= 60% (a clearly-stronger old match beats a weak fresh one)
+export const RECENCY_FLOOR_DURABLE = 0.9;    // canonical or importance >= 4 barely decay
+export const RECENCY_FLOOR_VOLATILE = 0.15;  // tasks fade hard (paired with the 7-day half-life)
+
+// MMR diversity: how much the final top-K trades relevance for variety. Higher =
+// more relevance-focused, lower = more diverse. 0.7 keeps the top hit intact while
+// stopping near-duplicate (usually recent) memories from taking every slot.
+export const MMR_LAMBDA = 0.7;
 
 export function getHalfLifeMs(tags: string[]): number {
   if (tags.includes("task")) return 7 * 24 * 60 * 60 * 1000;  // 7 days
@@ -959,9 +978,19 @@ export function rerankWithTimeDecay(
       const rc = recallCounts.get(parentId) ?? 0;
 
       const halfLifeMs = getHalfLifeMs(tags);
-      const recencyMultiplier = Math.exp(-ageMs / halfLifeMs);
-      // Frequency can compensate for recency loss but never push above a fresh entry (cap at 1.0).
-      // Without the cap, high recall counts overwhelm recency and bury newly-stored memories.
+      const imp = importanceScores.get(parentId) ?? 0;
+
+      // Recency ranks but never excludes. The decay bottoms out at a durability-aware
+      // floor: canonical decisions and high-importance memories barely fade, ordinary
+      // memories keep at least RECENCY_FLOOR of their relevance, and only volatile tasks
+      // decay hard (paired with their short half-life). A strong old match therefore
+      // stays in contention instead of being annihilated by exp() toward zero.
+      const recencyFloor =
+        getStatus(tags) === "canonical" || imp >= 4 ? RECENCY_FLOOR_DURABLE
+        : tags.includes("task") ? RECENCY_FLOOR_VOLATILE
+        : RECENCY_FLOOR;
+      const recencyMultiplier = recencyFloor + (1 - recencyFloor) * Math.exp(-ageMs / halfLifeMs);
+      // Frequency lifts often-recalled memories toward a fresh entry (still capped at 1.0).
       const frequencyMultiplier = 1 + Math.log1p(rc);
       const combinedMultiplier = Math.min(1.0, recencyMultiplier * frequencyMultiplier);
       const isShortAppend = match.id.includes("-update-") &&
@@ -973,7 +1002,6 @@ export function rerankWithTimeDecay(
       // Survivors (net wins) rise toward 5; repeatedly-contradicted memories (net losses)
       // fall toward 1. log1p gives diminishing returns; clamp keeps the effect inside the
       // existing 0.88–1.20 importance band. The stored importance_score is never mutated.
-      const imp = importanceScores.get(parentId) ?? 0;
       const wins = contradictionWins.get(parentId) ?? 0;
       const losses = contradictionLosses.get(parentId) ?? 0;
       const net = wins - losses;
@@ -995,6 +1023,41 @@ export function rerankWithTimeDecay(
       return { ...match, score: match.score * combinedMultiplier * appendPenalty * rolledUpPenalty * importanceMultiplier * tagBoost };
     })
     .sort((a, b) => b.score - a.score);
+}
+
+// Maximal Marginal Relevance: greedily pick a diverse top-K instead of taking the K
+// highest-scoring candidates. Taking the top K by score alone lets near-duplicate
+// (usually recent) memories fill every slot and crowd out distinct older ones. Each
+// pick maximizes  λ·relevance − (1−λ)·maxCosineSimilarityToAlreadyPicked.
+// Relevance is min-max normalized across the pool so it's on the same 0..1 scale as
+// the cosine redundancy term (the reranked score is on the RRF scale, not cosine).
+// Candidates without a vector (keyword-only hits) take no redundancy penalty — those
+// are exact-identifier matches we want to keep. The most-relevant item always seeds
+// the set, so the top result is unchanged; only the tail is diversified.
+export function mmrRerank<T extends VectorizeMatch>(candidates: T[], lambda: number, k: number): T[] {
+  if (candidates.length <= 1 || k <= 1) return candidates.slice(0, k);
+  const pool = [...candidates].sort((a, b) => b.score - a.score);
+  const maxRel = pool[0].score || 1;
+  const rel = (m: VectorizeMatch) => (maxRel > 0 ? m.score / maxRel : 0);
+
+  const selected: T[] = [pool.shift()!];
+  while (selected.length < k && pool.length) {
+    let bestIdx = 0;
+    let bestMmr = -Infinity;
+    for (let i = 0; i < pool.length; i++) {
+      const cand = pool[i];
+      let maxSim = 0;
+      if (cand.values) {
+        for (const s of selected) {
+          if (s.values) maxSim = Math.max(maxSim, cosineSim(cand.values, s.values));
+        }
+      }
+      const mmr = lambda * rel(cand) - (1 - lambda) * maxSim;
+      if (mmr > bestMmr) { bestMmr = mmr; bestIdx = i; }
+    }
+    selected.push(pool.splice(bestIdx, 1)[0]);
+  }
+  return selected;
 }
 
 // ─── Temporal phrase parsing ──────────────────────────────────────────────────
@@ -1634,6 +1697,7 @@ export interface RecallSearchResult {
   // True when the dense (Vectorize) step could not run — recall fell back to
   // keyword-only. Lets callers tell the user semantic search is unavailable.
   semanticUnavailable: boolean;
+  queryUsed?: string; // the distilled query actually embedded (transparency + debugging)
 }
 
 // Render recall matches as the MCP tool's text reply. Crucially includes each entry's
@@ -1666,6 +1730,44 @@ export function tokenizeQuery(query: string): string[] {
       .map(t => t.replace(/^[^\w#.]+|[^\w#.]+$/g, "").replace(/[%_]/g, ""))
       .filter(t => t.length >= KEYWORD_MIN_TOKEN_LEN && !KEYWORD_STOPWORDS.has(t))
   )];
+}
+
+// Reduce a query to the terms that actually discriminate in THIS brain, in one data-driven
+// pass: strip grammatical stopwords, then from a single corpus document-frequency scan drop
+// terms that saturate the corpus (framing words like "user"/"wants" and topic-common words
+// like "second brain" are both common → dropped) and keep only the rarest MAX_QUERY_TERMS.
+// This replaces the old static framing wordlist + LLM rewrite: it needs no wordlist, no AI
+// call, and adapts to each brain automatically. Word order is preserved for the embedding.
+// Falls back to the content words (then the raw query) if the scan is unavailable.
+export async function distillToRareTerms(query: string, env: Env): Promise<string> {
+  const words = query.split(/\s+/).filter(Boolean);
+  const norm = (w: string) => w.toLowerCase().replace(/^[^\w#.]+|[^\w#.]+$/g, "");
+  const content = words.filter(w => {
+    const n = norm(w);
+    return n.length >= KEYWORD_MIN_TOKEN_LEN && !KEYWORD_STOPWORDS.has(n);
+  });
+  if (content.length <= 1) return content.length ? content.join(" ") : query;
+
+  const uniq = [...new Set(content.map(norm))].slice(0, 16);
+  try {
+    const sums = uniq.map((_, i) => `SUM(CASE WHEN content LIKE ? THEN 1 ELSE 0 END) AS d${i}`).join(", ");
+    const row = await env.DB.prepare(`SELECT COUNT(*) AS total, ${sums} FROM entries`)
+      .bind(...uniq.map(t => `%${t}%`)).first() as Record<string, number> | null;
+    if (!row || !row.total) return content.join(" ");
+    const total = row.total;
+    const df = new Map(uniq.map((t, i) => [t, (row[`d${i}`] as number) ?? 0]));
+    // Drop corpus-saturating terms; if that leaves nothing, keep all and let the cap decide.
+    let candidates = uniq.filter(t => (df.get(t) ?? 0) / total <= QUERY_SATURATION_FRACTION);
+    if (!candidates.length) candidates = uniq;
+    // Keep only the rarest MAX_QUERY_TERMS so common words can't dilute the query.
+    const keep = new Set(
+      [...candidates].sort((a, b) => (df.get(a) ?? 0) - (df.get(b) ?? 0)).slice(0, MAX_QUERY_TERMS)
+    );
+    const rebuilt = [...new Set(content.filter(w => keep.has(norm(w))))];
+    return rebuilt.length ? rebuilt.join(" ") : content.join(" ");
+  } catch {
+    return content.join(" ");
+  }
 }
 
 // Keyword candidates: entries whose content contains any query token, bounded by
@@ -1711,8 +1813,16 @@ function fuseDenseAndKeyword(
   }
   const denseRanked = [...denseByParent.keys()];
 
-  const keywordRanked = keywordRows
-    .map(r => ({ row: r, weight: tokens.reduce((n, t) => n + (r.content.toLowerCase().includes(t) ? 1 : 0), 0) }))
+  // IDF over the keyword candidate pool: a token matching few candidates (distinctive,
+  // e.g. an identifier or a rare noun) is worth far more than one matching many (a common
+  // word). Without this, a verbose query's common words outvote the rare token that
+  // actually pins the intent. Frequencies are derived from the data — nothing hardcoded.
+  const kwLower = keywordRows.map(r => ({ row: r, lc: r.content.toLowerCase() }));
+  const kwN = kwLower.length || 1;
+  const kwDf = new Map(tokens.map(t => [t, kwLower.reduce((n, x) => n + (x.lc.includes(t) ? 1 : 0), 0)]));
+  const kwIdf = (t: string) => Math.log(1 + kwN / ((kwDf.get(t) ?? 0) + 1));
+  const keywordRanked = kwLower
+    .map(x => ({ row: x.row, weight: tokens.reduce((s, t) => s + (x.lc.includes(t) ? kwIdf(t) : 0), 0) }))
     .filter(x => x.weight > 0 && (allowKeywordOnly || denseByParent.has(x.row.id)))
     .sort((a, b) => b.weight - a.weight || b.row.created_at - a.row.created_at || (a.row.id < b.row.id ? -1 : 1));
 
@@ -1723,7 +1833,7 @@ function fuseDenseAndKeyword(
   for (const [pid, score] of fused) {
     const dm = denseByParent.get(pid);
     if (dm) {
-      out.push({ id: dm.id, score, metadata: dm.metadata });
+      out.push({ id: dm.id, score, metadata: dm.metadata, values: dm.values });
     } else {
       const r = keywordRowById.get(pid)!;
       out.push({ id: pid, score, metadata: { parentId: pid, created_at: r.created_at, tags: JSON.parse(r.tags ?? "[]"), content: r.content, source: r.source } });
@@ -1750,6 +1860,9 @@ export async function recallEntries(
     before = parsed.before;
     embedQuery = parsed.cleanQuery;
   }
+  // Reduce the query to the terms that actually discriminate in this brain (data-driven:
+  // strips framing + corpus-common words, keeps the rarest few) so it embeds on its subject.
+  embedQuery = await distillToRareTerms(embedQuery, env);
 
   const tokens = tokenizeQuery(embedQuery);
   const [values, queryTags] = await Promise.all([
@@ -1790,6 +1903,7 @@ export async function recallEntries(
         id: v.id,
         score: cosineSim(values, v.values as number[]),
         metadata: v.metadata,
+        values: v.values as number[],
       })) as VectorizeMatch[],
     };
   } else {
@@ -1798,7 +1912,7 @@ export async function recallEntries(
     const vectorizeTopK = Math.min(topK * VECTORIZE_TOP_K_MULTIPLIER, 50);
     const denseQuery = async (): Promise<{ matches: VectorizeMatch[] }> => {
       try {
-        return await env.VECTORIZE.query(values, { topK: vectorizeTopK, returnMetadata: "all" });
+        return await env.VECTORIZE.query(values, { topK: vectorizeTopK, returnMetadata: "all", returnValues: true });
       } catch (e) {
         // This is the authoritative signal that the Vectorize index is unreachable —
         // semanticUnavailable drives the dashboard banner (checkVectorizeHealth/GET /health
@@ -1814,7 +1928,7 @@ export async function recallEntries(
 
     if (!semanticUnavailable && results.matches.length && results.matches[0].score < DUPLICATE_FLAG_THRESHOLD) {
       try {
-        results = await env.VECTORIZE.query(values, { topK: 50, returnMetadata: "all" });
+        results = await env.VECTORIZE.query(values, { topK: 50, returnMetadata: "all", returnValues: true });
       } catch (e) {
         // Narrow query already succeeded with real matches, so the index works.
         // A transient widen failure must not claim semantic search is unavailable.
@@ -1850,12 +1964,16 @@ export async function recallEntries(
   const reranked = rerankWithTimeDecay(fusedMatches, recallCounts, importanceScores, queryTags, contradictionWins, contradictionLosses);
 
   const seen = new Set<string>();
-  const deduped = reranked.filter((m) => {
+  const dedupedAll = reranked.filter((m) => {
     const parentId = (m.metadata as any)?.parentId ?? m.id;
     if (seen.has(parentId)) return false;
     seen.add(parentId);
     return true;
-  }).slice(0, topK);
+  });
+  // Diversity: MMR-select the top-K so near-duplicate (usually recent) memories can't
+  // take every slot and bury distinct older ones. The top hit is preserved; the tail
+  // is diversified. Reduces to top-K-by-score when there's nothing to diversify.
+  const deduped = mmrRerank(dedupedAll, MMR_LAMBDA, topK);
 
   if (!deduped.length) return { matches: [], insight: "", semanticUnavailable };
 
@@ -1965,7 +2083,7 @@ export async function recallEntries(
     );
   }
 
-  return { matches, insight, semanticUnavailable };
+  return { matches, insight, semanticUnavailable, queryUsed: embedQuery };
 }
 
 // ─── Shared write path ────────────────────────────────────────────────────────
@@ -3040,12 +3158,13 @@ const defaultHandler = {
       const kind = kindParam && (KIND_VALUES as readonly string[]).includes(kindParam) ? kindParam as MemoryKind : undefined;
       const hops = Math.min(Math.max(parseInt(url.searchParams.get("hops") ?? "0", 10), 0), 3);
 
-      const { matches, insight, semanticUnavailable } = await recallEntries({ query, topK, tag, after, before, kind, hops }, env, ctx);
+      const { matches, insight, semanticUnavailable, queryUsed } = await recallEntries({ query, topK, tag, after, before, kind, hops }, env, ctx);
 
       if (!matches.length) {
         return json({
           ok: true,
           results: [],
+          query_used: queryUsed,
           semantic_unavailable: semanticUnavailable,
           message: semanticUnavailable
             ? `Semantic search unavailable (Vectorize index missing). Fix: ${VECTORIZE_FIX_HINT}.`
@@ -3055,6 +3174,7 @@ const defaultHandler = {
 
       return json({
         ok: true,
+        query_used: queryUsed,
         results: matches.map(m => ({
           id: m.id,
           content: m.content,

--- a/test/unit/distill-query.test.ts
+++ b/test/unit/distill-query.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { distillToRareTerms } from "../../src/index";
+
+// A minimal env whose D1 aggregation returns crafted document-frequencies. The columns
+// d0..dN map to the query's unique content tokens in order (as distillToRareTerms builds
+// them), so `dfByToken` lets each test declare how common each token is.
+function envWith(total: number, dfByToken: Record<string, number>, tokenOrder: string[]) {
+  const row: Record<string, number> = { total };
+  tokenOrder.forEach((t, i) => { row[`d${i}`] = dfByToken[t] ?? 0; });
+  return {
+    DB: {
+      prepare: () => ({ bind: () => ({ first: async () => row }) }),
+    },
+  } as any;
+}
+
+describe("distillToRareTerms", () => {
+  it("drops corpus-saturating terms and keeps the rare, discriminative ones", async () => {
+    // "second"/"brain" saturate the corpus (>30%); "dictawiz"/"reddit" are rare.
+    const order = ["second", "brain", "dictawiz", "reddit"];
+    const env = envWith(100, { second: 80, brain: 85, dictawiz: 2, reddit: 6 }, order);
+    const out = await distillToRareTerms("second brain dictawiz reddit", env);
+    expect(out).toBe("dictawiz reddit");
+  });
+
+  it("caps the query at the rarest MAX_QUERY_TERMS (3)", async () => {
+    // None saturating; keep the 3 rarest, drop the most common ("review").
+    const order = ["quarterly", "review", "budget", "finance"];
+    const env = envWith(100, { quarterly: 4, review: 25, budget: 3, finance: 2 }, order);
+    const out = await distillToRareTerms("quarterly review budget finance", env);
+    // "review" (df 25) is the most common of the four → dropped; order preserved.
+    expect(out).toBe("quarterly budget finance");
+  });
+
+  it("strips grammatical stopwords, then drops saturating content words", async () => {
+    // "what/on/the/to" are grammatical stopwords (removed first); "happened" is a content
+    // word but saturates the corpus (>30%) so it's dropped, leaving the rare subject.
+    const order = ["happened", "trip", "cleveland"];
+    const env = envWith(100, { happened: 45, trip: 12, cleveland: 3 }, order);
+    const out = await distillToRareTerms("what happened on the trip to cleveland", env);
+    expect(out).toBe("trip cleveland");
+  });
+
+  it("returns a single content word unchanged without touching the DB", async () => {
+    const env = { DB: { prepare: () => { throw new Error("should not query"); } } } as any;
+    expect(await distillToRareTerms("dictawiz", env)).toBe("dictawiz");
+  });
+
+  it("falls back to the content words if the frequency scan fails", async () => {
+    const env = { DB: { prepare: () => ({ bind: () => ({ first: async () => { throw new Error("db down"); } }) }) } } as any;
+    const out = await distillToRareTerms("alpha beta gamma", env);
+    expect(out).toBe("alpha beta gamma");
+  });
+});

--- a/test/unit/mmr.test.ts
+++ b/test/unit/mmr.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { mmrRerank } from "../../src/index";
+
+function m(id: string, score: number, values: number[]) {
+  return { id, score, metadata: { parentId: id }, values };
+}
+
+// Two clusters: several near-duplicate "recent" vectors and one distinct "older" vector.
+const DUP = [1, 0, 0];
+const DISTINCT = [0, 1, 0];
+
+describe("mmrRerank", () => {
+  it("surfaces a distinct item that a plain top-K by score would crowd out", () => {
+    const candidates = [
+      m("recent1", 0.60, DUP),
+      m("recent2", 0.58, DUP),
+      m("recent3", 0.57, DUP),
+      m("recent4", 0.56, DUP),
+      m("distinct", 0.50, DISTINCT),
+    ];
+    const picked = mmrRerank(candidates, 0.7, 3).map(x => x.id);
+    // Plain top-3 by score would be recent1/recent2/recent3 (all duplicates).
+    expect(picked[0]).toBe("recent1");        // top hit preserved
+    expect(picked).toContain("distinct");     // the distinct item reclaims a slot
+  });
+
+  it("keeps the highest-scoring item first", () => {
+    const picked = mmrRerank([
+      m("b", 0.5, DUP),
+      m("a", 0.9, DISTINCT),
+    ], 0.7, 2);
+    expect(picked[0].id).toBe("a");
+  });
+
+  it("candidates without vectors take no diversity penalty (kept by relevance)", () => {
+    const picked = mmrRerank([
+      { id: "x", score: 0.9, metadata: {} } as any,
+      { id: "y", score: 0.8, metadata: {} } as any,
+    ], 0.7, 2).map(x => x.id);
+    expect(picked).toEqual(["x", "y"]);
+  });
+
+  it("returns at most k items and never more than provided", () => {
+    const picked = mmrRerank([m("a", 0.9, DUP), m("b", 0.8, DISTINCT)], 0.7, 5);
+    expect(picked.length).toBe(2);
+  });
+});

--- a/test/unit/rerank.test.ts
+++ b/test/unit/rerank.test.ts
@@ -197,4 +197,31 @@ describe("rerankWithTimeDecay", () => {
     );
     expect(withDefault[0].score).toBeCloseTo(withEmpty[0].score, 6);
   });
+
+  // ── Recency floor: decay bottoms out instead of exp()-ing to zero ────────────
+
+  it("a clearly-stronger old match beats a weak fresh one (recency floor)", () => {
+    // Without the floor the year-old entry's recency multiplier ~ exp(-12) ≈ 0 and
+    // it could never outrank the fresh weak match. The floor keeps it in contention.
+    const result = rerankWithTimeDecay([
+      match("old-strong", 0.85, NOW - 365 * MS_DAY),
+      match("fresh-weak", 0.45, NOW - 2 * MS_DAY),
+    ], new Map());
+    expect(result[0].id).toBe("old-strong");
+  });
+
+  it("an old match retains at least the ordinary recency floor of its relevance", () => {
+    const [old] = rerankWithTimeDecay([match("old", 1.0, NOW - 5 * 365 * MS_DAY)], new Map());
+    // 5 years at the default half-life → recency multiplier bottoms out at the floor (0.6),
+    // so the score stays well above zero rather than being annihilated.
+    expect(old.score).toBeGreaterThan(0.5);
+  });
+
+  it("canonical old memory barely decays (durable floor) and beats an ordinary old one", () => {
+    const result = rerankWithTimeDecay([
+      match("ordinary", 0.8, NOW - 365 * MS_DAY),
+      match("canonical", 0.8, NOW - 365 * MS_DAY, ["status:canonical"]),
+    ], new Map());
+    expect(result[0].id).toBe("canonical");
+  });
 });


### PR DESCRIPTION
Recall quality overhaul, validated live on a real 1,300-memory brain. Two problems drove it: aging memories became impossible to surface, and verbose intent-framed queries returned unrelated results.

## Changes

- **Recency floor** — `rerankWithTimeDecay`'s recency multiplier now bottoms out at a durability-aware floor (`floor + (1-floor)·exp(-age/halfLife)`) instead of decaying toward zero. Ordinary memories keep ≥60%, canonical / importance≥4 barely decay (0.9), tasks still fade (0.15). A strong old match can no longer be annihilated by age; recency becomes a tie-breaker, not a gate. Staleness stays the job of `status` + contradiction.
- **MMR diversity** — after rerank + per-parent dedupe, the top-K is chosen by Maximal Marginal Relevance (`λ·relevance − (1-λ)·maxSimToPicked`, λ=0.7) so near-duplicate (usually recent) memories can't fill every slot and bury a distinct older one. Threads `returnValues` through the dense query so candidate vectors are available; the top hit is preserved.
- **Data-driven query distillation (`distillToRareTerms`)** — one corpus document-frequency scan (no table) drops query terms that saturate *this* brain — framing words (`user`, `wants`) and topic-common words (`second brain`) alike — and keeps the rarest few, so a non-discriminative common term can't pull the query toward the dominant cluster. Fully generic, no wordlists, no per-query LLM call, adapts per brain.
- **IDF-weighted keyword fusion** — the keyword/RRF path weights tokens by rarity so distinctive tokens outweigh common ones.
- **`query_used` in the `/recall` response** — transparency into the query actually embedded.

## Testing

- `npm run typecheck` — clean
- `npm test` — **614 pass** (602 existing + 12 new: recency-floor behaviour, MMR diversity, `distillToRareTerms` frequency logic)
- Validated end-to-end on a live brain: verbose queries that previously returned unrelated memories now land on their subject; a specific-fact query (a rare identifier) surfaces the right memory at #1.

## Release

- `SB_VERSION` 2.0.2 → 2.0.3 (drives the app's "your Second Brain is behind" prompt)
- installer 0.2.6 → 0.2.7

After merge: tag `installer-v0.2.7`.