### PR TITLE
fix(worker): failed re-embed no longer silently destroys an entry's searchability (v0.2.8)

### DIFF
--- a/installer/package.json
+++ b/installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "second-brain-installer",
   "private": true,
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -3761,7 +3761,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "second-brain-desktop"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain-desktop"
-version = "0.2.7"
+version = "0.2.8"
 description = "Second Brain desktop app — one-click setup and a native shell for your own memory dashboard"
 edition = "2021"
 rust-version = "1.82"

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Second Brain",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "identifier": "com.secondbrain.desktop",
   "build": {
     "beforeDevCommand": "npm run bundle-worker && npm run dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2239,21 +2239,34 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ const LLM_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 // Worker version, echoed by GET /health. The desktop app compares this against
 // the version it bundles to offer a one-click "update your Second Brain".
 // Bump (semver) when the Worker changes; see installer/README "Worker versioning".
-export const SB_VERSION = "2.0.3";
+export const SB_VERSION = "2.0.4";
 
 // ─── CORS ─────────────────────────────────────────────────────────────────────
 
@@ -1293,8 +1293,23 @@ async function storeEntry(
 // id, so the re-embedded vector reuses the old id. Deleting the full old set
 // would remove the vector we just inserted, leaving the entry unsearchable.
 async function deleteStaleVectors(env: Env, oldIds: string[], newIds: string[]): Promise<void> {
+  // Guard (#212): an empty newIds means the re-embed produced nothing — it failed.
+  // Deleting every old vector would leave the entry unsearchable, so keep them instead.
+  // storeEntry always yields >= 1 vector for non-empty content, so this never fires on success.
+  if (!newIds.length) return;
   const stale = oldIds.filter(v => !newIds.includes(v));
   if (stale.length) await env.VECTORIZE.deleteByIds(stale);
+}
+
+// Re-embed BEFORE mutating the entry so a failed embed can never leave it
+// updated-but-unsearchable (#212). storeEntry writes the new vectors and updates
+// vector_ids; on throw or an empty result the caller must NOT touch D1 content or
+// delete old vectors — the entry stays intact and searchable. Callers surface the
+// failure to the user instead of reporting success.
+async function reembedOrThrow(env: Env, id: string, content: string, tags: string[], source: string): Promise<string[]> {
+  const ids = await storeEntry(env, id, content, tags, source, Date.now());
+  if (!ids.length) throw new Error("re-embed produced no vectors");
+  return ids;
 }
 
 // ─── Append to existing entry ─────────────────────────────────────────────────
@@ -1328,17 +1343,14 @@ async function appendToEntry(
     // Combined content is too large for a single vector — re-chunk everything.
     // Same safe ordering as update/merge/replace: insert new → delete old.
 
-    // Step 1: Persist full combined content to D1
+    // Step 1: Re-embed FIRST (#212). If it fails this throws, and the /append handler
+    // surfaces a 500 with the entry's content and vectors left intact — instead of
+    // committing new content and then deleting every vector (silently unsearchable).
+    const newVectorIds = await reembedOrThrow(env, id, newContent, tags, source);
+
+    // Step 2: Embed succeeded → persist the full combined content to D1.
     await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`)
       .bind(newContent, id).run();
-
-    // Step 2: Re-chunk + re-embed full content (also updates vector_ids in D1)
-    let newVectorIds: string[] = [];
-    try {
-      newVectorIds = await storeEntry(env, id, newContent, tags, source, Date.now());
-    } catch (e) {
-      console.error("Vectorize re-embed failed (non-fatal):", e);
-    }
 
     // Step 3: Delete only stale vectors — ids reused by the re-embed must survive
     try {
@@ -2155,26 +2167,32 @@ export async function captureEntry(
         return { status: "flagged", id: crypto.randomUUID(), matchId: targetId, score: dup.score };
       }
 
-      // Step 1: Update D1 content
-      await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`).bind(newContent, targetId).run();
-
-      // Step 2: Re-embed new content — inserts new vectors, updates vector_ids in D1
-      let newVectorIds: string[] = [];
+      // Re-embed FIRST (#212): if it fails, leave the merge target completely
+      // untouched and fall through to a normal insert (keep_both, recoverable) —
+      // instead of overwriting its content and then deleting its vectors, which
+      // would silently destroy the target's searchability.
+      let newVectorIds: string[] | null = null;
       try {
-        newVectorIds = await storeEntry(env, targetId, newContent, existingTags, existingSource, Date.now());
-      } catch (e) { console.error("Vectorize re-embed failed (non-fatal):", e); }
+        newVectorIds = await reembedOrThrow(env, targetId, newContent, existingTags, existingSource);
+      } catch (e) {
+        console.error("Merge re-embed failed — keeping both, target untouched:", e);
+      }
 
-      // Step 3: Delete only stale vectors — ids reused by the re-embed must survive
-      try {
-        await deleteStaleVectors(env, oldVectorIds, newVectorIds);
-      } catch (e) { console.error("Old vector cleanup failed (non-fatal):", e); }
+      if (newVectorIds) {
+        // Embed succeeded → commit the merge onto the target.
+        await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`).bind(newContent, targetId).run();
+        try {
+          await deleteStaleVectors(env, oldVectorIds, newVectorIds);
+        } catch (e) { console.error("Old vector cleanup failed (non-fatal):", e); }
 
-      // Re-classify the merged/replaced content — updates importance_score + kind (and canonical if warranted) on the target.
-      scheduleClassifyAndTag(targetId, newContent, env, ctx);
+        // Re-classify the merged/replaced content — updates importance_score + kind (and canonical if warranted) on the target.
+        scheduleClassifyAndTag(targetId, newContent, env, ctx);
 
-      return mergeAction.action === "merge"
-        ? { status: "merged", id: targetId }
-        : { status: "replaced", id: targetId };
+        return mergeAction.action === "merge"
+          ? { status: "merged", id: targetId }
+          : { status: "replaced", id: targetId };
+      }
+      // Re-embed failed → fall through to the normal insert below (keep_both).
     }
     // target not found in DB — fall through to normal insert
   }
@@ -2992,16 +3010,20 @@ const defaultHandler = {
       const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
       const finalContent = cleanContent || newContent;
 
+      // Re-embed FIRST (#212): if it fails, leave the entry's content and vectors
+      // untouched and surface an error, instead of committing new content and then
+      // deleting every vector — which would leave the entry silently unsearchable.
+      let newVectorIds: string[];
+      try {
+        newVectorIds = await reembedOrThrow(env, id, finalContent, mergedTags, source);
+      } catch (e) {
+        console.error("Re-embed failed — entry left unchanged:", e);
+        return json({ ok: false, error: "Couldn't update: search re-index failed. Your memory is unchanged — please try again." }, 500);
+      }
+
+      // Embed succeeded → safe to commit the new content and retire stale vectors.
       await env.DB.prepare(`UPDATE entries SET content = ?, tags = ? WHERE id = ?`)
         .bind(finalContent, JSON.stringify(mergedTags), id).run();
-
-      let newVectorIds: string[] = [];
-      try {
-        newVectorIds = await storeEntry(env, id, finalContent, mergedTags, source, Date.now());
-      } catch (e) {
-        console.error("Vectorize re-embed failed (non-fatal):", e);
-      }
-      const newVectorCount = newVectorIds.length;
 
       try {
         await deleteStaleVectors(env, oldVectorIds, newVectorIds);
@@ -3009,7 +3031,7 @@ const defaultHandler = {
         console.error("Old vector cleanup failed (non-fatal):", e);
       }
 
-      return json({ ok: true, id, vectors: newVectorCount });
+      return json({ ok: true, id, vectors: newVectorIds.length });
     }
 
     // GET /count

--- a/test/integration/append.test.ts
+++ b/test/integration/append.test.ts
@@ -184,10 +184,15 @@ describe("POST /append", () => {
     expect(callOrder.indexOf("upsert")).toBeLessThan(callOrder.indexOf("delete"));
   });
 
-  it("oversized append: Vectorize re-embed failure is non-fatal — D1 still updated", async () => {
+  it("oversized append: re-embed failure fails loud, D1 unchanged, old vectors kept (regression #212)", async () => {
+    // The oversized-append re-embed must run before D1 is mutated. On failure the
+    // handler returns an error and leaves content + vectors intact — never commits
+    // the new content and then deletes every vector.
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({
         upsert: vi.fn().mockRejectedValue(new Error("Vectorize down")),
+        deleteByIds: deleteByIdsMock,
       }),
     });
     db.entries.push({
@@ -205,11 +210,11 @@ describe("POST /append", () => {
       ctx
     );
 
-    expect(res.status).toBe(200);
-    const data = await res.json() as any;
-    expect(data.ok).toBe(true);
-    // D1 content still updated even if Vectorize failed
-    expect(db.entries[0].content).toContain("More info");
+    expect(res.status).toBe(500);
+    // D1 content unchanged — the append did not commit.
+    expect(db.entries[0].content).toBe(LONG_CONTENT);
+    // Old vectors never deleted.
+    expect(deleteByIdsMock).not.toHaveBeenCalled();
   });
 
   it("oversized append: old vector deletion failure is non-fatal", async () => {

--- a/test/integration/smart-merge.test.ts
+++ b/test/integration/smart-merge.test.ts
@@ -291,14 +291,19 @@ describe("POST /capture — smart merge (flagged band 0.85–0.95)", () => {
 
   // ── Non-fatal error handling ──────────────────────────────────────────────────
 
-  it("replace: returns ok:true even when Vectorize re-embed throws", async () => {
-    seedEntry(db);
+  it("replace: re-embed failure degrades to keep_both, target untouched (regression #212)", async () => {
+    // On a failed re-embed the merge target must not be overwritten and then have its
+    // vectors deleted. Instead we keep both: the target is untouched and the new content
+    // is stored as its own (recoverable) entry.
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
+    seedEntry(db); // target "existing-id", content "I use VSCode"
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({
         query: vi.fn().mockResolvedValue({
           matches: [{ id: "existing-id", score: 0.88, metadata: { parentId: "existing-id" } }],
         }),
         upsert: vi.fn().mockRejectedValue(new Error("Vectorize down")),
+        deleteByIds: deleteByIdsMock,
       }),
       AI: makeMergeAI('{"action":"replace","target_id":"existing-id"}'),
     });
@@ -309,10 +314,12 @@ describe("POST /capture — smart merge (flagged band 0.85–0.95)", () => {
     );
 
     expect(res.status).toBe(200);
-    const data = await res.json() as any;
-    expect(data.ok).toBe(true);
-    // D1 content still updated even if Vectorize failed
-    expect(db.entries[0].content).toBe("I switched to Cursor");
+    // Target is untouched — its content did not change.
+    expect(db.entries.find(e => e.id === "existing-id")?.content).toBe("I use VSCode");
+    // The new content was stored as its own entry (keep_both).
+    expect(db.entries.some(e => e.content === "I switched to Cursor")).toBe(true);
+    // The target's vectors were never deleted.
+    expect(deleteByIdsMock).not.toHaveBeenCalled();
   });
 
   it("merge: returns ok:true even when deleteByIds throws", async () => {

--- a/test/integration/update.test.ts
+++ b/test/integration/update.test.ts
@@ -269,22 +269,29 @@ describe("POST /update", () => {
 
   // ── Non-fatal error handling ────────────────────────────────────────────────
 
-  it("returns ok:true even when the Vectorize re-embed throws", async () => {
+  it("fails loud and leaves the entry untouched when the re-embed throws (regression #212)", async () => {
+    // A failed re-embed must NOT commit new content and then delete every vector,
+    // which would leave the entry silently unsearchable. Embed-first: on failure the
+    // caller gets a 500 and D1 content + vectors are unchanged.
+    const deleteByIdsMock = vi.fn().mockResolvedValue({ mutationId: "m" });
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({
         upsert: vi.fn().mockRejectedValue(new Error("Vectorize down")),
+        deleteByIds: deleteByIdsMock,
       }),
     });
-    seedEntry(db);
+    seedEntry(db); // content: "Original content", vector_ids: ["entry-abc"]
     const res = await worker.fetch(
       req("POST", "/update", { body: { id: "entry-abc", content: "Updated content" } }),
       env, ctx
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(500);
     const data = await res.json() as any;
-    expect(data.ok).toBe(true);
-    // D1 content should still be updated
-    expect(db.entries[0].content).toBe("Updated content");
+    expect(data.ok).toBe(false);
+    // D1 content stays as it was — the update did not commit.
+    expect(db.entries[0].content).toBe("Original content");
+    // The old vectors were never deleted.
+    expect(deleteByIdsMock).not.toHaveBeenCalled();
   });
 
   it("returns ok:true even when deleteByIds throws", async () => {


### PR DESCRIPTION
Closes #212

## The bug

A failed re-embed (most realistically Workers AI daily neuron quota `4006`, hit during an import or a heavy day) left an entry **updated in D1 but with every vector deleted, and the caller told `ok: true`** — silently unsearchable, and destructive (it removed the searchability the entry already had).

Root cause, shared across write paths: D1 content is committed first → `storeEntry()` failure is swallowed as non-fatal (`newVectorIds = []`) → `deleteStaleVectors(oldIds, [])` treats every old vector as stale and deletes it.

## Audit — 5 sites, not 4

The reporter named four paths; the same trap existed at **five**. The two he didn't flag are sneakier: **`applyStatus`** (marking a memory canonical/deprecated) and the **nightly `runScheduledIntegrationSync`** cron — the latter fails unattended, at night, exactly when a day's quota is most likely spent.

## The fix

- **Universal guard** — `deleteStaleVectors` no-ops when `newIds` is empty (a failed re-embed), keeping the old vectors instead of orphaning the entry. `storeEntry` always yields ≥1 vector for non-empty content, so this never fires on success.
- **Embed-first + fail-loud** on the user-facing writes (`/update`, oversized `appendToEntry`, smart-merge in `captureEntry`) via `reembedOrThrow`: embed first; commit D1 and retire stale vectors only on success. On failure, surface a `500` with the entry untouched. Smart-merge degrades to **`keep_both`** so the merge target is never touched.
- `applyStatus` and the nightly sync are covered by the guard.

## Testing

Rewrites the three old "non-fatal, `ok:true`" tests to assert the new contract (the reporter's repro): `500` + unchanged D1 + `deleteByIds` never called for update/append, and target-untouched `keep_both` for smart-merge.

- `npm run typecheck` — clean
- `npm test` — **614 pass**

## Release
`SB_VERSION` 2.0.3 → 2.0.4, installer 0.2.7 → 0.2.8. After merge: tag `installer-v0.2.8`.

Same silent-failure family as #208/#210 — that one made re-embeds silently no-op; this one made failed re-embeds silently *destructive*.