### PR TITLE
docs: add brand lockup logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Second Brain
+<p align="center">
+  <a href="https://www.thesecondbrain.dev"><img src="https://www.thesecondbrain.dev/logos/sb-lockup.svg" alt="Second Brain" width="400"></a>
+</p>
 
 **One shared memory for Claude, ChatGPT, Cursor, Codex, and every other AI tool you use.**
 


### PR DESCRIPTION
Adds the new Second Brain brand lockup to the top of the README, replacing the plain `# Second Brain` heading with the centered logo (linked to thesecondbrain.dev).

- Uses the hosted SVG (`https://www.thesecondbrain.dev/logos/sb-lockup.svg`) — the logo is outlined paths with inline colors, so it renders identically everywhere (no font dependency), and external-SVG-via-`<img>` already works in this README (the Product Hunt badge does the same).
- Sized with `width="400"` (≈56px tall from the 566×79 viewBox) so the SVG doesn't render at full size.
- `alt="Second Brain"` for accessibility.

Docs-only — no code, no version change.