### PR TITLE
perf(recall): skip insight synthesis on the MCP path (v0.2.9)

### DIFF
--- a/installer/package.json
+++ b/installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "second-brain-installer",
   "private": true,
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -3761,7 +3761,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "second-brain-desktop"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain-desktop"
-version = "0.2.8"
+version = "0.2.9"
 description = "Second Brain desktop app — one-click setup and a native shell for your own memory dashboard"
 edition = "2021"
 rust-version = "1.82"

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Second Brain",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "identifier": "com.secondbrain.desktop",
   "build": {
     "beforeDevCommand": "npm run bundle-worker && npm run dev",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ const LLM_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 // Worker version, echoed by GET /health. The desktop app compares this against
 // the version it bundles to offer a one-click "update your Second Brain".
 // Bump (semver) when the Worker changes; see installer/README "Worker versioning".
-export const SB_VERSION = "2.0.4";
+export const SB_VERSION = "2.0.5";
 
 // ─── CORS ─────────────────────────────────────────────────────────────────────
 
@@ -1855,11 +1855,12 @@ function fuseDenseAndKeyword(
 }
 
 export async function recallEntries(
-  params: { query: string; topK: number; tag?: string; after?: number; before?: number; kind?: MemoryKind; hops?: number },
+  params: { query: string; topK: number; tag?: string; after?: number; before?: number; kind?: MemoryKind; hops?: number; synthesize?: boolean },
   env: Env,
   ctx: ExecutionContext
 ): Promise<RecallSearchResult> {
   const { query, topK } = params;
+  const synthesize = params.synthesize ?? true;
   let { tag, after, before, kind } = params;
   const hops = Math.max(0, Math.min(GRAPH_MAX_HOPS, params.hops ?? 0));
   const now = Date.now();
@@ -2083,8 +2084,10 @@ export async function recallEntries(
   if (maxScore > 0) for (const m of matches) m.score = m.score / maxScore;
 
   // Synthesize over exactly what's shown (seeds + any surfaced neighbors) so the
-  // insight stays grounded in the returned results.
-  const insight = matches.length > 1
+  // insight stays grounded in the returned results. Skipped when the caller opts
+  // out (synthesize=false): MCP clients re-synthesize the returned memories with
+  // their own model, so a server-side insight there is a redundant LLM call.
+  const insight = synthesize && matches.length > 1
     ? await synthesizeInsight(embedQuery, matches.map(m => ({ id: m.id, content: m.content })), env)
     : "";
 
@@ -2437,7 +2440,7 @@ async function runScheduledIntegrationSync(env: Env): Promise<void> {
 
 // ─── MCP Server ───────────────────────────────────────────────────────────────
 
-function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
+export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
   const server = new McpServer({ name: "second-brain", version: "1.0.0" });
 
   // ── remember ────────────────────────────────────────────────────────────
@@ -2621,7 +2624,7 @@ function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       },
     },
     async ({ query, topK, tag, after, before, kind, hops }) => {
-      const { matches, insight, semanticUnavailable } = await recallEntries({ query, topK, tag, after, before, kind: kind as MemoryKind | undefined, hops }, env, ctx);
+      const { matches, insight, semanticUnavailable } = await recallEntries({ query, topK, tag, after, before, kind: kind as MemoryKind | undefined, hops, synthesize: false }, env, ctx);
 
       const notice = semanticUnavailable
         ? `Note: semantic search is unavailable because the Vectorize index is missing, so these are keyword matches only. Fix: ${VECTORIZE_FIX_HINT}.\n\n`

--- a/test/integration/mcp-recall-insight.test.ts
+++ b/test/integration/mcp-recall-insight.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import worker, { buildMcpServer, recallEntries } from "../../src/index";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { makeTestEnv, makeTestDb, makeVectorizeMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/index";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+function makeMatch(id: string, score: number) {
+  return { id, score, metadata: { parentId: id, isUpdate: false } };
+}
+
+// Every LLM call the insight synthesizer makes carries this prompt fragment,
+// so filtering AI.run calls on it isolates the insight call from the other
+// LLM users on the recall path (tag inference, classification).
+const INSIGHT_PROMPT_MARKER = "Write a brief insight";
+
+function insightCalls(env: Env): any[] {
+  return (env.AI.run as ReturnType<typeof vi.fn>).mock.calls.filter(
+    ([, args]) => args?.messages?.[0]?.content?.includes?.(INSIGHT_PROMPT_MARKER)
+  );
+}
+
+// Seeds two entries that both dense-match the query so matches.length > 1 —
+// the precondition for insight synthesis to be considered at all.
+function makeTwoMatchEnv(db: D1Mock): Env {
+  db.entries.push(
+    { id: "entry-1", content: "First memory", tags: '["work"]', source: "api", created_at: 1000, vector_ids: "[]", recall_count: 0, importance_score: 0 },
+    { id: "entry-2", content: "Second memory", tags: '["idea"]', source: "api", created_at: 2000, vector_ids: "[]", recall_count: 0, importance_score: 0 },
+  );
+  return makeTestEnv(db, {
+    VECTORIZE: makeVectorizeMock({
+      query: vi.fn().mockResolvedValue({
+        matches: [makeMatch("entry-1", 0.9), makeMatch("entry-2", 0.8)],
+      }),
+    }),
+  });
+}
+
+// Drives the real MCP recall tool closure over an in-memory transport, so the
+// call-site contract (synthesize: false) is pinned by an actual tool call
+// rather than inferred from unit-level behavior.
+async function callMcpRecall(env: Env, query: string) {
+  const server = buildMcpServer(env, ctx);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  try {
+    return await client.callTool({ name: "recall", arguments: { query } });
+  } finally {
+    await client.close();
+  }
+}
+
+describe("recall insight synthesis: MCP skips it, HTTP keeps it", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTwoMatchEnv(db);
+  });
+
+  it("MCP recall returns matches without an insight and never invokes the insight LLM", async () => {
+    const result = await callMcpRecall(env, "memory");
+
+    const text = (result.content as any[])[0].text as string;
+    // The matches themselves still come through untouched.
+    expect(text).toContain("First memory");
+    expect(text).toContain("Second memory");
+    // No server-side insight: the MCP client synthesizes with its own model.
+    expect(text).not.toContain("**Insight:**");
+    expect(insightCalls(env)).toHaveLength(0);
+  });
+
+  it("recallEntries with synthesize:false returns an empty insight without calling the LLM", async () => {
+    const res = await recallEntries({ query: "memory", topK: 5, synthesize: false }, env, ctx);
+
+    expect(res.matches).toHaveLength(2);
+    expect(res.insight).toBe("");
+    expect(insightCalls(env)).toHaveLength(0);
+  });
+
+  it("recallEntries defaults to synthesizing when the flag is omitted", async () => {
+    // Guards the HTTP path: callers that don't opt out must keep today's behavior.
+    const res = await recallEntries({ query: "memory", topK: 5 }, env, ctx);
+
+    expect(res.matches).toHaveLength(2);
+    expect(insightCalls(env)).toHaveLength(1);
+    expect(res.insight).not.toBe("");
+  });
+
+  it("GET /recall still synthesizes an insight (web path unchanged)", async () => {
+    const res = await worker.fetch(req("GET", "/recall?query=memory"), env, ctx);
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.results).toHaveLength(2);
+    expect(insightCalls(env)).toHaveLength(1);
+    expect(data.insight).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

Recall no longer generates a server-side insight when called over MCP. The `recallEntries` pipeline gains an opt-out `synthesize` flag (defaults to `true`), and the MCP `recall` tool passes `false`. `GET /recall` is untouched, so the web UI keeps its insight.

## Why

The insight call was the single largest Workers AI neuron spender on the most frequent operation: every recall with more than one match ran llama-4-scout with up to 300 output tokens plus the full body of every returned memory as input. On the MCP path that work is thrown away, because the calling model (Claude Desktop, ChatGPT) synthesizes the returned memories itself. Skipping it:

- cuts the biggest per-recall neuron cost, which matters for anyone near the free-tier daily quota
- removes a blocking LLM call from recall latency
- changes nothing the user sees: MCP clients still get every match and synthesize as before

Tag inference and entry classification are deliberately untouched since both feed ranking and importance scoring.

## Tests

Four new tests in `test/integration/mcp-recall-insight.test.ts`. The MCP test drives the real registered tool closure over the SDK's in-memory transport (`buildMcpServer` is now exported), so the call-site contract is pinned end to end rather than inferred:

- MCP recall returns matches with no insight line and never invokes the insight LLM
- `recallEntries` with `synthesize: false` returns an empty insight without calling the LLM
- `recallEntries` defaults to synthesizing when the flag is omitted (guards the HTTP path)
- `GET /recall` still synthesizes (web path unchanged)

618 tests pass, typecheck clean.

## Versions

- `SB_VERSION` 2.0.4 -> 2.0.5 (worker redeploy prompt in the app)
- installer 0.2.8 -> 0.2.9