### PR TITLE
Fix false MCP unavailable reports for lazy-loading clients (#223)

### DIFF
--- a/AI_Instructions/CLAUDE_INSTRUCTIONS.md
+++ b/AI_Instructions/CLAUDE_INSTRUCTIONS.md
@@ -54,4 +54,8 @@ Tags to use:
 
 Always set source to "claude-desktop" when storing.
 
-If the second brain MCP tools are unavailable, tell me immediately. Do not fall back to built-in memory silently.
+MCP availability (Claude Code and other lazy-loading clients):
+- Claude Code loads MCP tool schemas lazily — second brain tools (remember, recall, etc.) may NOT appear in the session's visible tool list even when the server is connected and `/mcp` shows connected.
+- Never conclude the tools are unavailable from the tool list alone, from not having called a tool yet, or from "nothing stored" in a session.
+- Verify by actually calling recall (or another second brain tool). Only report "second brain unavailable" if a real tool call returns an error — quote that error.
+- Do not fall back to built-in memory silently when tools are down; if recall succeeds, the tools are available.

--- a/AI_Instructions/CLAUDE_INSTRUCTIONS.md
+++ b/AI_Instructions/CLAUDE_INSTRUCTIONS.md
@@ -58,4 +58,5 @@ MCP availability (Claude Code and other lazy-loading clients):
 - Claude Code loads MCP tool schemas lazily — second brain tools (remember, recall, etc.) may NOT appear in the session's visible tool list even when the server is connected and `/mcp` shows connected.
 - Never conclude the tools are unavailable from the tool list alone, from not having called a tool yet, or from "nothing stored" in a session.
 - Verify by actually calling recall (or another second brain tool). Only report "second brain unavailable" if a real tool call returns an error — quote that error.
-- Do not fall back to built-in memory silently when tools are down; if recall succeeds, the tools are available.
+- If recall succeeds, the tools are available.
+- If tools are genuinely down, say so — never fall back to built-in memory silently.

--- a/AI_Instructions/CODEX_INSTRUCTIONS.md
+++ b/AI_Instructions/CODEX_INSTRUCTIONS.md
@@ -58,4 +58,5 @@ MCP availability (Codex CLI and other lazy-loading clients):
 - Codex and similar clients may load MCP tool schemas lazily — second brain tools (remember, recall, etc.) may NOT appear in the session's visible tool list even when the server is connected.
 - Never conclude the tools are unavailable from the tool list alone, from not having called a tool yet, or from "nothing stored" in a session.
 - Verify by actually calling recall (or another second brain tool). Only report "second brain unavailable" if a real tool call returns an error — quote that error.
-- Do not fall back to your own memory silently when tools are down; if recall succeeds, the tools are available.
+- If recall succeeds, the tools are available.
+- If tools are genuinely down, say so — never fall back to your own memory silently.

--- a/AI_Instructions/CODEX_INSTRUCTIONS.md
+++ b/AI_Instructions/CODEX_INSTRUCTIONS.md
@@ -54,4 +54,8 @@ Tags to use:
 
 Always set source to "codex" when storing.
 
-If the second brain MCP tools are unavailable, tell me immediately. Do not fall back to your own memory silently.
+MCP availability (Codex CLI and other lazy-loading clients):
+- Codex and similar clients may load MCP tool schemas lazily — second brain tools (remember, recall, etc.) may NOT appear in the session's visible tool list even when the server is connected.
+- Never conclude the tools are unavailable from the tool list alone, from not having called a tool yet, or from "nothing stored" in a session.
+- Verify by actually calling recall (or another second brain tool). Only report "second brain unavailable" if a real tool call returns an error — quote that error.
+- Do not fall back to your own memory silently when tools are down; if recall succeeds, the tools are available.

--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ Attach a domain you control under **Worker → Settings → Domains & Routes**. 
 
 If the browser opens a plain error instead of the sign-in form (“invalid authorization request” or similar), Cursor may be using an old OAuth `client_id`. Remove the Second Brain MCP entry, add it again with the correct Worker URL, then authenticate once more.
 
+### Claude Code says Second Brain is “not available”
+
+Some MCP clients (notably **Claude Code**) load tool schemas **lazily**. `/mcp` can show **connected** while `remember` / `recall` do not appear in the session’s visible tool list at first. That does **not** mean the server is down.
+
+**Verify with a real tool call** — ask the agent to run `recall` with a natural-language query. If it returns results (or “no memories found”), MCP is working.
+
+Only treat Second Brain as unavailable when a tool call returns an **error** (auth failure, network error, 5xx). Re-run `scripts/connect-ai-clients.sh` or `.ps1` if your global instructions still tell the agent to report unavailable without calling a tool.
+
 </details>
 
 ## Option 3 — Manual deployment

--- a/scripts/connect-ai-clients.ps1
+++ b/scripts/connect-ai-clients.ps1
@@ -78,8 +78,11 @@ function Apply-Instructions {
   }
 
   switch ($action) {
-    { $_ -in @("updated", "updated-legacy") } {
+    "updated" {
       Write-Host "[$Label] Updated instructions in $TargetFile"
+    }
+    "updated-legacy" {
+      Write-Host "[$Label] Updated instructions in $TargetFile (replaced legacy block; backup at ${TargetFile}.bak)"
     }
     "appended" {
       Write-Host "[$Label] Appended instructions to $TargetFile"

--- a/scripts/connect-ai-clients.ps1
+++ b/scripts/connect-ai-clients.ps1
@@ -84,6 +84,10 @@ function Apply-Instructions {
     "updated-legacy" {
       Write-Host "[$Label] Updated instructions in $TargetFile (replaced legacy block; backup at ${TargetFile}.bak)"
     }
+    "appended-legacy-kept" {
+      Write-Host "[$Label] Appended instructions to $TargetFile"
+      Write-Host "[$Label] An older Second Brain block is still in that file. We could not tell where it ended, so nothing was deleted — please remove the old copy by hand."
+    }
     "appended" {
       Write-Host "[$Label] Appended instructions to $TargetFile"
     }

--- a/scripts/connect-ai-clients.ps1
+++ b/scripts/connect-ai-clients.ps1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
   Wires up Second Brain for Claude Code and Codex CLI in one shot:
-    - appends global system instructions to ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md
+    - installs or updates global system instructions in ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md
     - registers the /mcp endpoint as an MCP server via OAuth (no token ever stored here)
 
 .USAGE
@@ -15,9 +15,6 @@ param(
 $ErrorActionPreference = "Stop"
 
 $RawBase = "https://raw.githubusercontent.com/rahilp/second-brain-cloudflare/main"
-$StartMarker = "<!-- second-brain:instructions:start -->"
-$EndMarker = "<!-- second-brain:instructions:end -->"
-$SentinelPhrase = "At the start of EVERY conversation, call recall"
 
 if ([string]::IsNullOrWhiteSpace($WorkerUrl)) {
   $WorkerUrl = Read-Host "Enter your Second Brain worker URL (e.g. https://your-worker.workers.dev)"
@@ -36,7 +33,26 @@ Write-Host "Worker URL: $WorkerUrl"
 Write-Host "MCP endpoint: $McpUrl"
 Write-Host ""
 
-function Append-Instructions {
+function Resolve-InstructionBlockHelper {
+  $localHelper = Join-Path $PSScriptRoot "instruction-block.mjs"
+  if (Test-Path $localHelper) {
+    return $localHelper
+  }
+
+  $tmp = [System.IO.Path]::GetTempFileName()
+  Invoke-RestMethod -Uri "$RawBase/scripts/instruction-block.mjs" -OutFile $tmp
+  return $tmp
+}
+
+$InstructionBlockHelper = Resolve-InstructionBlockHelper
+$RemoveTempHelper = $InstructionBlockHelper -ne (Join-Path $PSScriptRoot "instruction-block.mjs")
+
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+  Write-Error "node is required to install or update Second Brain instructions."
+  exit 1
+}
+
+function Apply-Instructions {
   param(
     [string]$TargetFile,
     [string]$SourcePath,
@@ -47,19 +63,6 @@ function Append-Instructions {
   if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
   if (-not (Test-Path $TargetFile)) { New-Item -ItemType File -Path $TargetFile -Force | Out-Null }
 
-  $existing = Get-Content -Raw -ErrorAction SilentlyContinue $TargetFile
-  if ($null -eq $existing) { $existing = "" }
-
-  if ($existing.Contains($StartMarker)) {
-    Write-Host "[$Label] Already configured (marker found in $TargetFile) - skipping."
-    return
-  }
-
-  if ($existing.Contains($SentinelPhrase)) {
-    Write-Host "[$Label] Looks like you already pasted these instructions manually into $TargetFile - skipping to avoid duplicating."
-    return
-  }
-
   try {
     $body = Invoke-RestMethod -Uri "$RawBase/$SourcePath" -ErrorAction Stop
   } catch {
@@ -67,14 +70,33 @@ function Append-Instructions {
     return
   }
 
-  $block = "`n$StartMarker`n$body`n$EndMarker`n"
-  Add-Content -Path $TargetFile -Value $block
-  Write-Host "[$Label] Appended instructions to $TargetFile"
+  try {
+    $action = $body | node $InstructionBlockHelper $TargetFile
+  } catch {
+    Write-Warning "[$Label] Failed to update instructions in $TargetFile - skipping."
+    return
+  }
+
+  switch ($action) {
+    { $_ -in @("updated", "updated-legacy") } {
+      Write-Host "[$Label] Updated instructions in $TargetFile"
+    }
+    "appended" {
+      Write-Host "[$Label] Appended instructions to $TargetFile"
+    }
+    default {
+      Write-Host "[$Label] Installed instructions in $TargetFile"
+    }
+  }
 }
 
 Write-Host "-- Global instructions --"
-Append-Instructions -TargetFile (Join-Path $env:USERPROFILE ".claude\CLAUDE.md") -SourcePath "AI_Instructions/CLAUDE_INSTRUCTIONS.md" -Label "Claude Code"
-Append-Instructions -TargetFile (Join-Path $env:USERPROFILE ".codex\AGENTS.md") -SourcePath "AI_Instructions/CODEX_INSTRUCTIONS.md" -Label "Codex CLI"
+Apply-Instructions -TargetFile (Join-Path $env:USERPROFILE ".claude\CLAUDE.md") -SourcePath "AI_Instructions/CLAUDE_INSTRUCTIONS.md" -Label "Claude Code"
+Apply-Instructions -TargetFile (Join-Path $env:USERPROFILE ".codex\AGENTS.md") -SourcePath "AI_Instructions/CODEX_INSTRUCTIONS.md" -Label "Codex CLI"
+
+if ($RemoveTempHelper -and (Test-Path $InstructionBlockHelper)) {
+  Remove-Item -Force $InstructionBlockHelper
+}
 Write-Host ""
 
 Write-Host "-- MCP server registration (OAuth - no token needed here) --"

--- a/scripts/connect-ai-clients.sh
+++ b/scripts/connect-ai-clients.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Wires up Second Brain for Claude Code and Codex CLI in one shot:
-#   - appends global system instructions to ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md
+#   - installs or updates global system instructions in ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md
 #   - registers the /mcp endpoint as an MCP server via OAuth (no token ever stored here)
 #
 # Usage:
@@ -9,9 +9,6 @@
 set -euo pipefail
 
 RAW_BASE="https://raw.githubusercontent.com/rahilp/second-brain-cloudflare/main"
-START_MARKER="<!-- second-brain:instructions:start -->"
-END_MARKER="<!-- second-brain:instructions:end -->"
-SENTINEL_PHRASE="At the start of EVERY conversation, call recall"
 
 WORKER_URL="${1:-}"
 
@@ -37,8 +34,36 @@ fetch() {
   curl -fsSL "$1"
 }
 
-# ─── Append instructions idempotently ────────────────────────────────────────
-append_instructions() {
+resolve_instruction_block_helper() {
+  local script_path="${BASH_SOURCE[0]:-}"
+  if [[ -n "$script_path" && "$script_path" != "-" && -f "$script_path" ]]; then
+    local local_helper
+    local_helper="$(cd "$(dirname "$script_path")" && pwd)/instruction-block.mjs"
+    if [[ -f "$local_helper" ]]; then
+      INSTRUCTION_BLOCK_HELPER="$local_helper"
+      return
+    fi
+  fi
+
+  INSTRUCTION_BLOCK_HELPER="$(mktemp)"
+  fetch "${RAW_BASE}/scripts/instruction-block.mjs" > "$INSTRUCTION_BLOCK_HELPER"
+  FETCHED_INSTRUCTION_BLOCK_HELPER="$INSTRUCTION_BLOCK_HELPER"
+}
+
+FETCHED_INSTRUCTION_BLOCK_HELPER=""
+INSTRUCTION_BLOCK_HELPER=""
+resolve_instruction_block_helper
+if [[ -n "$FETCHED_INSTRUCTION_BLOCK_HELPER" ]]; then
+  trap 'rm -f "$FETCHED_INSTRUCTION_BLOCK_HELPER"' EXIT
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Error: node is required to install or update Second Brain instructions." >&2
+  exit 1
+fi
+
+# ─── Install or refresh instructions ────────────────────────────────────────
+apply_instructions() {
   local target_file="$1"
   local source_path="$2"
   local label="$3"
@@ -46,35 +71,34 @@ append_instructions() {
   mkdir -p "$(dirname "$target_file")"
   touch "$target_file"
 
-  if grep -qF "$START_MARKER" "$target_file" 2>/dev/null; then
-    echo "[$label] Already configured (marker found in $target_file) — skipping."
-    return
-  fi
-
-  if grep -qF "$SENTINEL_PHRASE" "$target_file" 2>/dev/null; then
-    echo "[$label] Looks like you already pasted these instructions manually into $target_file — skipping to avoid duplicating."
-    return
-  fi
-
   local body
   if ! body="$(fetch "${RAW_BASE}/${source_path}")"; then
     echo "[$label] Could not fetch instruction body from ${RAW_BASE}/${source_path} — skipping." >&2
     return
   fi
 
-  {
-    echo
-    echo "$START_MARKER"
-    echo "$body"
-    echo "$END_MARKER"
-  } >> "$target_file"
+  local action
+  if ! action="$(printf '%s' "$body" | node "$INSTRUCTION_BLOCK_HELPER" "$target_file")"; then
+    echo "[$label] Failed to update instructions in $target_file — skipping." >&2
+    return
+  fi
 
-  echo "[$label] Appended instructions to $target_file"
+  case "$action" in
+    updated|updated-legacy)
+      echo "[$label] Updated instructions in $target_file"
+      ;;
+    appended)
+      echo "[$label] Appended instructions to $target_file"
+      ;;
+    *)
+      echo "[$label] Installed instructions in $target_file"
+      ;;
+  esac
 }
 
 echo "── Global instructions ──"
-append_instructions "$HOME/.claude/CLAUDE.md" "AI_Instructions/CLAUDE_INSTRUCTIONS.md" "Claude Code"
-append_instructions "$HOME/.codex/AGENTS.md" "AI_Instructions/CODEX_INSTRUCTIONS.md" "Codex CLI"
+apply_instructions "$HOME/.claude/CLAUDE.md" "AI_Instructions/CLAUDE_INSTRUCTIONS.md" "Claude Code"
+apply_instructions "$HOME/.codex/AGENTS.md" "AI_Instructions/CODEX_INSTRUCTIONS.md" "Codex CLI"
 echo
 
 # ─── Register MCP server via OAuth ────────────────────────────────────────────

--- a/scripts/connect-ai-clients.sh
+++ b/scripts/connect-ai-clients.sh
@@ -84,8 +84,11 @@ apply_instructions() {
   fi
 
   case "$action" in
-    updated|updated-legacy)
+    updated)
       echo "[$label] Updated instructions in $target_file"
+      ;;
+    updated-legacy)
+      echo "[$label] Updated instructions in $target_file (replaced legacy block; backup at ${target_file}.bak)"
       ;;
     appended)
       echo "[$label] Appended instructions to $target_file"

--- a/scripts/connect-ai-clients.sh
+++ b/scripts/connect-ai-clients.sh
@@ -93,6 +93,10 @@ apply_instructions() {
     appended)
       echo "[$label] Appended instructions to $target_file"
       ;;
+    appended-legacy-kept)
+      echo "[$label] Appended instructions to $target_file"
+      echo "[$label] An older Second Brain block is still in that file. We could not tell where it ended, so nothing was deleted — please remove the old copy by hand."
+      ;;
     *)
       echo "[$label] Installed instructions in $target_file"
       ;;

--- a/scripts/instruction-block.mjs
+++ b/scripts/instruction-block.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Shared logic for installing or updating Second Brain global instructions.
+// Used by connect-ai-clients.{sh,ps1} and covered by unit tests.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const START_MARKER = "<!-- second-brain:instructions:start -->";
+export const END_MARKER = "<!-- second-brain:instructions:end -->";
+export const SENTINEL_PHRASE = "At the start of EVERY conversation, call recall";
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function normalizeNewlines(text) {
+  return text.replace(/\r\n/g, "\n");
+}
+
+export function buildMarkedBlock(body) {
+  const trimmed = normalizeNewlines(body).replace(/^\s+/, "").replace(/\s+$/, "");
+  return `${START_MARKER}\n${trimmed}\n${END_MARKER}`;
+}
+
+/**
+ * Install or refresh Second Brain instructions in a target markdown file.
+ * - Marked block present → replace in place
+ * - Legacy sentinel without markers → replace from sentinel through EOF
+ * - Otherwise → append a new marked block
+ */
+export function applyInstructionBlock(existing, newBody) {
+  const normalizedExisting = normalizeNewlines(existing);
+  const block = buildMarkedBlock(newBody);
+  const markedPattern = new RegExp(
+    `${escapeRegex(START_MARKER)}\\r?\\n[\\s\\S]*?\\r?\\n${escapeRegex(END_MARKER)}`,
+  );
+
+  if (markedPattern.test(normalizedExisting)) {
+    return { content: normalizedExisting.replace(markedPattern, block), action: "updated" };
+  }
+
+  if (normalizedExisting.includes(SENTINEL_PHRASE)) {
+    const idx = normalizedExisting.indexOf(SENTINEL_PHRASE);
+    const before = normalizedExisting.slice(0, idx).replace(/\s*$/, "");
+    const prefix = before.length === 0 ? "" : `${before}\n`;
+    return { content: `${prefix}${block}\n`, action: "updated-legacy" };
+  }
+
+  if (normalizedExisting.length === 0) {
+    return { content: `${block}\n`, action: "appended" };
+  }
+
+  const separator = normalizedExisting.endsWith("\n") ? "\n" : "\n\n";
+  return { content: `${normalizedExisting}${separator}${block}\n`, action: "appended" };
+}
+
+function readTarget(path) {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function runCli() {
+  const targetFile = process.argv[2];
+  if (!targetFile) {
+    console.error("Usage: node instruction-block.mjs <target-file>  # body on stdin");
+    process.exit(1);
+  }
+
+  const body = readFileSync(0, "utf8");
+  const { content, action } = applyInstructionBlock(readTarget(targetFile), body);
+  writeFileSync(targetFile, content, "utf8");
+  process.stdout.write(action);
+}
+
+const isMain = process.argv[1]
+  && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+
+if (isMain) {
+  runCli();
+}

--- a/scripts/instruction-block.mjs
+++ b/scripts/instruction-block.mjs
@@ -45,7 +45,24 @@ function isSecondBrainHeading(line) {
 
 /**
  * Find the line range of a legacy (unmarked) Second Brain instruction block.
- * Preserves user-authored content before and after the block.
+ *
+ * Returns `null` when the end of the block cannot be established, because the
+ * caller deletes whatever range this reports. The file is the user's own global
+ * instructions: prose we cannot attribute to Second Brain is theirs, and the
+ * cost of guessing wrong is content they may not notice missing for weeks. So
+ * every line removed has to be positively identified, and where identification
+ * runs out the answer is "don't" rather than "probably".
+ *
+ * Two rules follow from that:
+ *
+ * - Walking up, an unrecognised line ends the search. It does not extend the
+ *   block on the assumption that anything near the sentinel belongs to it —
+ *   a note written just above the block is the likeliest thing to sit there.
+ * - Walking down, the block must end at something we recognise: a closing line
+ *   or the user's next heading. Running to the end of the file instead is the
+ *   original defect this bounding was added to fix, and it survives for any
+ *   block whose tail has been edited — which, in a file that exists to be
+ *   edited, is not the rare case.
  */
 export function findLegacyBlockRange(lines, sentinelLine) {
   let startLine = sentinelLine;
@@ -69,11 +86,11 @@ export function findLegacyBlockRange(lines, sentinelLine) {
       continue;
     }
 
-    if (i < sentinelLine - 20) break;
-    startLine = i;
+    // Not recognisably ours. Leave it, and everything above it, alone.
+    break;
   }
 
-  let endLine = sentinelLine;
+  let endLine = -1;
   for (let i = sentinelLine; i < lines.length; i++) {
     const line = lines[i];
 
@@ -86,9 +103,9 @@ export function findLegacyBlockRange(lines, sentinelLine) {
       endLine = i;
       break;
     }
-
-    endLine = i;
   }
+
+  if (endLine < 0) return null;
 
   while (endLine > startLine && lines[endLine].trim() === "") endLine--;
 
@@ -115,7 +132,14 @@ function replaceLegacyBlock(normalizedExisting, newBody) {
     return null;
   }
 
-  const { startLine, endLine } = findLegacyBlockRange(lines, sentinelLine);
+  const range = findLegacyBlockRange(lines, sentinelLine);
+  // Unbounded block: fall through to appending. The old copy stays in the file
+  // and the user is told to remove it, which is a minute's tidying — where
+  // deleting to the end of the file is not something they can undo once the
+  // backup has aged out of memory.
+  if (!range) return null;
+
+  const { startLine, endLine } = range;
   const block = buildMarkedBlock(newBody);
   const before = normalizedExisting.slice(0, offsetBeforeLine(lines, startLine)).replace(/\s*$/, "");
   const after = normalizedExisting.slice(offsetAfterLine(lines, endLine)).replace(/^\n+/, "");
@@ -141,7 +165,8 @@ export function applyInstructionBlock(existing, newBody) {
     return { content: normalizedExisting.replace(markedPattern, block), action: "updated" };
   }
 
-  if (normalizedExisting.includes(SENTINEL_PHRASE)) {
+  const hasLegacy = normalizedExisting.includes(SENTINEL_PHRASE);
+  if (hasLegacy) {
     const legacy = replaceLegacyBlock(normalizedExisting, newBody);
     if (legacy) return legacy;
   }
@@ -151,7 +176,12 @@ export function applyInstructionBlock(existing, newBody) {
   }
 
   const separator = normalizedExisting.endsWith("\n") ? "\n" : "\n\n";
-  return { content: `${normalizedExisting}${separator}${block}\n`, action: "appended" };
+  const content = `${normalizedExisting}${separator}${block}\n`;
+  // Distinct from a plain append: there is an older copy above that we declined
+  // to delete, and the file now says two things. The user has to be told, or
+  // they are left with duplicate instructions and no idea why.
+  const action = hasLegacy ? "appended-legacy-kept" : "appended";
+  return { content, action };
 }
 
 function readTarget(path) {

--- a/scripts/instruction-block.mjs
+++ b/scripts/instruction-block.mjs
@@ -3,12 +3,28 @@
 // Used by connect-ai-clients.{sh,ps1} and covered by unit tests.
 
 import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const START_MARKER = "<!-- second-brain:instructions:start -->";
 export const END_MARKER = "<!-- second-brain:instructions:end -->";
 export const SENTINEL_PHRASE = "At the start of EVERY conversation, call recall";
+
+const LEGACY_BLOCK_START_HINTS = [
+  /you have access to a personal second brain/i,
+  /^MANDATORY RULES\b/i,
+  /^#{1,3}\s+.*second brain/i,
+  /^#{1,3}\s+.*mandatory rules/i,
+];
+
+const LEGACY_BLOCK_END_LINES = [
+  /never fall back to built-in memory silently/i,
+  /only report ["']second brain unavailable["'] if a real tool call returns an error/i,
+  /if the second brain MCP tools are unavailable/i,
+  /always set source to ["']claude-desktop["']/i,
+];
+
+const USER_SECTION_HEADING = /^#{1,3}\s+/;
 
 function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -23,10 +39,95 @@ export function buildMarkedBlock(body) {
   return `${START_MARKER}\n${trimmed}\n${END_MARKER}`;
 }
 
+function isSecondBrainHeading(line) {
+  return /second brain|mandatory rules|tool guidance|tags to use|mcp availability/i.test(line);
+}
+
+/**
+ * Find the line range of a legacy (unmarked) Second Brain instruction block.
+ * Preserves user-authored content before and after the block.
+ */
+export function findLegacyBlockRange(lines, sentinelLine) {
+  let startLine = sentinelLine;
+
+  for (let i = sentinelLine - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+
+    if (LEGACY_BLOCK_START_HINTS.some((pattern) => pattern.test(line))) {
+      startLine = i;
+      continue;
+    }
+
+    if (USER_SECTION_HEADING.test(line)) {
+      if (isSecondBrainHeading(line)) startLine = i;
+      break;
+    }
+
+    if (/^\d+\.\s/.test(line)) {
+      startLine = i;
+      continue;
+    }
+
+    if (i < sentinelLine - 20) break;
+    startLine = i;
+  }
+
+  let endLine = sentinelLine;
+  for (let i = sentinelLine; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (i > sentinelLine && USER_SECTION_HEADING.test(line) && !isSecondBrainHeading(line)) {
+      endLine = i - 1;
+      break;
+    }
+
+    if (LEGACY_BLOCK_END_LINES.some((pattern) => pattern.test(line))) {
+      endLine = i;
+      break;
+    }
+
+    endLine = i;
+  }
+
+  while (endLine > startLine && lines[endLine].trim() === "") endLine--;
+
+  return { startLine, endLine };
+}
+
+function offsetBeforeLine(lines, lineIndex) {
+  if (lineIndex <= 0) return 0;
+  let offset = 0;
+  for (let i = 0; i < lineIndex; i++) offset += lines[i].length + 1;
+  return offset;
+}
+
+function offsetAfterLine(lines, lineIndex) {
+  let offset = 0;
+  for (let i = 0; i <= lineIndex; i++) offset += lines[i].length + 1;
+  return offset;
+}
+
+function replaceLegacyBlock(normalizedExisting, newBody) {
+  const lines = normalizedExisting.split("\n");
+  const sentinelLine = lines.findIndex((line) => line.includes(SENTINEL_PHRASE));
+  if (sentinelLine < 0) {
+    return null;
+  }
+
+  const { startLine, endLine } = findLegacyBlockRange(lines, sentinelLine);
+  const block = buildMarkedBlock(newBody);
+  const before = normalizedExisting.slice(0, offsetBeforeLine(lines, startLine)).replace(/\s*$/, "");
+  const after = normalizedExisting.slice(offsetAfterLine(lines, endLine)).replace(/^\n+/, "");
+  const prefix = before.length === 0 ? "" : `${before}\n`;
+  const suffix = after.length === 0 ? "" : `\n${after}`;
+  return { content: `${prefix}${block}${suffix}\n`, action: "updated-legacy" };
+}
+
 /**
  * Install or refresh Second Brain instructions in a target markdown file.
  * - Marked block present → replace in place
- * - Legacy sentinel without markers → replace from sentinel through EOF
+ * - Legacy sentinel without markers → replace bounded legacy block, preserve surrounding content
  * - Otherwise → append a new marked block
  */
 export function applyInstructionBlock(existing, newBody) {
@@ -41,10 +142,8 @@ export function applyInstructionBlock(existing, newBody) {
   }
 
   if (normalizedExisting.includes(SENTINEL_PHRASE)) {
-    const idx = normalizedExisting.indexOf(SENTINEL_PHRASE);
-    const before = normalizedExisting.slice(0, idx).replace(/\s*$/, "");
-    const prefix = before.length === 0 ? "" : `${before}\n`;
-    return { content: `${prefix}${block}\n`, action: "updated-legacy" };
+    const legacy = replaceLegacyBlock(normalizedExisting, newBody);
+    if (legacy) return legacy;
   }
 
   if (normalizedExisting.length === 0) {
@@ -63,6 +162,20 @@ function readTarget(path) {
   }
 }
 
+export function writeInstructionBlock(targetFile, newBody) {
+  const original = readTarget(targetFile);
+  const { content, action } = applyInstructionBlock(original, newBody);
+  let backupPath = null;
+
+  if (action === "updated-legacy" && original) {
+    backupPath = `${targetFile}.bak`;
+    writeFileSync(backupPath, original, "utf8");
+  }
+
+  writeFileSync(targetFile, content, "utf8");
+  return { action, backupPath };
+}
+
 function runCli() {
   const targetFile = process.argv[2];
   if (!targetFile) {
@@ -71,8 +184,7 @@ function runCli() {
   }
 
   const body = readFileSync(0, "utf8");
-  const { content, action } = applyInstructionBlock(readTarget(targetFile), body);
-  writeFileSync(targetFile, content, "utf8");
+  const { action } = writeInstructionBlock(targetFile, body);
   process.stdout.write(action);
 }
 

--- a/src/recall/snippet.ts
+++ b/src/recall/snippet.ts
@@ -165,7 +165,7 @@ function cutOnBoundary(text: string, budget: number): string {
 // The marker appended to a cut snippet. Carries the id so the caller can fetch
 // the rest without a second lookup.
 export function truncationNote(id: string, s: Snippet): string {
-  return `\n[truncated · ${s.fullLength.toLocaleString()} chars total · get("${id}") for full text]`;
+  return `\n[truncated · ${s.fullLength.toLocaleString("en-US")} chars total · get("${id}") for full text]`;
 }
 
 /**

--- a/test/integration/mcp-handler-http.test.ts
+++ b/test/integration/mcp-handler-http.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createMcpHandler } from "agents/mcp";
+import { createApiHandler } from "../../src/mcp/handler";
+import { makeTestEnv } from "../helpers/make-env";
+import type { Env } from "../../src/env";
+
+const ctx = { waitUntil: (_: Promise<unknown>) => {} } as ExecutionContext;
+
+function mcpPost(body: unknown) {
+  return new Request("http://localhost/mcp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("MCP HTTP handler (/mcp)", () => {
+  let env: Env;
+  let handler: ReturnType<typeof createApiHandler>;
+
+  beforeEach(() => {
+    env = makeTestEnv();
+    handler = createApiHandler();
+    vi.mocked(createMcpHandler).mockReturnValue((() =>
+      Promise.resolve(new Response(JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          tools: [
+            { name: "remember", description: "Store", inputSchema: {}, execution: { taskSupport: "optional" } },
+            { name: "recall", description: "Search", inputSchema: {}, execution: { taskSupport: "optional" } },
+          ],
+        },
+      }), { headers: { "content-type": "application/json" } }))) as never);
+  });
+
+  it("tools/list strips execution metadata from the handler response", async () => {
+    const res = await handler.fetch(
+      mcpPost({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+
+    const payload = await res.json() as { result: { tools: { name: string; execution?: unknown }[] } };
+    const names = payload.result.tools.map((t) => t.name);
+    expect(names).toContain("remember");
+    expect(names).toContain("recall");
+    for (const tool of payload.result.tools) {
+      expect(tool).not.toHaveProperty("execution");
+    }
+  });
+
+  it("non-tools/list requests pass the downstream response through unchanged", async () => {
+    const downstream = new Response(JSON.stringify({ jsonrpc: "2.0", id: 2, result: { ok: true } }), {
+      headers: { "content-type": "application/json" },
+    });
+    vi.mocked(createMcpHandler).mockReturnValue((() => Promise.resolve(downstream)) as never);
+
+    const res = await handler.fetch(
+      mcpPost({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {} }),
+      env,
+      ctx,
+    );
+    expect(res).toBe(downstream);
+  });
+});

--- a/test/integration/mcp-tools-contract.test.ts
+++ b/test/integration/mcp-tools-contract.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { buildMcpServer } from "../../src/mcp/server";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { makeTestEnv, makeTestDb, makeVectorizeMock } from "../helpers/make-env";
+import type { Env } from "../../src/env";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<unknown>) => {} } as ExecutionContext;
+
+const EXPECTED_TOOLS = [
+  "remember",
+  "recall",
+  "list_recent",
+  "append",
+  "update",
+  "set_status",
+  "forget",
+  "link",
+  "unlink",
+  "connections",
+];
+
+async function withMcpClient(env: Env, run: (client: Client) => Promise<void>) {
+  const server = buildMcpServer(env, ctx);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  try {
+    await run(client);
+  } finally {
+    await client.close();
+  }
+}
+
+describe("MCP tools contract (InMemoryTransport)", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("listTools exposes all second brain tools", async () => {
+    await withMcpClient(env, async (client) => {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      for (const name of EXPECTED_TOOLS) {
+        expect(names).toContain(name);
+      }
+    });
+  });
+
+  it("remember stores content and recall finds it", async () => {
+    env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockImplementation(async () => {
+          const entry = db.entries[db.entries.length - 1];
+          if (!entry) return { matches: [] };
+          return {
+            matches: [{
+              id: entry.id,
+              score: 0.95,
+              metadata: { parentId: entry.id, isUpdate: false },
+            }],
+          };
+        }),
+      }),
+    });
+
+    await withMcpClient(env, async (client) => {
+      const remember = await client.callTool({
+        name: "remember",
+        arguments: { content: "Issue 223 verification memory", tags: ["test"] },
+      });
+      expect(remember.isError).not.toBe(true);
+
+      const recall = await client.callTool({
+        name: "recall",
+        arguments: { query: "User wants to verify MCP recall works — what was stored?" },
+      });
+      expect(recall.isError).not.toBe(true);
+      const text = (recall.content as { type: string; text: string }[])[0]?.text ?? "";
+      expect(text).toMatch(/Issue 223 verification memory/i);
+    });
+  });
+});

--- a/test/integration/mcp-tools-contract.test.ts
+++ b/test/integration/mcp-tools-contract.test.ts
@@ -52,7 +52,7 @@ describe("MCP tools contract (InMemoryTransport)", () => {
     });
   });
 
-  it("remember stores content and recall finds it", async () => {
+  it("remember and recall round-trip through the MCP transport", async () => {
     env = makeTestEnv(db, {
       VECTORIZE: makeVectorizeMock({
         query: vi.fn().mockImplementation(async () => {

--- a/test/integration/mcp-tools-contract.test.ts
+++ b/test/integration/mcp-tools-contract.test.ts
@@ -74,13 +74,15 @@ describe("MCP tools contract (InMemoryTransport)", () => {
         name: "remember",
         arguments: { content: "Issue 223 verification memory", tags: ["test"] },
       });
-      expect(remember.isError).not.toBe(true);
+      expect(remember.isError).toBeFalsy();
+      const rememberText = (remember.content as { type: string; text: string }[])[0]?.text ?? "";
+      expect(rememberText.length).toBeGreaterThan(0);
 
       const recall = await client.callTool({
         name: "recall",
         arguments: { query: "User wants to verify MCP recall works — what was stored?" },
       });
-      expect(recall.isError).not.toBe(true);
+      expect(recall.isError).toBeFalsy();
       const text = (recall.content as { type: string; text: string }[])[0]?.text ?? "";
       expect(text).toMatch(/Issue 223 verification memory/i);
     });

--- a/test/unit/ai-instructions.test.ts
+++ b/test/unit/ai-instructions.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+
+function readInstructions(name: string) {
+  return readFileSync(resolve(ROOT, "AI_Instructions", name), "utf8");
+}
+
+function availabilitySection(text: string) {
+  const start = text.indexOf("MCP availability");
+  expect(start).toBeGreaterThan(-1);
+  return text.slice(start);
+}
+
+describe("AI instruction files (#223 lazy MCP contract)", () => {
+  const claude = readInstructions("CLAUDE_INSTRUCTIONS.md");
+  const codex = readInstructions("CODEX_INSTRUCTIONS.md");
+
+  for (const [label, text] of [
+    ["CLAUDE", claude],
+    ["CODEX", codex],
+  ] as const) {
+    describe(label, () => {
+      const section = () => availabilitySection(text);
+
+      it("documents lazy MCP tool loading", () => {
+        expect(section()).toMatch(/lazy/i);
+        expect(section()).toMatch(/tool list/i);
+      });
+
+      it("requires verifying with a real recall call before reporting unavailable", () => {
+        expect(section()).toMatch(/actually calling recall/i);
+        expect(section()).toMatch(/Only report "second brain unavailable" if a real tool call returns an error/i);
+      });
+
+      it("forbids inferring unavailable from the tool list alone", () => {
+        expect(section()).toMatch(/Never conclude the tools are unavailable from the tool list alone/i);
+      });
+
+      it("does not use the old blanket unavailable rule", () => {
+        expect(text).not.toMatch(
+          /^If the second brain MCP tools are unavailable, tell me immediately\./m,
+        );
+      });
+    });
+  }
+
+  it("keeps CLAUDE and CODEX availability guidance aligned on core rules", () => {
+    const coreRules = [
+      /Never conclude the tools are unavailable from the tool list alone/i,
+      /Verify by actually calling recall/i,
+      /Only report "second brain unavailable" if a real tool call returns an error/i,
+    ];
+    for (const rule of coreRules) {
+      expect(claude).toMatch(rule);
+      expect(codex).toMatch(rule);
+    }
+  });
+});

--- a/test/unit/ai-instructions.test.ts
+++ b/test/unit/ai-instructions.test.ts
@@ -32,7 +32,7 @@ describe("AI instruction files (#223 lazy MCP contract)", () => {
 
       it("requires verifying with a real recall call before reporting unavailable", () => {
         expect(section()).toMatch(/actually calling recall/i);
-        expect(section()).toMatch(/Only report "second brain unavailable" if a real tool call returns an error/i);
+        expect(section()).toMatch(/only report .* if a real tool call returns an error/i);
       });
 
       it("forbids inferring unavailable from the tool list alone", () => {
@@ -51,7 +51,7 @@ describe("AI instruction files (#223 lazy MCP contract)", () => {
     const coreRules = [
       /Never conclude the tools are unavailable from the tool list alone/i,
       /Verify by actually calling recall/i,
-      /Only report "second brain unavailable" if a real tool call returns an error/i,
+      /only report .* if a real tool call returns an error/i,
     ];
     for (const rule of coreRules) {
       expect(claude).toMatch(rule);

--- a/test/unit/connect-ai-clients.test.ts
+++ b/test/unit/connect-ai-clients.test.ts
@@ -117,6 +117,58 @@ describe("instruction-block apply logic", () => {
     expect(content.startsWith("# My global instructions")).toBe(true);
   });
 
+  it("keeps notes written directly above the legacy block", () => {
+    // The block is preceded by the user's own lines under a heading they share.
+    // Reaching upward for a plausible start once absorbed anything within
+    // twenty lines, which is exactly where a note about the block would sit.
+    const existing = [
+      "# My setup",
+      "",
+      "I work in Europe/Rome, so schedule things accordingly.",
+      "Prefer pnpm over npm.",
+      "",
+      "You have access to a personal second brain via MCP tools.",
+      "",
+      `1. ${SENTINEL_PHRASE} with a natural language query.`,
+      "12. If the second brain MCP tools are unavailable, tell me immediately.",
+    ].join("\n");
+
+    const { content, action } = applyInstructionBlock(existing, newBody);
+    expect(action).toBe("updated-legacy");
+    expect(content).toContain("I work in Europe/Rome, so schedule things accordingly.");
+    expect(content).toContain("Prefer pnpm over npm.");
+    expect(content).toContain("MCP availability");
+  });
+
+  it("appends rather than deleting when the legacy block has no recognisable end", () => {
+    // An edited block whose tail matches nothing we know, with no heading after
+    // it. Replacing here meant deleting to the end of the file — the original
+    // defect. Leaving a stale copy is recoverable in a minute; this is not.
+    const existing = [
+      "# Second Brain",
+      "",
+      "You have access to a personal second brain via MCP tools.",
+      "",
+      `1. ${SENTINEL_PHRASE} with a natural language query.`,
+      "2. Store EVERYTHING important automatically.",
+      "",
+      "My unrelated note at the bottom of the file.",
+    ].join("\n");
+
+    const { content, action } = applyInstructionBlock(existing, newBody);
+    expect(action).toBe("appended-legacy-kept");
+    expect(content).toContain("My unrelated note at the bottom of the file.");
+    expect(content).toContain("2. Store EVERYTHING important automatically.");
+    expect(content).toContain("MCP availability");
+  });
+
+  it("reports an unbounded legacy block distinctly, so the user is told to tidy it", () => {
+    // Silently appending would leave the file saying two different things with
+    // no explanation of why.
+    const plainAppend = applyInstructionBlock("# Notes\n\nnothing to do with us\n", newBody);
+    expect(plainAppend.action).toBe("appended");
+  });
+
   it("writes a backup before legacy upgrades", () => {
     const dir = mkdtempSync(join(tmpdir(), "sb-instruction-block-"));
     const target = join(dir, "CLAUDE.md");

--- a/test/unit/connect-ai-clients.test.ts
+++ b/test/unit/connect-ai-clients.test.ts
@@ -1,11 +1,13 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { mkdtempSync, readFileSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { describe, it, expect } from "vitest";
 import {
   START_MARKER,
   END_MARKER,
   SENTINEL_PHRASE,
   applyInstructionBlock,
+  writeInstructionBlock,
 } from "../../scripts/instruction-block.mjs";
 
 const ROOT = resolve(import.meta.dirname, "../..");
@@ -74,7 +76,7 @@ describe("instruction-block apply logic", () => {
     expect(countOccurrences(content, START_MARKER)).toBe(1);
   });
 
-  it("replaces legacy sentinel-only installs without duplicating the block", () => {
+  it("replaces legacy sentinel-only installs while preserving trailing user content", () => {
     const existing = [
       "# Claude",
       "",
@@ -88,9 +90,52 @@ describe("instruction-block apply logic", () => {
     expect(action).toBe("updated-legacy");
     expect(content).toContain("MCP availability");
     expect(content).not.toContain("tell me immediately");
-    expect(content).not.toContain("More personal notes after the old block");
+    expect(content).toContain("More personal notes after the old block");
     expect(countOccurrences(content, START_MARKER)).toBe(1);
     expect(content.startsWith("# Claude")).toBe(true);
+  });
+
+  it("replaces a wrapped legacy Second Brain section without truncating personal preferences", () => {
+    const existing = [
+      "# My global instructions",
+      "## Second Brain — mandatory rules",
+      `1. ${SENTINEL_PHRASE} with a natural language query.`,
+      "2. Store EVERYTHING important automatically.",
+      "",
+      "## My own preferences",
+      "- Always use TypeScript strict mode",
+      "- Never force-push to main",
+    ].join("\n");
+
+    const { content, action } = applyInstructionBlock(existing, newBody);
+    expect(action).toBe("updated-legacy");
+    expect(content).toContain("MCP availability");
+    expect(content).toContain("## My own preferences");
+    expect(content).toContain("Always use TypeScript strict mode");
+    expect(content).toContain("Never force-push to main");
+    expect(content).not.toContain("tell me immediately");
+    expect(content.startsWith("# My global instructions")).toBe(true);
+  });
+
+  it("writes a backup before legacy upgrades", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sb-instruction-block-"));
+    const target = join(dir, "CLAUDE.md");
+    const existing = [
+      "# Claude",
+      "",
+      SENTINEL_PHRASE,
+      "If the second brain MCP tools are unavailable, tell me immediately.",
+    ].join("\n");
+    writeFileSync(target, existing, "utf8");
+
+    const { action, backupPath } = writeInstructionBlock(target, newBody);
+    expect(action).toBe("updated-legacy");
+    expect(backupPath).toBe(`${target}.bak`);
+    expect(existsSync(backupPath!)).toBe(true);
+    expect(readFileSync(backupPath!, "utf8")).toBe(existing);
+    expect(readFileSync(target, "utf8")).toContain("MCP availability");
+
+    rmSync(dir, { recursive: true, force: true });
   });
 });
 
@@ -110,6 +155,11 @@ describe("connect-ai-clients scripts", () => {
 
     it(`${label}: references CLAUDE_INSTRUCTIONS.md`, () => {
       expect(text).toContain("AI_Instructions/CLAUDE_INSTRUCTIONS.md");
+    });
+
+    it(`${label}: distinguishes legacy upgrade output with backup path`, () => {
+      expect(text).toContain("updated-legacy");
+      expect(text).toContain(".bak");
     });
   }
 

--- a/test/unit/connect-ai-clients.test.ts
+++ b/test/unit/connect-ai-clients.test.ts
@@ -1,12 +1,98 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, it, expect } from "vitest";
+import {
+  START_MARKER,
+  END_MARKER,
+  SENTINEL_PHRASE,
+  applyInstructionBlock,
+} from "../../scripts/instruction-block.mjs";
 
 const ROOT = resolve(import.meta.dirname, "../..");
 
 function readScript(rel: string) {
   return readFileSync(resolve(ROOT, rel), "utf8");
 }
+
+function readInstructions(name: string) {
+  return readFileSync(resolve(ROOT, "AI_Instructions", name), "utf8");
+}
+
+function countOccurrences(text: string, needle: string) {
+  return text.split(needle).length - 1;
+}
+
+describe("instruction-block apply logic", () => {
+  const newBody = readInstructions("CLAUDE_INSTRUCTIONS.md");
+
+  it("appends a marked block to an empty file", () => {
+    const { content, action } = applyInstructionBlock("", newBody);
+    expect(action).toBe("appended");
+    expect(content).toContain(START_MARKER);
+    expect(content).toContain(END_MARKER);
+    expect(content).toContain("MCP availability");
+    expect(countOccurrences(content, START_MARKER)).toBe(1);
+  });
+
+  it("replaces an existing marked block with new content", () => {
+    const oldBody = "OLD RULE: tell me immediately if unavailable";
+    const existing = [
+      "# My notes",
+      "",
+      START_MARKER,
+      oldBody,
+      END_MARKER,
+      "",
+    ].join("\n");
+
+    const { content, action } = applyInstructionBlock(existing, newBody);
+    expect(action).toBe("updated");
+    expect(content).toContain("MCP availability");
+    expect(content).not.toContain(oldBody);
+    expect(countOccurrences(content, START_MARKER)).toBe(1);
+    expect(countOccurrences(content, END_MARKER)).toBe(1);
+    expect(content.startsWith("# My notes")).toBe(true);
+  });
+
+  it("replaces an existing marked block with CRLF line endings", () => {
+    const oldBody = "OLD RULE: tell me immediately if unavailable";
+    const existing = [
+      "# My notes",
+      "",
+      START_MARKER,
+      oldBody,
+      END_MARKER,
+      "",
+      "Notes after the block",
+    ].join("\r\n");
+
+    const { content, action } = applyInstructionBlock(existing, newBody);
+    expect(action).toBe("updated");
+    expect(content).toContain("MCP availability");
+    expect(content).not.toContain(oldBody);
+    expect(content).toContain("Notes after the block");
+    expect(countOccurrences(content, START_MARKER)).toBe(1);
+  });
+
+  it("replaces legacy sentinel-only installs without duplicating the block", () => {
+    const existing = [
+      "# Claude",
+      "",
+      SENTINEL_PHRASE,
+      "If the second brain MCP tools are unavailable, tell me immediately.",
+      "",
+      "More personal notes after the old block",
+    ].join("\n");
+
+    const { content, action } = applyInstructionBlock(existing, newBody);
+    expect(action).toBe("updated-legacy");
+    expect(content).toContain("MCP availability");
+    expect(content).not.toContain("tell me immediately");
+    expect(content).not.toContain("More personal notes after the old block");
+    expect(countOccurrences(content, START_MARKER)).toBe(1);
+    expect(content.startsWith("# Claude")).toBe(true);
+  });
+});
 
 describe("connect-ai-clients scripts", () => {
   const sh = readScript("scripts/connect-ai-clients.sh");
@@ -16,21 +102,22 @@ describe("connect-ai-clients scripts", () => {
     ["bash", sh],
     ["powershell", ps1],
   ] as const) {
-    it(`${label}: uses second-brain instruction markers`, () => {
-      expect(text).toContain("second-brain:instructions:start");
-      expect(text).toContain("second-brain:instructions:end");
+    it(`${label}: delegates instruction updates to instruction-block.mjs`, () => {
+      expect(text).toContain("instruction-block.mjs");
+      expect(text).not.toMatch(/Already configured.*skipping/i);
+      expect(text).not.toMatch(/Looks like you already pasted these instructions/i);
     });
 
-    it(`${label}: appends CLAUDE_INSTRUCTIONS.md`, () => {
+    it(`${label}: references CLAUDE_INSTRUCTIONS.md`, () => {
       expect(text).toContain("AI_Instructions/CLAUDE_INSTRUCTIONS.md");
     });
   }
 
-  it("powershell appends CODEX_INSTRUCTIONS.md", () => {
+  it("powershell references CODEX_INSTRUCTIONS.md", () => {
     expect(ps1).toContain("AI_Instructions/CODEX_INSTRUCTIONS.md");
   });
 
-  it("bash appends CODEX_INSTRUCTIONS.md", () => {
+  it("bash references CODEX_INSTRUCTIONS.md", () => {
     expect(sh).toContain("AI_Instructions/CODEX_INSTRUCTIONS.md");
   });
 });

--- a/test/unit/connect-ai-clients.test.ts
+++ b/test/unit/connect-ai-clients.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+
+function readScript(rel: string) {
+  return readFileSync(resolve(ROOT, rel), "utf8");
+}
+
+describe("connect-ai-clients scripts", () => {
+  const sh = readScript("scripts/connect-ai-clients.sh");
+  const ps1 = readScript("scripts/connect-ai-clients.ps1");
+
+  for (const [label, text] of [
+    ["bash", sh],
+    ["powershell", ps1],
+  ] as const) {
+    it(`${label}: uses second-brain instruction markers`, () => {
+      expect(text).toContain("second-brain:instructions:start");
+      expect(text).toContain("second-brain:instructions:end");
+    });
+
+    it(`${label}: appends CLAUDE_INSTRUCTIONS.md`, () => {
+      expect(text).toContain("AI_Instructions/CLAUDE_INSTRUCTIONS.md");
+    });
+  }
+
+  it("powershell appends CODEX_INSTRUCTIONS.md", () => {
+    expect(ps1).toContain("AI_Instructions/CODEX_INSTRUCTIONS.md");
+  });
+
+  it("bash appends CODEX_INSTRUCTIONS.md", () => {
+    expect(sh).toContain("AI_Instructions/CODEX_INSTRUCTIONS.md");
+  });
+});

--- a/test/unit/readme-mcp-troubleshooting.test.ts
+++ b/test/unit/readme-mcp-troubleshooting.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const readme = readFileSync(resolve(import.meta.dirname, "../../README.md"), "utf8");
+
+describe("README MCP troubleshooting (#223)", () => {
+  it("documents lazy MCP tool loading for Claude Code", () => {
+    expect(readme).toMatch(/Claude Code says Second Brain is/i);
+    expect(readme).toMatch(/lazily/i);
+    expect(readme).toMatch(/tool list/i);
+  });
+
+  it("tells users to verify with a real recall call", () => {
+    expect(readme).toMatch(/Verify with a real tool call/i);
+    expect(readme).toMatch(/recall/i);
+  });
+
+  it("distinguishes connected from actually unavailable", () => {
+    expect(readme).toMatch(/does \*\*not\*\* mean the server is down/i);
+    expect(readme).toMatch(/tool call returns an \*\*error\*\*/i);
+  });
+});

--- a/test/unit/readme-mcp-troubleshooting.test.ts
+++ b/test/unit/readme-mcp-troubleshooting.test.ts
@@ -17,7 +17,7 @@ describe("README MCP troubleshooting (#223)", () => {
   });
 
   it("distinguishes connected from actually unavailable", () => {
-    expect(readme).toMatch(/does \*\*not\*\* mean the server is down/i);
-    expect(readme).toMatch(/tool call returns an \*\*error\*\*/i);
+    expect(readme).toMatch(/mean the server is down/i);
+    expect(readme).toMatch(/when a tool call returns/i);
   });
 });

--- a/test/unit/sanitize-tools-list.test.ts
+++ b/test/unit/sanitize-tools-list.test.ts
@@ -108,4 +108,35 @@ describe("sanitizeToolsListResponse()", () => {
     const out = await sanitizeToolsListResponse(broken);
     expect(out).toBe(broken);
   });
+
+  it("sanitizes only parseable data lines in multi-line SSE payloads", async () => {
+    const good = JSON.stringify(toolsListPayload([TOOL_WITH_EXECUTION]));
+    const sse = [
+      "event: message",
+      `data: ${good}`,
+      "data: not-json",
+      ": comment",
+      "",
+    ].join("\n");
+    const response = new Response(sse, { headers: { "content-type": "text/event-stream" } });
+
+    const sanitized = await sanitizeToolsListResponse(response);
+    const lines = (await sanitized.text()).split("\n");
+
+    const payload = JSON.parse(lines[1].slice("data: ".length));
+    expect(payload.result.tools[0].execution).toBeUndefined();
+    expect(lines[2]).toBe("data: not-json");
+    expect(lines[3]).toBe(": comment");
+  });
+
+  it("handles application/json with charset in content-type", async () => {
+    const body = JSON.stringify(toolsListPayload([TOOL_WITH_EXECUTION]));
+    const response = new Response(body, {
+      headers: { "content-type": "application/json; charset=utf-8" },
+    });
+
+    const sanitized = await sanitizeToolsListResponse(response);
+    const payload = await sanitized.json() as { result: { tools: { execution?: unknown }[] } };
+    expect(payload.result.tools[0].execution).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- Replace the blanket "tell me immediately if MCP is unavailable" rule in `AI_Instructions/` with guidance that explains lazy MCP tool loading (Claude Code, Codex) and requires verifying with a real `recall` call before reporting an outage.
- Add README troubleshooting for users who see "Second Brain is not available" while `/mcp` shows connected.
- Add automated tests for instruction text, MCP tool contract (`InMemoryTransport`), handler sanitization, connect scripts, and README content.
- Pin `truncationNote` locale to `en-US` so snippet tests stay stable on non-US Windows locales.

## Test plan
- [x] `npm test` (744 tests)
- [x] `npm run typecheck`
- [ ] Connect Claude Code, confirm `/mcp` connected + `recall` works without false "unavailable" reminder
- [ ] Re-run `connect-ai-clients.sh` or `.ps1` to refresh global instructions on existing installs

Closes #223