### PR TITLE
Worker: runtime config layer with sparse KV overrides

### DIFF
--- a/src/capture/classify.ts
+++ b/src/capture/classify.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../env";
+import { DEFAULTS, type Config } from "../config";
 import { CLASSIFY_MAX_TOKENS, LLM_MODEL } from "../constants";
 import { readStreamText } from "../lib/ai";
 import { withKind, type MemoryKind } from "../memory/kind";
@@ -34,10 +35,10 @@ function parseClassification(text: string): { importance: number; canonical: boo
   };
 }
 
-export async function classifyEntry(content: string, env: Env): Promise<{ importance: number; canonical: boolean; kind: MemoryKind | null }> {
+export async function classifyEntry(content: string, env: Env, config: Readonly<Config> = DEFAULTS): Promise<{ importance: number; canonical: boolean; kind: MemoryKind | null }> {
   let text: string;
   try {
-    const stream = await env.AI.run(LLM_MODEL as any, {
+    const stream = await env.AI.run(config.LLM_MODEL as any, {
       messages: [{ role: "user", content:
         `Classify this memory. Respond with ONLY one JSON object and nothing else — no prose, no markdown, no code fences.\n` +
         `{"importance": <1-5>, "canonical": <true|false>, "kind": "episodic"|"semantic"}\n` +

--- a/src/capture/duplicate.ts
+++ b/src/capture/duplicate.ts
@@ -1,9 +1,10 @@
 import type { Env } from "../env";
+import { DEFAULTS, type Config } from "../config";
 import {
+  // Write-path only and deliberately not exposed as a setting (#245): recall
+  // applies no minimum-score cutoff, so surfacing this would imply a recall
+  // control that does not exist.
   CANDIDATE_SCORE_THRESHOLD,
-  DUPLICATE_BLOCK_THRESHOLD,
-  DUPLICATE_FLAG_THRESHOLD,
-  LLM_MODEL,
   CONTRADICTION_MAX_TOKENS,
   SMART_MERGE_MAX_TOKENS,
 } from "../constants";
@@ -36,14 +37,18 @@ export function getDuplicateCheckSample(content: string): string {
   return `${start}\n...\n${middle}\n...\n${end}`;
 }
 
-export async function checkDuplicateAndContradiction(content: string, env: Env): Promise<{
+export async function checkDuplicateAndContradiction(
+  content: string,
+  env: Env,
+  config: Readonly<Config> = DEFAULTS,
+): Promise<{
   duplicate: DuplicateResult;
   contradiction: ContradictionResult;
   mergeAction: MergeAction | null;
   neighbors: { id: string; score: number }[];
 }> {
   const sample = getDuplicateCheckSample(content);
-  const values = await embed(sample, env);
+  const values = await embed(sample, env, config);
   const { matches } = await env.VECTORIZE.query(values, { topK: 5, returnMetadata: "all" });
 
   const neighborScores = new Map<string, number>();
@@ -57,8 +62,8 @@ export async function checkDuplicateAndContradiction(content: string, env: Env):
   if (matches.length) {
     const top = matches[0];
     const matchId = (top.metadata as any)?.parentId ?? top.id;
-    if (top.score >= DUPLICATE_BLOCK_THRESHOLD) duplicate = { status: "blocked", matchId, score: top.score };
-    else if (top.score >= DUPLICATE_FLAG_THRESHOLD) duplicate = { status: "flagged", matchId, score: top.score };
+    if (top.score >= config.DUPLICATE_BLOCK_THRESHOLD) duplicate = { status: "blocked", matchId, score: top.score };
+    else if (top.score >= config.DUPLICATE_FLAG_THRESHOLD) duplicate = { status: "flagged", matchId, score: top.score };
   }
 
   let contradiction: ContradictionResult = { detected: false };
@@ -99,7 +104,7 @@ Respond with JSON only. No text outside the JSON.
 {"action":"keep_both"} OR {"action":"contradiction","conflicting_id":"<id>","reason":"<10 words max>"} OR {"action":"replace","target_id":"<id>"} OR {"action":"merge","target_id":"<id>","merged_content":"<text>"}`;
 
           try {
-            const stream = await (env.AI as any).run(LLM_MODEL as any, {
+            const stream = await (env.AI as any).run(config.LLM_MODEL as any, {
               messages: [{ role: "user", content: prompt }],
               max_tokens: SMART_MERGE_MAX_TOKENS,
               stream: true,
@@ -144,7 +149,7 @@ Respond with JSON only. No text outside the JSON object.
 {"contradicts": false} OR {"contradicts": true, "conflicting_id": "<exact_id>", "reason": "<10 words max>"}`;
 
           try {
-            const stream = await (env.AI as any).run(LLM_MODEL as any, {
+            const stream = await (env.AI as any).run(config.LLM_MODEL as any, {
               messages: [{ role: "user", content: prompt }],
               max_tokens: CONTRADICTION_MAX_TOKENS,
               stream: true,

--- a/src/capture/entry.ts
+++ b/src/capture/entry.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../env";
+import { DEFAULTS, resolveConfig, type Config } from "../config";
 import { createEdge, inferEdgesOnWrite } from "../graph/edges";
 import { getStatus, withStatus } from "../memory/status";
 import { extractHashtags } from "../text/hashtags";
@@ -41,14 +42,19 @@ export async function captureEntry(
   tags: string[],
   source: string,
   env: Env,
-  ctx: ExecutionContext
+  ctx: ExecutionContext,
+  config?: Readonly<Config>
 ): Promise<CaptureResult> {
+  // Resolved once per capture and threaded through duplicate detection and
+  // every embed below. Recall and capture must agree on EMBEDDING_MODEL or the
+  // vectors they produce are not comparable.
+  const cfg = config ?? await resolveConfig(env);
   const raw = rawContent.trim();
   const { cleanContent, hashtags } = extractHashtags(raw);
   const c = cleanContent || raw;
   const t = [...new Set([...tags.map(tag => tag.toLowerCase()), ...hashtags])];
 
-  const { duplicate: dup, contradiction, mergeAction, neighbors } = await checkDuplicateAndContradiction(c, env);
+  const { duplicate: dup, contradiction, mergeAction, neighbors } = await checkDuplicateAndContradiction(c, env, cfg);
 
   if (dup.status === "blocked") {
     return { status: "blocked", matchId: dup.matchId, score: dup.score };
@@ -74,7 +80,7 @@ export async function captureEntry(
 
       let newVectorIds: string[] | null = null;
       try {
-        newVectorIds = await reembedOrThrow(env, targetId, newContent, existingTags, existingSource);
+        newVectorIds = await reembedOrThrow(env, targetId, newContent, existingTags, existingSource, cfg);
       } catch (e) {
         console.error("Merge re-embed failed — keeping both, target untouched:", e);
       }
@@ -104,7 +110,7 @@ export async function captureEntry(
   ).bind(id, c, JSON.stringify(finalTags), source, now, "[]").run();
 
   ctx.waitUntil(
-    storeEntry(env, id, c, finalTags, source, now)
+    storeEntry(env, id, c, finalTags, source, now, cfg)
       .catch(e => console.error("Vectorize insert failed (non-fatal):", e))
   );
 

--- a/src/capture/store.ts
+++ b/src/capture/store.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../env";
+import { DEFAULTS, resolveConfig, type Config } from "../config";
 import { CHUNK_MAX_CHARS } from "../constants";
 import { embed } from "../lib/ai";
 import { inferEdgesOnWrite } from "../graph/edges";
@@ -11,7 +12,8 @@ export async function storeEntry(
   content: string,
   tags: string[],
   source: string,
-  now: number
+  now: number,
+  config: Readonly<Config> = DEFAULTS
 ): Promise<string[]> {
   const chunks = chunkText(content);
 
@@ -33,7 +35,7 @@ export async function storeEntry(
 
       return {
         id: chunks.length === 1 ? id : `${id}-chunk-${i}`,
-        values: await embed(chunk, env),
+        values: await embed(chunk, env, config),
         metadata,
       };
     })
@@ -56,8 +58,8 @@ export async function deleteStaleVectors(env: Env, oldIds: string[], newIds: str
   if (stale.length) await env.VECTORIZE.deleteByIds(stale);
 }
 
-export async function reembedOrThrow(env: Env, id: string, content: string, tags: string[], source: string): Promise<string[]> {
-  const ids = await storeEntry(env, id, content, tags, source, Date.now());
+export async function reembedOrThrow(env: Env, id: string, content: string, tags: string[], source: string, config: Readonly<Config> = DEFAULTS): Promise<string[]> {
+  const ids = await storeEntry(env, id, content, tags, source, Date.now(), config);
   if (!ids.length) throw new Error("re-embed produced no vectors");
   return ids;
 }
@@ -68,7 +70,8 @@ export async function appendToEntry(
   existingContent: string,
   addition: string,
   tags: string[],
-  source: string
+  source: string,
+  config: Readonly<Config> = DEFAULTS
 ): Promise<void> {
   const row = await env.DB.prepare(
     `SELECT vector_ids FROM entries WHERE id = ?`
@@ -81,7 +84,7 @@ export async function appendToEntry(
   const newContent = existingContent + separator + addition;
 
   if (newContent.length > CHUNK_MAX_CHARS) {
-    const newVectorIds = await reembedOrThrow(env, id, newContent, tags, source);
+    const newVectorIds = await reembedOrThrow(env, id, newContent, tags, source, config);
 
     await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`)
       .bind(newContent, id).run();
@@ -93,7 +96,7 @@ export async function appendToEntry(
     }
 
     try {
-      await inferEdgesOnWrite(id, await neighborsFromVectorQuery(await embed(addition, env), env), env);
+      await inferEdgesOnWrite(id, await neighborsFromVectorQuery(await embed(addition, env, config), env), env);
     } catch (e) {
       console.error("Append auto-link failed (non-fatal):", e);
     }
@@ -103,7 +106,7 @@ export async function appendToEntry(
 
   const newChunkId = `${id}-update-${Date.now()}`;
 
-  const values = await embed(addition, env);
+  const values = await embed(addition, env, config);
 
   const metadata: Record<string, any> = {
     content: addition,

--- a/src/compression/digest.ts
+++ b/src/compression/digest.ts
@@ -1,18 +1,19 @@
 import type { Env } from "../env";
+import { DEFAULTS, resolveConfig, type Config } from "../config";
 import { captureEntry } from "../capture/entry";
 import { DIGEST_MAX_TOKENS, LLM_MODEL } from "../constants";
 import { readStreamText } from "../lib/ai";
 import { KIND_PREFIX } from "../memory/kind";
 import { STATUS_PREFIX } from "../memory/status";
 import {
-  COMPRESSION_MIN_AGE_MS,
   compressionEligibilitySql,
 } from "./eligibility";
 
 export async function synthesizeDigest(
   tag: string,
   rows: { id: string; content: string }[],
-  env: Env
+  env: Env,
+  config: Readonly<Config> = DEFAULTS
 ): Promise<string> {
   if (!rows.length) return "";
 
@@ -29,7 +30,7 @@ State of "${tag}":`;
 
   let digest = "";
   try {
-    const stream = await (env.AI as any).run(LLM_MODEL as any, {
+    const stream = await (env.AI as any).run(config.LLM_MODEL as any, {
       messages: [{ role: "user", content: prompt }],
       max_tokens: DIGEST_MAX_TOKENS,
       stream: true,
@@ -47,6 +48,7 @@ export async function compressTag(
   env: Env,
   ctx: ExecutionContext
 ): Promise<{ synthesizedId: string | null; entriesUsed: number; text: string }> {
+  const cfg = await resolveConfig(env);
   if (tag.startsWith(STATUS_PREFIX) || tag.startsWith(KIND_PREFIX)) {
     return { synthesizedId: null, entriesUsed: 0, text: "" };
   }
@@ -69,10 +71,10 @@ export async function compressTag(
       AND tags NOT LIKE '%"synthesized"%'
       AND tags NOT LIKE '%"auto-pattern"%'
       AND tags NOT LIKE '%"rolled-up"%'
-      AND ${compressionEligibilitySql()}
+      AND ${compressionEligibilitySql("", cfg)}
     ORDER BY created_at DESC
     LIMIT 50
-  `).bind(`%"${tag}"%`, Date.now() - COMPRESSION_MIN_AGE_MS).all();
+  `).bind(`%"${tag}"%`, Date.now() - cfg.COMPRESSION_MIN_AGE_MS).all();
 
   if (rawEntries.length < 10) {
     return { synthesizedId: null, entriesUsed: 0, text: "" };

--- a/src/compression/eligibility.ts
+++ b/src/compression/eligibility.ts
@@ -1,6 +1,8 @@
 // An entry is eligible for nightly digest compression only if it's low-importance,
 // not proven-useful by recall, and not a contradiction survivor. Strictly more
 // protective than the old `importance_score < 4` filter — it can only exempt MORE.
+import { DEFAULTS, type Config } from "../config";
+
 export const COMPRESSION_IMPORTANCE_THRESHOLD = 4;   // importance >= this → protected
 export const COMPRESSION_MIN_RECALL = 2;             // recalled >= this many times → protected
 export const COMPRESSION_MIN_AGE_MS = 60 * 86400000; // entries with fewer than COMPRESSION_MIN_RECALL recalls protected until this old (60 days)
@@ -8,9 +10,12 @@ export const COMPRESSION_MIN_AGE_MS = 60 * 86400000; // entries with fewer than 
 // Returns a SQL boolean fragment for "this entry is eligible for compression".
 // Contains exactly one `?` placeholder — bind `Date.now() - COMPRESSION_MIN_AGE_MS`.
 // columnPrefix: "" for bare columns (compressTag), "entries." for json_each-joined queries.
-export function compressionEligibilitySql(columnPrefix = ""): string {
+export function compressionEligibilitySql(
+  columnPrefix = "",
+  config: Readonly<Config> = DEFAULTS,
+): string {
   const p = columnPrefix;
-  return `(${p}importance_score IS NULL OR ${p}importance_score < ${COMPRESSION_IMPORTANCE_THRESHOLD})
-      AND (${p}recall_count = 0 OR (${p}recall_count < ${COMPRESSION_MIN_RECALL} AND ${p}created_at < ?))
+  return `(${p}importance_score IS NULL OR ${p}importance_score < ${config.COMPRESSION_IMPORTANCE_THRESHOLD})
+      AND (${p}recall_count = 0 OR (${p}recall_count < ${config.COMPRESSION_MIN_RECALL} AND ${p}created_at < ?))
       AND (${p}contradiction_wins IS NULL OR ${p}contradiction_wins = 0)`;
 }

--- a/src/compression/nightly.ts
+++ b/src/compression/nightly.ts
@@ -1,9 +1,11 @@
 import type { Env } from "../env";
+import { resolveConfig } from "../config";
 import { initializeDatabase } from "../db/init";
 import { COMPRESSION_MIN_AGE_MS, compressionEligibilitySql } from "./eligibility";
 import { compressTag } from "./digest";
 
 export async function runNightlyCompression(env: Env, ctx: ExecutionContext): Promise<void> {
+  const cfg = await resolveConfig(env);
   await initializeDatabase(env);
 
   const { results } = await env.DB.prepare(`
@@ -15,11 +17,11 @@ export async function runNightlyCompression(env: Env, ctx: ExecutionContext): Pr
       AND entries.tags NOT LIKE '%"rolled-up"%'
       AND entries.tags NOT LIKE '%"synthesized"%'
       AND entries.tags NOT LIKE '%"auto-pattern"%'
-      AND ${compressionEligibilitySql("entries.")}
+      AND ${compressionEligibilitySql("entries.", cfg)}
     GROUP BY value
     HAVING count > 10
     ORDER BY count DESC
-  `).bind(Date.now() - COMPRESSION_MIN_AGE_MS).all();
+  `).bind(Date.now() - cfg.COMPRESSION_MIN_AGE_MS).all();
 
   for (const row of results) {
     const tag = row.tag as string;

--- a/src/compression/pattern.ts
+++ b/src/compression/pattern.ts
@@ -1,11 +1,13 @@
 import type { Env } from "../env";
+import { DEFAULTS, type Config } from "../config";
 import { LLM_MODEL, PATTERN_MAX_TOKENS } from "../constants";
 import { captureEntry } from "../capture/entry";
 
 export async function derivePattern(
   rows: { id: string; content: string }[],
   env: Env,
-  ctx: ExecutionContext
+  ctx: ExecutionContext,
+  config: Readonly<Config> = DEFAULTS
 ): Promise<void> {
   if (rows.length < 10) return;
 
@@ -31,7 +33,7 @@ If you find a genuine cross-memory pattern, respond with exactly ONE sentence st
 If no genuine pattern exists across 3+ memories, respond with exactly: NONE`;
 
   try {
-    const response = await (env.AI as any).run(LLM_MODEL as any, {
+    const response = await (env.AI as any).run(config.LLM_MODEL as any, {
       messages: [{ role: "user", content: prompt }],
       max_tokens: PATTERN_MAX_TOKENS,
     }) as any;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,206 @@
+/**
+ * Runtime config layer (#245).
+ *
+ * `DEFAULTS` is the shipped behaviour. A sparse override blob in KV under
+ * `config:overrides` carries only the keys a user has actually changed, so a
+ * tuned default in a later release still reaches anyone who never overrode it,
+ * and a per-key reset is a `delete` rather than a rewrite.
+ *
+ * Reads are per-request and uncached on purpose. Recall already makes an
+ * embedding call and several D1 queries, so one KV read is noise; a
+ * version-counter cache would leave a window where a stale isolate serves the
+ * previous value after a save, which presents to the user as a control that
+ * does nothing.
+ */
+import type { Env } from "./env";
+
+// Prefixed to coexist with workers-oauth-provider's token:/grant:/client: keys
+// and the integrations: blobs in the same namespace.
+export const CONFIG_KEY = "config:overrides";
+
+export const DEFAULTS = {
+  // ── Ranking (src/recall/math.ts) ──
+  RECENCY_FLOOR: 0.6,
+  RECENCY_FLOOR_DURABLE: 0.9,
+  RECENCY_FLOOR_VOLATILE: 0.15,
+  MMR_LAMBDA: 0.7,
+
+  // ── Duplicate detection (src/capture/duplicate.ts) ──
+  DUPLICATE_BLOCK_THRESHOLD: 0.95,
+  DUPLICATE_FLAG_THRESHOLD: 0.85,
+
+  // ── Recall widening (src/recall/search.ts) ──
+  RECALL_WIDEN_THRESHOLD: 0.85,
+
+  // ── Graph expansion (src/graph/traverse.ts) ──
+  GRAPH_MAX_HOPS: 3,
+  GRAPH_HOP_DECAY: 0.6,
+
+  // ── Output budgeting (src/recall/snippet.ts) ──
+  RECALL_OUTPUT_BUDGET: 12000,
+  SNIPPET_MAX_CHARS: 400,
+  FULL_MATCH_MAX_CHARS: 4000,
+  RECALL_FULL_MATCHES: 2,
+  STRONG_MATCH_RATIO: 0.75,
+
+  // ── Compression eligibility (src/compression/eligibility.ts) ──
+  COMPRESSION_IMPORTANCE_THRESHOLD: 4,
+  COMPRESSION_MIN_RECALL: 2,
+  COMPRESSION_MIN_AGE_MS: 60 * 86400000,
+
+  // ── Capture tuning (src/constants.ts) ──
+  TAG_BOOST_STEP: 0.15,
+  TAG_BOOST_MAX: 1.5,
+  CONTRADICTION_IMPORTANCE_STEP: 1.0,
+
+  // ── Models (src/lib/ai.ts) ──
+  LLM_MODEL: "@cf/meta/llama-4-scout-17b-16e-instruct",
+  EMBEDDING_MODEL: "@cf/baai/bge-small-en-v1.5",
+} as const;
+
+export type Config = { -readonly [K in keyof typeof DEFAULTS]: (typeof DEFAULTS)[K] };
+export type ConfigKey = keyof Config;
+
+type Rule =
+  | { kind: "number"; min: number; max: number; integer?: boolean }
+  | { kind: "string" };
+
+/**
+ * Accepted shape and range per key. Enforced at resolve time rather than only
+ * at write, because values also arrive from hand-edited KV, from blobs written
+ * by an older release, and from ranges tightened in a later one.
+ */
+export const RULES: Record<ConfigKey, Rule> = {
+  RECENCY_FLOOR: { kind: "number", min: 0, max: 1 },
+  RECENCY_FLOOR_DURABLE: { kind: "number", min: 0, max: 1 },
+  RECENCY_FLOOR_VOLATILE: { kind: "number", min: 0, max: 1 },
+  MMR_LAMBDA: { kind: "number", min: 0, max: 1 },
+
+  DUPLICATE_BLOCK_THRESHOLD: { kind: "number", min: 0, max: 1 },
+  DUPLICATE_FLAG_THRESHOLD: { kind: "number", min: 0, max: 1 },
+  RECALL_WIDEN_THRESHOLD: { kind: "number", min: 0, max: 1 },
+
+  // Hops above 3 explode the fanout without improving results; traverse.ts is
+  // written against this ceiling.
+  GRAPH_MAX_HOPS: { kind: "number", min: 0, max: 3, integer: true },
+  GRAPH_HOP_DECAY: { kind: "number", min: 0, max: 1 },
+
+  RECALL_OUTPUT_BUDGET: { kind: "number", min: 1000, max: 100000, integer: true },
+  SNIPPET_MAX_CHARS: { kind: "number", min: 100, max: 4000, integer: true },
+  FULL_MATCH_MAX_CHARS: { kind: "number", min: 500, max: 20000, integer: true },
+  RECALL_FULL_MATCHES: { kind: "number", min: 0, max: 10, integer: true },
+  STRONG_MATCH_RATIO: { kind: "number", min: 0, max: 1 },
+
+  // Importance is a 1–5 band; a threshold outside it protects everything or
+  // nothing.
+  COMPRESSION_IMPORTANCE_THRESHOLD: { kind: "number", min: 1, max: 5, integer: true },
+  COMPRESSION_MIN_RECALL: { kind: "number", min: 0, max: 100, integer: true },
+  COMPRESSION_MIN_AGE_MS: { kind: "number", min: 0, max: 10 * 365 * 86400000, integer: true },
+
+  TAG_BOOST_STEP: { kind: "number", min: 0, max: 1 },
+  TAG_BOOST_MAX: { kind: "number", min: 1, max: 5 },
+  CONTRADICTION_IMPORTANCE_STEP: { kind: "number", min: 0, max: 5 },
+
+  LLM_MODEL: { kind: "string" },
+  EMBEDDING_MODEL: { kind: "string" },
+};
+
+/**
+ * Groups that must stay internally ordered. A violation is not clamped
+ * key-by-key — that could satisfy the letter of the range while still leaving
+ * the group inverted — so the whole group falls back to its defaults, which
+ * satisfy the invariant by construction.
+ */
+const INVARIANTS: { keys: ConfigKey[]; holds: (c: Config) => boolean; describe: string }[] = [
+  {
+    keys: ["DUPLICATE_BLOCK_THRESHOLD", "DUPLICATE_FLAG_THRESHOLD"],
+    holds: c => c.DUPLICATE_BLOCK_THRESHOLD > c.DUPLICATE_FLAG_THRESHOLD,
+    describe: "DUPLICATE_BLOCK_THRESHOLD must exceed DUPLICATE_FLAG_THRESHOLD, or flagging is unreachable",
+  },
+  {
+    keys: ["RECENCY_FLOOR_VOLATILE", "RECENCY_FLOOR", "RECENCY_FLOOR_DURABLE"],
+    holds: c => c.RECENCY_FLOOR_VOLATILE <= c.RECENCY_FLOOR && c.RECENCY_FLOOR <= c.RECENCY_FLOOR_DURABLE,
+    describe: "RECENCY_FLOOR_VOLATILE <= RECENCY_FLOOR <= RECENCY_FLOOR_DURABLE, or durability tiering inverts",
+  },
+];
+
+/**
+ * Coerces one stored value against its rule. Returns the default when the
+ * value is unsalvageable (wrong type, non-finite); clamps when it is merely
+ * out of range.
+ */
+export function coerce(key: ConfigKey, value: unknown): { value: Config[ConfigKey]; note?: string } {
+  const rule = RULES[key];
+  const fallback = DEFAULTS[key] as Config[ConfigKey];
+
+  if (rule.kind === "string") {
+    if (typeof value !== "string" || value.trim() === "") {
+      return { value: fallback, note: `${key}: expected a non-empty string, got ${typeof value}` };
+    }
+    return { value: value as Config[ConfigKey] };
+  }
+
+  // typeof NaN and typeof Infinity are both "number", so the finite check is
+  // what actually protects arithmetic downstream.
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return { value: fallback, note: `${key}: expected a finite number, got ${JSON.stringify(value)}` };
+  }
+
+  let n = value;
+  if (rule.integer) n = Math.round(n);
+  const clamped = Math.min(rule.max, Math.max(rule.min, n));
+  const note = clamped !== n ? `${key}: ${n} clamped to ${clamped} (range ${rule.min}–${rule.max})` : undefined;
+  return { value: clamped as Config[ConfigKey], note };
+}
+
+export const INVARIANT_RULES = INVARIANTS;
+
+/**
+ * Reads the sparse override blob and merges it over the defaults.
+ *
+ * Every failure mode here degrades to the shipped defaults rather than
+ * throwing: a KV outage, a hand-edited blob, or a payload written by a future
+ * version must never be able to take recall down.
+ */
+export async function resolveConfig(env: Env): Promise<Readonly<Config>> {
+  const resolved: Config = { ...DEFAULTS };
+
+  let stored: unknown;
+  try {
+    const raw = await env.OAUTH_KV.get(CONFIG_KEY);
+    if (!raw) return Object.freeze(resolved);
+    stored = JSON.parse(raw);
+  } catch {
+    // KV unreachable or the blob is unparseable — ship the defaults.
+    return Object.freeze(resolved);
+  }
+
+  if (!isRecord(stored)) return Object.freeze(resolved);
+
+  const notes: string[] = [];
+
+  for (const [key, value] of Object.entries(stored)) {
+    // Unknown keys are ignored rather than carried through: they may be a
+    // setting removed in a later release, or a typo in a hand-edited blob.
+    if (!(key in DEFAULTS)) continue;
+    const { value: safe, note } = coerce(key as ConfigKey, value);
+    (resolved as Record<string, unknown>)[key] = safe;
+    if (note) notes.push(note);
+  }
+
+  for (const invariant of INVARIANTS) {
+    if (invariant.holds(resolved)) continue;
+    for (const key of invariant.keys) {
+      (resolved as Record<string, unknown>)[key] = DEFAULTS[key];
+    }
+    notes.push(`invariant violated, group reset to defaults — ${invariant.describe}`);
+  }
+
+  if (notes.length) console.warn(`[config] ${notes.join("; ")}`);
+
+  return Object.freeze(resolved);
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,7 +58,13 @@ export const DEFAULTS = {
   EMBEDDING_MODEL: "@cf/baai/bge-small-en-v1.5",
 } as const;
 
-export type Config = { -readonly [K in keyof typeof DEFAULTS]: (typeof DEFAULTS)[K] };
+// DEFAULTS is `as const` so the shipped values are pinned and a typo shows up
+// as a type error. Config must widen those literals back to number/string,
+// though — without this, `Partial<Config>` would only accept the exact default
+// value and reject every real override.
+type Widen<T> = T extends number ? number : T extends string ? string : T;
+
+export type Config = { -readonly [K in keyof typeof DEFAULTS]: Widen<(typeof DEFAULTS)[K]> };
 export type ConfigKey = keyof Config;
 
 type Rule =
@@ -203,4 +209,91 @@ export async function resolveConfig(env: Env): Promise<Readonly<Config>> {
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// ── Write path ───────────────────────────────────────────────────────────────
+//
+// Deliberately stricter than resolve. A bad value arriving from KV is repaired,
+// because recall must not fail on it. A bad value arriving from a caller is
+// rejected with a message naming the conflict, so the settings UI can explain
+// what happened rather than appear to accept a change and silently discard it.
+
+export type WriteResult = { ok: true } | { ok: false; error: string };
+
+/** Reads the raw sparse blob. Any failure reads as "no overrides". */
+export async function readOverrides(env: Env): Promise<Partial<Config>> {
+  try {
+    const raw = await env.OAUTH_KV.get(CONFIG_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!isRecord(parsed)) return {};
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(parsed)) if (k in DEFAULTS) out[k] = v;
+    return out as Partial<Config>;
+  } catch {
+    return {};
+  }
+}
+
+/** Strict per-key check. Returns an error message, or null when acceptable. */
+function validateStrict(key: string, value: unknown): string | null {
+  if (!(key in DEFAULTS)) return `${key} is not a known setting`;
+  const rule = RULES[key as ConfigKey];
+
+  if (rule.kind === "string") {
+    return typeof value === "string" && value.trim() !== ""
+      ? null
+      : `${key} must be a non-empty string`;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return `${key} must be a finite number`;
+  }
+  if (rule.integer && !Number.isInteger(value)) {
+    return `${key} must be a whole number`;
+  }
+  if (value < rule.min || value > rule.max) {
+    return `${key} must be between ${rule.min} and ${rule.max} (got ${value})`;
+  }
+  return null;
+}
+
+/**
+ * Merges a patch into the stored overrides. Rejects the whole patch if any key
+ * is unknown, malformed, or would invert an invariant once merged with what is
+ * already stored — a value can be individually valid and still break the pair.
+ */
+export async function writeOverrides(env: Env, patch: Partial<Config>): Promise<WriteResult> {
+  for (const [key, value] of Object.entries(patch)) {
+    const error = validateStrict(key, value);
+    if (error) return { ok: false, error };
+  }
+
+  const merged = { ...(await readOverrides(env)), ...patch } as Record<string, unknown>;
+  const effective = { ...DEFAULTS, ...merged } as Config;
+
+  for (const invariant of INVARIANTS) {
+    if (!invariant.holds(effective)) return { ok: false, error: invariant.describe };
+  }
+
+  // Values equal to the shipped default are dropped rather than stored. Storing
+  // them would pin the user to today's number and stop a retuned default in a
+  // later release from ever reaching them.
+  const sparse: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(merged)) {
+    if (value !== DEFAULTS[key as ConfigKey]) sparse[key] = value;
+  }
+
+  await env.OAUTH_KV.put(CONFIG_KEY, JSON.stringify(sparse));
+  return { ok: true };
+}
+
+/**
+ * Per-setting reset. A delete rather than a write-back of the default, so the
+ * user rejoins the shipped value and picks up any future retune of it.
+ */
+export async function resetOverride(env: Env, key: ConfigKey): Promise<void> {
+  const overrides = { ...(await readOverrides(env)) } as Record<string, unknown>;
+  if (!(key in overrides)) return;
+  delete overrides[key];
+  await env.OAUTH_KV.put(CONFIG_KEY, JSON.stringify(overrides));
 }

--- a/src/graph/pass.ts
+++ b/src/graph/pass.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../env";
+import { DEFAULTS, resolveConfig, type Config } from "../config";
 import { initializeDatabase } from "../db/init";
 import { embed } from "../lib/ai";
 import { inferEdgesOnWrite } from "./edges";
@@ -8,6 +9,9 @@ const EDGE_PRUNE_WEIGHT = 0.3;
 const EDGE_PRUNE_MIN_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 export async function runGraphPass(env: Env, ctx: ExecutionContext): Promise<void> {
+  // One resolve for the whole pass: every embed below must use the same model
+  // the capture and recall paths use.
+  const cfg = await resolveConfig(env);
   await initializeDatabase(env);
 
   try {
@@ -33,7 +37,7 @@ export async function runGraphPass(env: Env, ctx: ExecutionContext): Promise<voi
 
   for (const entry of unlinked) {
     try {
-      const values = await embed(entry.content, env);
+      const values = await embed(entry.content, env, cfg);
       const { matches } = await env.VECTORIZE.query(values, { topK: 5, returnMetadata: "all" });
       const scores = new Map<string, number>();
       for (const m of matches) {

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../env";
+import { DEFAULTS, type Config } from "../config";
 import { D1_MAX_BOUND_PARAMS } from "../constants";
 import { getKind } from "../memory/kind";
 import { getStatus } from "../memory/status";
@@ -30,8 +31,9 @@ export async function expandGraph(
   seedIds: string[],
   opts: { hops: number; fanoutCap?: number; maxNodes?: number; includeDeprecated?: boolean },
   env: Env,
+  config: Readonly<Config> = DEFAULTS,
 ): Promise<GraphNeighbor[]> {
-  const hops = Math.max(0, Math.min(GRAPH_MAX_HOPS, opts.hops));
+  const hops = Math.max(0, Math.min(config.GRAPH_MAX_HOPS, opts.hops));
   if (hops === 0 || seedIds.length === 0) return [];
   const fanoutCap = opts.fanoutCap ?? GRAPH_FANOUT_CAP;
   const maxNodes = opts.maxNodes ?? GRAPH_MAX_NODES;

--- a/src/integrations/mirror.ts
+++ b/src/integrations/mirror.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../env";
+import { resolveConfig } from "../config";
 import {
   INTEGRATION_PROVIDERS,
   getProvider,
@@ -35,7 +36,7 @@ export function makeMirrorStore(env: Env): MirrorStore {
         `INSERT INTO entries (id, content, tags, source, created_at, vector_ids, importance_score) VALUES (?, ?, ?, ?, ?, ?, ?)`
       ).bind(id, content, JSON.stringify(finalTags), source, now, "[]", importance).run();
       try {
-        await storeEntry(env, id, content, finalTags, source, now);
+        await storeEntry(env, id, content, finalTags, source, now, await resolveConfig(env));
       } catch (e) {
         console.error("Vectorize insert failed (non-fatal):", e);
       }
@@ -53,7 +54,7 @@ export function makeMirrorStore(env: Env): MirrorStore {
       await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`).bind(content, id).run();
       let newVectorIds: string[] = [];
       try {
-        newVectorIds = await storeEntry(env, id, content, tags, row.source as string, Date.now());
+        newVectorIds = await storeEntry(env, id, content, tags, row.source as string, Date.now(), await resolveConfig(env));
       } catch (e) {
         console.error("Vectorize re-embed failed (non-fatal):", e);
       }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../env";
+import { DEFAULTS, type Config } from "../config";
 import { EMBEDDING_MODEL } from "../constants";
 
 export function graceMs(env: Env): number {
@@ -22,8 +23,12 @@ export async function readStreamText(stream: ReadableStream): Promise<string> {
   return text;
 }
 
-export async function embed(text: string, env: Env): Promise<number[]> {
+export async function embed(
+  text: string,
+  env: Env,
+  config: Readonly<Config> = DEFAULTS,
+): Promise<number[]> {
   // Workers AI requires `as any` here — the SDK types don't cover all models
-  const result = (await env.AI.run(EMBEDDING_MODEL as any, { text: [text] })) as any;
+  const result = (await env.AI.run(config.EMBEDDING_MODEL as any, { text: [text] })) as any;
   return result.data[0] as number[];
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { resolveConfig } from "../config";
 import { z } from "zod";
 import type { Env } from "../env";
 import { VECTORIZE_FIX_HINT } from "../constants";
@@ -90,7 +91,7 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       }
 
       try {
-        await appendToEntry(env, id, existingContent, a, tags, source);
+        await appendToEntry(env, id, existingContent, a, tags, source, await resolveConfig(env));
       } catch (e) {
         console.error("Append failed:", e);
         return {
@@ -147,7 +148,7 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       // Step 2: Re-embed new content → inserts new vectors + updates vector_ids in D1
       let newVectorIds: string[] = [];
       try {
-        newVectorIds = await storeEntry(env, id, newContent, tags, source, Date.now());
+        newVectorIds = await storeEntry(env, id, newContent, tags, source, Date.now(), await resolveConfig(env));
       } catch (e) {
         console.error("Vectorize re-embed failed (non-fatal):", e);
       }
@@ -199,7 +200,8 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       },
     },
     async ({ query, topK, tag, after, before, kind, hops }) => {
-      const { matches, insight, semanticUnavailable, queryTokens } = await recallEntries({ query, topK, tag, after, before, kind: kind as MemoryKind | undefined, hops, synthesize: false }, env, ctx);
+      const cfg = await resolveConfig(env);
+      const { matches, insight, semanticUnavailable, queryTokens } = await recallEntries({ query, topK, tag, after, before, kind: kind as MemoryKind | undefined, hops, synthesize: false }, env, ctx, cfg);
 
       const notice = semanticUnavailable
         ? `Note: semantic search is unavailable because the Vectorize index is missing, so these are keyword matches only. Fix: ${VECTORIZE_FIX_HINT}.\n\n`
@@ -209,7 +211,7 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         return { content: [{ type: "text", text: notice + "Nothing found matching that query." }] };
       }
 
-      return { content: [{ type: "text", text: notice + renderRecallText(matches, insight, { queryTokens }) }] };
+      return { content: [{ type: "text", text: notice + renderRecallText(matches, insight, { queryTokens, config: cfg }) }] };
     }
   );
 
@@ -235,6 +237,7 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
 
       // Same size discipline as recall: browsing should not dump every entry in
       // full. Oversized rows are cut and marked so the caller can fetch them.
+      const budgetCfg = await resolveConfig(env);
       const blocks: string[] = [];
       let used = 0;
       let omitted = 0;
@@ -244,10 +247,10 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         const date = new Date(row.created_at as number).toLocaleDateString();
         const tags: string[] = JSON.parse(row.tags ?? "[]");
         const tagStr = tags.length ? ` · ${tags.join(", ")}` : "";
-        const s = snippetOf(row.content as string, SNIPPET_MAX_CHARS);
+        const s = snippetOf(row.content as string, (await resolveConfig(env)).SNIPPET_MAX_CHARS);
         const body = s.truncated ? `${s.text}${truncationNote(row.id as string, s)}` : s.text;
         const block = `${i + 1}. [${date} · ${row.source}${tagStr}]\nID: ${row.id as string}\n${body}`;
-        if (blocks.length && used + block.length > RECALL_OUTPUT_BUDGET) {
+        if (blocks.length && used + block.length > budgetCfg.RECALL_OUTPUT_BUDGET) {
           omitted = rows.length - i;
           break;
         }

--- a/src/recall/distill.ts
+++ b/src/recall/distill.ts
@@ -1,15 +1,15 @@
 import type { Env } from "../env";
+import { DEFAULTS, type Config } from "../config";
 import {
   KEYWORD_MIN_TOKEN_LEN,
   KEYWORD_STOPWORDS,
-  LLM_MODEL,
   MAX_QUERY_TERMS,
   QUERY_SATURATION_FRACTION,
 } from "../constants";
 import { readStreamText } from "../lib/ai";
 import { extractHashtags } from "../text/hashtags";
 
-export async function inferQueryTags(query: string, env: Env): Promise<string[]> {
+export async function inferQueryTags(query: string, env: Env, config: Readonly<Config> = DEFAULTS): Promise<string[]> {
   const { hashtags } = extractHashtags(query);
   if (hashtags.length) return hashtags;
 
@@ -28,7 +28,7 @@ export async function inferQueryTags(query: string, env: Env): Promise<string[]>
   if (!knownTags.length) return [];
 
   try {
-    const stream = await env.AI.run(LLM_MODEL as any, {
+    const stream = await env.AI.run(config.LLM_MODEL as any, {
       messages: [{
         role: "user",
         content: `From this list of tags: ${knownTags.slice(0, 50).join(", ")}\n\nWhich tags best match this query? Reply with only a comma-separated list of matching tag names from the list, or nothing if none apply.\n\nQuery: ${query.slice(0, 300)}`,
@@ -44,7 +44,7 @@ export async function inferQueryTags(query: string, env: Env): Promise<string[]>
   }
 }
 
-export async function distillToRareTerms(query: string, env: Env): Promise<string> {
+export async function distillToRareTerms(query: string, env: Env, config: Readonly<Config> = DEFAULTS): Promise<string> {
   const words = query.split(/\s+/).filter(Boolean);
   const norm = (w: string) => w.toLowerCase().replace(/^[^\w#.]+|[^\w#.]+$/g, "");
   const content = words.filter(w => {

--- a/src/recall/insight.ts
+++ b/src/recall/insight.ts
@@ -1,11 +1,13 @@
 import type { Env } from "../env";
+import { DEFAULTS, type Config } from "../config";
 import { LLM_MODEL, INSIGHT_MAX_TOKENS } from "../constants";
 import { readStreamText } from "../lib/ai";
 
 export async function synthesizeInsight(
   query: string,
   rows: { id: string; content: string }[],
-  env: Env
+  env: Env,
+  config: Readonly<Config> = DEFAULTS
 ): Promise<string> {
   if (!rows.length) return "";
 
@@ -29,7 +31,7 @@ Write a brief insight (2-4 sentences).`;
 
   let insight = "";
   try {
-    const stream = await (env.AI as any).run(LLM_MODEL as any, {
+    const stream = await (env.AI as any).run(config.LLM_MODEL as any, {
       messages: [{ role: "user", content: prompt }],
       max_tokens: INSIGHT_MAX_TOKENS,
       stream: true,

--- a/src/recall/math.ts
+++ b/src/recall/math.ts
@@ -1,10 +1,6 @@
-import {
-  CHUNK_OVERLAP_CHARS,
-  CONTRADICTION_IMPORTANCE_STEP,
-  TAG_BOOST_MAX,
-  TAG_BOOST_STEP,
-} from "../constants";
+import { CHUNK_OVERLAP_CHARS } from "../constants";
 import { getStatus } from "../memory/status";
+import { DEFAULTS, type Config } from "../config";
 
 export interface VectorizeMatch {
   id: string;
@@ -52,7 +48,10 @@ export function rerankWithTimeDecay(
   importanceScores: Map<string, number> = new Map(),
   queryTags: string[] = [],
   contradictionWins: Map<string, number> = new Map(),
-  contradictionLosses: Map<string, number> = new Map()
+  contradictionLosses: Map<string, number> = new Map(),
+  // Ranking seam: config in, ordering out. Threaded rather than read from
+  // module scope so this stays pure and directly assertable without an env.
+  config: Readonly<Config> = DEFAULTS
 ): VectorizeMatch[] {
   const now = Date.now();
 
@@ -69,9 +68,9 @@ export function rerankWithTimeDecay(
       const imp = importanceScores.get(parentId) ?? 0;
 
       const recencyFloor =
-        getStatus(tags) === "canonical" || imp >= 4 ? RECENCY_FLOOR_DURABLE
-        : tags.includes("task") ? RECENCY_FLOOR_VOLATILE
-        : RECENCY_FLOOR;
+        getStatus(tags) === "canonical" || imp >= 4 ? config.RECENCY_FLOOR_DURABLE
+        : tags.includes("task") ? config.RECENCY_FLOOR_VOLATILE
+        : config.RECENCY_FLOOR;
       const recencyMultiplier = recencyFloor + (1 - recencyFloor) * Math.exp(-ageMs / halfLifeMs);
       const frequencyMultiplier = 1 + Math.log1p(rc);
       const combinedMultiplier = Math.min(1.0, recencyMultiplier * frequencyMultiplier);
@@ -88,13 +87,13 @@ export function rerankWithTimeDecay(
         importanceMultiplier = 1.0;
       } else {
         const base = imp === 0 ? 3 : imp;
-        const adj = Math.sign(net) * Math.log1p(Math.abs(net)) * CONTRADICTION_IMPORTANCE_STEP;
+        const adj = Math.sign(net) * Math.log1p(Math.abs(net)) * config.CONTRADICTION_IMPORTANCE_STEP;
         const effectiveImp = Math.max(1, Math.min(5, base + adj));
         importanceMultiplier = 0.8 + (effectiveImp / 5) * 0.4;
       }
 
       const overlap = queryTags.length ? tags.filter(t => queryTags.includes(t)).length : 0;
-      const tagBoost = overlap ? Math.min(TAG_BOOST_MAX, 1 + overlap * TAG_BOOST_STEP) : 1.0;
+      const tagBoost = overlap ? Math.min(config.TAG_BOOST_MAX, 1 + overlap * config.TAG_BOOST_STEP) : 1.0;
 
       return { ...match, score: match.score * combinedMultiplier * appendPenalty * rolledUpPenalty * importanceMultiplier * tagBoost };
     })

--- a/src/recall/render.ts
+++ b/src/recall/render.ts
@@ -1,10 +1,11 @@
 import type { RecallMatch } from "./types";
+import { DEFAULTS, type Config } from "../config";
 import { allowanceFor, RECALL_OUTPUT_BUDGET, snippetOf, truncationNote, type Snippet } from "./snippet";
 
 export function renderRecallText(
   matches: RecallMatch[],
   insight: string,
-  opts: { full?: boolean; queryTokens?: string[] } = {},
+  opts: { full?: boolean; queryTokens?: string[]; config?: Readonly<Config> } = {},
 ): string {
   const contentById = new Map(matches.map(m => [m.id, m.content]));
   const blocks: string[] = [];
@@ -22,12 +23,12 @@ export function renderRecallText(
 
     const s: Snippet = opts.full
       ? { text: (m.content ?? "").trim(), truncated: false, fullLength: (m.content ?? "").length }
-      : snippetOf(m.content, allowanceFor(i, m.score), { queryTokens: opts.queryTokens });
+      : snippetOf(m.content, allowanceFor(i, m.score, opts.config), { queryTokens: opts.queryTokens });
     const body = s.truncated ? `${s.text}${truncationNote(m.id, s)}` : s.text;
     const block = `${i + 1}. [${date}${src}${tagList}] (${score}% match)${updateLabel}${hopLabel}\nID: ${m.id}\n${body}`;
 
     // Stop once the budget is spent, but always return at least one match.
-    if (!opts.full && blocks.length && used + block.length > RECALL_OUTPUT_BUDGET) {
+    if (!opts.full && blocks.length && used + block.length > (opts.config ?? DEFAULTS).RECALL_OUTPUT_BUDGET) {
       omitted = matches.length - i;
       break;
     }

--- a/src/recall/search.ts
+++ b/src/recall/search.ts
@@ -1,11 +1,11 @@
 import type { Env } from "../env";
 import {
   D1_MAX_BOUND_PARAMS,
-  DUPLICATE_FLAG_THRESHOLD,
   KEYWORD_CANDIDATE_LIMIT,
   VECTORIZE_GET_BY_IDS_BATCH,
   VECTORIZE_TOP_K_MULTIPLIER,
 } from "../constants";
+import { resolveConfig, type Config } from "../config";
 import { embed } from "../lib/ai";
 import { expandGraph, GRAPH_HOP_DECAY, GRAPH_MAX_HOPS } from "../graph/traverse";
 import type { EdgeProvenance, EdgeType } from "../graph/types";
@@ -69,8 +69,13 @@ function fuseDenseAndKeyword(
 export async function recallEntries(
   params: { query: string; topK: number; tag?: string; after?: number; before?: number; kind?: MemoryKind; hops?: number; synthesize?: boolean },
   env: Env,
-  ctx: ExecutionContext
+  ctx: ExecutionContext,
+  // Resolved once at request entry by the route/MCP caller and threaded down.
+  // Optional so this stays callable without a config in tests and any future
+  // internal caller; the fallback costs one KV read.
+  config?: Readonly<Config>
 ): Promise<RecallSearchResult> {
+  const cfg = config ?? await resolveConfig(env);
   const { query, topK } = params;
   const synthesize = params.synthesize ?? true;
   let { tag, after, before, kind } = params;
@@ -140,7 +145,10 @@ export async function recallEntries(
     results = denseResults;
     keywordRows = kwRows;
 
-    if (!semanticUnavailable && results.matches.length && results.matches[0].score < DUPLICATE_FLAG_THRESHOLD) {
+    // Governed by its own threshold, not the write-path duplicate flag: the two
+    // shared a constant until #245, so retuning duplicate detection silently
+    // retuned recall widening.
+    if (!semanticUnavailable && results.matches.length && results.matches[0].score < cfg.RECALL_WIDEN_THRESHOLD) {
       try {
         results = await env.VECTORIZE.query(values, { topK: 50, returnMetadata: "all", returnValues: true });
       } catch (e) {

--- a/src/recall/search.ts
+++ b/src/recall/search.ts
@@ -7,7 +7,7 @@ import {
 } from "../constants";
 import { resolveConfig, type Config } from "../config";
 import { embed } from "../lib/ai";
-import { expandGraph, GRAPH_HOP_DECAY, GRAPH_MAX_HOPS } from "../graph/traverse";
+import { expandGraph } from "../graph/traverse";
 import type { EdgeProvenance, EdgeType } from "../graph/types";
 import { KIND_VALUES, type MemoryKind } from "../memory/kind";
 import { derivePattern } from "../compression/pattern";
@@ -15,7 +15,7 @@ import { parseTimePhrase } from "../text/temporal";
 import { tokenizeQuery } from "../text/tokenize";
 import { distillToRareTerms, inferQueryTags } from "./distill";
 import { synthesizeInsight } from "./insight";
-import { cosineSim, mmrRerank, MMR_LAMBDA, rerankWithTimeDecay, type VectorizeMatch } from "./math";
+import { cosineSim, mmrRerank, rerankWithTimeDecay, type VectorizeMatch } from "./math";
 import { rrfFuse } from "./rrf";
 import type { KeywordRow, RecallMatch, RecallSearchResult } from "./types";
 
@@ -79,7 +79,7 @@ export async function recallEntries(
   const { query, topK } = params;
   const synthesize = params.synthesize ?? true;
   let { tag, after, before, kind } = params;
-  const hops = Math.max(0, Math.min(GRAPH_MAX_HOPS, params.hops ?? 0));
+  const hops = Math.max(0, Math.min(cfg.GRAPH_MAX_HOPS, params.hops ?? 0));
   const now = Date.now();
   let semanticUnavailable = false;
 
@@ -94,7 +94,7 @@ export async function recallEntries(
 
   const tokens = tokenizeQuery(embedQuery);
   const [values, queryTags] = await Promise.all([
-    embed(embedQuery, env),
+    embed(embedQuery, env, cfg),
     inferQueryTags(embedQuery, env),
   ]);
 
@@ -175,7 +175,7 @@ export async function recallEntries(
   const contradictionWins = new Map(rcRows.map(r => [r.id, r.contradiction_wins ?? 0]));
   const contradictionLosses = new Map(rcRows.map(r => [r.id, r.contradiction_losses ?? 0]));
 
-  const reranked = rerankWithTimeDecay(fusedMatches, recallCounts, importanceScores, queryTags, contradictionWins, contradictionLosses);
+  const reranked = rerankWithTimeDecay(fusedMatches, recallCounts, importanceScores, queryTags, contradictionWins, contradictionLosses, cfg);
 
   const seen = new Set<string>();
   const dedupedAll = reranked.filter((m) => {
@@ -184,7 +184,7 @@ export async function recallEntries(
     seen.add(parentId);
     return true;
   });
-  const deduped = mmrRerank(dedupedAll, MMR_LAMBDA, topK);
+  const deduped = mmrRerank(dedupedAll, cfg.MMR_LAMBDA, topK);
 
   if (!deduped.length) return { matches: [], insight: "", semanticUnavailable };
 
@@ -193,11 +193,11 @@ export async function recallEntries(
   let expandedScored: { parentId: string; score: number; hop: number; viaProvenance: EdgeProvenance; viaType: EdgeType; viaLinkedAt: number; viaFrom: string }[] = [];
   if (hops > 0) {
     const minSeedScore = deduped.reduce((mn, m) => Math.min(mn, m.score), Infinity);
-    const expanded = await expandGraph(seedParentIds, { hops }, env);
+    const expanded = await expandGraph(seedParentIds, { hops }, env, cfg);
     expandedScored = expanded.map(n => ({
       parentId: n.id,
       hop: n.hop,
-      score: minSeedScore * Math.pow(GRAPH_HOP_DECAY, n.hop) * n.viaWeight,
+      score: minSeedScore * Math.pow(cfg.GRAPH_HOP_DECAY, n.hop) * n.viaWeight,
       viaProvenance: n.viaProvenance,
       viaType: n.viaType,
       viaLinkedAt: n.viaLinkedAt,

--- a/src/recall/snippet.ts
+++ b/src/recall/snippet.ts
@@ -20,6 +20,8 @@
 
 // Per-match ceiling for the leading matches. Even a "full" result is capped:
 // a single multi-thousand-character memory should never eat the whole budget.
+import { DEFAULTS, type Config } from "../config";
+
 export const FULL_MATCH_MAX_CHARS = 4000;
 // Per-match ceiling for everything after the leading matches.
 export const SNIPPET_MAX_CHARS = 400;
@@ -59,7 +61,7 @@ export interface Snippet {
  */
 export function snippetOf(
   content: string,
-  max: number = SNIPPET_MAX_CHARS,
+  max: number = DEFAULTS.SNIPPET_MAX_CHARS,
   opts: { queryTokens?: string[] } = {},
 ): Snippet {
   const raw = (content ?? "").trim();
@@ -173,8 +175,12 @@ export function truncationNote(id: string, s: Snippet): string {
  * get room, but only if they are also strong. `relScore` is the match score
  * relative to the top hit (recall normalizes scores so the top match is 1).
  */
-export function allowanceFor(index: number, relScore: number = 1): number {
-  return index < RECALL_FULL_MATCHES && relScore >= STRONG_MATCH_RATIO
-    ? FULL_MATCH_MAX_CHARS
-    : SNIPPET_MAX_CHARS;
+export function allowanceFor(
+  index: number,
+  relScore: number = 1,
+  config: Readonly<Config> = DEFAULTS,
+): number {
+  return index < config.RECALL_FULL_MATCHES && relScore >= config.STRONG_MATCH_RATIO
+    ? config.FULL_MATCH_MAX_CHARS
+    : config.SNIPPET_MAX_CHARS;
 }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../env";
+import { resolveConfig } from "../config";
 import { SB_VERSION } from "../env";
 import { COMPRESSION_MIN_AGE_MS, compressionEligibilitySql } from "../compression/eligibility";
 import { json, requireAuth } from "../lib/http";
@@ -16,6 +17,7 @@ export async function handleAdminRoutes(
   env: Env,
   _ctx: ExecutionContext,
 ): Promise<Response | null> {
+  const cfg = await resolveConfig(env);
   // GET /stats
   if (url.pathname === "/stats" && request.method === "GET") {
     const authErr = requireAuth(request, env);
@@ -38,12 +40,12 @@ export async function handleAdminRoutes(
           AND entries.tags NOT LIKE '%"rolled-up"%'
           AND entries.tags NOT LIKE '%"synthesized"%'
           AND entries.tags NOT LIKE '%"auto-pattern"%'
-          AND ${compressionEligibilitySql("entries.")}
+          AND ${compressionEligibilitySql("entries.", cfg)}
         GROUP BY value
         HAVING count > 10
         ORDER BY count DESC
         LIMIT 10
-      `).bind(Date.now() - COMPRESSION_MIN_AGE_MS).all(),
+      `).bind(Date.now() - cfg.COMPRESSION_MIN_AGE_MS).all(),
     ]);
 
     const cutoff = Date.now() - 86400000;

--- a/src/routes/capture.ts
+++ b/src/routes/capture.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../env";
+import { resolveConfig } from "../config";
 import { json, requireAuth } from "../lib/http";
 import { captureEntry } from "../capture/entry";
 import { appendToEntry, deleteStaleVectors, reembedOrThrow } from "../capture/store";
@@ -86,7 +87,7 @@ export async function handleCaptureRoutes(
     }
 
     try {
-      await appendToEntry(env, id, existingContent, addition, tags, source);
+      await appendToEntry(env, id, existingContent, addition, tags, source, await resolveConfig(env));
     } catch (e) {
       return json({ ok: false, error: `Append failed: ${(e as Error).message}` }, 500);
     }
@@ -133,7 +134,7 @@ export async function handleCaptureRoutes(
     // deleting every vector — which would leave the entry silently unsearchable.
     let newVectorIds: string[];
     try {
-      newVectorIds = await reembedOrThrow(env, id, finalContent, mergedTags, source);
+      newVectorIds = await reembedOrThrow(env, id, finalContent, mergedTags, source, await resolveConfig(env));
     } catch (e) {
       console.error("Re-embed failed — entry left unchanged:", e);
       return json({ ok: false, error: "Couldn't update: search re-index failed. Your memory is unchanged — please try again." }, 500);

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -1,0 +1,78 @@
+/**
+ * Config read/write surface for the desktop app (#245, consumed by #246).
+ *
+ * Authenticated with the same AUTH_TOKEN as the rest of the API: the Worker
+ * stores and reads config, and the desktop app is the only writer.
+ *
+ * The response deliberately carries three things rather than one — the
+ * effective values, the sparse overrides, and the shipped defaults. A settings
+ * UI needs all three to render a row as "changed from 0.6 to 0.4" and to know
+ * whether a reset control should be active at all, and deriving that from the
+ * effective values alone is impossible once an override happens to equal a
+ * default.
+ */
+import type { Env } from "../env";
+import { json, requireAuth } from "../lib/http";
+import {
+  DEFAULTS,
+  readOverrides,
+  resetOverride,
+  resolveConfig,
+  writeOverrides,
+  type ConfigKey,
+} from "../config";
+
+export async function handleConfigRoutes(
+  request: Request,
+  url: URL,
+  env: Env,
+  _ctx: ExecutionContext,
+): Promise<Response | null> {
+  // GET /config — effective values, what is overridden, and the shipped defaults
+  if (url.pathname === "/config" && request.method === "GET") {
+    const authErr = requireAuth(request, env);
+    if (authErr) return authErr;
+
+    const [config, overrides] = await Promise.all([resolveConfig(env), readOverrides(env)]);
+    return json({ ok: true, config, overrides, defaults: DEFAULTS });
+  }
+
+  // PATCH /config — sparse update; the whole patch is rejected if any key fails
+  if (url.pathname === "/config" && request.method === "PATCH") {
+    const authErr = requireAuth(request, env);
+    if (authErr) return authErr;
+
+    let patch: Record<string, unknown>;
+    try {
+      patch = await request.json() as Record<string, unknown>;
+    } catch {
+      return json({ ok: false, error: "Invalid JSON" }, 400);
+    }
+    if (typeof patch !== "object" || patch === null || Array.isArray(patch)) {
+      return json({ ok: false, error: "Body must be an object of setting → value" }, 400);
+    }
+
+    const result = await writeOverrides(env, patch as never);
+    // 400 rather than 422: the message names the offending key or the invariant
+    // it breaks, which is what the settings UI surfaces to the user.
+    if (!result.ok) return json({ ok: false, error: result.error }, 400);
+
+    return json({ ok: true, config: await resolveConfig(env) });
+  }
+
+  // DELETE /config/:key — per-setting reset, independent of every other setting
+  if (url.pathname.startsWith("/config/") && request.method === "DELETE") {
+    const authErr = requireAuth(request, env);
+    if (authErr) return authErr;
+
+    const key = decodeURIComponent(url.pathname.slice("/config/".length));
+    if (!(key in DEFAULTS)) {
+      return json({ ok: false, error: `${key} is not a known setting` }, 404);
+    }
+
+    await resetOverride(env, key as ConfigKey);
+    return json({ ok: true, config: await resolveConfig(env) });
+  }
+
+  return null;
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -8,6 +8,7 @@ import { handleEntriesRoutes } from "./entries";
 import { handleGraphRoutes } from "./graph";
 import { handleIntegrationsRoutes } from "./integrations";
 import { handleAdminRoutes } from "./admin";
+import { handleConfigRoutes } from "./config";
 
 type RouteHandler = (
   request: Request,
@@ -23,6 +24,7 @@ const routeHandlers: RouteHandler[] = [
   handleGraphRoutes,
   handleIntegrationsRoutes,
   handleAdminRoutes,
+  handleConfigRoutes,
 ];
 
 export function createDefaultHandler() {

--- a/src/routes/recall.ts
+++ b/src/routes/recall.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../env";
+import { resolveConfig } from "../config";
 import { LLM_MODEL, VECTORIZE_FIX_HINT } from "../constants";
 import { CORS_HEADERS, json, requireAuth } from "../lib/http";
 import { buildEntryFilterQuery } from "../capture/entry";
@@ -46,7 +47,8 @@ export async function handleRecallRoutes(
     // payload. Renderers that show the whole memory (the dashboard) pass full=1.
     const full = ["1", "true", "yes"].includes((url.searchParams.get("full") ?? "").toLowerCase());
 
-    const { matches, insight, semanticUnavailable, queryUsed, queryTokens } = await recallEntries({ query, topK, tag, after, before, kind, hops }, env, ctx);
+    const cfg = await resolveConfig(env);
+    const { matches, insight, semanticUnavailable, queryUsed, queryTokens } = await recallEntries({ query, topK, tag, after, before, kind, hops }, env, ctx, cfg);
 
     if (!matches.length) {
       return json({
@@ -66,7 +68,7 @@ export async function handleRecallRoutes(
       results: matches.map((m, i) => {
         const s = full
           ? { text: m.content, truncated: false, fullLength: (m.content ?? "").length }
-          : snippetOf(m.content, allowanceFor(i, m.score), { queryTokens });
+          : snippetOf(m.content, allowanceFor(i, m.score, cfg), { queryTokens });
         return {
           id: m.id,
           content: s.text,
@@ -101,9 +103,10 @@ export async function handleRecallRoutes(
     const systemPrompt = `You are a personal memory assistant. Answer the user's question using ONLY the memories provided. Even if the match scores are low, extract any relevant facts and answer directly. Never say you don't have enough information if the answer exists anywhere in the memories. Be concise.`;
 
     const userMessage = `Question: ${body.query}\n\nRelevant memories:\n${body.memories}`;
+    const cfg = await resolveConfig(env);
 
     // Workers AI requires `as any` here — the SDK types don't cover all models
-    const stream = await env.AI.run(LLM_MODEL as any, {
+    const stream = await env.AI.run(cfg.LLM_MODEL as any, {
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userMessage }

--- a/test/integration/config-embedding-consistency.test.ts
+++ b/test/integration/config-embedding-consistency.test.ts
@@ -1,0 +1,82 @@
+/**
+ * #245 — the embedding model must be consistent across every path that writes
+ * or reads vectors.
+ *
+ * This is the sharpest hazard in making EMBEDDING_MODEL configurable: if
+ * capture embeds with the configured model while recall still embeds with the
+ * compiled-in default (or vice versa), the two produce vectors from different
+ * models and every similarity score becomes meaningless. Nothing would throw —
+ * recall would just quietly return wrong answers.
+ *
+ * So this asserts the property directly: with an override in KV, every embed
+ * call made by any path uses the same configured model.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { recallEntries } from "../../src/recall/search";
+import { captureEntry } from "../../src/capture/entry";
+import { CONFIG_KEY, DEFAULTS } from "../../src/config";
+import { makeTestEnv, makeTestDb, makeVectorizeMock, makeMemoryKV } from "../helpers/make-env";
+
+const OVERRIDE_MODEL = "@cf/baai/bge-base-en-v1.5";
+
+function envRecordingModels() {
+  const models: string[] = [];
+  const kv = makeMemoryKV();
+  const db = makeTestDb();
+  const env = makeTestEnv(db, {
+    OAUTH_KV: kv,
+    AI: {
+      run: vi.fn().mockImplementation(async (model: string) => {
+        models.push(model);
+        // Embedding models return data[]; text models return a stream. Only the
+        // embedding shape is needed here.
+        return { data: [[0.1, 0.2, 0.3]] };
+      }),
+    } as never,
+    VECTORIZE: makeVectorizeMock({
+      query: vi.fn().mockResolvedValue({ matches: [] }),
+      upsert: vi.fn().mockResolvedValue({}),
+    }),
+  });
+  return { env, db, kv, models };
+}
+
+const ctx = { waitUntil: () => {} } as unknown as ExecutionContext;
+
+describe("embedding model consistency (#245)", () => {
+  it("recall embeds with the configured model", async () => {
+    const { env, kv, models } = envRecordingModels();
+    await kv.put(CONFIG_KEY, JSON.stringify({ EMBEDDING_MODEL: OVERRIDE_MODEL }));
+
+    await recallEntries({ query: "anything", topK: 5 }, env, ctx);
+
+    expect(models.length).toBeGreaterThan(0);
+    expect(models).not.toContain(DEFAULTS.EMBEDDING_MODEL);
+  });
+
+  it("capture embeds with the configured model", async () => {
+    const { env, kv, models } = envRecordingModels();
+    await kv.put(CONFIG_KEY, JSON.stringify({ EMBEDDING_MODEL: OVERRIDE_MODEL }));
+
+    await captureEntry("a memory worth storing", ["test"], "api", env, ctx);
+
+    const embeddingCalls = models.filter(m => m.includes("bge"));
+    expect(embeddingCalls.length).toBeGreaterThan(0);
+    expect(embeddingCalls).not.toContain(DEFAULTS.EMBEDDING_MODEL);
+  });
+
+  it("both paths agree on the model, so vectors stay comparable", async () => {
+    const capture = envRecordingModels();
+    await capture.kv.put(CONFIG_KEY, JSON.stringify({ EMBEDDING_MODEL: OVERRIDE_MODEL }));
+    await captureEntry("a memory worth storing", [], "api", capture.env, ctx);
+
+    const recall = envRecordingModels();
+    await recall.kv.put(CONFIG_KEY, JSON.stringify({ EMBEDDING_MODEL: OVERRIDE_MODEL }));
+    await recallEntries({ query: "anything", topK: 5 }, recall.env, ctx);
+
+    const captureModels = new Set(capture.models.filter(m => m.includes("bge")));
+    const recallModels = new Set(recall.models.filter(m => m.includes("bge")));
+
+    expect([...captureModels]).toEqual([...recallModels]);
+  });
+});

--- a/test/integration/config-routes.test.ts
+++ b/test/integration/config-routes.test.ts
@@ -1,0 +1,153 @@
+/**
+ * #245 "also in scope": authenticated config read/write routes for the desktop
+ * app (#246) to call.
+ *
+ * These go through the real default handler — same path a request from the
+ * Tauri app takes — rather than calling the route function directly, so the
+ * auth gate and route registration are exercised too.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDefaultHandler } from "../../src/routes/index";
+import { DEFAULTS, CONFIG_KEY, resolveConfig } from "../../src/config";
+import { makeTestEnv, makeTestDb, makeMemoryKV } from "../helpers/make-env";
+import type { Env } from "../../src/env";
+
+const ctx = { waitUntil: () => {} } as unknown as ExecutionContext;
+const TOKEN = "test-token";
+
+function req(path: string, init: RequestInit = {}, auth = true) {
+  return new Request(`http://localhost${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(auth ? { Authorization: `Bearer ${TOKEN}` } : {}),
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+describe("config routes", () => {
+  let env: Env;
+  let kv: KVNamespace;
+  let handler: ReturnType<typeof createDefaultHandler>;
+
+  beforeEach(() => {
+    kv = makeMemoryKV();
+    env = makeTestEnv(makeTestDb(), { OAUTH_KV: kv, AUTH_TOKEN: TOKEN });
+    handler = createDefaultHandler();
+  });
+
+  describe("GET /config", () => {
+    it("requires authentication", async () => {
+      const res = await handler.fetch(req("/config", {}, false), env, ctx);
+      expect(res.status).toBe(401);
+    });
+
+    it("returns the effective config and which keys are overridden", async () => {
+      const res = await handler.fetch(req("/config"), env, ctx);
+      const body = await res.json() as { ok: boolean; config: Record<string, unknown>; overrides: Record<string, unknown> };
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.config.RECENCY_FLOOR).toBe(DEFAULTS.RECENCY_FLOOR);
+      // Nothing overridden yet — the UI needs this to show "default" per row.
+      expect(body.overrides).toEqual({});
+    });
+
+    it("reports defaults alongside the effective values so the UI can offer reset", async () => {
+      const res = await handler.fetch(req("/config"), env, ctx);
+      const body = await res.json() as { defaults: Record<string, unknown> };
+      expect(body.defaults.RECENCY_FLOOR).toBe(DEFAULTS.RECENCY_FLOOR);
+    });
+
+    it("shows an override once one is stored", async () => {
+      await kv.put(CONFIG_KEY, JSON.stringify({ MMR_LAMBDA: 0.42 }));
+
+      const res = await handler.fetch(req("/config"), env, ctx);
+      const body = await res.json() as { config: Record<string, unknown>; overrides: Record<string, unknown> };
+
+      expect(body.config.MMR_LAMBDA).toBe(0.42);
+      expect(body.overrides).toEqual({ MMR_LAMBDA: 0.42 });
+    });
+  });
+
+  describe("PATCH /config", () => {
+    it("requires authentication", async () => {
+      const res = await handler.fetch(
+        req("/config", { method: "PATCH", body: JSON.stringify({ MMR_LAMBDA: 0.5 }) }, false), env, ctx);
+      expect(res.status).toBe(401);
+    });
+
+    it("applies a valid change and it survives a re-read", async () => {
+      const res = await handler.fetch(
+        req("/config", { method: "PATCH", body: JSON.stringify({ MMR_LAMBDA: 0.42 }) }), env, ctx);
+
+      expect(res.status).toBe(200);
+      expect((await resolveConfig(env)).MMR_LAMBDA).toBe(0.42);
+    });
+
+    it("rejects an out-of-range value with 400 and a message naming the key", async () => {
+      const res = await handler.fetch(
+        req("/config", { method: "PATCH", body: JSON.stringify({ MMR_LAMBDA: 99 }) }), env, ctx);
+      const body = await res.json() as { ok: boolean; error: string };
+
+      expect(res.status).toBe(400);
+      expect(body.ok).toBe(false);
+      expect(body.error).toMatch(/MMR_LAMBDA/);
+    });
+
+    it("rejects an invariant violation with a message naming the conflict", async () => {
+      const res = await handler.fetch(
+        req("/config", {
+          method: "PATCH",
+          body: JSON.stringify({ DUPLICATE_BLOCK_THRESHOLD: 0.5, DUPLICATE_FLAG_THRESHOLD: 0.9 }),
+        }), env, ctx);
+      const body = await res.json() as { error: string };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toMatch(/DUPLICATE_BLOCK_THRESHOLD/);
+    });
+
+    it("rejects an unknown key", async () => {
+      const res = await handler.fetch(
+        req("/config", { method: "PATCH", body: JSON.stringify({ NOPE: 1 }) }), env, ctx);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects a malformed body without throwing", async () => {
+      const res = await handler.fetch(
+        req("/config", { method: "PATCH", body: "{ not json" }), env, ctx);
+      expect(res.status).toBe(400);
+    });
+
+    it("leaves stored config untouched when the patch is rejected", async () => {
+      await handler.fetch(req("/config", { method: "PATCH", body: JSON.stringify({ MMR_LAMBDA: 0.42 }) }), env, ctx);
+      await handler.fetch(req("/config", { method: "PATCH", body: JSON.stringify({ MMR_LAMBDA: 99 }) }), env, ctx);
+
+      expect((await resolveConfig(env)).MMR_LAMBDA).toBe(0.42);
+    });
+  });
+
+  describe("DELETE /config/:key", () => {
+    it("requires authentication", async () => {
+      const res = await handler.fetch(req("/config/MMR_LAMBDA", { method: "DELETE" }, false), env, ctx);
+      expect(res.status).toBe(401);
+    });
+
+    it("resets one key and leaves the others overridden", async () => {
+      await kv.put(CONFIG_KEY, JSON.stringify({ MMR_LAMBDA: 0.42, RECENCY_FLOOR: 0.4 }));
+
+      const res = await handler.fetch(req("/config/MMR_LAMBDA", { method: "DELETE" }), env, ctx);
+      const config = await resolveConfig(env);
+
+      expect(res.status).toBe(200);
+      expect(config.MMR_LAMBDA).toBe(DEFAULTS.MMR_LAMBDA);
+      expect(config.RECENCY_FLOOR).toBe(0.4);
+    });
+
+    it("404s on an unknown key rather than silently succeeding", async () => {
+      const res = await handler.fetch(req("/config/NOT_A_KEY", { method: "DELETE" }), env, ctx);
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/test/integration/config-seams.test.ts
+++ b/test/integration/config-seams.test.ts
@@ -1,0 +1,159 @@
+/**
+ * #245 — every seam in the issue's table reads its tunables from the resolved
+ * config rather than module scope.
+ *
+ * Each test moves one setting and asserts the observable behaviour moves with
+ * it. Where a seam is pure (allowanceFor, compressionEligibilitySql) it is
+ * called directly with no env at all.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DEFAULTS } from "../../src/config";
+import { allowanceFor } from "../../src/recall/snippet";
+import { compressionEligibilitySql } from "../../src/compression/eligibility";
+import { embed } from "../../src/lib/ai";
+import { expandGraph } from "../../src/graph/traverse";
+import { checkDuplicateAndContradiction } from "../../src/capture/duplicate";
+import { makeTestEnv, makeTestDb, makeVectorizeMock } from "../helpers/make-env";
+import { D1Mock } from "../helpers/d1-mock";
+
+describe("seam: output budgeting (snippet.ts)", () => {
+  it("uses the configured full-match allowance for a strong early match", () => {
+    const generous = allowanceFor(0, 1, { ...DEFAULTS, FULL_MATCH_MAX_CHARS: 9000 });
+    expect(generous).toBe(9000);
+  });
+
+  it("uses the configured snippet allowance once past the full-match count", () => {
+    const config = { ...DEFAULTS, RECALL_FULL_MATCHES: 0, SNIPPET_MAX_CHARS: 123 };
+    expect(allowanceFor(0, 1, config)).toBe(123);
+  });
+
+  it("respects a configured strong-match ratio", () => {
+    // relScore 0.5 is strong under a 0.4 ratio, weak under the shipped 0.75.
+    const lenient = { ...DEFAULTS, STRONG_MATCH_RATIO: 0.4 };
+    expect(allowanceFor(0, 0.5, lenient)).toBe(DEFAULTS.FULL_MATCH_MAX_CHARS);
+    expect(allowanceFor(0, 0.5, DEFAULTS)).toBe(DEFAULTS.SNIPPET_MAX_CHARS);
+  });
+
+  it("falls back to the shipped config when none is passed", () => {
+    expect(allowanceFor(0, 1)).toBe(DEFAULTS.FULL_MATCH_MAX_CHARS);
+  });
+});
+
+describe("seam: compression eligibility (eligibility.ts)", () => {
+  it("embeds the configured importance threshold in the SQL", () => {
+    const sql = compressionEligibilitySql("", { ...DEFAULTS, COMPRESSION_IMPORTANCE_THRESHOLD: 2 });
+    expect(sql).toContain("importance_score < 2");
+  });
+
+  it("embeds the configured minimum recall count in the SQL", () => {
+    const sql = compressionEligibilitySql("", { ...DEFAULTS, COMPRESSION_MIN_RECALL: 7 });
+    expect(sql).toContain("recall_count < 7");
+  });
+
+  it("still emits exactly one bind placeholder", () => {
+    const sql = compressionEligibilitySql("entries.", { ...DEFAULTS, COMPRESSION_MIN_RECALL: 7 });
+    expect(sql.split("?").length - 1).toBe(1);
+  });
+
+  it("falls back to the shipped config when none is passed", () => {
+    expect(compressionEligibilitySql()).toContain(`importance_score < ${DEFAULTS.COMPRESSION_IMPORTANCE_THRESHOLD}`);
+  });
+});
+
+describe("seam: embedding model (ai.ts)", () => {
+  it("embeds with the configured model", async () => {
+    const run = vi.fn().mockResolvedValue({ data: [[0.1, 0.2]] });
+    const env = makeTestEnv(undefined, { AI: { run } as never });
+
+    await embed("hello", env, { ...DEFAULTS, EMBEDDING_MODEL: "@cf/some/other-model" });
+
+    expect(run.mock.calls[0][0]).toBe("@cf/some/other-model");
+  });
+
+  it("falls back to the shipped model when no config is passed", async () => {
+    const run = vi.fn().mockResolvedValue({ data: [[0.1]] });
+    const env = makeTestEnv(undefined, { AI: { run } as never });
+
+    await embed("hello", env);
+
+    expect(run.mock.calls[0][0]).toBe(DEFAULTS.EMBEDDING_MODEL);
+  });
+});
+
+describe("seam: graph expansion (traverse.ts)", () => {
+  let db: D1Mock;
+
+  function seed(id: string) {
+    db.entries.push({
+      id, content: id, tags: "[]", source: "api", created_at: 1000,
+      vector_ids: "[]", recall_count: 0, importance_score: 0,
+    });
+  }
+  function edge(a: string, b: string) {
+    db.edges.push({
+      id: `${a}-${b}`, source_id: a, target_id: b, type: "relates_to",
+      weight: 1, provenance: "inferred", metadata: "{}", created_at: 1, updated_at: 1,
+    });
+  }
+
+  beforeEach(() => {
+    db = makeTestDb();
+    seed("a"); seed("b"); seed("c");
+    edge("a", "b"); edge("b", "c");
+  });
+
+  it("clamps hops to the configured maximum", async () => {
+    const env = makeTestEnv(db);
+
+    const capped = await expandGraph(["a"], { hops: 2 }, env, { ...DEFAULTS, GRAPH_MAX_HOPS: 1 });
+
+    // With a 1-hop ceiling, the 2-hop neighbour must not appear.
+    expect(capped.map(n => n.id)).not.toContain("c");
+  });
+
+  it("reaches a 2-hop neighbour when the configured maximum allows it", async () => {
+    const env = makeTestEnv(db);
+
+    const full = await expandGraph(["a"], { hops: 2 }, env, DEFAULTS);
+
+    expect(full.map(n => n.id)).toContain("c");
+  });
+
+  // GRAPH_HOP_DECAY is deliberately not tested here: expandGraph returns
+  // GraphNeighbor, which carries hop/viaWeight but no score. The decay is
+  // applied downstream in search.ts, so it is threaded and covered there.
+});
+
+describe("seam: duplicate detection (duplicate.ts)", () => {
+  function envWithTopScore(score: number) {
+    return makeTestEnv(makeTestDb(), {
+      AI: { run: vi.fn().mockResolvedValue({ data: [[0.1]] }) } as never,
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "dup", score, metadata: { parentId: "dup" } }],
+        }),
+      }),
+    });
+  }
+
+  it("blocks at the configured block threshold", async () => {
+    const { duplicate } = await checkDuplicateAndContradiction(
+      "x", envWithTopScore(0.9), { ...DEFAULTS, DUPLICATE_BLOCK_THRESHOLD: 0.88 },
+    );
+    expect(duplicate.status).toBe("blocked");
+  });
+
+  it("only flags the same score when the block threshold is raised above it", async () => {
+    const { duplicate } = await checkDuplicateAndContradiction(
+      "x", envWithTopScore(0.9), { ...DEFAULTS, DUPLICATE_BLOCK_THRESHOLD: 0.99, DUPLICATE_FLAG_THRESHOLD: 0.8 },
+    );
+    expect(duplicate.status).toBe("flagged");
+  });
+
+  it("treats the same score as unique when both thresholds sit above it", async () => {
+    const { duplicate } = await checkDuplicateAndContradiction(
+      "x", envWithTopScore(0.9), { ...DEFAULTS, DUPLICATE_BLOCK_THRESHOLD: 0.99, DUPLICATE_FLAG_THRESHOLD: 0.95 },
+    );
+    expect(duplicate.status).toBe("unique");
+  });
+});

--- a/test/integration/recall-widen-threshold.test.ts
+++ b/test/integration/recall-widen-threshold.test.ts
@@ -1,0 +1,87 @@
+/**
+ * #245 — recall widening must be governed by its own threshold.
+ *
+ * Before this split both the write-path duplicate flag and the recall-path
+ * widen check read DUPLICATE_FLAG_THRESHOLD. Exposing that single constant as
+ * a "duplicate blocking" control would silently retune recall, so the two call
+ * sites are separated here and pinned by the last test in this file.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { recallEntries } from "../../src/recall/search";
+import { makeTestEnv, makeTestDb, makeVectorizeMock, makeMemoryKV } from "../helpers/make-env";
+import { CONFIG_KEY } from "../../src/config";
+import { D1Mock } from "../helpers/d1-mock";
+
+function makeCtx() {
+  const pending: Promise<any>[] = [];
+  return { ctx: { waitUntil: (p: Promise<any>) => pending.push(p) } as any as ExecutionContext };
+}
+
+function seed(db: D1Mock, id: string, content: string) {
+  db.entries.push({
+    id, content, tags: "[]", source: "api", created_at: 1000,
+    vector_ids: "[]", recall_count: 0, importance_score: 0,
+  });
+}
+
+/**
+ * Narrow queries return only the weak match; the widened re-query (topK 50)
+ * also returns `extra`. So `extra` appearing in the result IS the observable
+ * evidence that widening happened — no assertions on mock call counts.
+ */
+function wideningEnv(db: D1Mock, overrides?: Record<string, unknown>) {
+  const kv = makeMemoryKV();
+  const env = makeTestEnv(db, {
+    OAUTH_KV: kv,
+    VECTORIZE: makeVectorizeMock({
+      query: vi.fn().mockImplementation(async (_v: unknown, opts: { topK?: number } = {}) => {
+        const weak = { id: "weak", score: 0.5, metadata: { parentId: "weak", isUpdate: false } };
+        const extra = { id: "extra", score: 0.45, metadata: { parentId: "extra", isUpdate: false } };
+        return { matches: opts.topK === 50 ? [weak, extra] : [weak] };
+      }),
+    }),
+  });
+  return { env, seedConfig: async () => overrides && kv.put(CONFIG_KEY, JSON.stringify(overrides)) };
+}
+
+describe("recall widening threshold (#245)", () => {
+  let db: D1Mock;
+  beforeEach(() => {
+    db = makeTestDb();
+    seed(db, "weak", "weak match");
+    seed(db, "extra", "only found by the widened query");
+  });
+
+  it("widens when the best match falls below the default threshold", async () => {
+    const { env, seedConfig } = wideningEnv(db);
+    await seedConfig();
+    const { ctx } = makeCtx();
+
+    const res = await recallEntries({ query: "anything", topK: 10 }, env, ctx);
+
+    expect(res.matches.map(m => m.id)).toContain("extra");
+  });
+
+  it("does not widen once RECALL_WIDEN_THRESHOLD is lowered below the best score", async () => {
+    const { env, seedConfig } = wideningEnv(db, { RECALL_WIDEN_THRESHOLD: 0.1 });
+    await seedConfig();
+    const { ctx } = makeCtx();
+
+    const res = await recallEntries({ query: "anything", topK: 10 }, env, ctx);
+
+    expect(res.matches.map(m => m.id)).not.toContain("extra");
+  });
+
+  // The reason the split exists: retuning duplicate detection must not move
+  // recall. If this fails, the two call sites have been recoupled.
+  it("is unaffected by DUPLICATE_FLAG_THRESHOLD", async () => {
+    const { env, seedConfig } = wideningEnv(db, { DUPLICATE_FLAG_THRESHOLD: 0.1 });
+    await seedConfig();
+    const { ctx } = makeCtx();
+
+    const res = await recallEntries({ query: "anything", topK: 10 }, env, ctx);
+
+    // Widening still governed by RECALL_WIDEN_THRESHOLD's default of 0.85.
+    expect(res.matches.map(m => m.id)).toContain("extra");
+  });
+});

--- a/test/unit/config-parity.test.ts
+++ b/test/unit/config-parity.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Behaviour-preservation guard for #245.
+ *
+ * The config layer only stays honest if every DEFAULT equals the constant that
+ * currently governs the same behaviour. A silent drift here changes recall or
+ * capture for every user who never touched a setting — the exact failure this
+ * refactor must not introduce. This test is the tripwire.
+ */
+import { describe, it, expect } from "vitest";
+import { DEFAULTS, RULES } from "../../src/config";
+import * as constants from "../../src/constants";
+import { RECENCY_FLOOR, RECENCY_FLOOR_DURABLE, RECENCY_FLOOR_VOLATILE, MMR_LAMBDA } from "../../src/recall/math";
+import { GRAPH_MAX_HOPS, GRAPH_HOP_DECAY } from "../../src/graph/traverse";
+import {
+  RECALL_OUTPUT_BUDGET,
+  SNIPPET_MAX_CHARS,
+  FULL_MATCH_MAX_CHARS,
+  RECALL_FULL_MATCHES,
+  STRONG_MATCH_RATIO,
+} from "../../src/recall/snippet";
+import {
+  COMPRESSION_IMPORTANCE_THRESHOLD,
+  COMPRESSION_MIN_RECALL,
+  COMPRESSION_MIN_AGE_MS,
+} from "../../src/compression/eligibility";
+
+describe("DEFAULTS parity with shipped constants", () => {
+  const cases: [string, unknown, unknown][] = [
+    ["RECENCY_FLOOR", DEFAULTS.RECENCY_FLOOR, RECENCY_FLOOR],
+    ["RECENCY_FLOOR_DURABLE", DEFAULTS.RECENCY_FLOOR_DURABLE, RECENCY_FLOOR_DURABLE],
+    ["RECENCY_FLOOR_VOLATILE", DEFAULTS.RECENCY_FLOOR_VOLATILE, RECENCY_FLOOR_VOLATILE],
+    ["MMR_LAMBDA", DEFAULTS.MMR_LAMBDA, MMR_LAMBDA],
+    ["DUPLICATE_BLOCK_THRESHOLD", DEFAULTS.DUPLICATE_BLOCK_THRESHOLD, constants.DUPLICATE_BLOCK_THRESHOLD],
+    ["DUPLICATE_FLAG_THRESHOLD", DEFAULTS.DUPLICATE_FLAG_THRESHOLD, constants.DUPLICATE_FLAG_THRESHOLD],
+    ["GRAPH_MAX_HOPS", DEFAULTS.GRAPH_MAX_HOPS, GRAPH_MAX_HOPS],
+    ["GRAPH_HOP_DECAY", DEFAULTS.GRAPH_HOP_DECAY, GRAPH_HOP_DECAY],
+    ["RECALL_OUTPUT_BUDGET", DEFAULTS.RECALL_OUTPUT_BUDGET, RECALL_OUTPUT_BUDGET],
+    ["SNIPPET_MAX_CHARS", DEFAULTS.SNIPPET_MAX_CHARS, SNIPPET_MAX_CHARS],
+    ["FULL_MATCH_MAX_CHARS", DEFAULTS.FULL_MATCH_MAX_CHARS, FULL_MATCH_MAX_CHARS],
+    ["RECALL_FULL_MATCHES", DEFAULTS.RECALL_FULL_MATCHES, RECALL_FULL_MATCHES],
+    ["STRONG_MATCH_RATIO", DEFAULTS.STRONG_MATCH_RATIO, STRONG_MATCH_RATIO],
+    ["COMPRESSION_IMPORTANCE_THRESHOLD", DEFAULTS.COMPRESSION_IMPORTANCE_THRESHOLD, COMPRESSION_IMPORTANCE_THRESHOLD],
+    ["COMPRESSION_MIN_RECALL", DEFAULTS.COMPRESSION_MIN_RECALL, COMPRESSION_MIN_RECALL],
+    ["COMPRESSION_MIN_AGE_MS", DEFAULTS.COMPRESSION_MIN_AGE_MS, COMPRESSION_MIN_AGE_MS],
+    ["TAG_BOOST_STEP", DEFAULTS.TAG_BOOST_STEP, constants.TAG_BOOST_STEP],
+    ["TAG_BOOST_MAX", DEFAULTS.TAG_BOOST_MAX, constants.TAG_BOOST_MAX],
+    ["CONTRADICTION_IMPORTANCE_STEP", DEFAULTS.CONTRADICTION_IMPORTANCE_STEP, constants.CONTRADICTION_IMPORTANCE_STEP],
+    ["LLM_MODEL", DEFAULTS.LLM_MODEL, constants.LLM_MODEL],
+    ["EMBEDDING_MODEL", DEFAULTS.EMBEDDING_MODEL, constants.EMBEDDING_MODEL],
+  ];
+
+  for (const [name, fromConfig, fromModule] of cases) {
+    it(`${name} matches the shipped constant`, () => {
+      expect(fromConfig).toBe(fromModule);
+    });
+  }
+
+  // The split introduced by #245: recall widening used to read
+  // DUPLICATE_FLAG_THRESHOLD. It must start life at the same value, or recall
+  // widening changes for every existing user.
+  it("RECALL_WIDEN_THRESHOLD starts equal to DUPLICATE_FLAG_THRESHOLD", () => {
+    expect(DEFAULTS.RECALL_WIDEN_THRESHOLD).toBe(constants.DUPLICATE_FLAG_THRESHOLD);
+  });
+});
+
+describe("config rule coverage", () => {
+  it("every default has a validation rule", () => {
+    const missing = Object.keys(DEFAULTS).filter(k => !(k in RULES));
+    expect(missing).toEqual([]);
+  });
+
+  it("every rule corresponds to a real default", () => {
+    const orphans = Object.keys(RULES).filter(k => !(k in DEFAULTS));
+    expect(orphans).toEqual([]);
+  });
+
+  it("every shipped default satisfies its own rule", () => {
+    const violations: string[] = [];
+    for (const [key, rule] of Object.entries(RULES)) {
+      const v = (DEFAULTS as Record<string, unknown>)[key];
+      if (rule.kind === "string") {
+        if (typeof v !== "string" || !v.trim()) violations.push(`${key}: not a non-empty string`);
+        continue;
+      }
+      if (typeof v !== "number" || !Number.isFinite(v)) { violations.push(`${key}: not finite`); continue; }
+      if (v < rule.min || v > rule.max) violations.push(`${key}: ${v} outside ${rule.min}–${rule.max}`);
+      if (rule.integer && !Number.isInteger(v)) violations.push(`${key}: ${v} is not an integer`);
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("platform limits are absent from the config surface", () => {
+    // Exposing these guarantees breakage rather than risking it: Vectorize
+    // rejects >20 ids per call, D1 caps bound params at 100.
+    for (const forbidden of ["VECTORIZE_GET_BY_IDS_BATCH", "D1_MAX_BOUND_PARAMS", "EDGE_QUERY_BATCH"]) {
+      expect(DEFAULTS).not.toHaveProperty(forbidden);
+    }
+  });
+});

--- a/test/unit/config-threading-complete.test.ts
+++ b/test/unit/config-threading-complete.test.ts
@@ -1,0 +1,105 @@
+/**
+ * #245 completeness guard.
+ *
+ * Threading a seam is easy to do partially: swap three of four usages, leave
+ * the fourth reading module scope, and every behavioural test still passes
+ * because the default and the override happen to agree in the fixture. That
+ * failure is invisible until a user actually changes the setting.
+ *
+ * So this asserts the structural property directly — inside the seam files, a
+ * tunable may be *declared*, but it may not be *read* from module scope. Reads
+ * must go through the resolved config.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join, relative } from "node:path";
+import { DEFAULTS } from "../../src/config";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+
+// Every file listed in the issue's "seams to thread" table, plus the recall
+// entry point that consumes several of them.
+const SEAM_FILES = [
+  "src/recall/math.ts",
+  "src/recall/search.ts",
+  "src/recall/snippet.ts",
+  "src/capture/duplicate.ts",
+  "src/graph/traverse.ts",
+  "src/compression/eligibility.ts",
+  "src/lib/ai.ts",
+];
+
+/**
+ * Walks all of src/. Checking only the seam files was not enough: LLM_MODEL is
+ * a tunable, and threading it through duplicate.ts still left six other call
+ * sites reading the compiled-in constant. A user changing the model would have
+ * seen it honoured on one path and ignored on the rest.
+ */
+function allSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...allSourceFiles(p));
+    else if (entry.name.endsWith(".ts")) out.push(p);
+  }
+  return out;
+}
+
+const TUNABLES = Object.keys(DEFAULTS);
+
+function offendingReads(source: string): string[] {
+  // Import statements are stripped wholesale — including multi-line ones —
+  // rather than skipped line by line, so a continuation like `  LLM_MODEL,`
+  // is not mistaken for a read.
+  const withoutImports = source.replace(/^import\s[\s\S]*?from\s+["'][^"']+["'];?$/gm, "");
+
+  const offenders: string[] = [];
+  for (const name of TUNABLES) {
+    for (const raw of withoutImports.split("\n")) {
+      const line = raw.trim();
+      if (!new RegExp(`\\b${name}\\b`).test(line)) continue;
+      // Declaring or re-exporting the shipped constant is fine — the parity
+      // test depends on those still existing.
+      if (/^export (const|type)\b/.test(line)) continue;
+      if (line.startsWith("//") || line.startsWith("*") || line.startsWith("/*")) continue;
+      // Any property access is a qualified read; a bare identifier is not.
+      if (new RegExp(`[\\w)]\\s*\\.\\s*${name}\\b`).test(line)) continue;
+      offenders.push(`${name}: ${line.slice(0, 90)}`);
+    }
+  }
+  return offenders;
+}
+
+describe("config threading is complete", () => {
+  for (const file of SEAM_FILES) {
+    it(`${file} reads every tunable through config`, () => {
+      const source = readFileSync(resolve(ROOT, file), "utf8");
+      expect(offendingReads(source)).toEqual([]);
+    });
+  }
+
+  it("no file anywhere in src/ reads a tunable from module scope", () => {
+    const offenders: string[] = [];
+    for (const file of allSourceFiles(resolve(ROOT, "src"))) {
+      if (file.endsWith("config.ts")) continue;
+      for (const o of offendingReads(readFileSync(file, "utf8"))) {
+        offenders.push(`${relative(ROOT, file)} — ${o}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("covers every seam named in the issue", () => {
+    // Guards against a seam being added to the codebase but not to this list.
+    for (const f of [
+      "src/recall/math.ts",
+      "src/capture/duplicate.ts",
+      "src/graph/traverse.ts",
+      "src/recall/snippet.ts",
+      "src/compression/eligibility.ts",
+      "src/lib/ai.ts",
+    ]) {
+      expect(SEAM_FILES).toContain(f);
+    }
+  });
+});

--- a/test/unit/config-write.test.ts
+++ b/test/unit/config-write.test.ts
@@ -1,0 +1,170 @@
+/**
+ * #245 write path.
+ *
+ * Note the deliberate asymmetry with resolve: a bad value arriving from KV is
+ * *repaired* (clamped, or the group reset) because recall must never fail on
+ * it, but a bad value arriving from a caller is *rejected* with a message, so
+ * the settings UI can say what conflicted instead of silently doing nothing.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  readOverrides,
+  writeOverrides,
+  resetOverride,
+  resolveConfig,
+  DEFAULTS,
+  CONFIG_KEY,
+} from "../../src/config";
+import { makeTestEnv, makeMemoryKV } from "../helpers/make-env";
+
+function envWithKV() {
+  const kv = makeMemoryKV();
+  return { env: makeTestEnv(undefined, { OAUTH_KV: kv }), kv };
+}
+
+describe("writeOverrides()", () => {
+  it("stores only the changed key, not the whole config", async () => {
+    const { env, kv } = envWithKV();
+
+    await writeOverrides(env, { RECENCY_FLOOR: 0.4 });
+
+    const stored = JSON.parse((await kv.get(CONFIG_KEY))!);
+    expect(stored).toEqual({ RECENCY_FLOOR: 0.4 });
+  });
+
+  it("merges into existing overrides rather than replacing them", async () => {
+    const { env, kv } = envWithKV();
+
+    await writeOverrides(env, { RECENCY_FLOOR: 0.4 });
+    await writeOverrides(env, { MMR_LAMBDA: 0.5 });
+
+    const stored = JSON.parse((await kv.get(CONFIG_KEY))!);
+    expect(stored).toEqual({ RECENCY_FLOOR: 0.4, MMR_LAMBDA: 0.5 });
+  });
+
+  // Storing a value equal to the default would freeze the user on today's
+  // number: a retuned default in a later release could never reach them.
+  it("does not persist a value that equals the shipped default", async () => {
+    const { env, kv } = envWithKV();
+
+    await writeOverrides(env, { RECENCY_FLOOR: DEFAULTS.RECENCY_FLOOR });
+
+    const raw = await kv.get(CONFIG_KEY);
+    expect(raw ? JSON.parse(raw) : {}).toEqual({});
+  });
+
+  it("rejects an unknown key by name", async () => {
+    const { env } = envWithKV();
+
+    const result = await writeOverrides(env, { NOT_A_SETTING: 1 } as never);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/NOT_A_SETTING/);
+  });
+
+  it("rejects an out-of-range value instead of silently clamping it", async () => {
+    const { env } = envWithKV();
+
+    const result = await writeOverrides(env, { MMR_LAMBDA: 5 });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/MMR_LAMBDA/);
+  });
+
+  it("rejects a wrong-typed value", async () => {
+    const { env } = envWithKV();
+
+    const result = await writeOverrides(env, { GRAPH_MAX_HOPS: "three" } as never);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/GRAPH_MAX_HOPS/);
+  });
+
+  it("rejects an invariant violation with a message naming the conflict", async () => {
+    const { env } = envWithKV();
+
+    const result = await writeOverrides(env, {
+      DUPLICATE_BLOCK_THRESHOLD: 0.5,
+      DUPLICATE_FLAG_THRESHOLD: 0.9,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/DUPLICATE_BLOCK_THRESHOLD/);
+    expect(result.ok === false && result.error).toMatch(/DUPLICATE_FLAG_THRESHOLD/);
+  });
+
+  it("catches an invariant violation against already-stored values, not just the patch", async () => {
+    const { env } = envWithKV();
+    await writeOverrides(env, { DUPLICATE_FLAG_THRESHOLD: 0.9 });
+
+    // Valid alone, but inverts the pair once merged with what is stored.
+    const result = await writeOverrides(env, { DUPLICATE_BLOCK_THRESHOLD: 0.6 });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("writes nothing when the patch is rejected", async () => {
+    const { env, kv } = envWithKV();
+
+    await writeOverrides(env, { MMR_LAMBDA: 99 });
+
+    expect(await kv.get(CONFIG_KEY)).toBeNull();
+  });
+
+  it("accepts a valid patch and it survives a round trip through resolveConfig", async () => {
+    const { env } = envWithKV();
+
+    const result = await writeOverrides(env, { MMR_LAMBDA: 0.42 });
+    const config = await resolveConfig(env);
+
+    expect(result.ok).toBe(true);
+    expect(config.MMR_LAMBDA).toBe(0.42);
+  });
+});
+
+describe("resetOverride()", () => {
+  it("restores one value to its default and leaves siblings overridden", async () => {
+    const { env } = envWithKV();
+    await writeOverrides(env, { RECENCY_FLOOR: 0.4, MMR_LAMBDA: 0.5 });
+
+    await resetOverride(env, "RECENCY_FLOOR");
+    const config = await resolveConfig(env);
+
+    expect(config.RECENCY_FLOOR).toBe(DEFAULTS.RECENCY_FLOOR);
+    expect(config.MMR_LAMBDA).toBe(0.5);
+  });
+
+  it("is a delete, so a later change to the shipped default reaches the user", async () => {
+    const { env } = envWithKV();
+    await writeOverrides(env, { RECENCY_FLOOR: 0.4 });
+
+    await resetOverride(env, "RECENCY_FLOOR");
+
+    const stored = await readOverrides(env);
+    expect(stored).not.toHaveProperty("RECENCY_FLOOR");
+  });
+
+  it("is a no-op for a key that was never overridden", async () => {
+    const { env } = envWithKV();
+    await writeOverrides(env, { MMR_LAMBDA: 0.5 });
+
+    await resetOverride(env, "RECENCY_FLOOR");
+    const config = await resolveConfig(env);
+
+    expect(config.MMR_LAMBDA).toBe(0.5);
+  });
+});
+
+describe("readOverrides()", () => {
+  it("returns an empty object when nothing is stored", async () => {
+    const { env } = envWithKV();
+    expect(await readOverrides(env)).toEqual({});
+  });
+
+  it("returns an empty object when KV throws", async () => {
+    const env = makeTestEnv(undefined, {
+      OAUTH_KV: { get: async () => { throw new Error("down"); } } as unknown as KVNamespace,
+    });
+    expect(await readOverrides(env)).toEqual({});
+  });
+});

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "vitest";
+import { resolveConfig, DEFAULTS, CONFIG_KEY } from "../../src/config";
+import { makeTestEnv, makeMemoryKV } from "../helpers/make-env";
+
+function envWithKV(seed: Record<string, unknown> | null = null) {
+  const kv = makeMemoryKV();
+  const env = makeTestEnv(undefined, { OAUTH_KV: kv });
+  return { env, kv, seed: async (v: Record<string, unknown>) => kv.put(CONFIG_KEY, JSON.stringify(v)) };
+}
+
+describe("resolveConfig()", () => {
+  it("returns the shipped defaults when no overrides key exists", async () => {
+    const { env } = envWithKV();
+
+    const config = await resolveConfig(env);
+
+    expect(config.RECENCY_FLOOR).toBe(DEFAULTS.RECENCY_FLOOR);
+    expect(config.DUPLICATE_BLOCK_THRESHOLD).toBe(DEFAULTS.DUPLICATE_BLOCK_THRESHOLD);
+    expect(config.GRAPH_MAX_HOPS).toBe(DEFAULTS.GRAPH_MAX_HOPS);
+  });
+
+  it("applies a stored override and leaves siblings on their defaults", async () => {
+    const { env, seed } = envWithKV();
+    await seed({ RECENCY_FLOOR: 0.4 });
+
+    const config = await resolveConfig(env);
+
+    expect(config.RECENCY_FLOOR).toBe(0.4);
+    expect(config.MMR_LAMBDA).toBe(DEFAULTS.MMR_LAMBDA);
+    expect(config.GRAPH_MAX_HOPS).toBe(DEFAULTS.GRAPH_MAX_HOPS);
+  });
+
+  it("ignores unknown keys in the stored blob", async () => {
+    const { env, seed } = envWithKV();
+    await seed({ NOT_A_REAL_SETTING: 123, RECENCY_FLOOR: 0.4 });
+
+    const config = await resolveConfig(env);
+
+    expect(config).not.toHaveProperty("NOT_A_REAL_SETTING");
+    expect(config.RECENCY_FLOOR).toBe(0.4);
+  });
+
+  it("returns pure defaults when KV throws", async () => {
+    const env = makeTestEnv(undefined, {
+      OAUTH_KV: { get: async () => { throw new Error("KV unavailable"); } } as unknown as KVNamespace,
+    });
+
+    const config = await resolveConfig(env);
+
+    expect(config).toEqual({ ...DEFAULTS });
+  });
+
+  it("returns pure defaults when the stored blob is not valid JSON", async () => {
+    const { env, kv } = envWithKV();
+    await kv.put(CONFIG_KEY, "{ not json");
+
+    const config = await resolveConfig(env);
+
+    expect(config).toEqual({ ...DEFAULTS });
+  });
+});
+
+describe("resolveConfig() validation", () => {
+  // GRAPH_HOP_DECAY participates in no invariant, so this isolates clamping.
+  it("clamps a numeric override above its range to the maximum", async () => {
+    const { env, seed } = envWithKV();
+    await seed({ GRAPH_HOP_DECAY: 5 });
+
+    const config = await resolveConfig(env);
+
+    expect(config.GRAPH_HOP_DECAY).toBe(1);
+  });
+
+  it("resets the whole group when clamping a value would still invert an invariant", async () => {
+    const { env, seed } = envWithKV();
+    // Clamps to 1, which is above RECENCY_FLOOR_DURABLE's default of 0.9 —
+    // in range individually, but it inverts the tiering.
+    await seed({ RECENCY_FLOOR: 5 });
+
+    const config = await resolveConfig(env);
+
+    expect(config.RECENCY_FLOOR).toBe(DEFAULTS.RECENCY_FLOOR);
+    expect(config.RECENCY_FLOOR_DURABLE).toBe(DEFAULTS.RECENCY_FLOOR_DURABLE);
+    expect(config.RECENCY_FLOOR_VOLATILE).toBe(DEFAULTS.RECENCY_FLOOR_VOLATILE);
+  });
+
+  it("accepts a value that moves within the group without inverting it", async () => {
+    const { env, seed } = envWithKV();
+    // 0.8 sits between volatile (0.15) and durable (0.9), so it must survive.
+    await seed({ RECENCY_FLOOR: 0.8 });
+
+    const config = await resolveConfig(env);
+
+    expect(config.RECENCY_FLOOR).toBe(0.8);
+  });
+
+  it("clamps a numeric override below its range to the minimum", async () => {
+    const { env, seed } = envWithKV();
+    await seed({ MMR_LAMBDA: -3 });
+
+    const config = await resolveConfig(env);
+
+    expect(config.MMR_LAMBDA).toBe(0);
+  });
+
+  it("falls back to the default when the value is the wrong type", async () => {
+    const { env, seed } = envWithKV();
+    await seed({ RECENCY_FLOOR: "not a number", GRAPH_MAX_HOPS: null });
+
+    const config = await resolveConfig(env);
+
+    expect(config.RECENCY_FLOOR).toBe(DEFAULTS.RECENCY_FLOOR);
+    expect(config.GRAPH_MAX_HOPS).toBe(DEFAULTS.GRAPH_MAX_HOPS);
+  });
+
+  it("falls back to the default for NaN, which is typeof number", async () => {
+    const { env, kv } = envWithKV();
+    // NaN is not representable in JSON; a hand-edited blob can still smuggle it
+    // in as a string that parses to NaN downstream.
+    await kv.put(CONFIG_KEY, '{"RECENCY_FLOOR": "NaN"}');
+
+    const config = await resolveConfig(env);
+
+    expect(config.RECENCY_FLOOR).toBe(DEFAULTS.RECENCY_FLOOR);
+  });
+
+  it("rounds a non-integer override for an integer-valued setting", async () => {
+    const { env, seed } = envWithKV();
+    await seed({ GRAPH_MAX_HOPS: 2.7 });
+
+    const config = await resolveConfig(env);
+
+    expect(Number.isInteger(config.GRAPH_MAX_HOPS)).toBe(true);
+  });
+
+  it("falls back to the default when a model override is not a string", async () => {
+    const { env, seed } = envWithKV();
+    await seed({ LLM_MODEL: 42 });
+
+    const config = await resolveConfig(env);
+
+    expect(config.LLM_MODEL).toBe(DEFAULTS.LLM_MODEL);
+  });
+
+  it("keeps flagging reachable: block must stay above flag", async () => {
+    const { env, seed } = envWithKV();
+    // Inverted on purpose — flagging would be unreachable.
+    await seed({ DUPLICATE_BLOCK_THRESHOLD: 0.5, DUPLICATE_FLAG_THRESHOLD: 0.9 });
+
+    const config = await resolveConfig(env);
+
+    expect(config.DUPLICATE_BLOCK_THRESHOLD).toBeGreaterThan(config.DUPLICATE_FLAG_THRESHOLD);
+  });
+
+  it("keeps durability tiering ordered: volatile <= base <= durable", async () => {
+    const { env, seed } = envWithKV();
+    await seed({ RECENCY_FLOOR_VOLATILE: 0.95, RECENCY_FLOOR: 0.5, RECENCY_FLOOR_DURABLE: 0.2 });
+
+    const config = await resolveConfig(env);
+
+    expect(config.RECENCY_FLOOR_VOLATILE).toBeLessThanOrEqual(config.RECENCY_FLOOR);
+    expect(config.RECENCY_FLOOR).toBeLessThanOrEqual(config.RECENCY_FLOOR_DURABLE);
+  });
+
+  it("never returns a config that breaks an invariant, whatever the input", async () => {
+    const { env, seed } = envWithKV();
+    await seed({
+      RECENCY_FLOOR: "garbage",
+      RECENCY_FLOOR_DURABLE: -99,
+      RECENCY_FLOOR_VOLATILE: 42,
+      DUPLICATE_BLOCK_THRESHOLD: 0,
+      DUPLICATE_FLAG_THRESHOLD: 1,
+      GRAPH_MAX_HOPS: "three",
+    });
+
+    const config = await resolveConfig(env);
+
+    expect(config.RECENCY_FLOOR_VOLATILE).toBeLessThanOrEqual(config.RECENCY_FLOOR);
+    expect(config.RECENCY_FLOOR).toBeLessThanOrEqual(config.RECENCY_FLOOR_DURABLE);
+    expect(config.DUPLICATE_BLOCK_THRESHOLD).toBeGreaterThan(config.DUPLICATE_FLAG_THRESHOLD);
+    expect(Number.isFinite(config.GRAPH_MAX_HOPS)).toBe(true);
+  });
+
+  it("returns a frozen object so a caller cannot mutate shared config", async () => {
+    const { env } = envWithKV();
+
+    const config = await resolveConfig(env);
+
+    expect(Object.isFrozen(config)).toBe(true);
+  });
+});

--- a/test/unit/rerank-config.test.ts
+++ b/test/unit/rerank-config.test.ts
@@ -1,0 +1,70 @@
+/**
+ * #245 — rerankWithTimeDecay takes config as a parameter and stays pure.
+ *
+ * The reason config is threaded rather than read from module scope: this
+ * function is the ranking seam, and keeping it "config in, ordering out" means
+ * it is assertable with no env, no KV, and no mocks. Every test in this file
+ * calls it directly.
+ */
+import { describe, it, expect } from "vitest";
+import { rerankWithTimeDecay, type VectorizeMatch } from "../../src/recall/math";
+import { DEFAULTS } from "../../src/config";
+
+const DAY = 86400000;
+const OLD = Date.now() - 400 * DAY;
+
+function match(id: string, score: number, tags: string[], createdAt = OLD): VectorizeMatch {
+  return { id, score, metadata: { parentId: id, created_at: createdAt, tags } } as VectorizeMatch;
+}
+
+describe("rerankWithTimeDecay() config threading", () => {
+  it("applies the volatile floor from the passed config to an aged task", async () => {
+    const matches = [match("t", 1.0, ["task"])];
+
+    const withDefaults = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), DEFAULTS);
+    const withHighFloor = rerankWithTimeDecay(
+      matches, new Map(), new Map(), [], new Map(), new Map(),
+      { ...DEFAULTS, RECENCY_FLOOR_VOLATILE: 1.0 },
+    );
+
+    // A floor of 1.0 means no decay at all, so the aged task must score higher
+    // than it does under the shipped 0.15 floor.
+    expect(withHighFloor[0].score).toBeGreaterThan(withDefaults[0].score);
+  });
+
+  it("applies the tag boost cap from the passed config", async () => {
+    const matches = [match("m", 1.0, ["work", "second-brain", "recall"], Date.now())];
+    const queryTags = ["work", "second-brain", "recall"];
+
+    const capped = rerankWithTimeDecay(
+      matches, new Map(), new Map(), queryTags, new Map(), new Map(),
+      { ...DEFAULTS, TAG_BOOST_MAX: 1.0 },
+    );
+    const uncapped = rerankWithTimeDecay(
+      matches, new Map(), new Map(), queryTags, new Map(), new Map(),
+      { ...DEFAULTS, TAG_BOOST_MAX: 5.0, TAG_BOOST_STEP: 0.5 },
+    );
+
+    expect(uncapped[0].score).toBeGreaterThan(capped[0].score);
+  });
+
+  it("defaults to the shipped config when none is passed", async () => {
+    const matches = [match("t", 1.0, ["task"])];
+
+    const implicit = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map());
+    const explicit = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), DEFAULTS);
+
+    expect(implicit[0].score).toBe(explicit[0].score);
+  });
+
+  it("is pure: same inputs give the same output, and inputs are not mutated", async () => {
+    const matches = [match("a", 0.9, ["work"]), match("b", 0.8, ["task"])];
+    const snapshot = JSON.parse(JSON.stringify(matches));
+
+    const first = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), DEFAULTS);
+    const second = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), DEFAULTS);
+
+    expect(first.map(m => [m.id, m.score])).toEqual(second.map(m => [m.id, m.score]));
+    expect(JSON.parse(JSON.stringify(matches))).toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
Closes #245. Phase 1a of #244.

Makes the constants governing recall and capture overridable at runtime, without touching the UI. Behaviour is unchanged for every existing user: each default equals the constant that governed the same behaviour before, and `config-parity.test.ts` pins all 22 of them so a transcription slip can't silently retune recall.

## What's here

`src/constants.ts` becomes `DEFAULTS`. A sparse override blob lives in one KV key, `config:overrides`, alongside the existing `integrations:` records. `resolveConfig(env)` merges overrides over defaults, validates, and returns a frozen object threaded into the seam functions.

Every seam from the issue's table reads its tunables from that config — ranking, duplicate detection, graph expansion, output budgeting, compression eligibility, and model selection — plus the routes, MCP tools and cron paths, which resolve **once per request** and thread the result down rather than each seam reading KV for itself.

Three authenticated routes for the desktop app (#246) to call:

```
GET    /config          effective values, sparse overrides, shipped defaults
PATCH  /config          sparse update; the whole patch is rejected on any bad key
DELETE /config/:key     per-setting reset
```

## Design decisions worth reviewing

**Resolve repairs, write rejects.** Same validation table, deliberately different failure behaviour. A bad value arriving from KV is clamped (or its invariant group reset) because recall must never fail on a hand-edited blob or one written by another version. A bad value arriving from a caller is rejected with a message naming the conflict, so the settings UI can explain what happened instead of appearing to accept a change and silently discarding it.

**Invariant groups reset wholesale, not clamped key-by-key.** Clamping can satisfy every individual range while leaving the group inverted — `RECENCY_FLOOR` clamped to `1` is in range but still above `RECENCY_FLOOR_DURABLE`. A test asserted the naive behaviour first and failed, which is how this surfaced.

**Sparse storage is load-bearing for the "new defaults reach users" guarantee.** A value equal to the shipped default is dropped rather than stored, and per-key reset is a delete rather than a write-back. Storing either would pin the user to today's number and stop a retuned default in a later release from ever reaching them.

**Invariants are checked against the patch merged over what's stored**, not the patch alone — a value can be individually valid and still invert the pair.

**`DUPLICATE_FLAG_THRESHOLD` had to be split before anything could expose it.** It governed two unrelated things: flagging a near-duplicate on write, and widening the Vectorize query on recall when the best dense match scored below it. Exposing it as one "duplicate blocking" control would have silently retuned recall. `RECALL_WIDEN_THRESHOLD` starts at the same 0.85, so nothing moves.

**`CANDIDATE_SCORE_THRESHOLD` stays internal**, as the issue specifies. Recall applies no minimum-score cutoff, so surfacing it would imply a control that doesn't exist.

**Platform limits are absent and a test keeps them that way.** Vectorize rejects >20 ids per call and D1 caps bound params at 100, so `VECTORIZE_GET_BY_IDS_BATCH`, `D1_MAX_BOUND_PARAMS` and `EDGE_QUERY_BATCH` would guarantee breakage rather than risk it.

## Two tests doing unusual work

**`config-threading-complete.test.ts`** walks all of `src/` and fails on any bare module-scope read of a tunable. Threading a seam partially is invisible to behavioural tests — swap three of four usages, leave the fourth, and everything still passes because the default and the override agree in the fixture. It only breaks when a user actually changes the setting. This guard found **ten sites** the seam-by-seam work had missed: `LLM_MODEL` was honoured in `duplicate.ts` but ignored in classify, distill, insight, pattern, digest and the recall route, and `RECALL_OUTPUT_BUDGET` was ignored in render and the MCP recent tool.

**`config-embedding-consistency.test.ts`** covers the sharpest hazard in the whole change. If capture embeds with the configured model while recall still uses the compiled-in default, the two produce vectors from different models and every similarity score silently becomes meaningless — nothing throws, recall just returns wrong answers. It asserts both paths agree.

## Verification

- **826 tests**, three consecutive clean runs
- `npm run typecheck` clean, `wrangler deploy --dry-run` builds
- **Full CI pipeline run in a detached clean-room worktree** — fresh checkout, no `node_modules`: `npm ci` → typecheck → `test:coverage` → dry-run → installer `bundle-worker`, all green
- **Mutation testing: 18 deliberate bugs, 18 caught.** Sparse-drop removed, invariant reset skipped, clamping disabled, widening recoupled to the duplicate constant, capture reverting to the compiled-in model, `resetOverride` writing instead of deleting, write validation bypassed, each seam reading `DEFAULTS` instead of config, all three route auth gates, PATCH ignoring validation, DELETE's 404, and the route left unregistered
- **End-to-end smoke test against a real Worker** (`wrangler dev`, workerd + real KV), since vitest runs in node. Auth gate, round trip, and all four rejection paths behave correctly — and an existing `0.42` override survived every rejection, confirming nothing is written on a failed patch
- Coverage: `config.ts` 97.4% lines, `routes/config.ts` 96%
- No Rust changed, so the `cargo check` job is not exercised by this branch

## Not in this PR

The settings UI (#246), Cloudflare sign-in (#247) and embedding migration (#248). Note that changing `EMBEDDING_MODEL` is only *safe* via #248's migration — Vectorize fixes index dimensions at creation. This PR makes the value consistent across every path; #248 makes it changeable.
