### PR TITLE
fix(installer): dry-run no longer prompts for Keychain access

### DIFF
--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod windows;
 mod worker_bundle;
 
 use commands::SetupSession;
+use secure_store::SetupInfo;
 use tauri::menu::{Menu, MenuBuilder, MenuItem, SubmenuBuilder};
 use tauri::tray::TrayIconBuilder;
 use tauri::{AppHandle, Manager};
@@ -83,6 +84,24 @@ fn confirm_logout(app: &AppHandle) {
                 commands::perform_logout(&handle);
             }
         });
+}
+
+/// Resolves the stored setup for launch, skipping secure storage entirely in
+/// dry-run.
+///
+/// The loader is taken lazily rather than as a value because reading it prompts
+/// for Keychain access on macOS. Dry-run always launches into the setup flow, so
+/// the loaded value was discarded anyway — the old `match` paid a credential
+/// prompt for a result it threw away, which made `SECOND_BRAIN_DRY_RUN=1`
+/// unusable for demoing on a machine that already has a Second Brain.
+fn load_setup_unless_dry_run(
+    dry_run: bool,
+    load: impl FnOnce() -> Option<SetupInfo>,
+) -> Option<SetupInfo> {
+    if dry_run {
+        return None;
+    }
+    load()
 }
 
 pub fn run() {
@@ -229,8 +248,8 @@ pub fn run() {
 
             // Mode selection. Dry-run always shows setup so the flow can be
             // demoed even on a machine that already has a Second Brain.
-            match secure_store::load_setup() {
-                Some(info) if !dry_run => {
+            match load_setup_unless_dry_run(dry_run, secure_store::load_setup) {
+                Some(info) => {
                     windows::open_wrapper_window(&handle, &info.worker_url, &info.auth_token)?;
                     // In wrapper mode, quietly check whether the deployed Worker
                     // is behind what this app bundles and offer to update it.
@@ -248,4 +267,46 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    fn info() -> SetupInfo {
+        SetupInfo { worker_url: "https://example.workers.dev".into(), auth_token: "t".into() }
+    }
+
+    #[test]
+    fn dry_run_does_not_read_secure_storage() {
+        let called = Cell::new(false);
+
+        let got = load_setup_unless_dry_run(true, || {
+            called.set(true);
+            Some(info())
+        });
+
+        assert!(!called.get(), "dry-run must not touch the keychain");
+        assert!(got.is_none(), "dry-run always launches into setup");
+    }
+
+    #[test]
+    fn normal_launch_reads_secure_storage() {
+        let called = Cell::new(false);
+
+        let got = load_setup_unless_dry_run(false, || {
+            called.set(true);
+            Some(info())
+        });
+
+        assert!(called.get());
+        assert_eq!(got.map(|i| i.worker_url), Some("https://example.workers.dev".to_string()));
+    }
+
+    #[test]
+    fn normal_launch_without_stored_setup_falls_through_to_setup() {
+        let got = load_setup_unless_dry_run(false, || None);
+        assert!(got.is_none());
+    }
 }


### PR DESCRIPTION
Found while running the desktop app locally to eyeball #241.

`SECOND_BRAIN_DRY_RUN=1` exists so the setup flow can be demoed on a machine that already has a Second Brain. It could not be — launching still raised a macOS Keychain prompt naming the user's credentials, and you have to answer it before the app will show anything.

## Cause

The startup match evaluates the loader before the dry-run guard:

```rust
match secure_store::load_setup() {        // ← runs unconditionally
    Some(info) if !dry_run => { wrapper }
    _ => setup
}
```

In dry-run the guard can never match, so the loaded value is discarded. The app pays a credential prompt for a result it throws away.

`secure_store` reads through the `keyring` crate, and macOS Keychain ACLs are bound to the code signature. A dev build is ad-hoc signed (`Signature=adhoc, linker-signed`, identifier `second_brain_desktop-<buildhash>`), so it is a different app to the Keychain than the signed release — it must ask every time, and the identifier changes across rebuilds.

## Fix

`load_setup_unless_dry_run()` takes the loader lazily and short-circuits before calling it. Behaviour is otherwise identical — dry-run already always launched into setup, and the non-dry-run arms are untouched.

## Tests

Three, asserting on **whether the loader was invoked** rather than on its return value. The property being protected is the absence of a side effect, which a test on the result alone cannot see. `lib.rs` had no test module before this.

Both mutations caught: removing the guard (regressing to the old behaviour) and inverting it.

## Verification

45 Rust tests, `cargo check` clean, 826 Worker tests unaffected, typecheck clean, `bundle-worker` and `wrangler deploy --dry-run` both green.

## Not in scope

Nothing changes for the shipped app. A signed release asks once and the grant is remembered; this only removes a prompt that dry-run should never have triggered.

This is independent of #241 — the startup block is byte-identical on `v2.2`, and #241 only swaps hardcoded error strings there for i18n keys.