### PR TITLE
fix(installer): the About panel actually shows the credits on macOS

### DIFF
--- a/installer/src-tauri/src/app_menus.rs
+++ b/installer/src-tauri/src/app_menus.rs
@@ -168,21 +168,42 @@ fn about_metadata(app: &AppHandle) -> AboutMetadata<'_> {
     }
 }
 
-/// Registers credits with the native About dialog. Instantiating the predefined
-/// About item configures the macOS panel; on Windows/Linux we add Help › About.
+/// Gives the native About panel our metadata.
+///
+/// `Menu::default` builds its own About item with no metadata, and merely
+/// *instantiating* a configured `PredefinedMenuItem::about` does not reconfigure
+/// it — the metadata belongs to the item, not to the application. So the panel
+/// only shows credits if the item we built is the one the user actually clicks.
+///
+/// The previous version created the configured item and then dropped it unless
+/// no Help submenu existed. macOS always has Help, so on macOS the credits were
+/// never reachable: the panel fell back to the name and version macOS derives
+/// from the bundle.
 fn wire_about_dialog(app: &AppHandle, menu: &Menu<tauri::Wry>) -> tauri::Result<()> {
     let about = PredefinedMenuItem::about(app, None, Some(about_metadata(app)))?;
 
+    // macOS: the first submenu is the application menu and its first entry is
+    // About. Swap that entry for ours rather than rebuilding the whole submenu,
+    // which would risk dropping Services / Hide Others / Show All.
+    if let Some(MenuItemKind::Submenu(app_menu)) = menu.items()?.into_iter().next() {
+        let existing = app_menu.items()?;
+        // Only replace when the menu has the shape we expect; a surprise layout
+        // should leave the menu intact rather than be mangled.
+        if let Some(MenuItemKind::Predefined(first)) = existing.first() {
+            app_menu.remove(first)?;
+            app_menu.insert(&about, 0)?;
+            return Ok(());
+        }
+    }
+
+    // Windows / Linux: no application menu, so surface it under Help.
     let has_help = menu.items()?.iter().any(|item| {
         matches!(item, MenuItemKind::Submenu(s) if s.text().ok().as_deref() == Some("Help"))
     });
-
     if !has_help {
         let help = SubmenuBuilder::new(app, "Help").item(&about).build()?;
         menu.append(&help)?;
     }
-
-    let _ = about;
     Ok(())
 }
 
@@ -286,4 +307,47 @@ where
         .on_menu_event(on_menu_event)
         .build(app)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    /// The configured About item must be *attached* to a menu, not merely
+    /// created.
+    ///
+    /// #241 built it and then dropped it unless no Help submenu existed. macOS
+    /// always has Help, so the credits were unreachable there: the panel showed
+    /// only the name and version macOS derives from the bundle. Attaching the
+    /// item cannot be asserted without a running app, so this asserts on the
+    /// source instead — the specific mistake was a discard, and a discard is
+    /// visible in the text.
+    #[test]
+    fn the_configured_about_item_is_never_discarded() {
+        let src = include_str!("app_menus.rs");
+        let start = src.find("fn wire_about_dialog").expect("wire_about_dialog");
+        let end = src[start..].find("\n}\n").expect("end of fn") + start;
+        let body = &src[start..end];
+
+        assert!(
+            !body.contains("let _ = about"),
+            "the configured About item is being discarded — on macOS that leaves the panel with no credits"
+        );
+        assert!(
+            body.contains("insert(&about"),
+            "the configured About item must be inserted into the app menu, not just created"
+        );
+    }
+
+    /// The metadata is worthless if the roster is empty.
+    #[test]
+    fn about_metadata_carries_the_full_roster() {
+        let credits = crate::credits::credits_text();
+        assert!(credits.contains("Created by"), "credits text has no creator line");
+        for person in crate::credits::MAINTAINERS {
+            assert!(
+                credits.contains(person.name),
+                "credits text omits maintainer {}",
+                person.name
+            );
+        }
+    }
 }


### PR DESCRIPTION
Found while answering "when will the credits show in the installer app?" — the honest answer turned out to be "they would not have."

## The bug

#241 added credits to the native About dialog. On macOS they never reached it. `wire_about_dialog` built a configured `PredefinedMenuItem::about` and then threw it away:

```rust
if !has_help { ...append it under Help... }
let _ = about;
```

macOS always has a Help submenu, so `has_help` was always true, the branch never ran, and the item was dropped. The About entry the user actually clicks comes from `Menu::default` and carries no metadata — so the panel fell back to the name and version macOS derives from the bundle.

The old comment asserted that instantiating the item "configures the macOS panel". It does not: the metadata belongs to the item, not to the application. Windows and Linux were fine, because they have no Help submenu and the item did get appended — which is presumably why this went unnoticed.

## The fix

Replace the app menu's default About entry with the configured one.

Two deliberate choices. It swaps a **single item** rather than rebuilding the app submenu, so `Services` / `Hide Others` / `Show All` cannot be lost. And the `MenuItemKind::Predefined` check means an unexpected menu layout leaves the menu **intact** and falls through to the Windows/Linux path, rather than being mangled.

## Verification

Opened the panel in the running app. It now shows:

```
Second Brain
Version 1.1.0 (1.1.0)

Created by Rahil Pirani (@rahilp)

Maintainers:
 • Vincenzo Fabiano
 • Aneesh Grover (@Aneesh-382005)
 • Mike Stanley (@mikestanley00)
 • Mochammad Fadhlan Al-Ghiffari (@MFA-G)
 • Phillip Smith (@phillipadsmith)
 • Robert Brandin (@tumes)

© Rahil Pirani
```

Before the fix, the same panel showed only the first two lines.

Two tests. One asserts the item is inserted and never discarded — attachment cannot be verified without a running app, but the specific mistake was a discard, and a discard is visible in the source. The other asserts every maintainer appears in `credits_text()`, since correctly wiring empty metadata would still display nothing.

89 Rust tests, 836 Worker tests, 0 cargo warnings.

## Note

This was my miss reviewing #241. I checked that it compiled and that the menu bar rendered, but never opened the About panel — and `cargo check` cannot catch a value being deliberately discarded.