### PR TITLE
feat(dashboard): download-the-app button in the sidebar

### DIFF
--- a/installer/src-tauri/src/windows.rs
+++ b/installer/src-tauri/src/windows.rs
@@ -177,6 +177,11 @@ fn open_wrapper_window_impl(
     let token_js = serde_json::to_string(auth_token).expect("string serializes");
     let mut init = format!(
         r#"(function () {{
+  // Tells the dashboard it is running inside the desktop app, so it can hide
+  // the "download the app" button. Set unconditionally: unlike the auth keys
+  // below it carries nothing sensitive, and it must be true even when the
+  // origin check fails.
+  try {{ window.SB_DESKTOP = true; }} catch (_) {{}}
   try {{
     if (location.origin === {origin_js}) {{
       localStorage.setItem('sb_url', {origin_js});

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -2452,3 +2452,63 @@
           transition-duration: 0.05s !important;
         }
       }
+
+      /* Download-the-app CTA (sidebar footer).
+         A solid pill rather than another nav row like Settings — it is the one
+         thing here aimed at someone who has not installed the app yet.
+         .sb-footer-btn was written for <button>, so as an <a> it also needs the
+         underline removed. */
+      #sb-download-app {
+        --dl-bg: #1f2532;
+        --dl-fg: #ffffff;
+        box-sizing: border-box;
+        justify-content: center;
+        gap: 9px;
+        margin-bottom: 10px;
+        padding: 11px 14px;
+        border: none;
+        border-radius: var(--radius-pill);
+        background: var(--dl-bg);
+        color: var(--dl-fg);
+        font-weight: 650;
+        /* "Download for Windows" is the longest label and wraps to two lines in
+           a narrow sidebar, which reads as broken rather than tight. */
+        white-space: nowrap;
+        font-size: 14px;
+        text-decoration: none;
+        box-shadow: 0 1px 2px rgba(22, 22, 22, 0.14);
+        transition:
+          background 0.15s,
+          box-shadow 0.15s,
+          transform 0.08s;
+      }
+
+      /* Inverted in dark mode: the light-mode fill is nearly --bg there, so the
+         button would disappear into the sidebar. */
+      html[data-theme='dark'] #sb-download-app {
+        --dl-bg: var(--text-primary);
+        --dl-fg: #161616;
+        box-shadow: none;
+      }
+
+      #sb-download-app i {
+        color: inherit;
+        font-size: 17px;
+      }
+
+      #sb-download-app:hover {
+        background: #2a3444;
+        color: var(--dl-fg);
+        box-shadow: 0 2px 6px rgba(22, 22, 22, 0.18);
+      }
+
+      html[data-theme='dark'] #sb-download-app:hover {
+        background: #ffffff;
+      }
+
+      /* A press that visibly depresses is most of what makes a link feel like a
+         button. */
+      #sb-download-app:active {
+        transform: translateY(1px);
+        box-shadow: 0 1px 1px rgba(22, 22, 22, 0.16);
+      }

--- a/public/index.html
+++ b/public/index.html
@@ -332,6 +332,7 @@
     <script src="js/graph-canvas.js"></script>
     <script src="js/nav.js"></script>
     <script src="js/auth.js"></script>
+    <script src="js/download-app.js"></script>
     <script src="js/app.js"></script>
   </body>
 </html>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,6 +1,7 @@
 function init() {
   applyTheme()
   if (typeof renderAboutCredits === 'function') renderAboutCredits()
+  if (typeof renderDownloadButton === 'function') renderDownloadButton()
   // Auto-populate URL from the current page origin (UI is hosted on the same Worker)
   const origin = window.location.origin
   document.getElementById('auth-url').value = origin

--- a/public/js/download-app.js
+++ b/public/js/download-app.js
@@ -1,0 +1,108 @@
+// "Download the app" button in the sidebar footer.
+//
+// Release asset filenames carry the version (Second Brain_1.1.0_universal.dmg),
+// so there is no fixed URL for "the latest .dmg". The button therefore renders
+// immediately pointing at the releases page — which always works, with no
+// network call — and then upgrades its href to the exact installer once the
+// GitHub API answers. If that call fails, is rate limited, or the OS is not one
+// we ship for, the releases page is what the user gets.
+//
+// Assets are matched by extension rather than by name: the API's
+// browser_download_url percent-encodes spaces as dots, so matching the
+// displayed filename would be fragile.
+
+const SB_REPO = 'rahilp/second-brain-cloudflare'
+const SB_RELEASES_PAGE = `https://github.com/${SB_REPO}/releases/latest`
+
+/**
+ * 'mac' | 'windows' | 'mobile' | 'unknown'.
+ *
+ * 'mobile' and 'unknown' are deliberately separate. There is no desktop build a
+ * phone or tablet can install, so those get no button at all — offering one is
+ * pure noise on the device where sidebar space is scarcest. An unrecognised
+ * *desktop* (Linux, or a browser that reports nothing useful) still gets a
+ * button pointing at the releases page, since the user may well be able to use
+ * one of the builds.
+ */
+function detectDesktopOs() {
+  const data = navigator.userAgentData
+  const platform = String((data && data.platform) || navigator.platform || '')
+  const ua = navigator.userAgent || ''
+
+  // iPadOS reports itself as MacIntel, so the touch check has to come before
+  // the Mac check or every iPad is offered a .dmg it cannot open.
+  if (/Android|iPhone|iPad|iPod/i.test(ua)) return 'mobile'
+  if (data && data.mobile === true) return 'mobile'
+  if ((navigator.maxTouchPoints || 0) > 1 && /Mac/i.test(platform)) return 'mobile'
+
+  if (/Mac|darwin/i.test(platform) || /Mac OS X/i.test(ua)) return 'mac'
+  if (/Win/i.test(platform) || /Windows NT/i.test(ua)) return 'windows'
+  return 'unknown'
+}
+
+function sbDownloadIcon(os) {
+  if (os === 'mac') return 'ti-brand-apple'
+  if (os === 'windows') return 'ti-brand-windows'
+  return 'ti-download'
+}
+
+function sbDownloadLabel(os) {
+  if (os === 'mac') return 'Download for Mac'
+  if (os === 'windows') return 'Download for Windows'
+  return 'Download the app'
+}
+
+/** Swaps the href for the exact installer. Silent no-op on any failure. */
+async function upgradeDownloadHref(os, anchor) {
+  if (!anchor || (os !== 'mac' && os !== 'windows')) return
+  try {
+    const res = await fetch(`https://api.github.com/repos/${SB_REPO}/releases/latest`, {
+      headers: { Accept: 'application/vnd.github+json' },
+    })
+    if (!res.ok) return
+    const release = await res.json()
+    const ext = os === 'mac' ? '.dmg' : '.exe'
+    const asset = (release.assets || []).find(
+      (a) => typeof a.name === 'string' && a.name.toLowerCase().endsWith(ext),
+    )
+    if (asset && asset.browser_download_url) {
+      anchor.href = asset.browser_download_url
+      if (release.tag_name) anchor.title = `${sbDownloadLabel(os)} (${release.tag_name})`
+    }
+  } catch {
+    // Offline, rate limited, or blocked — the releases page href still stands.
+  }
+}
+
+function renderDownloadButton() {
+  // Pointless inside the desktop app, which sets this flag on the wrapper
+  // window before the page runs.
+  if (window.SB_DESKTOP) return
+
+  const footer = document.querySelector('.sb-footer')
+  if (!footer) return
+  // Idempotent: the footer can re-render, and two buttons would be worse than
+  // none.
+  if (document.getElementById('sb-download-app')) return
+
+  const os = detectDesktopOs()
+  // No desktop build exists for a phone or tablet, so show nothing rather than
+  // a link the user cannot act on.
+  if (os === 'mobile') return
+  const label = sbDownloadLabel(os)
+
+  const link = document.createElement('a')
+  link.id = 'sb-download-app'
+  link.className = 'sb-footer-btn'
+  link.href = SB_RELEASES_PAGE
+  link.target = '_blank'
+  link.rel = 'noopener noreferrer'
+  link.title = label
+  link.innerHTML = `<i class="ti ${sbDownloadIcon(os)}"></i><span>${label}</span>`
+
+  // First entry in the footer: it is the only one aimed at someone who has not
+  // installed the app yet, so it should not sit below Settings.
+  footer.prepend(link)
+
+  void upgradeDownloadHref(os, link)
+}

--- a/test/ui/dashboard-modules.test.ts
+++ b/test/ui/dashboard-modules.test.ts
@@ -21,6 +21,7 @@ const DASHBOARD_SCRIPTS = [
   "public/js/graph-canvas.js",
   "public/js/nav.js",
   "public/js/auth.js",
+  "public/js/download-app.js",
   "public/js/app.js",
 ];
 

--- a/test/ui/download-app.test.ts
+++ b/test/ui/download-app.test.ts
@@ -1,0 +1,247 @@
+/**
+ * The sidebar "download the app" button.
+ *
+ * Two properties matter more than the rest. The button must render a working
+ * href with no network at all — the GitHub API is rate limited to 60 requests
+ * an hour per IP unauthenticated, so a dashboard that depended on it would
+ * quietly lose its download link. And a device we ship no desktop build for
+ * must never be offered a .dmg or .exe; iPadOS is the trap there, since it
+ * reports itself as MacIntel.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import vm from "node:vm";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+const SOURCE = readFileSync(resolve(ROOT, "public/js/download-app.js"), "utf8");
+const RELEASES_PAGE = "https://github.com/rahilp/second-brain-cloudflare/releases/latest";
+
+type Anchor = {
+  id: string; className: string; href: string; target: string;
+  rel: string; title: string; innerHTML: string;
+};
+
+function run(opts: {
+  platform?: string;
+  userAgent?: string;
+  maxTouchPoints?: number;
+  desktop?: boolean;
+  footer?: boolean;
+  existing?: boolean;
+  fetchImpl?: unknown;
+}) {
+  const prepended: Anchor[] = [];
+  const footer = { prepend: (el: Anchor) => prepended.push(el) };
+  const sandbox: Record<string, unknown> = {
+    navigator: {
+      platform: opts.platform ?? "",
+      userAgent: opts.userAgent ?? "",
+      maxTouchPoints: opts.maxTouchPoints ?? 0,
+    },
+    document: {
+      querySelector: (sel: string) => (sel === ".sb-footer" && opts.footer !== false ? footer : null),
+      getElementById: (id: string) =>
+        opts.existing && id === "sb-download-app" ? ({} as unknown) : null,
+      createElement: () =>
+        ({ id: "", className: "", href: "", target: "", rel: "", title: "", innerHTML: "" } as Anchor),
+    },
+    fetch: opts.fetchImpl ?? (async () => { throw new Error("network disabled"); }),
+    console,
+  };
+  sandbox.window = sandbox;
+  if (opts.desktop) sandbox.SB_DESKTOP = true;
+  vm.createContext(sandbox);
+  vm.runInContext(SOURCE + "\n;renderDownloadButton();", sandbox);
+  return { prepended, sandbox };
+}
+
+const MAC = { platform: "MacIntel", userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" };
+const WIN = { platform: "Win32", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" };
+
+describe("download button — OS detection", () => {
+  it("offers the Apple icon on macOS", () => {
+    const { prepended } = run({ ...MAC, footer: true });
+    expect(prepended).toHaveLength(1);
+    expect(prepended[0].innerHTML).toContain("ti-brand-apple");
+    expect(prepended[0].innerHTML).toContain("Download for Mac");
+  });
+
+  it("offers the Windows icon on Windows", () => {
+    const { prepended } = run({ ...WIN, footer: true });
+    expect(prepended[0].innerHTML).toContain("ti-brand-windows");
+    expect(prepended[0].innerHTML).toContain("Download for Windows");
+  });
+
+  it("falls back to a plain download icon on Linux", () => {
+    const { prepended } = run({ platform: "Linux x86_64", userAgent: "X11; Linux", footer: true });
+    expect(prepended[0].innerHTML).toContain("ti-download");
+    expect(prepended[0].innerHTML).toContain("Download the app");
+    expect(prepended[0].href).toBe(RELEASES_PAGE);
+  });
+
+  // iPadOS reports MacIntel. Without the touch check an iPad is treated as a
+  // Mac and handed a .dmg it cannot open.
+  it("shows nothing on an iPad reporting itself as MacIntel", () => {
+    const { prepended } = run({ platform: "MacIntel", userAgent: "Mozilla/5.0 (Macintosh)", maxTouchPoints: 5, footer: true });
+    expect(prepended).toHaveLength(0);
+  });
+
+  it("shows nothing on iPhone or Android", () => {
+    for (const ua of ["Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)", "Mozilla/5.0 (Linux; Android 14)"]) {
+      const { prepended } = run({ platform: "", userAgent: ua, footer: true });
+      expect(prepended).toHaveLength(0);
+    }
+  });
+
+  it("shows nothing when userAgentData reports a mobile client", () => {
+    const prepended: Anchor[] = [];
+    const sandbox: Record<string, unknown> = {
+      navigator: { userAgentData: { platform: "Android", mobile: true }, platform: "", userAgent: "", maxTouchPoints: 5 },
+      document: {
+        querySelector: () => ({ prepend: (el: Anchor) => prepended.push(el) }),
+        getElementById: () => null,
+        createElement: () => ({ id: "", className: "", href: "", target: "", rel: "", title: "", innerHTML: "" }),
+      },
+      fetch: async () => { throw new Error("no network"); },
+      console,
+    };
+    sandbox.window = sandbox;
+    vm.createContext(sandbox);
+    vm.runInContext(SOURCE + "\n;renderDownloadButton();", sandbox);
+    expect(prepended).toHaveLength(0);
+  });
+
+  // A desktop we ship no build for is NOT the same as mobile: the user may
+  // still be able to use one of the installers, so the releases page is useful.
+  it("still shows a fallback button on an unrecognised desktop", () => {
+    const { prepended } = run({ platform: "FreeBSD amd64", userAgent: "X11; FreeBSD", footer: true });
+    expect(prepended).toHaveLength(1);
+    expect(prepended[0].innerHTML).toContain("ti-download");
+  });
+
+  it("prefers userAgentData.platform when present", () => {
+    const prepended: Anchor[] = [];
+    const sandbox: Record<string, unknown> = {
+      navigator: { userAgentData: { platform: "Windows" }, platform: "", userAgent: "", maxTouchPoints: 0 },
+      document: {
+        querySelector: () => ({ prepend: (el: Anchor) => prepended.push(el) }),
+        getElementById: () => null,
+        createElement: () => ({ id: "", className: "", href: "", target: "", rel: "", title: "", innerHTML: "" }),
+      },
+      fetch: async () => { throw new Error("no network"); },
+      console,
+    };
+    sandbox.window = sandbox;
+    vm.createContext(sandbox);
+    vm.runInContext(SOURCE + "\n;renderDownloadButton();", sandbox);
+    expect(prepended[0].innerHTML).toContain("ti-brand-windows");
+  });
+});
+
+describe("download button — resilience", () => {
+  it("renders a working href with no network at all", () => {
+    const { prepended } = run({ ...MAC, footer: true });
+    // The releases page is always a valid destination, so a rate-limited or
+    // offline dashboard still gets the user to a download.
+    expect(prepended[0].href).toBe(RELEASES_PAGE);
+    expect(prepended[0].target).toBe("_blank");
+    expect(prepended[0].rel).toContain("noopener");
+  });
+
+  it("upgrades the href to the exact installer once the API answers", async () => {
+    const dmg = "https://github.com/rahilp/second-brain-cloudflare/releases/download/installer-v1.1.0/Second.Brain_1.1.0_universal.dmg";
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        tag_name: "installer-v1.1.0",
+        assets: [
+          { name: "latest.json", browser_download_url: "x" },
+          { name: "Second Brain_1.1.0_universal.app.tar.gz", browser_download_url: "y" },
+          { name: "Second Brain_1.1.0_x64-setup.exe.sig", browser_download_url: "z" },
+          { name: "Second Brain_1.1.0_universal.dmg", browser_download_url: dmg },
+        ],
+      }),
+    }));
+    const { prepended } = run({ ...MAC, footer: true, fetchImpl });
+    await new Promise(r => setTimeout(r, 0));
+    expect(prepended[0].href).toBe(dmg);
+    expect(prepended[0].title).toContain("installer-v1.1.0");
+  });
+
+  it("picks the .exe on Windows and never a .sig", async () => {
+    const exe = "https://example.test/Second.Brain_1.1.0_x64-setup.exe";
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        tag_name: "installer-v1.1.0",
+        assets: [
+          { name: "Second Brain_1.1.0_x64-setup.exe.sig", browser_download_url: "SIG" },
+          { name: "Second Brain_1.1.0_x64-setup.exe", browser_download_url: exe },
+        ],
+      }),
+    }));
+    const { prepended } = run({ ...WIN, footer: true, fetchImpl });
+    await new Promise(r => setTimeout(r, 0));
+    expect(prepended[0].href).toBe(exe);
+  });
+
+  it("keeps the releases page when the API errors or is rate limited", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 403, json: async () => ({}) }));
+    const { prepended } = run({ ...MAC, footer: true, fetchImpl });
+    await new Promise(r => setTimeout(r, 0));
+    expect(prepended[0].href).toBe(RELEASES_PAGE);
+  });
+
+  it("keeps the releases page when the release has no matching asset", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ tag_name: "installer-v1.1.0", assets: [{ name: "latest.json", browser_download_url: "x" }] }),
+    }));
+    const { prepended } = run({ ...MAC, footer: true, fetchImpl });
+    await new Promise(r => setTimeout(r, 0));
+    expect(prepended[0].href).toBe(RELEASES_PAGE);
+  });
+
+  it("does not call the API for an unrecognised desktop", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
+    run({ platform: "Linux", userAgent: "X11", footer: true, fetchImpl });
+    await new Promise(r => setTimeout(r, 0));
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("download button — placement", () => {
+  it("renders nothing inside the desktop app", () => {
+    const { prepended } = run({ ...MAC, footer: true, desktop: true });
+    expect(prepended).toHaveLength(0);
+  });
+
+  it("renders nothing when the footer is absent", () => {
+    const { prepended } = run({ ...MAC, footer: false });
+    expect(prepended).toHaveLength(0);
+  });
+
+  it("is idempotent — a re-render cannot produce two buttons", () => {
+    const { prepended } = run({ ...MAC, footer: true, existing: true });
+    expect(prepended).toHaveLength(0);
+  });
+});
+
+describe("download button — wiring", () => {
+  it("is loaded by index.html before app.js, which calls it", () => {
+    const html = readFileSync(resolve(ROOT, "public/index.html"), "utf8");
+    const dl = html.indexOf("js/download-app.js");
+    const app = html.indexOf("js/app.js");
+    expect(dl).toBeGreaterThan(-1);
+    expect(app).toBeGreaterThan(-1);
+    // Classic scripts, so definition order matters.
+    expect(dl).toBeLessThan(app);
+    expect(readFileSync(resolve(ROOT, "public/js/app.js"), "utf8")).toContain("renderDownloadButton");
+  });
+
+  it("the desktop app sets the flag that suppresses it", () => {
+    const rs = readFileSync(resolve(ROOT, "installer/src-tauri/src/windows.rs"), "utf8");
+    expect(rs).toContain("window.SB_DESKTOP = true");
+  });
+});


### PR DESCRIPTION
Adds a sidebar footer button linking to the installer for the visitor's OS — Apple icon and the `.dmg` on macOS, Windows icon and the `.exe` on Windows.

## Why it is not just a static link

Release asset filenames carry the version (`Second Brain_1.1.0_universal.dmg`), so there is no fixed URL for "the latest .dmg". `releases/latest/download/<name>` only works for assets whose name never changes — `latest.json` qualifies, the installers do not.

So the button **renders immediately pointing at the releases page**, which always works with no network call, and then **upgrades its href** to the exact installer once the GitHub API answers. The API allows 60 requests an hour per IP unauthenticated, so a dashboard that depended on it would quietly lose its download link. Every failure path — offline, rate limited, no matching asset, undetected OS — leaves the releases page in place.

Assets are matched by **extension, not name**: `browser_download_url` percent-encodes spaces as dots, so matching the displayed filename would be fragile. Matching `.exe` also cannot accidentally pick up `.exe.sig`.

## Mobile shows nothing

Deliberately no button on phones and tablets, rather than the generic fallback — there is no build they can install, and sidebar space is scarcest there.

That is kept **distinct from an unrecognised desktop** (Linux, or a browser reporting nothing useful), which still gets the releases page, since the user may well be able to use one of the builds.

iPadOS is the trap: it reports itself as `MacIntel`, so the touch check has to run before the Mac check or every iPad is offered a `.dmg` it cannot open.

## Not shown inside the desktop app

The wrapper window now sets `window.SB_DESKTOP`, and the button is suppressed when present — offering "download the app" to someone already in the app is just confusing. Older installed apps predate the flag and will still show it; that self-corrects as they update.

## Verification

**19 tests** covering each detection branch, the no-network render, the href upgrade, every failure path, mobile vs desktop-unknown, idempotence, and that `index.html` loads the module before `app.js` calls it.

Four mutations verified caught: mobile guard removed, mobile UA detection removed, iPad touch check removed, in-app suppression removed.

Icon names checked against the Tabler webfont the dashboard actually loads — `ti-brand-apple`, `ti-brand-windows` and `ti-download` all exist. (`ti-sliders` did not, which is how the Advanced Settings button silently rendered no icon in #253.)

855 tests, 0 TypeScript errors, 0 cargo warnings, `wrangler dry-run` builds.