### PR TITLE
test: make three presence-only assertions actually discriminate

### DIFF
--- a/installer/src-tauri/src/cf/discover.rs
+++ b/installer/src-tauri/src/cf/discover.rs
@@ -527,14 +527,63 @@ mod tests {
             .join("")
     }
 
+    /// The sign-in button must actually reach the scan.
+    ///
+    /// An earlier version of this test asserted only that the two command names
+    /// appeared *somewhere* in the file. That could not distinguish a wired
+    /// button from a dead one: replacing the click handler with a no-op breaks
+    /// the entire feature while leaving both `invoke` calls sitting in the
+    /// source, so every test stayed green. Assert the chain instead.
     #[test]
-    fn the_existing_brain_path_offers_cloudflare_sign_in() {
+    fn the_sign_in_button_is_wired_through_to_the_scan() {
         let ui = setup_ui();
-        assert!(ui.contains(r#"invoke<Account[]>("connect_cloudflare""#));
+
+        // 1. The button reaches the sign-in screen.
         assert!(
-            ui.contains(r#"invoke<DiscoveredBrain[]>("discover_brains""#),
-            "signing in must lead to a scan, or nothing is discovered"
+            ui.contains(r#"signIn.addEventListener("click", () => void discoverScreen())"#),
+            "the sign-in button must be wired to discoverScreen"
         );
+
+        // 2. That screen signs in to Cloudflare, and
+        // 3. hands off to the scan, which calls discover_brains.
+        let sign_in = fn_body(&ui, "async function discoverScreen(");
+        assert!(
+            sign_in.contains(r#"invoke<Account[]>("connect_cloudflare""#),
+            "discoverScreen must sign in to Cloudflare"
+        );
+        // Both branches, named separately. A bare contains("runDiscovery()")
+        // passes while one of them is broken, because the other still mentions
+        // it — and the single-account branch is the common case.
+        assert!(
+            sign_in.contains("await runDiscovery();"),
+            "the single-account path must scan straight away"
+        );
+        assert!(
+            sign_in.contains("() => void runDiscovery()"),
+            "the multi-account path must scan once an account is picked"
+        );
+
+        let scan = fn_body(&ui, "async function runDiscovery(");
+        assert!(
+            scan.contains(r#"invoke<DiscoveredBrain[]>("discover_brains""#),
+            "the scan must call discover_brains, or nothing is ever discovered"
+        );
+    }
+
+    /// The body of a top-level function in main.ts, up to the next one.
+    fn fn_body<'a>(ui: &'a str, signature: &str) -> &'a str {
+        let start = ui
+            .find(signature)
+            .unwrap_or_else(|| panic!("main.ts has no {signature}"));
+        let rest = &ui[start..];
+        let end = rest
+            .find("\nfunction ")
+            .into_iter()
+            .chain(rest.find("\nasync function "))
+            .filter(|i| *i > 0)
+            .min()
+            .unwrap_or(rest.len());
+        &rest[..end]
     }
 
     /// Manual entry cannot be removed. A custom domain, a brain in another

--- a/test/integration/default-hops.test.ts
+++ b/test/integration/default-hops.test.ts
@@ -78,9 +78,28 @@ describe("DEFAULT_HOPS (#246 connections control)", () => {
     expect(res.matches.map(m => m.id)).toContain("neighbor");
   });
 
-  it("still clamps the default to GRAPH_MAX_HOPS, which stays a hard cap", async () => {
-    const res = await recallEntries({ query: "x", topK: 5 }, env(db, { DEFAULT_HOPS: 99 }), ctx);
-    // 99 is clamped at resolve time; recall must not throw or explode the fanout.
-    expect(Array.isArray(res.matches)).toBe(true);
+  it("clamps a raised default to GRAPH_MAX_HOPS, which stays a hard cap", async () => {
+    // A chain one hop longer than the cap. GRAPH_MAX_HOPS is 3, so with
+    // DEFAULT_HOPS asking for 99 the third link must still be reachable and the
+    // fourth must not — which is what distinguishes a clamp from no cap at all.
+    //
+    // The cap is enforced three times over: the DEFAULT_HOPS rule in config.ts
+    // clamps at resolve time, search.ts clamps again when it picks the hop
+    // count, and traverse.ts clamps once more. Removing any single one leaves the
+    // other two, so this asserts the end-to-end property rather than any one
+    // implementation — verified by mutation: it only goes red when all three are
+    // removed together, and it does go red then.
+    for (const id of ["h1", "h2", "h3", "h4"]) seed(db, id);
+    edge(db, "seed", "h1");
+    edge(db, "h1", "h2");
+    edge(db, "h2", "h3");
+    edge(db, "h3", "h4");
+
+    // topK is generous so the assertion is about traversal depth, not truncation.
+    const res = await recallEntries({ query: "x", topK: 50 }, env(db, { DEFAULT_HOPS: 99 }), ctx);
+    const ids = res.matches.map(m => m.id);
+
+    expect(ids).toContain("h3");
+    expect(ids).not.toContain("h4");
   });
 });

--- a/test/unit/parse-temporal.test.ts
+++ b/test/unit/parse-temporal.test.ts
@@ -41,10 +41,25 @@ describe("parseTimePhrase", () => {
     expect(r.after).toBeCloseTo(NOW - 3 * DAY, -4);
   });
 
-  it("parses 'last month'", () => {
+  it("parses 'last month' as the whole of the previous calendar month", () => {
     const r = parseTimePhrase("last month", NOW);
-    expect(r.after).toBeDefined();
-    expect(r.before).toBeDefined();
+    // NOW is 20 May 2026, so "last month" is April: [1 Apr, 1 May).
+    // The expectation is built with the same local-time constructors the parser
+    // uses, so it holds on runners in any timezone rather than pinning a UTC
+    // instant that only matches America/New_York.
+    expect(r.after).toBe(new Date(2026, 3, 1).getTime());
+    expect(r.before).toBe(new Date(2026, 4, 1).getTime());
+    // The discriminating property against "this month": the window closes
+    // before now, so today is outside it.
+    expect(r.before!).toBeLessThanOrEqual(NOW);
+  });
+
+  // The bare phrase can't exercise phrase-stripping — replacing the whole query
+  // leaves an empty string, and the parser falls back to returning it intact.
+  it("strips 'last month' out of a longer query", () => {
+    const r = parseTimePhrase("last month invoices", NOW);
+    expect(r.cleanQuery).toBe("invoices");
+    expect(r.after).toBe(new Date(2026, 3, 1).getTime());
   });
 
   it("'this week' called on a Sunday walks back 6 days to Monday", () => {


### PR DESCRIPTION
Test-only. **No production source changed** — `git diff --stat` touches two `test/` files and one `#[cfg(test)]` block.

Came out of a suite audit. The suite is 919 cases and, encouragingly, almost nothing in it is redundant — the ten-file `src/config` cluster looks like bloat but each file targets a distinct failure mode, and the 18 near-identical auth tests are necessary per-route repetition. What the audit did find was three tests that **passed while the thing they named was broken.** All three failed the same way: they asserted that something *existed* rather than that it was correct or connected.

## 1. `parse-temporal` → "parses 'last month'"

Asserted only that `after` and `before` were *defined*. A parser returning 1970 → now would pass; so would one returning tomorrow. The only way it failed was if the parser stopped setting the fields at all — a crash, not a wrong answer, which for a date parser is the bug that actually happens.

Now asserts the real calendar window: `[1 Apr, 1 May)` for the 20 May 2026 fixture. Built with the same local-time constructors the parser uses, so it holds on runners in any timezone instead of pinning an instant that only matches `America/New_York`.

Added a second case for phrase-stripping. Worth noting why it has to be separate: when the phrase *is* the whole query, stripping leaves an empty string and the parser falls back to returning it intact — so `cleanQuery` is `"last month"`, not `""`. My first plan was to assert an emptied `cleanQuery` on the bare phrase, which would have been a wrong assertion. Running the parser caught it.

## 2. `default-hops` → "still clamps the default to `GRAPH_MAX_HOPS`"

Asserted `Array.isArray(res.matches)` — always true, whatever the code does. The name promised clamping was covered; the cap could have been deleted outright with this staying green.

Now walks a chain one hop longer than the cap and asserts the fourth link is unreachable.

Mutation testing turned up something worth recording in the test itself: **the cap is enforced three times over** — the `DEFAULT_HOPS` rule at resolve time (`config.ts`), again in `search.ts`, and again in `traverse.ts`. Removing any single clamp leaves the other two and the test stays green. It only goes red when all three go, and it does go red then. That makes it a guard on the end-to-end property rather than on one implementation, which is the right level — but it is documented in the test so the insensitivity is not mistaken for the tautology it replaced.

## 3. `discover` → the sign-in guard

Asserted that `connect_cloudflare` and `discover_brains` appeared *somewhere* in `main.ts`. That cannot distinguish a wired button from a dead one: replacing the sign-in click handler with a no-op breaks the entire feature while leaving both `invoke` calls sitting in the source. **All 919 tests stayed green.**

Now follows the chain: button → `discoverScreen` → `connect_cloudflare` → `runDiscovery` → `discover_brains`.

The first rewrite still had a hole. A bare `contains("runDiscovery()")` matched the multi-account branch while the single-account branch — the common case — was broken. Both branches are now asserted separately.

## Verification

Verified by mutation, not by passing. Six mutations, all caught:

| Mutation | Result |
|---|---|
| Sign-in click handler → no-op (the original hole) | caught |
| `discoverScreen` stops signing in to Cloudflare | caught |
| Single-account path skips the scan | caught |
| Multi-account path skips the scan | caught |
| Scan stops calling `discover_brains` | caught |
| All three hop clamps removed together | caught |

865 Worker tests, 112 Rust, `tsc --noEmit` and `cargo check` clean.

## The trend this is about

Thirteen tests now assert on source text rather than behaviour, five of them added in #259. They are legitimate where behaviour cannot be observed — a Windows deadlock has no value to assert, and a cross-language contract has no shared runtime — but they are the least robust category, and three of the five probed had holes. The failure mode is always the same shape: **the string being grepped for is still there after the bug is introduced.**

The rule worth keeping: any test asserting presence gets one mutation before it is trusted. Break the thing it names, confirm it goes red. It took about thirty seconds per test here and found all three.