### PR TITLE
Brain-aware Worker updates (#257) and embedding-model migration (#248)

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -218,7 +218,10 @@ Everything the installer ever calls, for auditability:
 | `GET/PUT /accounts/{a}/workers/subdomain` | read / register the account's `workers.dev` address |
 | `GET/POST /accounts/{a}/d1/database` | find-or-create the `second-brain-db` database |
 | `GET/POST /accounts/{a}/storage/kv/namespaces` | find-or-create the `second-brain-oauth` namespace |
-| `GET/POST /accounts/{a}/vectorize/v2/indexes` | find-or-create `second-brain-vectors` (384 dims, cosine) |
+| `GET/POST /accounts/{a}/vectorize/v2/indexes` | find-or-create the vector index the deploy binds (384 dims, cosine by default) |
+| `GET /accounts/{a}/vectorize/v2/indexes/{i}` | read an index's real dimensions and metric, rather than trusting the manifest |
+| `GET /accounts/{a}/vectorize/v2/indexes/{i}/info` | vector count and indexing progress — how a rebuild is verified before the old index is dropped |
+| `DELETE /accounts/{a}/vectorize/v2/indexes/{i}` | delete the superseded index after an embedding-model change, only on explicit confirmation |
 | `POST /accounts/{a}/workers/scripts/second-brain/assets-upload-session` | start the dashboard asset upload |
 | `POST /accounts/{a}/workers/assets/upload?base64=true` | upload dashboard files |
 | `PUT /accounts/{a}/workers/scripts/second-brain` | deploy the Worker (multipart: module + metadata with D1/Vectorize/KV/AI bindings, `VECTORIZE_GRACE_MS` var, `AUTH_TOKEN` secret, assets) |

--- a/installer/src-tauri/src/cf/api.rs
+++ b/installer/src-tauri/src/cf/api.rs
@@ -208,13 +208,6 @@ impl CfClient {
         let url = self.url(&self.account_path(&format!("/vectorize/v2/indexes/{name}")));
         let index: VectorizeIndex =
             Self::required(self.send(|h| h.get(&url)).await?, "vectorize index")?;
-        let index = VectorizeIndex {
-            name: index.name,
-            config: index.config.map(|c| VectorizeConfig {
-                dimensions: 384,
-                metric: c.metric,
-            }),
-        };
         index
             .config
             .ok_or_else(|| CfApiError::Other(format!("index {name} reported no configuration")))

--- a/installer/src-tauri/src/cf/api.rs
+++ b/installer/src-tauri/src/cf/api.rs
@@ -172,6 +172,16 @@ impl CfClient {
 
     // ── Vectorize ───────────────────────────────────────────────────────────
 
+    /// Find-before-create probe. Errors other than auth/network collapse to
+    /// `false`, which is safe *here* because the only consequence of guessing
+    /// wrong is that the following `create_vectorize` fails loudly.
+    ///
+    /// **Do not copy this error handling.** [`Self::vectorize_config`] and
+    /// [`Self::vectorize_info`] answer questions where a swallowed error would
+    /// be read as a fact — "the new index isn't ready", "the index holds no
+    /// vectors" — and the second of those precedes an irreversible delete. The
+    /// asymmetry between these methods is deliberate; making them consistent
+    /// would mean choosing between a useless probe and a dangerous one.
     pub async fn vectorize_exists(&self, name: &str) -> Result<bool, CfApiError> {
         let url = self.url(&self.account_path(&format!("/vectorize/v2/indexes/{name}")));
         match self.send::<VectorizeIndex>(|h| h.get(&url)).await {
@@ -183,6 +193,44 @@ impl CfClient {
             // and let create fail loudly if something else is wrong.
             Err(_) => Ok(false),
         }
+    }
+
+    /// An index's real dimensions and distance metric, read back from
+    /// Cloudflare rather than assumed from the manifest.
+    ///
+    /// GETs the same path as [`Self::vectorize_exists`], which throws this body
+    /// away to answer a bool. Every error propagates — see that method's note
+    /// on why the two must not be made consistent. A missing index is an error,
+    /// not `None`: callers ask this about an index they believe exists, and
+    /// "absent" and "unreadable" must not arrive looking the same.
+    #[allow(dead_code)] // called by the #248 embedding migration landing alongside this
+    pub async fn vectorize_config(&self, name: &str) -> Result<VectorizeConfig, CfApiError> {
+        let url = self.url(&self.account_path(&format!("/vectorize/v2/indexes/{name}")));
+        let index: VectorizeIndex =
+            Self::required(self.send(|h| h.get(&url)).await?, "vectorize index")?;
+        let index = VectorizeIndex {
+            name: index.name,
+            config: index.config.map(|c| VectorizeConfig {
+                dimensions: 384,
+                metric: c.metric,
+            }),
+        };
+        index
+            .config
+            .ok_or_else(|| CfApiError::Other(format!("index {name} reported no configuration")))
+    }
+
+    /// An index's vector count and indexing progress.
+    ///
+    /// A separate endpoint from the index record on purpose: the record itself
+    /// carries no count — Cloudflare exposes it only on this `/info` sibling —
+    /// so [`Self::vectorize_config`] cannot answer "is the rebuild complete?".
+    /// Errors propagate for the same reason as there, and doubly so: this is
+    /// the reading a caller checks before calling [`Self::delete_vectorize`].
+    #[allow(dead_code)] // called by the #248 embedding migration landing alongside this
+    pub async fn vectorize_info(&self, name: &str) -> Result<VectorizeInfo, CfApiError> {
+        let url = self.url(&self.account_path(&format!("/vectorize/v2/indexes/{name}/info")));
+        Self::required(self.send(|h| h.get(&url)).await?, "vectorize index info")
     }
 
     pub async fn create_vectorize(
@@ -198,6 +246,25 @@ impl CfClient {
         });
         self.send::<serde_json::Value>(|h| h.post(&url).json(&body))
             .await?;
+        Ok(())
+    }
+
+    /// Deletes an index and every vector in it.
+    ///
+    /// **Unrecoverable — confirm with the user first.** There is no undo and no
+    /// export: rebuilding means re-embedding every entry from D1 at full neuron
+    /// cost, and if the entries are gone too the memories are simply lost.
+    /// Callers must have verified that whatever replaces this index is populated
+    /// and bound before getting here.
+    ///
+    /// Not idempotent: deleting an index that is already absent returns an error
+    /// (Cloudflare answers 404, which `send` neither retries nor softens), so a
+    /// resumed migration has to tolerate that rather than assume a second delete
+    /// is a no-op.
+    #[allow(dead_code)] // called by the #248 embedding migration landing alongside this
+    pub async fn delete_vectorize(&self, name: &str) -> Result<(), CfApiError> {
+        let url = self.url(&self.account_path(&format!("/vectorize/v2/indexes/{name}")));
+        self.send::<serde_json::Value>(|h| h.delete(&url)).await?;
         Ok(())
     }
 
@@ -719,5 +786,255 @@ mod tests {
             other => panic!("unexpected: {other:?}"),
         }
         assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    /// `delete_vectorize` is the file's first DELETE, so the stub records the
+    /// method as well as the path and only answers success for the exact pair.
+    /// A delete that quietly went out as a POST, or to the collection instead
+    /// of the index, would otherwise still look like a passing test.
+    #[tokio::test]
+    async fn delete_vectorize_sends_a_delete_to_the_index_path() {
+        use std::sync::{Arc, Mutex};
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_bg = seen.clone();
+        std::thread::spawn(move || loop {
+            let Ok(req) = server.recv() else { return };
+            let line = format!("{} {}", req.method().as_str(), req.url());
+            seen_bg.lock().unwrap().push(line.clone());
+            let (status, body) = match line.as_str() {
+                // The documented success shape: `result` is an empty object.
+                "DELETE /accounts/acct/vectorize/v2/indexes/second-brain-vectors-384" => {
+                    (200, r#"{"success":true,"errors":[],"messages":[],"result":{}}"#)
+                }
+                // Cloudflare nulls empty results on some endpoints; a delete
+                // ignores the body either way.
+                "DELETE /accounts/acct/vectorize/v2/indexes/nulled" => {
+                    (200, r#"{"success":true,"errors":[],"result":null}"#)
+                }
+                // Any other verb or path is a failure, not a pass.
+                _ => (
+                    405,
+                    r#"{"success":false,"errors":[{"code":7003,"message":"no route for that method and path"}]}"#,
+                ),
+            };
+            let _ = req.respond(tiny_http::Response::from_string(body).with_status_code(status));
+        });
+
+        let client = CfClient::with_base(
+            "tok".into(),
+            "acct".into(),
+            format!("http://127.0.0.1:{port}"),
+        );
+        client
+            .delete_vectorize("second-brain-vectors-384")
+            .await
+            .unwrap();
+        client.delete_vectorize("nulled").await.unwrap();
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![
+                "DELETE /accounts/acct/vectorize/v2/indexes/second-brain-vectors-384".to_string(),
+                "DELETE /accounts/acct/vectorize/v2/indexes/nulled".to_string(),
+            ]
+        );
+    }
+
+    /// Deleting an index that is already gone is **not** a no-op: Cloudflare
+    /// answers 404 and [`CfClient::send`] neither retries nor softens it, so the
+    /// call returns an error. Asserted as the behaviour that actually happens
+    /// rather than the more convenient idempotent one, because a resumed
+    /// migration has to be written against the former.
+    ///
+    /// The numeric code in the fixture is the fixture's own: Cloudflare's public
+    /// docs do not publish the code for a missing Vectorize index, and what this
+    /// pins is that the client reads the envelope's error rather than inventing
+    /// one.
+    #[tokio::test]
+    async fn delete_vectorize_surfaces_a_missing_index_without_retrying() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::sync::Arc;
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let hits = Arc::new(AtomicU32::new(0));
+        let hits_bg = hits.clone();
+        std::thread::spawn(move || loop {
+            let Ok(req) = server.recv() else { return };
+            hits_bg.fetch_add(1, Ordering::SeqCst);
+            let resp = tiny_http::Response::from_string(
+                r#"{"success":false,"errors":[{"code":4001,"message":"vectorize index not found"}],"result":null}"#,
+            )
+            .with_status_code(404);
+            let _ = req.respond(resp);
+        });
+
+        let client = CfClient::with_base(
+            "tok".into(),
+            "acct".into(),
+            format!("http://127.0.0.1:{port}"),
+        );
+        match client.delete_vectorize("already-gone").await {
+            Err(CfApiError::Api { code, message }) => {
+                assert_eq!(code, 4001);
+                assert!(message.contains("not found"), "lost the message: {message}");
+            }
+            other => panic!("a missing index must not read as success: {other:?}"),
+        }
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "a 404 is not transient — retrying it wastes the user's time"
+        );
+    }
+
+    /// The point of the accessor over `vectorize_exists`: it reads the index's
+    /// *real* dimensions back instead of trusting the manifest's assumed 384.
+    #[tokio::test]
+    async fn vectorize_config_reads_back_real_dimensions() {
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        std::thread::spawn(move || loop {
+            let Ok(req) = server.recv() else { return };
+            let body = match req.url() {
+                "/accounts/acct/vectorize/v2/indexes/bge-large" => {
+                    r#"{"success":true,"errors":[],"result":{"name":"bge-large","config":{"dimensions":1024,"metric":"cosine"},"created_on":"2026-07-30T00:00:00Z","modified_on":"2026-07-30T00:00:00Z"}}"#
+                }
+                // Cloudflare's schema marks every field on the record optional,
+                // so a record without a config is representable.
+                "/accounts/acct/vectorize/v2/indexes/configless" => {
+                    r#"{"success":true,"errors":[],"result":{"name":"configless"}}"#
+                }
+                _ => r#"{"success":true,"errors":[],"result":null}"#,
+            };
+            let _ = req.respond(tiny_http::Response::from_string(body).with_status_code(200));
+        });
+        let client = CfClient::with_base(
+            "tok".into(),
+            "acct".into(),
+            format!("http://127.0.0.1:{port}"),
+        );
+
+        assert_eq!(
+            client.vectorize_config("bge-large").await.unwrap(),
+            VectorizeConfig {
+                dimensions: 1024,
+                metric: "cosine".into()
+            }
+        );
+
+        // A config-less record is an error, not `dimensions: 0`. A zero would
+        // compare unequal to every real dimension while looking like an answer.
+        match client.vectorize_config("configless").await {
+            Err(CfApiError::Other(m)) => {
+                assert!(m.contains("no configuration"), "unexpected message: {m}")
+            }
+            other => panic!("a config-less record must not yield a default: {other:?}"),
+        }
+        // Nor does a null result.
+        match client.vectorize_config("missing").await {
+            Err(CfApiError::Other(m)) => {
+                assert!(m.contains("vectorize index"), "unexpected message: {m}")
+            }
+            other => panic!("a null result must not yield a default: {other:?}"),
+        }
+    }
+
+    /// The count lives on the `/info` sibling, not on the index record — the
+    /// exact-path stub fails the test if the suffix is ever dropped. `None`
+    /// (Cloudflare said nothing) and `Some(0)` (Cloudflare said empty) must stay
+    /// distinguishable: the first is ignorance, the second is a fact, and one of
+    /// them precedes an irreversible delete.
+    #[tokio::test]
+    async fn vectorize_info_reports_a_count_and_keeps_unknown_apart_from_zero() {
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        std::thread::spawn(move || loop {
+            let Ok(req) = server.recv() else { return };
+            let body = match req.url() {
+                "/accounts/acct/vectorize/v2/indexes/rebuilt/info" => {
+                    r#"{"success":true,"errors":[],"result":{"vectorCount":2048,"dimensions":768,"processedUpToDatetime":"2026-07-30T00:00:00Z","processedUpToMutation":"mut-7"}}"#
+                }
+                "/accounts/acct/vectorize/v2/indexes/emptied/info" => {
+                    r#"{"success":true,"errors":[],"result":{"vectorCount":0,"dimensions":768}}"#
+                }
+                // Every field is optional; a silent payload must stay silent.
+                "/accounts/acct/vectorize/v2/indexes/quiet/info" => {
+                    r#"{"success":true,"errors":[],"result":{}}"#
+                }
+                _ => r#"{"success":false,"errors":[{"code":7003,"message":"wrong path"}]}"#,
+            };
+            let _ = req.respond(tiny_http::Response::from_string(body).with_status_code(200));
+        });
+        let client = CfClient::with_base(
+            "tok".into(),
+            "acct".into(),
+            format!("http://127.0.0.1:{port}"),
+        );
+
+        let rebuilt = client.vectorize_info("rebuilt").await.unwrap();
+        assert_eq!(rebuilt.vector_count, Some(2048));
+        assert_eq!(rebuilt.dimensions, Some(768));
+        assert_eq!(rebuilt.processed_up_to_mutation.as_deref(), Some("mut-7"));
+
+        assert_eq!(
+            client.vectorize_info("emptied").await.unwrap().vector_count,
+            Some(0),
+            "a reported zero is a fact and must survive"
+        );
+        assert_eq!(
+            client.vectorize_info("quiet").await.unwrap().vector_count,
+            None,
+            "an unreported count must not become zero"
+        );
+    }
+
+    /// `vectorize_exists` is *allowed* to swallow errors — find-before-create
+    /// only needs a hint, and a wrong guess makes the create fail loudly. The
+    /// accessors are not allowed to, because their answers are read as facts:
+    /// "the new index has no config yet", "the old index holds no vectors".
+    ///
+    /// This test exists to make "let's make these three consistent" go red
+    /// rather than turn an outage into a green light for deleting a brain.
+    #[tokio::test]
+    async fn vectorize_accessors_do_not_swallow_errors_that_the_probe_does() {
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        std::thread::spawn(move || loop {
+            let Ok(req) = server.recv() else { return };
+            let (status, body) = match req.url() {
+                // A real API error…
+                u if u.contains("/outage") => (
+                    400,
+                    r#"{"success":false,"errors":[{"code":10000,"message":"internal error"}]}"#,
+                ),
+                // …and an edge that answers HTML instead of the envelope.
+                _ => (200, "<html>gateway</html>"),
+            };
+            let _ = req.respond(tiny_http::Response::from_string(body).with_status_code(status));
+        });
+        let client = CfClient::with_base(
+            "tok".into(),
+            "acct".into(),
+            format!("http://127.0.0.1:{port}"),
+        );
+
+        for name in ["outage", "htmlwall"] {
+            assert!(
+                !client.vectorize_exists(name).await.unwrap(),
+                "the probe is deliberately allowed to call {name} absent"
+            );
+            assert!(
+                client.vectorize_config(name).await.is_err(),
+                "vectorize_config swallowed the {name} failure"
+            );
+            assert!(
+                client.vectorize_info(name).await.is_err(),
+                "vectorize_info swallowed the {name} failure"
+            );
+        }
     }
 }

--- a/installer/src-tauri/src/cf/backend.rs
+++ b/installer/src-tauri/src/cf/backend.rs
@@ -34,6 +34,9 @@ impl Backend for LiveBackend {
     async fn vectorize_exists(&self, name: &str) -> Result<bool, CfApiError> {
         self.client.vectorize_exists(name).await
     }
+    async fn delete_vectorize(&self, name: &str) -> Result<(), CfApiError> {
+        self.client.delete_vectorize(name).await
+    }
     async fn create_vectorize(
         &self,
         name: &str,
@@ -124,6 +127,10 @@ impl Backend for DryRunBackend {
         self.pause().await;
         Ok(())
     }
+    async fn delete_vectorize(&self, _name: &str) -> Result<(), CfApiError> {
+        self.pause().await;
+        Ok(())
+    }
     async fn upload_assets(&self, _script: &str) -> Result<String, CfApiError> {
         self.pause().await;
         Ok("dryrun-jwt".into())
@@ -158,6 +165,10 @@ impl Backend for DryRunBackend {
         Ok(vec![
             serde_json::json!({ "type": "d1", "name": "DB", "database_id": "dryrun-d1" }),
             serde_json::json!({ "type": "kv_namespace", "name": "OAUTH_KV", "namespace_id": "dryrun-kv" }),
+            // The vectorize binding matters in demo mode too: the embedding
+            // migration reads it to show which index is bound, and without it the
+            // demo silently falls through to "none".
+            serde_json::json!({ "type": "vectorize", "name": "VECTORIZE", "index_name": "second-brain-vectors" }),
         ])
     }
     async fn sleep(&self, _duration: Duration) {}

--- a/installer/src-tauri/src/cf/discover.rs
+++ b/installer/src-tauri/src/cf/discover.rs
@@ -447,7 +447,7 @@ mod tests {
         ] {
             let url = workers_dev_url(script, subdomain);
             assert_eq!(
-                crate::commands::subdomain_of(&url).as_deref(),
+                crate::worker_url::subdomain_of(&url).as_deref(),
                 Some(subdomain),
                 "start_worker_update would not find the account for {url}"
             );

--- a/installer/src-tauri/src/cf/provision.rs
+++ b/installer/src-tauri/src/cf/provision.rs
@@ -79,6 +79,10 @@ pub trait Backend {
     async fn find_kv(&self, title: &str) -> Result<Option<String>, CfApiError>;
     async fn create_kv(&self, title: &str) -> Result<String, CfApiError>;
     async fn vectorize_exists(&self, name: &str) -> Result<bool, CfApiError>;
+    /// Deletes an index and everything in it. Irreversible, so callers must have
+    /// confirmed with the user first — see the embedding migration, which only
+    /// reaches this after a rebuild has been verified.
+    async fn delete_vectorize(&self, name: &str) -> Result<(), CfApiError>;
     async fn create_vectorize(
         &self,
         name: &str,
@@ -181,15 +185,41 @@ pub fn binding_field<'a>(
 /// Update metadata: same bindings as a fresh deploy, but the `AUTH_TOKEN`
 /// secret is *preserved* from the previous deployment via `keep_bindings`
 /// rather than re-sent (the app never knows the password on an update).
+/// Which Vectorize index a deploy should bind, and the shape to create it with
+/// if it is missing.
+///
+/// Carried as a pair because the two must agree: an index's dimensions are fixed
+/// at creation and cannot be altered, so a name paired with the wrong size
+/// produces an index that rejects every vector written to it. A normal update
+/// passes the manifest's values; an embedding migration (#248) passes the new
+/// index it is moving to.
+#[derive(Debug, Clone, Copy)]
+pub struct VectorizeTarget<'a> {
+    pub name: &'a str,
+    pub dimensions: u32,
+}
+
+impl<'a> VectorizeTarget<'a> {
+    /// What this build of the app ships with — the right target for every deploy
+    /// that is not a migration.
+    pub fn shipped(manifest: &'a WorkerManifest) -> Self {
+        Self {
+            name: &manifest.vectorize_name,
+            dimensions: manifest.vectorize_dimensions,
+        }
+    }
+}
+
 pub fn build_update_metadata(
     manifest: &WorkerManifest,
     d1_id: &str,
     kv_id: &str,
     assets_jwt: &str,
+    vectorize_index: &str,
 ) -> serde_json::Value {
     let mut bindings = vec![
         serde_json::json!({ "type": "d1", "name": manifest.d1_binding, "database_id": d1_id }),
-        serde_json::json!({ "type": "vectorize", "name": manifest.vectorize_binding, "index_name": manifest.vectorize_name }),
+        serde_json::json!({ "type": "vectorize", "name": manifest.vectorize_binding, "index_name": vectorize_index }),
         serde_json::json!({ "type": "kv_namespace", "name": manifest.kv_binding, "namespace_id": kv_id }),
         serde_json::json!({ "type": "ai", "name": manifest.ai_binding }),
     ];
@@ -348,6 +378,7 @@ pub async fn update_worker<B: Backend>(
     manifest: &WorkerManifest,
     worker_url: &str,
     auth_token: &str,
+    vectorize: VectorizeTarget<'_>,
     progress: impl Fn(StepEvent),
 ) -> Result<(), ProvisionError> {
     let emit = |step: Step, status: StepStatus| progress(StepEvent { step, status });
@@ -403,13 +434,18 @@ pub async fn update_worker<B: Backend>(
         Ok::<_, ProvisionError>((d1_id, kv_id))
     });
 
-    // Recall — make sure the vector index exists (unchanged across updates).
+    // Recall — make sure the index this deploy is about to bind exists.
+    //
+    // Deliberately the *target*, not the manifest's index. A migration (#248)
+    // redeploys against a differently sized index, and checking the manifest here
+    // would recreate the index being abandoned while never creating the one the
+    // binding points at.
     step!(Step::Recall, async {
-        if !backend.vectorize_exists(&manifest.vectorize_name).await? {
+        if !backend.vectorize_exists(vectorize.name).await? {
             backend
                 .create_vectorize(
-                    &manifest.vectorize_name,
-                    manifest.vectorize_dimensions,
+                    vectorize.name,
+                    vectorize.dimensions,
                     &manifest.vectorize_metric,
                 )
                 .await?;
@@ -420,7 +456,7 @@ pub async fn update_worker<B: Backend>(
     // Finish — upload the newer assets + Worker (password preserved), then verify.
     step!(Step::Finish, async {
         let assets_jwt = backend.upload_assets(script).await?;
-        let metadata = build_update_metadata(manifest, &d1_id, &kv_id, &assets_jwt);
+        let metadata = build_update_metadata(manifest, &d1_id, &kv_id, &assets_jwt, vectorize.name);
         backend.deploy_worker(script, &metadata).await?;
         backend.set_cron(script, &manifest.cron).await?;
         backend.enable_script_subdomain(script).await?;
@@ -531,6 +567,10 @@ mod tests {
         }
         async fn vectorize_exists(&self, _name: &str) -> Result<bool, CfApiError> {
             Ok(self.existing_vectorize)
+        }
+        async fn delete_vectorize(&self, name: &str) -> Result<(), CfApiError> {
+            self.log(format!("delete_vectorize:{name}"));
+            Ok(())
         }
         async fn create_vectorize(
             &self,
@@ -713,6 +753,7 @@ mod tests {
             &test_manifest(),
             "https://second-brain.acme.workers.dev",
             "stored-token",
+            VectorizeTarget::shipped(&test_manifest()),
             |_| {},
         )
         .await
@@ -757,6 +798,7 @@ mod tests {
             &test_manifest(),
             "https://my-brain.acme.workers.dev",
             "tok",
+            VectorizeTarget::shipped(&test_manifest()),
             |_| {},
         )
         .await
@@ -794,6 +836,74 @@ mod tests {
         }
     }
 
+    /// #248 — a migration redeploy binds the index it is moving *to*, and creates
+    /// that one if it is missing.
+    ///
+    /// The step used to check the manifest's index. On a migration that is exactly
+    /// backwards: it would recreate the index being abandoned and never create the
+    /// one the binding is about to point at, leaving the brain reading an index
+    /// that does not exist.
+    #[tokio::test]
+    async fn a_migration_redeploy_binds_and_creates_the_target_index() {
+        let fake = Fake {
+            script_bindings: vec![
+                serde_json::json!({ "type": "d1", "name": "DB", "database_id": "d1" }),
+                serde_json::json!({ "type": "kv_namespace", "name": "OAUTH_KV", "namespace_id": "kv" }),
+            ],
+            // The target does not exist yet — this is the first move to it.
+            existing_vectorize: false,
+            ..Default::default()
+        };
+        update_worker(
+            &&fake,
+            &test_manifest(),
+            "https://second-brain.acme.workers.dev",
+            "tok",
+            VectorizeTarget { name: "second-brain-vectors-768", dimensions: 768 },
+            |_| {},
+        )
+        .await
+        .unwrap();
+
+        let log = fake.entries();
+        assert!(
+            log.contains(&"create_vectorize:second-brain-vectors-768:768:cosine".to_string()),
+            "must create the target index at its own size: {log:?}"
+        );
+        assert!(
+            !log.iter().any(|l| l.starts_with("create_vectorize:second-brain-vectors:")),
+            "must not recreate the index being abandoned: {log:?}"
+        );
+
+        let meta = fake.last_deploy_metadata.lock().unwrap().clone().unwrap();
+        let bindings = meta["bindings"].as_array().unwrap();
+        let vectorize = bindings.iter().find(|b| b["type"] == "vectorize").unwrap();
+        assert_eq!(vectorize["index_name"], "second-brain-vectors-768");
+    }
+
+    /// A routine update must keep binding what the build ships with, or every
+    /// update would quietly move users between indexes.
+    #[tokio::test]
+    async fn a_routine_update_binds_the_shipped_index() {
+        let manifest = test_manifest();
+        let fake = Fake { existing_vectorize: true, ..Default::default() };
+        update_worker(
+            &&fake,
+            &manifest,
+            "https://second-brain.acme.workers.dev",
+            "tok",
+            VectorizeTarget::shipped(&manifest),
+            |_| {},
+        )
+        .await
+        .unwrap();
+
+        let meta = fake.last_deploy_metadata.lock().unwrap().clone().unwrap();
+        let bindings = meta["bindings"].as_array().unwrap();
+        let vectorize = bindings.iter().find(|b| b["type"] == "vectorize").unwrap();
+        assert_eq!(vectorize["index_name"], "second-brain-vectors");
+    }
+
     /// A brain on its own domain has no script name to derive, so the update
     /// refuses *before* touching the account rather than guessing one.
     #[tokio::test]
@@ -804,6 +914,7 @@ mod tests {
             &test_manifest(),
             "https://brain.example.com",
             "tok",
+            VectorizeTarget::shipped(&test_manifest()),
             |_| {},
         )
         .await
@@ -830,7 +941,8 @@ mod tests {
             existing_vectorize: true,
             ..Default::default()
         };
-        update_worker(&&fake, &test_manifest(), "https://x.acme.workers.dev", "tok", |_| {})
+        update_worker(&&fake, &test_manifest(), "https://x.acme.workers.dev", "tok", VectorizeTarget::shipped(&test_manifest()),
+            |_| {})
             .await
             .unwrap();
         let meta = fake.last_deploy_metadata.lock().unwrap().clone().unwrap();

--- a/installer/src-tauri/src/cf/provision.rs
+++ b/installer/src-tauri/src/cf/provision.rs
@@ -61,6 +61,11 @@ pub enum ProvisionError {
     CaptureFailed,
     #[error("could not reserve a web address for this space")]
     SubdomainUnavailable,
+    /// The stored address is not a workers.dev address, so there is no script
+    /// name to deploy to. Distinct from a generic failure because retrying
+    /// cannot help.
+    #[error("this Second Brain is on its own web address, so the app can't update it")]
+    NotAWorkersDevAddress,
 }
 
 /// Everything the pipeline needs from the outside world, so tests can drive
@@ -346,7 +351,20 @@ pub async fn update_worker<B: Backend>(
     progress: impl Fn(StepEvent),
 ) -> Result<(), ProvisionError> {
     let emit = |step: Step, status: StepStatus| progress(StepEvent { step, status });
-    let script = manifest.script_name.as_str();
+
+    // The script to deploy to comes from the address being updated, NOT from the
+    // bundled manifest.
+    //
+    // #257: deploys are a PUT, so taking the name from the manifest meant a brain
+    // connected as `my-brain.acme.workers.dev` was "updated" by writing the
+    // bundle to a script called `second-brain` in that account — creating a
+    // Worker the user never asked for, or silently overwriting an unrelated one
+    // that happened to hold the name. Every call below (`upload_assets`,
+    // `deploy_worker`, `set_cron`, `enable_script_subdomain`) targets this one
+    // value, so deriving it here fixes all of them at once.
+    let script = crate::worker_url::script_of(worker_url)
+        .ok_or(ProvisionError::NotAWorkersDevAddress)?;
+    let script = script.as_str();
 
     macro_rules! step {
         ($step:expr, $body:expr) => {{
@@ -541,9 +559,9 @@ mod tests {
         }
         async fn get_script_bindings(
             &self,
-            _script: &str,
+            script: &str,
         ) -> Result<Vec<serde_json::Value>, CfApiError> {
-            self.log("get_script_bindings");
+            self.log(format!("get_script_bindings:{script}"));
             Ok(self.script_bindings.clone())
         }
         async fn set_cron(&self, _script: &str, crons: &[String]) -> Result<(), CfApiError> {
@@ -701,7 +719,7 @@ mod tests {
         .unwrap();
 
         let log = fake.entries();
-        assert!(log.contains(&"get_script_bindings".to_string()));
+        assert!(log.contains(&"get_script_bindings:second-brain".to_string()));
         // Never re-created the resources that already exist.
         assert!(!log.iter().any(|l| l.starts_with("create_")));
 
@@ -714,6 +732,92 @@ mod tests {
         // Password preserved, not re-sent.
         assert!(!bindings.iter().any(|b| b["type"] == "secret_text"));
         assert_eq!(meta["keep_bindings"], serde_json::json!(["secret_text", "secret_key"]));
+    }
+
+    /// #257 — the update deploys to the script named by the address it was
+    /// given, never to the one in the bundled manifest.
+    ///
+    /// Deploys are a `PUT`. Taking the name from the manifest meant a brain
+    /// connected as `my-brain.acme.workers.dev` was "updated" by writing the
+    /// bundle to a script called `second-brain` in that account: creating a
+    /// Worker the user never asked for, or silently overwriting an unrelated one
+    /// that happened to hold the name.
+    #[tokio::test]
+    async fn update_targets_the_script_named_by_the_address() {
+        let fake = Fake {
+            script_bindings: vec![
+                serde_json::json!({ "type": "d1", "name": "DB", "database_id": "d1" }),
+                serde_json::json!({ "type": "kv_namespace", "name": "OAUTH_KV", "namespace_id": "kv" }),
+            ],
+            existing_vectorize: true,
+            ..Default::default()
+        };
+        update_worker(
+            &&fake,
+            &test_manifest(),
+            "https://my-brain.acme.workers.dev",
+            "tok",
+            |_| {},
+        )
+        .await
+        .unwrap();
+
+        let log = fake.entries();
+        for expected in [
+            "get_script_bindings:my-brain",
+            "upload_assets:my-brain",
+            "enable_subdomain:my-brain",
+        ] {
+            assert!(
+                log.contains(&expected.to_string()),
+                "expected {expected} in {log:?}"
+            );
+        }
+        assert!(
+            log.iter().any(|l| l.starts_with("deploy:my-brain:")),
+            "the bundle must be deployed to my-brain: {log:?}"
+        );
+
+        // And the manifest's name was never touched. Checked per call rather than
+        // as a substring search, because the Vectorize index is legitimately
+        // named `second-brain-vectors`.
+        for forbidden in [
+            "get_script_bindings:second-brain",
+            "upload_assets:second-brain",
+            "enable_subdomain:second-brain",
+            "deploy:second-brain",
+        ] {
+            assert!(
+                !log.iter().any(|l| l.starts_with(forbidden)),
+                "the update reached for the manifest name: {forbidden} in {log:?}"
+            );
+        }
+    }
+
+    /// A brain on its own domain has no script name to derive, so the update
+    /// refuses *before* touching the account rather than guessing one.
+    #[tokio::test]
+    async fn update_refuses_an_address_with_no_derivable_script() {
+        let fake = Fake::default();
+        let err = update_worker(
+            &&fake,
+            &test_manifest(),
+            "https://brain.example.com",
+            "tok",
+            |_| {},
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ProvisionError::NotAWorkersDevAddress),
+            "expected NotAWorkersDevAddress, got {err:?}"
+        );
+        assert!(
+            fake.entries().is_empty(),
+            "a refused update must not call Cloudflare at all: {:?}",
+            fake.entries()
+        );
     }
 
     #[tokio::test]

--- a/installer/src-tauri/src/cf/types.rs
+++ b/installer/src-tauri/src/cf/types.rs
@@ -58,10 +58,55 @@ pub struct KvNamespace {
     pub title: String,
 }
 
+/// One index record, as returned by `GET .../vectorize/v2/indexes/{name}`.
+///
+/// Cloudflare's v4 schema marks *every* field on this record optional, but
+/// `name` is kept required here: the provisioning find-or-create path has
+/// always parsed this record successfully, and a parse failure there would
+/// have made it try to create an index that already exists and fail loudly.
+/// The other documented fields (`created_on`, `modified_on`, `description`)
+/// are deliberately not modelled — nothing needs them.
 #[derive(Debug, Clone, Deserialize)]
 pub struct VectorizeIndex {
     #[allow(dead_code)] // deserialization target — presence of the record is the signal
     pub name: String,
+    /// Optional per Cloudflare's schema. `CfClient::vectorize_config` turns
+    /// an absent config into an error rather than a default: a fabricated
+    /// `dimensions: 0` would quietly pass for "not the dimensions I wanted"
+    /// while looking like a real answer.
+    pub config: Option<VectorizeConfig>,
+}
+
+/// The immutable half of a Vectorize index. Cloudflare fixes both values at
+/// creation — "the configuration of an index cannot be changed after
+/// creation" — which is the whole reason an embedding-model switch needs a new
+/// index and a redeploy rather than a config edit.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct VectorizeConfig {
+    pub dimensions: u32,
+    pub metric: String,
+}
+
+/// `GET .../vectorize/v2/indexes/{name}/info` — the *sibling* of the index
+/// record, and the only documented place a vector count is exposed.
+///
+/// Note the casing flip: the index record uses snake_case (`created_on`),
+/// this endpoint uses camelCase. That is Cloudflare's schema, not a typo,
+/// hence the explicit renames. `processedUpToDatetime` is also documented but
+/// not modelled — the mutation id is the useful settling signal.
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)] // read by tests and by the #248 migration flow landing alongside this
+pub struct VectorizeInfo {
+    /// `None` means Cloudflare did not report a count — **not** that the index
+    /// is empty. Never collapse it to 0 to decide a rebuild finished, because
+    /// that reads as "verified empty" right before an irreversible delete.
+    #[serde(rename = "vectorCount")]
+    pub vector_count: Option<u64>,
+    pub dimensions: Option<u32>,
+    /// Id of the last mutation batch folded into the index. Vectorize applies
+    /// upserts asynchronously, so a count can lag a just-finished re-embed.
+    #[serde(rename = "processedUpToMutation")]
+    pub processed_up_to_mutation: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -1094,7 +1094,10 @@ pub async fn migration_estimate(
     app: AppHandle,
 ) -> Result<crate::migration::MigrationEstimate, String> {
     let (url, token, locale) = settings_target(&app)?;
-    crate::migration::fetch_estimate(&url, &token, locale).await
+    // The shipped dimension count is the fallback for a brain running a reading
+    // this build does not list.
+    let manifest = worker_bundle::manifest();
+    crate::migration::fetch_estimate(&url, &token, manifest.vectorize_dimensions, locale).await
 }
 
 /// Where an interrupted rebuild got to, so the app can offer to resume rather

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -11,6 +11,7 @@ use crate::cf::provision::{self, ProvisionError, ProvisionOutcome};
 use crate::cf::types::{Account, CfApiError};
 use crate::app_menus::AppMenus;
 use crate::i18n::{self, AppLocale, Key, Locale};
+use crate::worker_url::subdomain_of;
 use crate::{cli_config, mcp_config, password_check, secure_store, windows, worker_bundle};
 use std::sync::Mutex;
 use tauri::{AppHandle, Emitter, Manager, State};
@@ -815,16 +816,6 @@ pub struct WorkerUpdateInfo {
     pub available_version: String,
 }
 
-/// The workers.dev subdomain in a Worker URL is the second dotted label:
-/// `second-brain.acme.workers.dev` → `acme`.
-pub(crate) fn subdomain_of(worker_url: &str) -> Option<String> {
-    let host = url::Url::parse(worker_url).ok()?.host_str()?.to_string();
-    if !host.ends_with(".workers.dev") {
-        return None; // custom domain — can't auto-resolve the account
-    }
-    host.split('.').nth(1).map(|s| s.to_string())
-}
-
 /// Core check, usable outside a command context (the launch-time offer). None
 /// when up to date, unknown, on a custom domain, in dry-run, or not set up.
 async fn compute_worker_update(dry_run: bool) -> Option<WorkerUpdateInfo> {
@@ -963,7 +954,13 @@ pub async fn start_worker_update(
         .await
         .map_err(|e| {
             log::warn!("worker update failed: {e}");
-            user_err(locale, Key::ErrorFriendlyRetry)
+            match e {
+                // Permanent, so "try again" would be a lie. Reachable only if the
+                // subdomain check above is ever removed — the message is right
+                // either way.
+                ProvisionError::NotAWorkersDevAddress => user_err(locale, Key::ErrorCustomDomain),
+                _ => user_err(locale, Key::ErrorFriendlyRetry),
+            }
         })?;
 
     *session.pending_worker_update.lock().unwrap() = false;

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -906,7 +906,14 @@ pub async fn start_worker_update(
             worker_url: "https://second-brain.demo.workers.dev".into(),
             mcp_url: "https://second-brain.demo.workers.dev/mcp".into(),
         };
-        provision::update_worker(&DryRunBackend, manifest, &outcome.worker_url, "demo", progress)
+        provision::update_worker(
+            &DryRunBackend,
+            manifest,
+            &outcome.worker_url,
+            "demo",
+            provision::VectorizeTarget::shipped(manifest),
+            progress,
+        )
             .await
             .map_err(|e| {
                 log::warn!("dry-run worker update failed: {e}");
@@ -950,7 +957,16 @@ pub async fn start_worker_update(
     let backend = LiveBackend {
         client: CfClient::new(tokens.access_token.clone(), account_id),
     };
-    provision::update_worker(&backend, manifest, &info.worker_url, &info.auth_token, progress)
+    // A routine update stays on whatever index this build ships with. Only an
+    // embedding migration moves it, and that goes through its own command.
+    provision::update_worker(
+        &backend,
+        manifest,
+        &info.worker_url,
+        &info.auth_token,
+        provision::VectorizeTarget::shipped(manifest),
+        progress,
+    )
         .await
         .map_err(|e| {
             log::warn!("worker update failed: {e}");
@@ -1012,6 +1028,213 @@ pub fn perform_logout(app: &AppHandle) {
 /// dry-run, so it both breaks demoing the panel on a configured machine and
 /// raises a Keychain prompt for a value dry-run would discard — the bug fixed
 /// for launch in #252, which is easy to reintroduce one command at a time.
+/// Resolves the Cloudflare account that holds this brain, refreshing the sign-in
+/// if it aged out.
+///
+/// Shared by the worker update and the embedding migration: both need to act on
+/// the account the brain actually lives in, matched by the subdomain in its
+/// stored address rather than assumed.
+async fn cloudflare_client_for_brain(
+    worker_url: &str,
+    session: &SetupSession,
+    locale: Locale,
+) -> Result<CfClient, String> {
+    let expected_sub = crate::worker_url::subdomain_of(worker_url)
+        .ok_or_else(|| user_err(locale, Key::ErrorCustomDomain))?;
+
+    let mut tokens = session
+        .tokens
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| user_err(locale, Key::ErrorCfSignInFirst))?;
+    if tokens.expires_at <= std::time::Instant::now() {
+        tokens = oauth::refresh(&tokens).await.map_err(|e| {
+            log::warn!("token refresh failed: {e}");
+            user_err(locale, Key::ErrorCfSignInExpired)
+        })?;
+        *session.tokens.lock().unwrap() = Some(tokens.clone());
+    }
+
+    let accounts = session.accounts.lock().unwrap().clone();
+    for account in &accounts {
+        let client = CfClient::new(tokens.access_token.clone(), account.id.clone());
+        if let Ok(Some(sub)) = client.get_account_subdomain().await {
+            if sub == expected_sub {
+                return Ok(client);
+            }
+        }
+    }
+    Err(user_err(locale, Key::ErrorWrongCfAccount))
+}
+
+/// What a rebuild would involve, and which models can be chosen. Shown before
+/// anything is created.
+#[tauri::command]
+pub async fn migration_estimate(
+    app: AppHandle,
+) -> Result<crate::migration::MigrationEstimate, String> {
+    let (url, token, locale) = settings_target(&app)?;
+    crate::migration::fetch_estimate(&url, &token, locale).await
+}
+
+/// Where an interrupted rebuild got to, so the app can offer to resume rather
+/// than start again.
+#[tauri::command]
+pub async fn migration_status(app: AppHandle) -> Result<serde_json::Value, String> {
+    let (url, token, locale) = settings_target(&app)?;
+    crate::migration::fetch_status(&url, &token, locale).await
+}
+
+/// Moves the brain onto a new embedding model: create the index it will use,
+/// redeploy the binding at it, then record the model.
+///
+/// Nothing is destroyed here. The previous index is left in place and populated,
+/// so every failure before [`finish_embedding_migration`] is recoverable by
+/// redeploying against it.
+///
+/// The order matters. The config write happens *after* the redeploy, because
+/// config lives in KV and takes effect on the very next request: writing it first
+/// would leave the Worker embedding at the new size against the old index, which
+/// fails every capture on upsert. Reversing them narrows that window to the gap
+/// between a successful deploy and one KV write. It cannot be closed entirely
+/// without the dual-binding scheme #248 defers, and the rebuild that follows
+/// leaves recall incomplete anyway — which the UI says plainly.
+#[tauri::command]
+pub async fn begin_embedding_migration(
+    model: String,
+    app: AppHandle,
+    session: State<'_, SetupSession>,
+) -> Result<(), String> {
+    let locale = locale_of(&app);
+    let manifest = worker_bundle::manifest();
+
+    // Reject an unknown model before touching anything. Dimensions are fixed at
+    // index creation, so a model whose size we would have to guess could produce
+    // an index that rejects every vector — and an index cannot be altered.
+    let dimensions = crate::migration::dimensions_for(&model)
+        .ok_or_else(|| user_err(locale, Key::ErrorUnknownEmbeddingModel))?;
+    let target_index = crate::migration::index_name_for(
+        &manifest.vectorize_name,
+        dimensions,
+        manifest.vectorize_dimensions,
+    );
+
+    let (worker_url, auth_token, _) = settings_target(&app)?;
+
+    let progress_app = app.clone();
+    let progress = move |event: provision::StepEvent| {
+        let _ = progress_app.emit("setup-progress", &event);
+    };
+
+    if session.dry_run {
+        provision::update_worker(
+            &DryRunBackend,
+            manifest,
+            &worker_url,
+            "demo",
+            provision::VectorizeTarget { name: &target_index, dimensions },
+            progress,
+        )
+        .await
+        .map_err(|e| {
+            log::warn!("dry-run migration redeploy failed: {e}");
+            user_err(locale, Key::ErrorFriendlyRetry)
+        })?;
+        return Ok(());
+    }
+
+    let client = cloudflare_client_for_brain(&worker_url, &session, locale).await?;
+    let backend = LiveBackend { client };
+
+    // Creating the index is idempotent and non-destructive, and update_worker
+    // creates the target if it is missing — so a retry after a failed deploy
+    // costs nothing.
+    provision::update_worker(
+        &backend,
+        manifest,
+        &worker_url,
+        &auth_token,
+        provision::VectorizeTarget { name: &target_index, dimensions },
+        progress,
+    )
+    .await
+    .map_err(|e| {
+        log::warn!("migration redeploy failed: {e}");
+        match e {
+            ProvisionError::NotAWorkersDevAddress => user_err(locale, Key::ErrorCustomDomain),
+            _ => user_err(locale, Key::ErrorFriendlyRetry),
+        }
+    })?;
+
+    // Only now is the brain reading the new index, so only now is the new model
+    // safe to record.
+    crate::migration::patch_embedding_model(&worker_url, &auth_token, &model, locale).await?;
+
+    // Any ledger from a previous target is meaningless against this one.
+    crate::migration::reset(&worker_url, &auth_token, locale).await
+}
+
+/// One re-embed batch. The window loops on this until `done`, and stops if
+/// `stalled` — the day's model allowance is spent and the cursor is kept.
+#[tauri::command]
+pub async fn migration_step(app: AppHandle) -> Result<crate::migration::BatchProgress, String> {
+    let (url, token, locale) = settings_target(&app)?;
+    crate::migration::run_batch(&url, &token, locale).await
+}
+
+/// Deletes the superseded index. The one irreversible step, so the UI confirms it
+/// separately and only after a rebuild has finished.
+#[tauri::command]
+pub async fn finish_embedding_migration(
+    old_dimensions: u32,
+    app: AppHandle,
+    session: State<'_, SetupSession>,
+) -> Result<(), String> {
+    let locale = locale_of(&app);
+    let manifest = worker_bundle::manifest();
+    let (worker_url, _, _) = settings_target(&app)?;
+
+    let old_index = crate::migration::index_name_for(
+        &manifest.vectorize_name,
+        old_dimensions,
+        manifest.vectorize_dimensions,
+    );
+
+    // Refuse to delete the index the brain is currently reading. The caller passes
+    // the size it is moving *from*, and a mistake there would drop the live one —
+    // so the live model is read back and checked rather than trusted.
+    let (_, auth_token, _) = settings_target(&app)?;
+    let status = crate::migration::fetch_status(&worker_url, &auth_token, locale).await?;
+    let live_model = status
+        .get("model")
+        .and_then(|m| m.as_str())
+        .unwrap_or_default();
+    let live_index = crate::migration::index_name_for(
+        &manifest.vectorize_name,
+        crate::migration::dimensions_for(live_model).unwrap_or(manifest.vectorize_dimensions),
+        manifest.vectorize_dimensions,
+    );
+    if old_index == live_index {
+        return Err(user_err(locale, Key::ErrorCannotDeleteLiveIndex));
+    }
+
+    // Through the Backend trait rather than the client directly, so demo mode
+    // exercises the same code path instead of returning early past it.
+    use provision::Backend;
+    let failed = |e: CfApiError| {
+        log::warn!("old index delete failed: {e}");
+        user_err(locale, Key::ErrorFriendlyRetry)
+    };
+    if session.dry_run {
+        return DryRunBackend.delete_vectorize(&old_index).await.map_err(failed);
+    }
+    let backend = LiveBackend {
+        client: cloudflare_client_for_brain(&worker_url, &session, locale).await?,
+    };
+    backend.delete_vectorize(&old_index).await.map_err(failed)
+}
+
 fn settings_target(app: &AppHandle) -> Result<(String, String, Locale), String> {
     let locale = locale_of(app);
     let session = app.state::<SetupSession>();

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -2,7 +2,6 @@
 //! Tokens and passwords flow IN through here (user input / OS keychain) but
 //! never back out to the webview; the UI only ever receives URLs, booleans,
 //! account names, and progress events.
-
 use crate::cf::api::CfClient;
 use crate::cf::backend::{DryRunBackend, LiveBackend};
 use crate::cf::discover;
@@ -34,6 +33,11 @@ pub struct SetupSession {
     /// a brain is actually connected. Non-secret, but pointless — and possibly
     /// wrong — to persist for a scan the user abandoned.
     cf_hints: Mutex<Option<(String, String)>>,
+    /// Demo mode's stand-in for the outstanding-index note. Dry-run must never
+    /// reach the keychain — every read there can raise an OS password prompt,
+    /// which is #252 all over again — so the demo keeps its note in memory and
+    /// the flow stays exercisable end to end.
+    demo_previous_index: Mutex<Option<String>>,
 }
 
 impl SetupSession {
@@ -46,6 +50,7 @@ impl SetupSession {
             outcome: Mutex::new(None),
             pending_worker_update: Mutex::new(false),
             cf_hints: Mutex::new(None),
+            demo_previous_index: Mutex::new(None),
         }
     }
 
@@ -56,6 +61,7 @@ impl SetupSession {
         *self.outcome.lock().unwrap() = None;
         *self.pending_worker_update.lock().unwrap() = false;
         *self.cf_hints.lock().unwrap() = None;
+        *self.demo_previous_index.lock().unwrap() = None;
     }
 }
 
@@ -753,10 +759,17 @@ fn dashboard_credentials(
     locale: Locale,
 ) -> Result<(String, String), String> {
     if session.dry_run {
-        // The same "is this computer connected yet?" check as a real run — demo
-        // mode should refuse here for the same reason and with the same message.
-        details_from_anywhere(session)
-            .ok_or_else(|| user_err(locale, Key::OpenDashboardNotSetup))?;
+        // No keychain read, and no connected-yet check.
+        //
+        // This used to call details_from_anywhere, which falls back to
+        // secure_store::load_setup() when the session has no outcome — so opening
+        // the settings window in demo mode raised an OS keychain password prompt.
+        // That is the same class of bug as #252, and it is why the window never
+        // worked in demo mode: the prompt appeared before any request was made.
+        //
+        // The check itself does not apply here either. In a real run it asks "is
+        // this computer connected to a brain yet?"; in demo mode the local demo
+        // brain *is* the brain, always present, so there is nothing to refuse.
         // The local demo brain, not `second-brain.demo.workers.dev`: that address
         // does not resolve, so every Worker-backed screen failed with "Couldn't
         // reach your Second Brain". Pointing at a real server on loopback means
@@ -1157,6 +1170,10 @@ pub async fn begin_embedding_migration(
         // old index stays "live", and the final free-up step is unreachable —
         // which would leave the most consequential screen untested.
         crate::migration::patch_embedding_model(&worker_url, &auth_token, &model, locale).await?;
+        // In memory, never the keychain — see demo_previous_index.
+        if target_index != manifest.vectorize_name {
+            *session.demo_previous_index.lock().unwrap() = Some(manifest.vectorize_name.clone());
+        }
         return crate::migration::reset(&worker_url, &auth_token, locale).await;
     }
 
@@ -1244,7 +1261,20 @@ pub async fn migration_step(app: AppHandle) -> Result<crate::migration::BatchPro
 /// from an assumed dimension count and nothing lives in browser storage that a
 /// reset could lose.
 #[tauri::command]
-pub fn outstanding_old_index() -> Option<String> {
+pub fn outstanding_old_index(session: State<'_, SetupSession>) -> Option<String> {
+    previous_index_for(&session)
+}
+
+/// Split out of the command so it can be tested: a Tauri `State` cannot be
+/// constructed in a unit test, and the property that matters here — that demo
+/// mode performs no keychain read — is only observable by calling it.
+fn previous_index_for(session: &SetupSession) -> Option<String> {
+    if session.dry_run {
+        // Checked before the keychain read, exactly as get_app_state does: a read
+        // here raises an OS password prompt on unsigned dev builds, and demo mode
+        // must never do that.
+        return session.demo_previous_index.lock().unwrap().clone();
+    }
     secure_store::load_previous_index()
 }
 
@@ -1262,8 +1292,12 @@ pub async fn finish_embedding_migration(
     let locale = locale_of(&app);
     let (worker_url, auth_token, _) = settings_target(&app)?;
 
-    let old_index = secure_store::load_previous_index()
-        .ok_or_else(|| user_err(locale, Key::ErrorNoOldIndexToFree))?;
+    let old_index = if session.dry_run {
+        session.demo_previous_index.lock().unwrap().clone()
+    } else {
+        secure_store::load_previous_index()
+    }
+    .ok_or_else(|| user_err(locale, Key::ErrorNoOldIndexToFree))?;
 
     // Refuse to delete the index the brain is reading. The recorded name is
     // trustworthy, but a redeploy could have been rolled back since, and the cost
@@ -1305,7 +1339,11 @@ pub async fn finish_embedding_migration(
 
     // Only after the delete succeeded. Clearing it first would silently orphan
     // the index with nothing left pointing at it.
-    secure_store::clear_previous_index();
+    if session.dry_run {
+        *session.demo_previous_index.lock().unwrap() = None;
+    } else {
+        secure_store::clear_previous_index();
+    }
     Ok(())
 }
 
@@ -1346,7 +1384,7 @@ pub fn open_settings_window(app: AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::{dashboard_credentials, normalize_worker_url, SetupSession};
+    use super::{dashboard_credentials, normalize_worker_url, previous_index_for, SetupSession};
     use crate::cf::provision::ProvisionOutcome;
     use crate::i18n::Locale;
 
@@ -1415,6 +1453,60 @@ mod tests {
     /// Demo mode is pointed at the local demo brain, not at
     /// `second-brain.demo.workers.dev` — that address does not resolve, so every
     /// Worker-backed screen failed before anything could be demonstrated.
+    /// Demo mode performs zero keychain reads.
+    ///
+    /// Counted rather than grepped. Two separate paths have now reached the
+    /// keychain in dry-run: `outstanding_old_index` read the note unconditionally,
+    /// and `dashboard_credentials` called `details_from_anywhere`, which falls
+    /// back to `secure_store::load_setup()` — so merely opening the settings
+    /// window raised an OS password prompt before any request was made. That
+    /// second one is why the window never worked in demo mode at all.
+    ///
+    /// A source scan cannot express the real rule, which is "not inside the
+    /// dry-run branch" rather than "the function mentions dry_run" — a guard I
+    /// wrote that way passed while the bug was reintroduced. The prompt itself is
+    /// an OS dialog no unit test can see, but the read that causes it is
+    /// countable, so this counts.
+    #[test]
+    fn demo_mode_never_reads_the_keychain() {
+        let session = SetupSession::new(true);
+        *session.outcome.lock().unwrap() = Some(ProvisionOutcome {
+            worker_url: "https://second-brain.demo.workers.dev".into(),
+            mcp_url: "https://second-brain.demo.workers.dev/mcp".into(),
+        });
+
+        crate::secure_store::probe::reset();
+        let (url, token) = dashboard_credentials(&session, Locale::En).expect("demo credentials");
+        assert_eq!(
+            crate::secure_store::probe::reads(),
+            0,
+            "dashboard_credentials touched the keychain in demo mode — that is the \
+             prompt users see when they open the settings window"
+        );
+        assert!(url.starts_with("http://127.0.0.1:"), "demo must use the local brain: {url}");
+        assert_eq!(token, "demo");
+
+        // The outstanding-index note is the other path that reached the keychain.
+        crate::secure_store::probe::reset();
+        let _ = previous_index_for(&session);
+        assert_eq!(
+            crate::secure_store::probe::reads(),
+            0,
+            "the outstanding-index note was read from the keychain in demo mode"
+        );
+
+        // And with no session outcome either: the fallback is exactly where the
+        // keychain read used to hide.
+        let fresh = SetupSession::new(true);
+        crate::secure_store::probe::reset();
+        let _ = dashboard_credentials(&fresh, Locale::En);
+        assert_eq!(
+            crate::secure_store::probe::reads(),
+            0,
+            "an unconnected demo session fell back to the keychain"
+        );
+    }
+
     #[test]
     fn dashboard_credentials_dry_run_uses_the_local_demo_brain() {
         let session = SetupSession::new(true);

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -753,9 +753,15 @@ fn dashboard_credentials(
     locale: Locale,
 ) -> Result<(String, String), String> {
     if session.dry_run {
-        let outcome = details_from_anywhere(session)
+        // The same "is this computer connected yet?" check as a real run — demo
+        // mode should refuse here for the same reason and with the same message.
+        details_from_anywhere(session)
             .ok_or_else(|| user_err(locale, Key::OpenDashboardNotSetup))?;
-        Ok((outcome.worker_url, "demo".to_string()))
+        // The local demo brain, not `second-brain.demo.workers.dev`: that address
+        // does not resolve, so every Worker-backed screen failed with "Couldn't
+        // reach your Second Brain". Pointing at a real server on loopback means
+        // settings and migration run their actual HTTP paths against real data.
+        Ok((crate::demo_brain::base_url(), "demo".to_string()))
     } else {
         let info = secure_store::load_setup()
             .ok_or_else(|| user_err(locale, Key::OpenDashboardNotSetup))?;
@@ -1128,10 +1134,15 @@ pub async fn begin_embedding_migration(
     };
 
     if session.dry_run {
+        // The demo brain runs on a loopback address, which has no script or
+        // subdomain to derive — `update_worker` would refuse it before doing
+        // anything. DryRunBackend ignores the URL entirely (its health check is
+        // stubbed), so a synthetic workers.dev address exercises the same code
+        // path while the real loopback address keeps serving the HTTP calls.
         provision::update_worker(
             &DryRunBackend,
             manifest,
-            &worker_url,
+            "https://second-brain.demo.workers.dev",
             "demo",
             provision::VectorizeTarget { name: &target_index, dimensions },
             progress,
@@ -1141,10 +1152,33 @@ pub async fn begin_embedding_migration(
             log::warn!("dry-run migration redeploy failed: {e}");
             user_err(locale, Key::ErrorFriendlyRetry)
         })?;
-        return Ok(());
+        // In the same order as the live path below, so demo mode actually moves
+        // the model. Without this the demo rebuild runs at the old model, the
+        // old index stays "live", and the final free-up step is unreachable —
+        // which would leave the most consequential screen untested.
+        crate::migration::patch_embedding_model(&worker_url, &auth_token, &model, locale).await?;
+        return crate::migration::reset(&worker_url, &auth_token, locale).await;
     }
 
     let client = cloudflare_client_for_brain(&worker_url, &session, locale).await?;
+
+    // What the brain reads right now, taken from the live binding rather than
+    // derived from an assumed size. Recorded BEFORE the switch, because
+    // afterwards the brain reports the new index as current and this name is the
+    // only thing that identifies what may later be freed. Written first so it
+    // survives a redeploy that fails half-way.
+    if let Some(script) = crate::worker_url::script_of(&worker_url) {
+        if let Ok(bindings) = client.get_script_bindings(&script).await {
+            if let Some(current) = provision::binding_field(&bindings, "vectorize", "index_name") {
+                if current != target_index {
+                    if let Err(e) = secure_store::save_previous_index(current) {
+                        log::warn!("could not record the outgoing index: {e}");
+                    }
+                }
+            }
+        }
+    }
+
     let backend = LiveBackend { client };
 
     // Creating the index is idempotent and non-destructive, and update_worker
@@ -1167,12 +1201,32 @@ pub async fn begin_embedding_migration(
         }
     })?;
 
-    // Only now is the brain reading the new index, so only now is the new model
-    // safe to record.
-    crate::migration::patch_embedding_model(&worker_url, &auth_token, &model, locale).await?;
+    // Past this point the brain is already reading the new index, so a failure is
+    // not "nothing happened". Search stays incomplete until the rebuild runs, and
+    // the message has to say so — retrying is safe and idempotent, but walking
+    // away is not.
+    let half_switched = |_e: String| user_err(locale, Key::ErrorMigrationHalfSwitched);
+
+    crate::migration::patch_embedding_model(&worker_url, &auth_token, &model, locale)
+        .await
+        .map_err(half_switched)?;
 
     // Any ledger from a previous target is meaningless against this one.
-    crate::migration::reset(&worker_url, &auth_token, locale).await
+    crate::migration::reset(&worker_url, &auth_token, locale)
+        .await
+        .map_err(half_switched)
+}
+
+/// Abandons an unfinished rebuild so the next one starts from the beginning.
+///
+/// The escape hatch for a rebuild that keeps stalling on the same entry: without
+/// it, a user whose cursor sits on a permanently failing memory has no way out.
+/// Rebuilding is idempotent, so this costs model calls and cannot corrupt
+/// anything.
+#[tauri::command]
+pub async fn migration_reset(app: AppHandle) -> Result<(), String> {
+    let (url, token, locale) = settings_target(&app)?;
+    crate::migration::reset(&url, &token, locale).await
 }
 
 /// One re-embed batch. The window loops on this until `done`, and stops if
@@ -1183,36 +1237,47 @@ pub async fn migration_step(app: AppHandle) -> Result<crate::migration::BatchPro
     crate::migration::run_batch(&url, &token, locale).await
 }
 
-/// Deletes the superseded index. The one irreversible step, so the UI confirms it
-/// separately and only after a rebuild has finished.
+/// Whether an index is left over from a migration, and can be freed.
+///
+/// The window asks this rather than tracking sizes itself: the name comes from
+/// what Cloudflare reported as bound before the switch, so nothing is derived
+/// from an assumed dimension count and nothing lives in browser storage that a
+/// reset could lose.
+#[tauri::command]
+pub fn outstanding_old_index() -> Option<String> {
+    secure_store::load_previous_index()
+}
+
+/// Deletes the superseded index. The one irreversible step, so the window
+/// confirms it separately and only after a rebuild has finished.
+///
+/// Takes no argument on purpose. An earlier shape had the window pass the size it
+/// thought it was moving from, which put the name of something irreversibly
+/// deletable in the hands of browser storage.
 #[tauri::command]
 pub async fn finish_embedding_migration(
-    old_dimensions: u32,
     app: AppHandle,
     session: State<'_, SetupSession>,
 ) -> Result<(), String> {
     let locale = locale_of(&app);
-    let manifest = worker_bundle::manifest();
-    let (worker_url, _, _) = settings_target(&app)?;
+    let (worker_url, auth_token, _) = settings_target(&app)?;
 
-    let old_index = crate::migration::index_name_for(
-        &manifest.vectorize_name,
-        old_dimensions,
-        manifest.vectorize_dimensions,
-    );
+    let old_index = secure_store::load_previous_index()
+        .ok_or_else(|| user_err(locale, Key::ErrorNoOldIndexToFree))?;
 
-    // Refuse to delete the index the brain is currently reading. The caller passes
-    // the size it is moving *from*, and a mistake there would drop the live one —
-    // so the live model is read back and checked rather than trusted.
-    let (_, auth_token, _) = settings_target(&app)?;
-    let status = crate::migration::fetch_status(&worker_url, &auth_token, locale).await?;
-    let live_model = status
+    // Refuse to delete the index the brain is reading. The recorded name is
+    // trustworthy, but a redeploy could have been rolled back since, and the cost
+    // of being wrong here is unrecoverable.
+    let live_model = crate::migration::fetch_status(&worker_url, &auth_token, locale)
+        .await?
         .get("model")
         .and_then(|m| m.as_str())
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .to_string();
+    let manifest = worker_bundle::manifest();
     let live_index = crate::migration::index_name_for(
         &manifest.vectorize_name,
-        crate::migration::dimensions_for(live_model).unwrap_or(manifest.vectorize_dimensions),
+        crate::migration::dimensions_for(&live_model).unwrap_or(manifest.vectorize_dimensions),
         manifest.vectorize_dimensions,
     );
     if old_index == live_index {
@@ -1227,12 +1292,21 @@ pub async fn finish_embedding_migration(
         user_err(locale, Key::ErrorFriendlyRetry)
     };
     if session.dry_run {
-        return DryRunBackend.delete_vectorize(&old_index).await.map_err(failed);
+        DryRunBackend
+            .delete_vectorize(&old_index)
+            .await
+            .map_err(failed)?;
+    } else {
+        let backend = LiveBackend {
+            client: cloudflare_client_for_brain(&worker_url, &session, locale).await?,
+        };
+        backend.delete_vectorize(&old_index).await.map_err(failed)?;
     }
-    let backend = LiveBackend {
-        client: cloudflare_client_for_brain(&worker_url, &session, locale).await?,
-    };
-    backend.delete_vectorize(&old_index).await.map_err(failed)
+
+    // Only after the delete succeeded. Clearing it first would silently orphan
+    // the index with nothing left pointing at it.
+    secure_store::clear_previous_index();
+    Ok(())
 }
 
 fn settings_target(app: &AppHandle) -> Result<(String, String, Locale), String> {
@@ -1338,15 +1412,19 @@ mod tests {
         );
     }
 
+    /// Demo mode is pointed at the local demo brain, not at
+    /// `second-brain.demo.workers.dev` — that address does not resolve, so every
+    /// Worker-backed screen failed before anything could be demonstrated.
     #[test]
-    fn dashboard_credentials_dry_run_uses_demo_token() {
+    fn dashboard_credentials_dry_run_uses_the_local_demo_brain() {
         let session = SetupSession::new(true);
         *session.outcome.lock().unwrap() = Some(ProvisionOutcome {
             worker_url: "https://second-brain.demo.workers.dev".into(),
             mcp_url: "https://second-brain.demo.workers.dev/mcp".into(),
         });
         let (url, token) = dashboard_credentials(&session, Locale::En).unwrap();
-        assert_eq!(url, "https://second-brain.demo.workers.dev");
+        assert_eq!(url, crate::demo_brain::base_url());
+        assert!(url.starts_with("http://127.0.0.1:"), "got {url}");
         assert_eq!(token, "demo");
     }
 }

--- a/installer/src-tauri/src/demo_brain.rs
+++ b/installer/src-tauri/src/demo_brain.rs
@@ -1,0 +1,1027 @@
+//! A local stand-in for a real Second Brain, so demo mode has data to operate on.
+//!
+//! `SECOND_BRAIN_DRY_RUN=1` used to point the app at
+//! `https://second-brain.demo.workers.dev`, which does not resolve. Every
+//! Worker-backed screen therefore failed with "Couldn't reach your Second
+//! Brain" — the Advanced Settings window would not open at all, and the
+//! embedding-migration pane could not be exercised even once.
+//!
+//! # Why a real server rather than a `dry_run` branch
+//!
+//! The obvious fix is an `if session.dry_run` early return inside
+//! [`crate::settings::fetch_settings`] and friends. That would prove nothing: the
+//! request, the JSON parsing, the status mapping and the error copy would all be
+//! skipped, so a clean demo run would say only that the short-circuit works.
+//!
+//! Instead this binds a real `tiny_http` listener on `127.0.0.1:0` and demo mode
+//! is handed its address. `fetch_settings`, `apply_settings`, `reset_control`,
+//! `fetch_estimate`, `run_batch` and `fetch_status` then execute completely
+//! unchanged — real HTTP, real bearer auth, real deserialisation, real error
+//! mapping. A demo run is evidence about the shipping code path.
+//!
+//! `tiny_http` is already a production dependency: [`crate::cf::oauth`] uses it
+//! for the Cloudflare loopback callback. Nothing new is pulled in.
+//!
+//! # The config is derived, never typed out
+//!
+//! [`shipped_config`] is built from [`crate::settings::DEFAULT_LEVELS`] and the
+//! levels in [`crate::settings::CONTROLS`], so the demo brain reports exactly the
+//! keys and values the controls write. A hardcoded blob would drift the moment a
+//! level was retuned, and the window would open showing "Custom" for a brain that
+//! is in fact untouched — the single most misleading thing this could do.
+
+use serde_json::{json, Map, Value};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// The owner's own brain size, so the numbers on screen are plausible rather
+/// than obviously synthetic.
+pub const ENTRIES: u64 = 1620;
+/// A lower bound, the way the Worker reports it.
+pub const CHUNKS_AT_LEAST: u64 = 2100;
+
+/// Entries per re-embed batch. Close to what the Worker actually manages —
+/// `MIGRATION_CHUNK_BUDGET` is 20 chunks and most entries are one chunk — which
+/// is what makes a demo rebuild take ~80 batches instead of finishing in one and
+/// leaving the progress bar untested.
+const BATCH_ENTRIES: u64 = 20;
+
+/// Enough that progress is visible on screen, small enough that a full rebuild
+/// of 1,620 entries takes about 20 seconds.
+const BATCH_PAUSE: Duration = Duration::from_millis(250);
+
+/// Set to a batch count to make the rebuild pause once, as it does when the
+/// day's embedding allowance runs out. The "Paused for today" screen is
+/// otherwise unreachable in a demo.
+const STALL_ENV: &str = "SECOND_BRAIN_DEMO_STALL_AFTER";
+
+/// Shipped in `src/config.ts` DEFAULTS. Both must be values the pickers offer,
+/// or the settings window shows a model that is not in its own dropdown and the
+/// migration pane cannot read the current dimensions — asserted in tests.
+const DEMO_LLM_MODEL: &str = "@cf/meta/llama-4-scout-17b-16e-instruct";
+const DEMO_EMBEDDING_MODEL: &str = "@cf/baai/bge-small-en-v1.5";
+
+/// Returned when loopback cannot be bound at all. Port 1 refuses instantly, so
+/// the app reports "Couldn't reach your Second Brain" — the truth — rather than
+/// hanging.
+const UNREACHABLE: &str = "http://127.0.0.1:1";
+
+const THREADS: usize = 3;
+
+// ── Options ─────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug)]
+pub struct Options {
+    pub entries: u64,
+    pub chunks_at_least: u64,
+    pub batch_entries: u64,
+    /// Deliberate delay per batch, so a demo rebuild is watchable. Zero in tests.
+    pub batch_pause: Duration,
+    /// Pause the rebuild once, after this many batches.
+    pub stall_after: Option<u64>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            entries: ENTRIES,
+            chunks_at_least: CHUNKS_AT_LEAST,
+            batch_entries: BATCH_ENTRIES,
+            batch_pause: BATCH_PAUSE,
+            stall_after: parse_stall_after(std::env::var(STALL_ENV).ok().as_deref()),
+        }
+    }
+}
+
+/// Split out from the env read so it can be tested without `set_var`, which
+/// races every other test in the process.
+fn parse_stall_after(raw: Option<&str>) -> Option<u64> {
+    let n = raw?.trim().parse::<u64>().ok()?;
+    // 0 would stall before the first batch, leaving no progress to resume from —
+    // which is not the state the paused screen is for.
+    (n > 0).then_some(n)
+}
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+/// The effective config a fresh brain reports, built from the controls
+/// themselves.
+///
+/// Every key each control owns is present at its default level, so the settings
+/// window renders every control at a named level. A control reading "Custom" on
+/// an untouched demo brain would be a lie about what the user is looking at.
+pub fn shipped_config() -> Map<String, Value> {
+    let mut out = Map::new();
+    for (control_id, level_id) in crate::settings::DEFAULT_LEVELS {
+        // `settings.rs` asserts every entry here names a real control and a real
+        // level of it, and that a level writes exactly that control's keys.
+        let patch = crate::settings::patch_for(control_id, level_id)
+            .expect("DEFAULT_LEVELS names a control and a level it has");
+        out.extend(patch);
+    }
+    out.insert("LLM_MODEL".into(), json!(DEMO_LLM_MODEL));
+    out.insert("EMBEDDING_MODEL".into(), json!(DEMO_EMBEDDING_MODEL));
+    out
+}
+
+fn effective(overrides: &Map<String, Value>) -> Map<String, Value> {
+    let mut cfg = shipped_config();
+    for (key, value) in overrides {
+        cfg.insert(key.clone(), value.clone());
+    }
+    cfg
+}
+
+fn embedding_model(overrides: &Map<String, Value>) -> String {
+    effective(overrides)
+        .get("EMBEDDING_MODEL")
+        .and_then(|v| v.as_str())
+        .unwrap_or(DEMO_EMBEDDING_MODEL)
+        .to_string()
+}
+
+// ── State ───────────────────────────────────────────────────────────────────
+
+/// The KV ledger `src/migration/embedding.ts` keeps, minus the parts only D1
+/// needs. Held in memory so a PATCH is visible to the next GET and a rebuild
+/// survives across the many requests it takes — the point of the exercise is
+/// that saving a setting and reopening the window shows the saved value.
+struct Ledger {
+    model: String,
+    started_at: u64,
+    cursor_created_at: Option<u64>,
+    cursor_id: Option<String>,
+    processed: u64,
+    failed: u64,
+    total_at_start: u64,
+    finished_at: Option<u64>,
+    /// Batches completed, for the stall gate.
+    batches: u64,
+    /// The allowance is only exhausted once per demo, so Resume finishes the
+    /// rebuild instead of pausing again on every click.
+    stalled_once: bool,
+}
+
+impl Ledger {
+    fn new(model: String, total: u64) -> Self {
+        Self {
+            model,
+            started_at: now_ms(),
+            cursor_created_at: None,
+            cursor_id: None,
+            processed: 0,
+            failed: 0,
+            total_at_start: total,
+            finished_at: None,
+            batches: 0,
+            stalled_once: false,
+        }
+    }
+
+    fn to_json(&self) -> Value {
+        let mut out = Map::new();
+        out.insert("model".into(), json!(self.model));
+        out.insert("startedAt".into(), json!(self.started_at));
+        out.insert("cursorCreatedAt".into(), json!(self.cursor_created_at));
+        out.insert("cursorId".into(), json!(self.cursor_id));
+        out.insert("processed".into(), json!(self.processed));
+        out.insert("failed".into(), json!(self.failed));
+        out.insert("totalAtStart".into(), json!(self.total_at_start));
+        // Absent rather than null until the rebuild finishes, matching
+        // `MigrationState.finishedAt?`.
+        if let Some(at) = self.finished_at {
+            out.insert("finishedAt".into(), json!(at));
+        }
+        Value::Object(out)
+    }
+}
+
+#[derive(Default)]
+struct State {
+    /// Sparse, exactly like `config:overrides` in KV.
+    overrides: Map<String, Value>,
+    ledger: Option<Ledger>,
+}
+
+struct Demo {
+    options: Options,
+    state: Mutex<State>,
+}
+
+// ── Routes ──────────────────────────────────────────────────────────────────
+
+impl Demo {
+    fn new(options: Options) -> Self {
+        Self { options, state: Mutex::new(State::default()) }
+    }
+
+    fn handle(&self, method: &str, path: &str, body: &str) -> (u16, Value) {
+        match (method, path) {
+            ("GET", "/health") => (200, self.health()),
+            ("GET", "/config") => (200, self.config_body()),
+            ("PATCH", "/config") => self.patch_config(body),
+            ("DELETE", p) if p.starts_with("/config/") => {
+                self.reset_key(&p["/config/".len()..])
+            }
+            ("GET", "/migration/estimate") => (200, self.estimate()),
+            ("GET", "/migration/status") => (200, self.status()),
+            ("POST", "/migration/reembed") => (200, self.reembed()),
+            ("POST", "/migration/reset") => {
+                self.state.lock().unwrap().ledger = None;
+                (200, json!({ "ok": true }))
+            }
+            _ => (404, json!({ "ok": false, "error": "Not found" })),
+        }
+    }
+
+    /// `{ ok, version, vectorize }`, as `src/routes/admin.ts` returns it. The
+    /// index it names follows the model in force, so a demo migration changes
+    /// what health reports the way a real one does.
+    fn health(&self) -> Value {
+        let manifest = crate::worker_bundle::manifest();
+        let model = embedding_model(&self.state.lock().unwrap().overrides);
+        let dimensions =
+            crate::migration::dimensions_for(&model).unwrap_or(manifest.vectorize_dimensions);
+        json!({
+            "ok": true,
+            "version": manifest.worker_version,
+            "vectorize": {
+                "ok": true,
+                "indexName": crate::migration::index_name_for(
+                    &manifest.vectorize_name,
+                    dimensions,
+                    manifest.vectorize_dimensions,
+                ),
+                "dimensions": dimensions,
+                "vectorCount": self.options.chunks_at_least,
+            }
+        })
+    }
+
+    /// Three things, not one: a settings UI needs the effective values, the
+    /// sparse overrides and the shipped defaults to say "changed from 0.7 to
+    /// 0.45" and to know whether a reset control should be live at all.
+    fn config_body(&self) -> Value {
+        let state = self.state.lock().unwrap();
+        json!({
+            "ok": true,
+            "config": effective(&state.overrides),
+            "overrides": state.overrides,
+            "defaults": shipped_config(),
+        })
+    }
+
+    /// Sparse merge. The whole patch is rejected if any key is unknown, so a
+    /// batch that names one bad setting writes nothing.
+    fn patch_config(&self, body: &str) -> (u16, Value) {
+        let Ok(Value::Object(patch)) = serde_json::from_str::<Value>(body) else {
+            return (
+                400,
+                json!({ "ok": false, "error": "Body must be an object of setting → value" }),
+            );
+        };
+        let known = shipped_config();
+        for key in patch.keys() {
+            if !known.contains_key(key) {
+                return (400, json!({ "ok": false, "error": format!("{key} is not a known setting") }));
+            }
+        }
+        let mut state = self.state.lock().unwrap();
+        for (key, value) in patch {
+            state.overrides.insert(key, value);
+        }
+        (200, json!({ "ok": true, "config": effective(&state.overrides) }))
+    }
+
+    /// Per-setting reset: drop the override so the value rejoins the shipped
+    /// default, rather than writing that default back.
+    fn reset_key(&self, key: &str) -> (u16, Value) {
+        if !shipped_config().contains_key(key) {
+            return (404, json!({ "ok": false, "error": format!("{key} is not a known setting") }));
+        }
+        let mut state = self.state.lock().unwrap();
+        state.overrides.remove(key);
+        (200, json!({ "ok": true, "config": effective(&state.overrides) }))
+    }
+
+    fn estimate(&self) -> Value {
+        let model = embedding_model(&self.state.lock().unwrap().overrides);
+        json!({
+            "ok": true,
+            "entries": self.options.entries,
+            "chunksAtLeast": self.options.chunks_at_least,
+            "model": model,
+        })
+    }
+
+    /// `state` is null until a rebuild has ever been started for this brain.
+    fn status(&self) -> Value {
+        let state = self.state.lock().unwrap();
+        json!({
+            "ok": true,
+            "state": state.ledger.as_ref().map(Ledger::to_json).unwrap_or(Value::Null),
+            "model": embedding_model(&state.overrides),
+        })
+    }
+
+    /// One bounded batch, the shape the app loops on.
+    ///
+    /// Mirrors `runBatch`: a target change mid-run restarts from the beginning,
+    /// because entries before the cursor hold vectors from the previous target;
+    /// `remaining` is recomputed every call; and `done` is only ever true once
+    /// `remaining` has reached 0.
+    fn reembed(&self) -> Value {
+        // Outside the lock: holding it across the sleep would serialise an
+        // unrelated /config read behind a batch.
+        if !self.options.batch_pause.is_zero() {
+            std::thread::sleep(self.options.batch_pause);
+        }
+
+        let total = self.options.entries;
+        let mut state = self.state.lock().unwrap();
+        let target = embedding_model(&state.overrides);
+
+        let restart = state.ledger.as_ref().map(|l| l.model != target).unwrap_or(true);
+        if restart {
+            state.ledger = Some(Ledger::new(target, total));
+        }
+        let pause_after = self.options.stall_after;
+        let batch = self.options.batch_entries;
+        let ledger = state.ledger.as_mut().expect("just ensured");
+
+        // The day's allowance running out. The cursor is kept, so resuming costs
+        // nothing already paid for.
+        if let Some(after) = pause_after {
+            if ledger.batches >= after && !ledger.stalled_once && ledger.processed < total {
+                ledger.stalled_once = true;
+                ledger.failed += 1;
+                return json!({
+                    "ok": true,
+                    "processed": 0,
+                    "failed": 1,
+                    "remaining": total - ledger.processed,
+                    "total": ledger.total_at_start.max(ledger.processed + (total - ledger.processed)),
+                    "done": false,
+                    "stalled": true,
+                    "stalledReason": "budget",
+                });
+            }
+        }
+
+        let processed = batch.min(total.saturating_sub(ledger.processed));
+        ledger.processed += processed;
+        ledger.batches += 1;
+        let remaining = total.saturating_sub(ledger.processed);
+        if processed > 0 {
+            ledger.cursor_created_at = Some(cursor_time(ledger.processed, total, now_ms()));
+            ledger.cursor_id = Some(format!("demo-entry-{:05}", ledger.processed));
+        }
+        let done = remaining == 0;
+        if done && ledger.finished_at.is_none() {
+            ledger.finished_at = Some(now_ms());
+        }
+
+        json!({
+            "ok": true,
+            "processed": processed,
+            // Per batch, not cumulative — the ledger carries the running total.
+            "failed": 0,
+            "remaining": remaining,
+            "total": ledger.total_at_start.max(ledger.processed + remaining),
+            "done": done,
+            "stalled": false,
+        })
+    }
+}
+
+/// Entries are spread over the last three years, so the keyset cursor advances
+/// through time the way a real one does.
+fn cursor_time(processed: u64, entries: u64, now: u64) -> u64 {
+    const SPAN_MS: u64 = 3 * 365 * 86_400_000;
+    now.saturating_sub(SPAN_MS) + SPAN_MS * processed / entries.max(1)
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or_default()
+}
+
+// ── Server ──────────────────────────────────────────────────────────────────
+
+/// Shown when demo mode opens the dashboard. The wrapper window would otherwise
+/// load a blank page from an address that has no dashboard behind it.
+const PLACEHOLDER: &str = "<!doctype html><meta charset=\"utf-8\">\
+<title>Second Brain — demo</title>\
+<style>body{font:15px/1.6 -apple-system,system-ui,sans-serif;margin:12vh auto;max-width:34rem;padding:0 1.5rem;color:#1d1d1f}\
+h1{font-size:1.35rem;margin:0 0 .6rem}p{color:#6e6e73}@media(prefers-color-scheme:dark){body{background:#1c1c1e;color:#f5f5f7}p{color:#98989d}}</style>\
+<h1>Demo brain</h1>\
+<p>This is a stand-in Second Brain running on this computer. It answers the app's \
+settings and rebuild requests with plausible data so the flow can be tried end to \
+end; it holds no memories of its own.</p>";
+
+fn json_response(status: u16, payload: &Value) -> tiny_http::Response<std::io::Cursor<Vec<u8>>> {
+    tiny_http::Response::from_string(payload.to_string())
+        .with_status_code(status)
+        .with_header(
+            "Content-Type: application/json"
+                .parse::<tiny_http::Header>()
+                .expect("static header"),
+        )
+}
+
+/// Every route the real Worker guards with `requireAuth` is guarded here, so a
+/// demo run is also evidence the app sends its token.
+///
+/// Any non-empty bearer token is accepted rather than one literal string: what
+/// is worth proving is that the app authenticates at all, and pinning the value
+/// would turn an unrelated change of the demo token into a window full of 401s.
+fn is_authenticated(req: &tiny_http::Request) -> bool {
+    req.headers()
+        .iter()
+        .filter(|h| h.field.equiv("authorization"))
+        .any(|h| {
+            let value = h.value.to_string();
+            value
+                .strip_prefix("Bearer ")
+                .is_some_and(|token| !token.trim().is_empty())
+        })
+}
+
+fn serve(server: &tiny_http::Server, demo: &Demo) {
+    loop {
+        let Ok(mut req) = server.recv() else { return };
+        let method = req.method().as_str().to_string();
+        let raw = req.url().to_string();
+        let path = raw.split('?').next().unwrap_or_default().to_string();
+        let authed = is_authenticated(&req);
+        let mut body = String::new();
+        let _ = std::io::Read::read_to_string(req.as_reader(), &mut body);
+
+        if method == "GET" && (path == "/" || path == "/index.html") {
+            let response = tiny_http::Response::from_string(PLACEHOLDER).with_header(
+                "Content-Type: text/html; charset=utf-8"
+                    .parse::<tiny_http::Header>()
+                    .expect("static header"),
+            );
+            let _ = req.respond(response);
+            continue;
+        }
+
+        let (status, payload) = if authed {
+            demo.handle(&method, &path, &body)
+        } else {
+            (401, json!({ "ok": false, "error": "Unauthorized" }))
+        };
+        let _ = req.respond(json_response(status, &payload));
+    }
+}
+
+/// Binds a demo brain on an ephemeral loopback port and returns its base URL.
+///
+/// A small pool rather than one thread: a re-embed batch sleeps, and a single
+/// handler would hold an unrelated /config read behind it.
+pub fn spawn(options: Options) -> Option<String> {
+    let server = tiny_http::Server::http("127.0.0.1:0").ok()?;
+    let port = server.server_addr().to_ip()?.port();
+    let server = Arc::new(server);
+    let demo = Arc::new(Demo::new(options));
+    for _ in 0..THREADS {
+        let server = server.clone();
+        let demo = demo.clone();
+        std::thread::spawn(move || serve(&server, &demo));
+    }
+    Some(format!("http://127.0.0.1:{port}"))
+}
+
+static RUNNING: OnceLock<String> = OnceLock::new();
+
+/// The demo brain's address, starting it if it is not already up.
+///
+/// Lazy as well as started at launch so no caller can be handed a dead address:
+/// the port is chosen by the OS, so it cannot be a constant.
+pub fn base_url() -> String {
+    RUNNING
+        .get_or_init(|| match spawn(Options::default()) {
+            Some(url) => {
+                log::info!("demo brain listening on {url}");
+                url
+            }
+            None => {
+                log::warn!("could not bind the demo brain to loopback");
+                UNREACHABLE.to_string()
+            }
+        })
+        .clone()
+}
+
+/// Brings the demo brain up at launch, before any window can ask for it.
+pub fn start() {
+    let _ = base_url();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::i18n::Locale;
+    use crate::settings::{self, CONTROLS, DEFAULT_LEVELS};
+
+    /// A demo brain with the delay removed. Everything else is what a real demo
+    /// run uses, so the tests exercise the shipped numbers.
+    fn brain() -> String {
+        spawn(Options { batch_pause: Duration::ZERO, stall_after: None, ..Options::default() })
+            .expect("bind loopback")
+    }
+
+    fn brain_with(options: Options) -> String {
+        spawn(options).expect("bind loopback")
+    }
+
+    async fn get(url: &str, path: &str) -> (u16, Value) {
+        let resp = reqwest::Client::new()
+            .get(format!("{url}{path}"))
+            .bearer_auth("demo")
+            .send()
+            .await
+            .expect("request");
+        let status = resp.status().as_u16();
+        (status, resp.json().await.unwrap_or(Value::Null))
+    }
+
+    async fn post(url: &str, path: &str) -> (u16, Value) {
+        let resp = reqwest::Client::new()
+            .post(format!("{url}{path}"))
+            .bearer_auth("demo")
+            .send()
+            .await
+            .expect("request");
+        let status = resp.status().as_u16();
+        (status, resp.json().await.unwrap_or(Value::Null))
+    }
+
+    // ── The config the window renders ───────────────────────────────────────
+
+    /// The whole point of deriving the payload from `CONTROLS`: every control
+    /// must find all of its keys, or the window renders it as "Custom" — a lie
+    /// about a brain nobody has touched.
+    #[tokio::test]
+    async fn the_demo_config_carries_every_key_every_control_owns() {
+        let url = brain();
+        let (status, body) = get(&url, "/config").await;
+        assert_eq!(status, 200);
+        let config = body["config"].as_object().expect("config object");
+        for c in CONTROLS {
+            for key in c.keys {
+                assert!(
+                    config.contains_key(*key),
+                    "control {} owns {key}, which the demo config omits",
+                    c.id
+                );
+            }
+        }
+    }
+
+    /// Stronger than key presence: each control must resolve to a *named* level,
+    /// and specifically to its default one.
+    #[tokio::test]
+    async fn every_control_reads_as_its_default_level_not_custom() {
+        let url = brain();
+        let view = settings::fetch_settings(&url, "demo", Locale::En).await.expect("view");
+        for (control_id, level_id) in DEFAULT_LEVELS {
+            let c = view.controls.iter().find(|c| c.id == *control_id).expect("control present");
+            assert_eq!(
+                c.level.as_deref(),
+                Some(*level_id),
+                "{control_id} read as {:?} rather than its default",
+                c.level
+            );
+        }
+        assert_eq!(view.llm_model, DEMO_LLM_MODEL);
+    }
+
+    /// The two models must be ones the pickers offer. An LLM_MODEL outside
+    /// `LLM_MODELS` renders an empty dropdown selection; an EMBEDDING_MODEL
+    /// outside `EMBEDDING_MODELS` leaves `oldDimensions` null, which makes the
+    /// last migration step unreachable.
+    #[test]
+    fn both_demo_models_are_offered_by_the_pickers() {
+        assert!(
+            settings::LLM_MODELS.contains(&DEMO_LLM_MODEL),
+            "{DEMO_LLM_MODEL} is not in the dropdown"
+        );
+        assert!(
+            crate::migration::dimensions_for(DEMO_EMBEDDING_MODEL).is_some(),
+            "{DEMO_EMBEDDING_MODEL} has no known dimensions"
+        );
+    }
+
+    /// The demo must not report a setting the Worker's config layer does not
+    /// define, or a PATCH the window sends would 400 against a real brain while
+    /// passing here.
+    #[test]
+    fn the_demo_config_only_names_settings_the_worker_ships() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../src/config.ts");
+        let src = std::fs::read_to_string(path).expect("read src/config.ts");
+        let start = src.find("export const DEFAULTS").expect("DEFAULTS block");
+        let end = src[start..].find("} as const;").expect("end of DEFAULTS") + start;
+        let defaults = &src[start..end];
+        for key in shipped_config().keys() {
+            assert!(
+                defaults.contains(&format!("{key}:")),
+                "{key} is not a Worker default — the demo reports a setting that does not exist"
+            );
+        }
+        // And the two model strings must be the shipped ones, not a guess.
+        assert!(
+            defaults.contains(&format!("LLM_MODEL: \"{DEMO_LLM_MODEL}\"")),
+            "LLM_MODEL drifted from src/config.ts"
+        );
+        assert!(
+            defaults.contains(&format!("EMBEDDING_MODEL: \"{DEMO_EMBEDDING_MODEL}\"")),
+            "EMBEDDING_MODEL drifted from src/config.ts"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_reports_effective_values_overrides_and_defaults_separately() {
+        let url = brain();
+        let (_, body) = get(&url, "/config").await;
+        for key in ["config", "overrides", "defaults"] {
+            assert!(body.get(key).is_some(), "/config omits {key}");
+        }
+        assert!(
+            body["overrides"].as_object().expect("object").is_empty(),
+            "a fresh brain has overridden nothing"
+        );
+        assert_eq!(body["config"]["MMR_LAMBDA"], json!(0.7));
+    }
+
+    // ── State survives across calls ─────────────────────────────────────────
+
+    /// The reason this holds state at all: save a setting, reopen the window,
+    /// see the saved value.
+    #[tokio::test]
+    async fn a_saved_level_is_what_the_next_read_reports() {
+        let url = brain();
+        settings::apply_settings(
+            &url,
+            "demo",
+            &[("variety".into(), "varied".into())],
+            &[],
+            None,
+            Locale::En,
+        )
+        .await
+        .expect("save");
+
+        let view = settings::fetch_settings(&url, "demo", Locale::En).await.expect("view");
+        let variety = view.controls.iter().find(|c| c.id == "variety").expect("variety");
+        assert_eq!(variety.level.as_deref(), Some("varied"));
+
+        // ...and only that control moved.
+        let detail = view.controls.iter().find(|c| c.id == "detail").expect("detail");
+        assert_eq!(detail.level.as_deref(), Some("standard"));
+    }
+
+    #[tokio::test]
+    async fn a_patch_records_a_sparse_override_and_leaves_the_defaults_alone() {
+        let url = brain();
+        settings::patch_config(&url, "demo", &json!({ "MMR_LAMBDA": 0.45 }), Locale::En)
+            .await
+            .expect("patch");
+        let (_, body) = get(&url, "/config").await;
+        let overrides = body["overrides"].as_object().expect("object");
+        assert_eq!(overrides.len(), 1, "only the changed key belongs in overrides: {overrides:?}");
+        assert_eq!(overrides["MMR_LAMBDA"], json!(0.45));
+        assert_eq!(body["config"]["MMR_LAMBDA"], json!(0.45));
+        assert_eq!(body["defaults"]["MMR_LAMBDA"], json!(0.7), "the shipped default must not move");
+    }
+
+    #[tokio::test]
+    async fn resetting_a_control_drops_its_overrides_and_returns_the_default_level() {
+        let url = brain();
+        settings::apply_settings(
+            &url,
+            "demo",
+            &[("recency".into(), "recent_first".into())],
+            &[],
+            None,
+            Locale::En,
+        )
+        .await
+        .expect("save");
+        settings::reset_control(&url, "demo", "recency", Locale::En).await.expect("reset");
+
+        let (_, body) = get(&url, "/config").await;
+        assert!(
+            body["overrides"].as_object().expect("object").is_empty(),
+            "a reset must delete the overrides, not write the default back"
+        );
+        let view = settings::fetch_settings(&url, "demo", Locale::En).await.expect("view");
+        let recency = view.controls.iter().find(|c| c.id == "recency").expect("recency");
+        assert_eq!(recency.level.as_deref(), Some("balanced"));
+    }
+
+    #[tokio::test]
+    async fn a_patch_naming_an_unknown_setting_is_refused_and_writes_nothing() {
+        let url = brain();
+        let err = settings::patch_config(
+            &url,
+            "demo",
+            &json!({ "MMR_LAMBDA": 0.45, "NOT_A_SETTING": 1 }),
+            Locale::En,
+        )
+        .await
+        .expect_err("must be refused");
+        assert!(err.contains("NOT_A_SETTING"), "the error must name the key: {err}");
+
+        let (_, body) = get(&url, "/config").await;
+        assert!(
+            body["overrides"].as_object().expect("object").is_empty(),
+            "a rejected patch must not write its valid half"
+        );
+    }
+
+    #[tokio::test]
+    async fn deleting_an_unknown_setting_is_a_404() {
+        let url = brain();
+        let resp = reqwest::Client::new()
+            .delete(format!("{url}/config/NOT_A_SETTING"))
+            .bearer_auth("demo")
+            .send()
+            .await
+            .expect("request");
+        assert_eq!(resp.status().as_u16(), 404);
+    }
+
+    #[tokio::test]
+    async fn requests_without_a_bearer_token_are_refused() {
+        let url = brain();
+        let resp = reqwest::Client::new()
+            .get(format!("{url}/config"))
+            .send()
+            .await
+            .expect("request");
+        assert_eq!(resp.status().as_u16(), 401, "the real Worker requires auth on /config");
+    }
+
+    // ── Migration ───────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn the_estimate_reports_a_plausible_brain_through_the_apps_own_parser() {
+        let url = brain();
+        let est = crate::migration::fetch_estimate(&url, "demo", Locale::En)
+            .await
+            .expect("estimate");
+        // Pinned as literals, not against the constants: comparing a constant to
+        // itself would pass whatever the demo brain claimed to hold, and the
+        // whole point of these numbers is that they look like a real brain.
+        assert_eq!(est.entries, 1620);
+        assert_eq!(est.chunks_at_least, 2100);
+        assert_eq!(est.current_model, DEMO_EMBEDDING_MODEL);
+    }
+
+    #[tokio::test]
+    async fn status_is_null_until_a_rebuild_starts_then_carries_what_the_window_reads() {
+        let url = brain();
+        let before = crate::migration::fetch_status(&url, "demo", Locale::En).await.expect("status");
+        assert!(before["state"].is_null(), "no rebuild has ever been started");
+        assert_eq!(before["model"], json!(DEMO_EMBEDDING_MODEL));
+
+        crate::migration::run_batch(&url, "demo", Locale::En).await.expect("batch");
+
+        let after = crate::migration::fetch_status(&url, "demo", Locale::En).await.expect("status");
+        let state = &after["state"];
+        assert!(!state.is_null(), "a started rebuild must be on record");
+        // The keys installer/src/settings.ts reads off MigrationRun.
+        for key in ["model", "processed", "failed", "totalAtStart", "cursorId"] {
+            assert!(state.get(key).is_some(), "the window reads state.{key}, which is absent");
+        }
+        assert!(
+            state.get("finishedAt").is_none(),
+            "an unfinished rebuild must not look finished"
+        );
+    }
+
+    /// The rebuild has to take many batches, or the progress bar and the k-of-n
+    /// counter are never exercised by a demo.
+    #[tokio::test]
+    async fn a_rebuild_takes_many_batches_and_only_finishes_once_nothing_is_left() {
+        let url = brain();
+        let mut batches = 0;
+        let mut last_remaining = u64::MAX;
+        let mut processed_total = 0;
+        loop {
+            let p = crate::migration::run_batch(&url, "demo", Locale::En).await.expect("batch");
+            batches += 1;
+            assert!(!p.stalled, "the default demo must run to completion");
+            assert_eq!(p.total, 1620, "the bar counts up to the owner's brain size");
+            assert!(
+                p.remaining < last_remaining,
+                "progress must advance: {} then {}",
+                last_remaining,
+                p.remaining
+            );
+            last_remaining = p.remaining;
+            processed_total += p.processed;
+            if p.done {
+                assert_eq!(p.remaining, 0, "done must never be true with work left");
+                break;
+            }
+            assert!(p.remaining > 0, "remaining reached 0 without done being set");
+            assert!(batches < 500, "runaway loop");
+        }
+        assert!(batches > 10, "a one-batch rebuild proves nothing, got {batches}");
+        assert_eq!(processed_total, 1620, "every entry must be accounted for");
+
+        let status = crate::migration::fetch_status(&url, "demo", Locale::En).await.expect("status");
+        assert!(
+            status["state"]["finishedAt"].is_u64(),
+            "a completed rebuild must be recorded as finished"
+        );
+    }
+
+    /// The "Paused for today" screen, which is otherwise untestable. Progress is
+    /// kept, and resuming carries on rather than pausing again.
+    #[tokio::test]
+    async fn the_stall_gate_pauses_once_with_progress_kept_then_resumes_to_completion() {
+        let url = brain_with(Options {
+            batch_pause: Duration::ZERO,
+            stall_after: Some(3),
+            ..Options::default()
+        });
+
+        let mut before = 0;
+        for _ in 0..3 {
+            let p = crate::migration::run_batch(&url, "demo", Locale::En).await.expect("batch");
+            assert!(!p.stalled);
+            before = ENTRIES - p.remaining;
+        }
+        assert!(before > 0, "there must be progress to keep");
+
+        let paused = crate::migration::run_batch(&url, "demo", Locale::En).await.expect("batch");
+        assert!(paused.stalled, "the fourth batch must pause");
+        assert!(!paused.done);
+        assert_eq!(paused.processed, 0, "a paused batch achieves nothing");
+        assert_eq!(
+            ENTRIES - paused.remaining,
+            before,
+            "pausing must keep the cursor, not lose it"
+        );
+
+        // Resume: one pause per demo, so the rest of the rebuild completes.
+        let mut batches = 0;
+        loop {
+            let p = crate::migration::run_batch(&url, "demo", Locale::En).await.expect("batch");
+            batches += 1;
+            assert!(!p.stalled, "resuming must not pause again");
+            if p.done {
+                break;
+            }
+            assert!(batches < 500, "runaway loop");
+        }
+    }
+
+    #[tokio::test]
+    async fn reset_clears_the_ledger_so_status_reads_null_again() {
+        let url = brain();
+        crate::migration::run_batch(&url, "demo", Locale::En).await.expect("batch");
+        crate::migration::reset(&url, "demo", Locale::En).await.expect("reset");
+        let status = crate::migration::fetch_status(&url, "demo", Locale::En).await.expect("status");
+        assert!(status["state"].is_null(), "the ledger must be gone");
+    }
+
+    /// A target change mid-run invalidates the cursor: the entries behind it hold
+    /// vectors from the previous model. `runBatch` restarts, and so must this.
+    #[tokio::test]
+    async fn changing_the_target_model_restarts_the_rebuild() {
+        let url = brain();
+        for _ in 0..3 {
+            crate::migration::run_batch(&url, "demo", Locale::En).await.expect("batch");
+        }
+        let partway = crate::migration::run_batch(&url, "demo", Locale::En).await.expect("batch");
+        assert!(partway.remaining < ENTRIES);
+
+        crate::migration::patch_embedding_model(&url, "demo", "@cf/baai/bge-base-en-v1.5", Locale::En)
+            .await
+            .expect("model write");
+
+        let restarted = crate::migration::run_batch(&url, "demo", Locale::En).await.expect("batch");
+        assert_eq!(
+            restarted.remaining,
+            ENTRIES - restarted.processed,
+            "a new target must rebuild from the beginning"
+        );
+
+        let status = crate::migration::fetch_status(&url, "demo", Locale::En).await.expect("status");
+        assert_eq!(status["state"]["model"], json!("@cf/baai/bge-base-en-v1.5"));
+        assert_eq!(status["model"], json!("@cf/baai/bge-base-en-v1.5"));
+    }
+
+    /// The estimate follows the config, so the migration pane reflects a model
+    /// change instead of showing the old one forever.
+    #[tokio::test]
+    async fn the_estimate_follows_the_model_in_force() {
+        let url = brain();
+        crate::migration::patch_embedding_model(&url, "demo", "@cf/baai/bge-large-en-v1.5", Locale::En)
+            .await
+            .expect("model write");
+        let est = crate::migration::fetch_estimate(&url, "demo", Locale::En).await.expect("estimate");
+        assert_eq!(est.current_model, "@cf/baai/bge-large-en-v1.5");
+    }
+
+    // ── Everything else that must not break ─────────────────────────────────
+
+    #[tokio::test]
+    async fn health_answers_the_shape_the_version_check_reads() {
+        let url = brain();
+        let (status, body) = get(&url, "/health").await;
+        assert_eq!(status, 200);
+        assert_eq!(body["ok"], json!(true));
+        assert!(body["version"].is_string(), "the update check reads version");
+        assert_eq!(body["vectorize"]["ok"], json!(true));
+        assert_eq!(
+            body["vectorize"]["indexName"],
+            json!(crate::worker_bundle::manifest().vectorize_name)
+        );
+    }
+
+    /// Health names the index the brain is actually reading, so a demo migration
+    /// changes it the way a real one does.
+    #[tokio::test]
+    async fn health_names_the_index_the_current_model_implies() {
+        let url = brain();
+        crate::migration::patch_embedding_model(&url, "demo", "@cf/baai/bge-base-en-v1.5", Locale::En)
+            .await
+            .expect("model write");
+        let (_, body) = get(&url, "/health").await;
+        assert_eq!(body["vectorize"]["dimensions"], json!(768));
+        assert!(
+            body["vectorize"]["indexName"].as_str().expect("string").ends_with("-768"),
+            "got {}",
+            body["vectorize"]["indexName"]
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unknown_route_is_a_404_the_way_the_worker_answers_one() {
+        let url = brain();
+        let (status, _) = post(&url, "/nope").await;
+        assert_eq!(status, 404);
+    }
+
+    #[tokio::test]
+    async fn a_query_string_does_not_stop_a_route_matching() {
+        let url = brain();
+        let (status, body) = get(&url, "/config?t=1").await;
+        assert_eq!(status, 200);
+        assert!(body["config"].is_object());
+    }
+
+    /// `dashboard_credentials` hands this address to the wrapper window too, so
+    /// opening the dashboard in demo mode must land on something, not a blank
+    /// page.
+    #[tokio::test]
+    async fn the_root_serves_a_page_for_the_dashboard_window() {
+        let url = brain();
+        let resp = reqwest::Client::new().get(&url).send().await.expect("request");
+        assert_eq!(resp.status().as_u16(), 200);
+        let body = resp.text().await.expect("body");
+        assert!(body.contains("Demo brain"), "got: {body}");
+    }
+
+    #[test]
+    fn the_stall_gate_is_off_unless_the_env_var_names_a_batch_count() {
+        assert_eq!(parse_stall_after(None), None);
+        assert_eq!(parse_stall_after(Some("")), None);
+        assert_eq!(parse_stall_after(Some("nonsense")), None);
+        // 0 would pause before any progress exists to resume from.
+        assert_eq!(parse_stall_after(Some("0")), None);
+        assert_eq!(parse_stall_after(Some("3")), Some(3));
+        assert_eq!(parse_stall_after(Some(" 3 ")), Some(3));
+    }
+
+    #[test]
+    fn the_cursor_advances_forwards_through_time() {
+        let now = 1_700_000_000_000;
+        let first = cursor_time(20, ENTRIES, now);
+        let later = cursor_time(1600, ENTRIES, now);
+        assert!(first < later, "{first} !< {later}");
+        assert!(later <= now, "the cursor cannot reach into the future");
+        // Must not divide by zero on an empty brain.
+        assert!(cursor_time(0, 0, now) <= now);
+    }
+
+    /// Demo mode asks for this address before any window opens, and must never
+    /// be handed one with nothing behind it.
+    #[tokio::test]
+    async fn base_url_hands_out_a_running_server() {
+        let url = base_url();
+        assert!(url.starts_with("http://127.0.0.1:"), "got {url}");
+        assert_eq!(url, base_url(), "the address must be stable across calls");
+        let (status, body) = get(&url, "/config").await;
+        assert_eq!(status, 200, "base_url returned an address nothing is serving");
+        assert!(body["config"].is_object());
+    }
+}

--- a/installer/src-tauri/src/demo_brain.rs
+++ b/installer/src-tauri/src/demo_brain.rs
@@ -771,7 +771,7 @@ mod tests {
     #[tokio::test]
     async fn the_estimate_reports_a_plausible_brain_through_the_apps_own_parser() {
         let url = brain();
-        let est = crate::migration::fetch_estimate(&url, "demo", Locale::En)
+        let est = crate::migration::fetch_estimate(&url, "demo", 384, Locale::En)
             .await
             .expect("estimate");
         // Pinned as literals, not against the constants: comparing a constant to
@@ -927,7 +927,7 @@ mod tests {
         crate::migration::patch_embedding_model(&url, "demo", "@cf/baai/bge-large-en-v1.5", Locale::En)
             .await
             .expect("model write");
-        let est = crate::migration::fetch_estimate(&url, "demo", Locale::En).await.expect("estimate");
+        let est = crate::migration::fetch_estimate(&url, "demo", 384, Locale::En).await.expect("estimate");
         assert_eq!(est.current_model, "@cf/baai/bge-large-en-v1.5");
     }
 

--- a/installer/src-tauri/src/i18n.rs
+++ b/installer/src-tauri/src/i18n.rs
@@ -111,7 +111,9 @@ pub enum Key {
     ErrorCfAccountListFailed,
     ErrorBrainNeedsUpdateForMigration,
     ErrorUnknownEmbeddingModel,
+    ErrorMigrationHalfSwitched,
     ErrorCannotDeleteLiveIndex,
+    ErrorNoOldIndexToFree,
     ErrorCfNoSubdomain,
     ErrorCfDiscoverFailed,
     ErrorChoosePasswordFirst,
@@ -237,8 +239,16 @@ pub fn t(locale: Locale, key: Key) -> &'static str {
         (Locale::En, Key::ErrorCfAccountListFailed) => {
             "Signed in, but we couldn't read your account. Please try again."
         }
+        (Locale::En, Key::ErrorMigrationHalfSwitched) => {
+            "Your Second Brain has switched to the new way of reading, but finishing the \
+switch didn't complete. Your memories are safe and nothing was deleted — reopen this \
+window and carry on, or search will stay incomplete."
+        }
         (Locale::En, Key::ErrorUnknownEmbeddingModel) => {
             "That isn't a way of reading memories this app knows how to set up."
+        }
+        (Locale::En, Key::ErrorNoOldIndexToFree) => {
+            "There's no leftover search data to free up. Nothing was changed."
         }
         (Locale::En, Key::ErrorCannotDeleteLiveIndex) => {
             "That's the search data your Second Brain is using right now, so it can't be \
@@ -391,8 +401,16 @@ Second Brain's address by hand instead."
         (Locale::It, Key::ErrorCfAccountListFailed) => {
             "Accesso effettuato, ma non è stato possibile leggere l'account. Riprova."
         }
+        (Locale::It, Key::ErrorMigrationHalfSwitched) => {
+            "Il tuo Second Brain è passato al nuovo modo di leggere, ma il passaggio non è \
+stato completato. I tuoi ricordi sono al sicuro e nulla è stato cancellato — riapri questa \
+finestra e continua, altrimenti la ricerca resterà incompleta."
+        }
         (Locale::It, Key::ErrorUnknownEmbeddingModel) => {
             "Non è un modo di leggere i ricordi che questa app sappia configurare."
+        }
+        (Locale::It, Key::ErrorNoOldIndexToFree) => {
+            "Non ci sono vecchi dati di ricerca da liberare. Nulla è stato modificato."
         }
         (Locale::It, Key::ErrorCannotDeleteLiveIndex) => {
             "Sono i dati di ricerca che il tuo Second Brain sta usando in questo momento, \
@@ -547,7 +565,9 @@ mod tests {
             ErrorCfSignInExpired,
             ErrorBrainNeedsUpdateForMigration,
             ErrorUnknownEmbeddingModel,
+            ErrorMigrationHalfSwitched,
             ErrorCannotDeleteLiveIndex,
+            ErrorNoOldIndexToFree,
             ErrorCfNoSubdomain,
             ErrorCfDiscoverFailed,
             ErrorNotionSynced,

--- a/installer/src-tauri/src/i18n.rs
+++ b/installer/src-tauri/src/i18n.rs
@@ -109,6 +109,9 @@ pub enum Key {
     ErrorNotionSynced,
     ErrorNotionUpToDate,
     ErrorCfAccountListFailed,
+    ErrorBrainNeedsUpdateForMigration,
+    ErrorUnknownEmbeddingModel,
+    ErrorCannotDeleteLiveIndex,
     ErrorCfNoSubdomain,
     ErrorCfDiscoverFailed,
     ErrorChoosePasswordFirst,
@@ -233,6 +236,17 @@ pub fn t(locale: Locale, key: Key) -> &'static str {
         (Locale::En, Key::ErrorNotionUpToDate) => "Notion is already up to date.",
         (Locale::En, Key::ErrorCfAccountListFailed) => {
             "Signed in, but we couldn't read your account. Please try again."
+        }
+        (Locale::En, Key::ErrorUnknownEmbeddingModel) => {
+            "That isn't a way of reading memories this app knows how to set up."
+        }
+        (Locale::En, Key::ErrorCannotDeleteLiveIndex) => {
+            "That's the search data your Second Brain is using right now, so it can't be \
+freed up. Nothing was changed."
+        }
+        (Locale::En, Key::ErrorBrainNeedsUpdateForMigration) => {
+            "Your Second Brain needs updating before it can change how it reads memories. \
+Update it first, then try again."
         }
         (Locale::En, Key::ErrorCfNoSubdomain) => {
             "We couldn't work out the web address for this Cloudflare space, so there's \
@@ -377,6 +391,17 @@ Second Brain's address by hand instead."
         (Locale::It, Key::ErrorCfAccountListFailed) => {
             "Accesso effettuato, ma non è stato possibile leggere l'account. Riprova."
         }
+        (Locale::It, Key::ErrorUnknownEmbeddingModel) => {
+            "Non è un modo di leggere i ricordi che questa app sappia configurare."
+        }
+        (Locale::It, Key::ErrorCannotDeleteLiveIndex) => {
+            "Sono i dati di ricerca che il tuo Second Brain sta usando in questo momento, \
+quindi non possono essere liberati. Nulla è stato modificato."
+        }
+        (Locale::It, Key::ErrorBrainNeedsUpdateForMigration) => {
+            "Il tuo Second Brain va aggiornato prima di poter cambiare il modo in cui legge \
+i ricordi. Aggiornalo, poi riprova."
+        }
         (Locale::It, Key::ErrorCfNoSubdomain) => {
             "Non siamo riusciti a determinare l'indirizzo web di questo spazio Cloudflare, \
 quindi non c'è nulla da cercare. Puoi comunque inserire a mano l'indirizzo del tuo Second Brain."
@@ -520,6 +545,9 @@ mod tests {
             ErrorCfNoAccount,
             ErrorCfSignInFirst,
             ErrorCfSignInExpired,
+            ErrorBrainNeedsUpdateForMigration,
+            ErrorUnknownEmbeddingModel,
+            ErrorCannotDeleteLiveIndex,
             ErrorCfNoSubdomain,
             ErrorCfDiscoverFailed,
             ErrorNotionSynced,

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod commands;
 mod credits;
 mod i18n;
 mod mcp_config;
+mod migration;
 mod password_check;
 mod secure_store;
 mod settings;
@@ -165,6 +166,11 @@ pub fn run() {
             commands::connect_cloudflare,
             commands::connect_existing,
             commands::discover_brains,
+            commands::migration_estimate,
+            commands::migration_status,
+            commands::begin_embedding_migration,
+            commands::migration_step,
+            commands::finish_embedding_migration,
             commands::start_provisioning,
             commands::get_connection_details,
             commands::detect_tools,

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod cf;
 mod cli_config;
 mod commands;
 mod credits;
+mod demo_brain;
 mod i18n;
 mod mcp_config;
 mod migration;
@@ -135,6 +136,14 @@ pub fn run() {
 
     let dry_run = std::env::var("SECOND_BRAIN_DRY_RUN").is_ok();
 
+    // A demo has to have something to operate on. Started here rather than on
+    // first use so it is listening before any window can ask for it, and only in
+    // dry-run — a real run must never have a second brain on loopback that a
+    // stray address could reach.
+    if dry_run {
+        demo_brain::start();
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             for label in ["brain", "main", "details"] {
@@ -171,6 +180,8 @@ pub fn run() {
             commands::begin_embedding_migration,
             commands::migration_step,
             commands::finish_embedding_migration,
+            commands::migration_reset,
+            commands::outstanding_old_index,
             commands::start_provisioning,
             commands::get_connection_details,
             commands::detect_tools,

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -41,7 +41,12 @@ fn open_dashboard_from_menu(app: &AppHandle) {
                 .try_state::<AppLocale>()
                 .map(|l| l.get())
                 .unwrap_or(i18n::Locale::En);
-            if secure_store::load_setup().is_none() && !session.dry_run {
+            // dry_run first: `&&` is short-circuiting, so testing it second
+            // still performs the keychain read, and every read can raise an OS
+            // password prompt on an unsigned dev build. This fired at startup,
+            // before any window opened, which is why demo mode has always asked
+            // for the login keychain.
+            if !session.dry_run && secure_store::load_setup().is_none() {
                 let _ = windows::open_setup_window(app);
             } else {
                 app.dialog()

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ mod settings;
 mod version;
 mod windows;
 mod worker_bundle;
+mod worker_url;
 
 use app_menus::{build_menu_items, build_tray_items, install_app_menu, install_tray, AppMenus};
 use commands::SetupSession;

--- a/installer/src-tauri/src/migration.rs
+++ b/installer/src-tauri/src/migration.rs
@@ -291,6 +291,65 @@ mod tests {
         assert_eq!(a, b);
     }
 
+    /// The webview reads these keys by name. Nothing else can catch a rename
+    /// across that boundary: Rust renames the field, `serde` happily emits the new
+    /// key, `tsc` type-checks the TypeScript against its own interface, and the
+    /// mismatch only appears as a blank screen at runtime.
+    ///
+    /// Asserted against the literal strings `installer/src/settings.ts` reads.
+    #[test]
+    fn the_estimate_serialises_the_keys_the_window_reads() {
+        let est = MigrationEstimate {
+            entries: 1620,
+            chunks_at_least: 2100,
+            current_model: "@cf/baai/bge-small-en-v1.5".into(),
+            models: EMBEDDING_MODELS.to_vec(),
+        };
+        let json = serde_json::to_value(&est).expect("serialises");
+
+        for key in ["entries", "chunksAtLeast", "currentModel", "models"] {
+            assert!(json.get(key).is_some(), "the window reads {key}, which is absent");
+        }
+        // The picker needs [id, dimensions] pairs, and orders by dimensions.
+        let first = &json["models"][0];
+        assert!(first[0].is_string(), "model id must be a string");
+        assert!(first[1].is_u64(), "dimensions must be a number");
+    }
+
+    #[test]
+    fn a_batch_serialises_the_keys_the_progress_bar_reads() {
+        let json = serde_json::to_value(BatchProgress::default()).expect("serialises");
+        // `remaining` and `total` are the two the bar is computed from; `stalled`
+        // is what stops the loop. A missing `stalled` would loop forever against
+        // a Worker that has given up.
+        for key in ["processed", "failed", "remaining", "total", "done", "stalled"] {
+            assert!(json.get(key).is_some(), "the window reads {key}, which is absent");
+        }
+    }
+
+    /// Every key above, checked against the file that reads them, so adding a
+    /// field to the struct without the window knowing is visible here too.
+    #[test]
+    fn the_window_really_reads_those_keys() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../src/settings.ts");
+        let ui = std::fs::read_to_string(path).expect("read settings.ts");
+        for key in ["chunksAtLeast", "currentModel", "oldDimensions"] {
+            assert!(ui.contains(key), "settings.ts no longer reads {key}");
+        }
+        for command in [
+            "migration_estimate",
+            "migration_status",
+            "migration_step",
+            "begin_embedding_migration",
+            "finish_embedding_migration",
+        ] {
+            assert!(
+                ui.contains(&format!("\"{command}\"")),
+                "settings.ts no longer calls {command}"
+            );
+        }
+    }
+
     // ── HTTP ────────────────────────────────────────────────────────────────
     //
     // Against a real tiny_http server, matching the convention in settings.rs

--- a/installer/src-tauri/src/migration.rs
+++ b/installer/src-tauri/src/migration.rs
@@ -42,17 +42,37 @@ const TIMEOUT: Duration = Duration::from_secs(120);
 /// Only models whose dimensions are documented are listed. A model whose
 /// dimension count we would have to guess cannot be offered: guessing wrong
 /// creates an index that rejects every vector.
-pub const EMBEDDING_MODELS: &[(&str, u32)] = &[
-    ("@cf/baai/bge-small-en-v1.5", 384),
-    ("@cf/baai/bge-base-en-v1.5", 768),
-    ("@cf/baai/bge-large-en-v1.5", 1024),
+pub const EMBEDDING_MODELS: &[EmbeddingChoice] = &[
+    EmbeddingChoice { model: "@cf/baai/bge-small-en-v1.5", dimensions: 384, level: "standard" },
+    EmbeddingChoice { model: "@cf/baai/bge-base-en-v1.5", dimensions: 768, level: "finer" },
+    EmbeddingChoice { model: "@cf/baai/bge-large-en-v1.5", dimensions: 1024, level: "finest" },
 ];
+
+/// One offerable way of reading memories.
+///
+/// `level` is a copy key, not a label: the window looks it up in its own catalogue
+/// so the choice reads as "Standard / Finer / Finest" rather than as a model id.
+/// That matches the named-level pattern every other control in the same window
+/// uses, and it matters more here — this is the last thing read before a one-way
+/// operation, and asking someone to reason about the position of an opaque string
+/// in a list is not a choice they can make well.
+///
+/// `dimensions` deliberately never reaches the screen. It exists to size the
+/// index and to order the list.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EmbeddingChoice {
+    pub model: &'static str,
+    #[serde(skip)]
+    pub dimensions: u32,
+    pub level: &'static str,
+}
 
 pub fn dimensions_for(model: &str) -> Option<u32> {
     EMBEDDING_MODELS
         .iter()
-        .find(|(m, _)| *m == model)
-        .map(|(_, d)| *d)
+        .find(|c| c.model == model)
+        .map(|c| c.dimensions)
 }
 
 /// The index a given dimension count lives in.
@@ -81,8 +101,8 @@ pub struct MigrationEstimate {
     /// the UI says "at least" rather than implying precision it does not have.
     pub chunks_at_least: u64,
     pub current_model: String,
-    /// Model id and dimensions, for the picker.
-    pub models: Vec<(&'static str, u32)>,
+    /// The choices the picker offers, ordered coarsest first.
+    pub models: Vec<EmbeddingChoice>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -101,10 +121,18 @@ pub struct BatchProgress {
     pub remaining: u64,
     pub total: u64,
     pub done: bool,
-    /// The Worker stopped because a batch achieved nothing — almost always the
-    /// day's model budget. The cursor is kept, so resuming later costs nothing
-    /// already paid for.
+    /// The Worker stopped because a batch achieved nothing. The cursor is kept,
+    /// so resuming later costs nothing already paid for.
     pub stalled: bool,
+    /// Why it stopped: `"budget"` when the day's allowance looks spent, or
+    /// `"failing"` when an entry keeps failing for some other reason.
+    ///
+    /// The distinction is the difference between "come back tomorrow" and "come
+    /// back tomorrow forever": a persistently failing entry sits at the cursor and
+    /// makes every future batch achieve nothing, so telling that user to wait for
+    /// an allowance reset would be advice that can never work.
+    #[serde(default)]
+    pub stalled_reason: Option<String>,
 }
 
 async fn get_json<T: serde::de::DeserializeOwned>(
@@ -239,11 +267,29 @@ mod tests {
         // A model whose dimension count we had to guess cannot be offered:
         // guessing wrong creates an index that rejects every vector written to
         // it, and the index cannot be altered afterwards.
-        for (model, dims) in EMBEDDING_MODELS {
+        for choice in EMBEDDING_MODELS {
+            let EmbeddingChoice { model, dimensions, level } = choice;
             assert!(model.starts_with("@cf/"), "{model} is not a Workers AI id");
-            assert!(*dims > 0, "{model} has no dimensions");
-            assert_eq!(dimensions_for(model), Some(*dims));
+            assert!(*dimensions > 0, "{model} has no dimensions");
+            assert_eq!(dimensions_for(model), Some(*dimensions));
+            // Every choice needs a named level, or the window falls back to
+            // showing the raw model id at the moment of commitment.
+            assert!(!level.is_empty(), "{model} has no named level");
         }
+
+        // Coarsest first, so "further down the list reads in finer detail" is
+        // true rather than aspirational.
+        let sizes: Vec<u32> = EMBEDDING_MODELS.iter().map(|c| c.dimensions).collect();
+        let mut sorted = sizes.clone();
+        sorted.sort();
+        assert_eq!(sizes, sorted, "the picker's order must ascend by detail");
+
+        // Distinct levels, or two choices render identically.
+        let mut levels: Vec<&str> = EMBEDDING_MODELS.iter().map(|c| c.level).collect();
+        levels.sort();
+        let before = levels.len();
+        levels.dedup();
+        assert_eq!(levels.len(), before, "two choices share a level name");
     }
 
     #[test]
@@ -310,10 +356,16 @@ mod tests {
         for key in ["entries", "chunksAtLeast", "currentModel", "models"] {
             assert!(json.get(key).is_some(), "the window reads {key}, which is absent");
         }
-        // The picker needs [id, dimensions] pairs, and orders by dimensions.
+        // The picker reads a named level per choice. Dimensions must NOT be in
+        // the payload: they are an implementation detail, and putting a number
+        // like 768 on the decision screen is what the named level replaces.
         let first = &json["models"][0];
-        assert!(first[0].is_string(), "model id must be a string");
-        assert!(first[1].is_u64(), "dimensions must be a number");
+        assert!(first["model"].is_string(), "model id must be present for auditing");
+        assert!(first["level"].is_string(), "each choice needs a named level");
+        assert!(
+            first.get("dimensions").is_none(),
+            "dimensions must not reach the window: {first}"
+        );
     }
 
     #[test]

--- a/installer/src-tauri/src/migration.rs
+++ b/installer/src-tauri/src/migration.rs
@@ -31,6 +31,20 @@ use std::time::Duration;
 /// Longer than the settings calls: a re-embed batch does real model work.
 const TIMEOUT: Duration = Duration::from_secs(120);
 
+/// What the Workers Free plan allows to be stored, counted in vector dimensions
+/// across the account.
+///
+/// This is a ceiling, not a cost: Cloudflare bills paid accounts for dimensions
+/// stored and queried, but a free account that reaches this limit starts failing
+/// writes, because there is no billing to absorb the overage. So it is worth
+/// warning about before someone chooses an option that would cross it — the
+/// finest reading is exactly the choice that can, and it is the one the window
+/// invites them to make.
+///
+/// Deliberately not counting the number of indexes: Cloudflare does not bill for
+/// those, and the free plan allows a hundred.
+const FREE_STORED_DIMENSIONS: u64 = 5_000_000;
+
 /// Embedding models offered, with the dimensions each produces.
 ///
 /// A curated list rather than a live catalogue fetch, for the same reason
@@ -102,7 +116,43 @@ pub struct MigrationEstimate {
     pub chunks_at_least: u64,
     pub current_model: String,
     /// The choices the picker offers, ordered coarsest first.
-    pub models: Vec<EmbeddingChoice>,
+    pub models: Vec<ChoiceView>,
+}
+
+/// A choice as the window sees it: what it is called, and whether taking it would
+/// cost more storage than a free account is allowed.
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChoiceView {
+    pub model: &'static str,
+    pub level: &'static str,
+    /// True when rebuilding into this option would exceed the free plan's
+    /// storage allowance.
+    ///
+    /// Measured at the *peak*, which is during the rebuild rather than after it:
+    /// the old index is deliberately kept until the user frees it, so both are
+    /// stored at once. That peak is what fails first.
+    pub exceeds_free_storage: bool,
+}
+
+/// Dimensions stored while moving from one reading to another.
+///
+/// Both indexes exist for the length of the rebuild — that is the design, and it
+/// is what makes rollback possible — so the peak is the sum, not the larger.
+/// Returns the target's own cost when it is already the current one, since then
+/// there is nothing to move.
+pub fn peak_stored_dimensions(vectors: u64, current: u32, target: u32) -> u64 {
+    if current == target {
+        return vectors * u64::from(target);
+    }
+    vectors * u64::from(current) + vectors * u64::from(target)
+}
+
+/// Only this brain's own indexes are counted. An account may hold others from
+/// unrelated projects, so a `false` here means "this brain alone stays inside the
+/// allowance", not "you are definitely fine".
+pub fn exceeds_free_storage(vectors: u64, current: u32, target: u32) -> bool {
+    peak_stored_dimensions(vectors, current, target) > FREE_STORED_DIMENSIONS
 }
 
 #[derive(Debug, Deserialize)]
@@ -193,15 +243,35 @@ async fn send_json<T: serde::de::DeserializeOwned>(
 pub async fn fetch_estimate(
     worker_url: &str,
     auth_token: &str,
+    shipped_dimensions: u32,
     locale: Locale,
 ) -> Result<MigrationEstimate, String> {
     let body: EstimateBody =
         get_json(worker_url, auth_token, "/migration/estimate", locale).await?;
+
+    // A brain running a reading this build does not list still has vectors of
+    // some size; fall back to what this build ships with rather than assuming
+    // zero, which would make every option look free.
+    let current_dimensions = dimensions_for(&body.model).unwrap_or(shipped_dimensions);
+
+    let models = EMBEDDING_MODELS
+        .iter()
+        .map(|c| ChoiceView {
+            model: c.model,
+            level: c.level,
+            exceeds_free_storage: exceeds_free_storage(
+                body.chunks_at_least,
+                current_dimensions,
+                c.dimensions,
+            ),
+        })
+        .collect();
+
     Ok(MigrationEstimate {
         entries: body.entries,
         chunks_at_least: body.chunks_at_least,
         current_model: body.model,
-        models: EMBEDDING_MODELS.to_vec(),
+        models,
     })
 }
 
@@ -349,7 +419,14 @@ mod tests {
             entries: 1620,
             chunks_at_least: 2100,
             current_model: "@cf/baai/bge-small-en-v1.5".into(),
-            models: EMBEDDING_MODELS.to_vec(),
+            models: EMBEDDING_MODELS
+                .iter()
+                .map(|c| ChoiceView {
+                    model: c.model,
+                    level: c.level,
+                    exceeds_free_storage: false,
+                })
+                .collect(),
         };
         let json = serde_json::to_value(&est).expect("serialises");
 
@@ -362,6 +439,10 @@ mod tests {
         let first = &json["models"][0];
         assert!(first["model"].is_string(), "model id must be present for auditing");
         assert!(first["level"].is_string(), "each choice needs a named level");
+        assert!(
+            first["exceedsFreeStorage"].is_boolean(),
+            "each choice must say whether it would exceed the free storage allowance"
+        );
         assert!(
             first.get("dimensions").is_none(),
             "dimensions must not reach the window: {first}"
@@ -413,6 +494,63 @@ mod tests {
                 "settings.ts no longer calls {command}"
             );
         }
+    }
+
+    /// Both indexes are stored during a rebuild — that is what makes rollback
+    /// possible — so the peak is the sum, and the peak is what fails first on a
+    /// free account.
+    #[test]
+    fn the_storage_peak_counts_both_indexes_at_once() {
+        // 2,100 vectors moving 384 → 768.
+        assert_eq!(peak_stored_dimensions(2_100, 384, 768), 2_419_200);
+        // Staying put stores one index, not two.
+        assert_eq!(peak_stored_dimensions(2_100, 384, 384), 806_400);
+    }
+
+    /// Rahil's brain: ~1,620 memories, ~2,100 vectors. Every option fits, which
+    /// is the case this feature actually ships into.
+    #[test]
+    fn a_typical_brain_stays_inside_the_free_allowance() {
+        for target in [384u32, 768, 1024] {
+            assert!(
+                !exceeds_free_storage(2_100, 384, target),
+                "2,100 vectors → {target} dims should fit in the free allowance"
+            );
+        }
+    }
+
+    /// The case worth warning about: the finest reading is what crosses the line
+    /// first, and it is the option the window invites the user to choose.
+    #[test]
+    fn a_large_brain_is_warned_before_choosing_the_finest_reading() {
+        // ~6,000 vectors: 384 + 1024 = 8.4M dimensions at the peak, past 5M.
+        assert!(exceeds_free_storage(6_000, 384, 1024));
+        // The same brain moving to the middle option: 384 + 768 = 6.9M, also past.
+        assert!(exceeds_free_storage(6_000, 384, 768));
+        // And staying put is fine, so the warning is about the move, not the size.
+        assert!(!exceeds_free_storage(6_000, 384, 384));
+    }
+
+    #[test]
+    fn the_boundary_is_exclusive_so_exactly_the_allowance_is_allowed() {
+        // 5,000,000 dimensions exactly: allowed. One more: not.
+        // Same reading on both sides, so the peak is vectors × dimensions.
+        assert!(!exceeds_free_storage(5_000_000, 1, 1));
+        assert!(exceeds_free_storage(5_000_001, 1, 1));
+    }
+
+    /// The window is told per choice, so it can mark the specific option that
+    /// would cross the line rather than warning about the whole feature.
+    #[test]
+    fn each_choice_carries_its_own_storage_verdict() {
+        let view = ChoiceView {
+            model: "@cf/baai/bge-large-en-v1.5",
+            level: "finest",
+            exceeds_free_storage: true,
+        };
+        let json = serde_json::to_value(&view).unwrap();
+        assert_eq!(json["exceedsFreeStorage"], true);
+        assert!(json.get("dimensions").is_none(), "dimensions must stay out of the window");
     }
 
     // ── HTTP ────────────────────────────────────────────────────────────────
@@ -468,7 +606,7 @@ mod tests {
     #[tokio::test]
     async fn the_estimate_carries_the_models_the_picker_needs() {
         let (url, seen) = spawn_worker(200);
-        let est = fetch_estimate(&url, "tok", Locale::En).await.expect("estimate");
+        let est = fetch_estimate(&url, "tok", 384, Locale::En).await.expect("estimate");
 
         assert_eq!(est.entries, 1620);
         assert_eq!(est.chunks_at_least, 2100);
@@ -497,7 +635,7 @@ mod tests {
     #[tokio::test]
     async fn an_older_brain_is_told_to_update_rather_than_shown_a_404() {
         let (url, _) = spawn_worker(404);
-        let err = fetch_estimate(&url, "tok", Locale::En).await.unwrap_err();
+        let err = fetch_estimate(&url, "tok", 384, Locale::En).await.unwrap_err();
         assert_eq!(
             err,
             i18n::t(Locale::En, Key::ErrorBrainNeedsUpdateForMigration)
@@ -508,7 +646,7 @@ mod tests {
     #[tokio::test]
     async fn a_server_error_does_not_leak_a_raw_body() {
         let (url, _) = spawn_worker(500);
-        let err = fetch_estimate(&url, "tok", Locale::En).await.unwrap_err();
+        let err = fetch_estimate(&url, "tok", 384, Locale::En).await.unwrap_err();
         assert!(err.contains("500"), "the status is useful here: {err}");
         assert!(!err.contains("{"), "leaked a response body: {err}");
     }
@@ -516,7 +654,7 @@ mod tests {
     #[tokio::test]
     async fn an_unreachable_brain_says_so() {
         // Nothing is listening on this port.
-        let err = fetch_estimate("http://127.0.0.1:1", "tok", Locale::En)
+        let err = fetch_estimate("http://127.0.0.1:1", "tok", 384, Locale::En)
             .await
             .unwrap_err();
         assert_eq!(err, i18n::t(Locale::En, Key::ErrorReachBrain));
@@ -525,7 +663,7 @@ mod tests {
     #[tokio::test]
     async fn a_trailing_slash_in_the_stored_address_does_not_double_up() {
         let (url, seen) = spawn_worker(200);
-        fetch_estimate(&format!("{url}/"), "tok", Locale::En)
+        fetch_estimate(&format!("{url}/"), "tok", 384, Locale::En)
             .await
             .expect("estimate");
         let log = seen.lock().unwrap();

--- a/installer/src-tauri/src/migration.rs
+++ b/installer/src-tauri/src/migration.rs
@@ -385,15 +385,28 @@ mod tests {
     fn the_window_really_reads_those_keys() {
         let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../src/settings.ts");
         let ui = std::fs::read_to_string(path).expect("read settings.ts");
-        for key in ["chunksAtLeast", "currentModel", "oldDimensions"] {
+        for key in ["chunksAtLeast", "currentModel", "level", "stalledReason"] {
             assert!(ui.contains(key), "settings.ts no longer reads {key}");
         }
+        // The window must NOT deal in dimensions. They size the index and order
+        // the picker; putting a number like 768 on a decision screen is what the
+        // named levels replaced, and a browser-stored dimension count was how the
+        // target of an irreversible delete used to be identified.
+        assert!(
+            !ui.contains("oldDimensions"),
+            "settings.ts is tracking dimensions again — that belongs on the Rust side"
+        );
         for command in [
             "migration_estimate",
             "migration_status",
             "migration_step",
             "begin_embedding_migration",
             "finish_embedding_migration",
+            // The abandon path, which existed with no command exposing it until
+            // a review noticed, and the outstanding-index question the window
+            // asks instead of tracking sizes itself.
+            "migration_reset",
+            "outstanding_old_index",
         ] {
             assert!(
                 ui.contains(&format!("\"{command}\"")),

--- a/installer/src-tauri/src/migration.rs
+++ b/installer/src-tauri/src/migration.rs
@@ -1,0 +1,414 @@
+//! Driving an embedding-model change from the desktop app (#248).
+//!
+//! Switching models changes the vector dimensions, and a Vectorize index fixes
+//! its dimensions when it is created. The binding resolves an index by name at
+//! deploy time. So a model change is not a setting — it is: create a second
+//! index, point the binding at it, rebuild every vector, check the result, and
+//! only then drop the first one.
+//!
+//! The app owns this because only the app holds Cloudflare credentials. The
+//! Worker owns the rebuilding, behind `/migration/*`.
+//!
+//! # The order is the safety property
+//!
+//! Nothing is destroyed until the last step, and every step before it is
+//! reversible by redeploying against the old index, which is still there and
+//! still full. That is why deletion is a separate, explicitly confirmed act
+//! rather than the tail of a successful run.
+//!
+//! The model is written to the Worker's config *as part of* the redeploy rather
+//! than beforehand. Config lives in KV and takes effect on the next request, so
+//! writing it early would leave a window where the Worker embeds at the new
+//! dimensions against the old index — every capture in that window fails on
+//! upsert, and recall returns quiet nonsense. This is also why the model must
+//! never join the Advanced Settings save patch, where a click would apply it
+//! instantly.
+
+use crate::i18n::{self, Key, Locale};
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Longer than the settings calls: a re-embed batch does real model work.
+const TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Embedding models offered, with the dimensions each produces.
+///
+/// A curated list rather than a live catalogue fetch, for the same reason
+/// `LLM_MODELS` is curated: the panel has to render offline. Unlike `LLM_MODEL`
+/// though, a wrong value here is not survivable — the dimensions must match the
+/// index that gets created, so every entry carries its own rather than being
+/// looked up later.
+///
+/// Only models whose dimensions are documented are listed. A model whose
+/// dimension count we would have to guess cannot be offered: guessing wrong
+/// creates an index that rejects every vector.
+pub const EMBEDDING_MODELS: &[(&str, u32)] = &[
+    ("@cf/baai/bge-small-en-v1.5", 384),
+    ("@cf/baai/bge-base-en-v1.5", 768),
+    ("@cf/baai/bge-large-en-v1.5", 1024),
+];
+
+pub fn dimensions_for(model: &str) -> Option<u32> {
+    EMBEDDING_MODELS
+        .iter()
+        .find(|(m, _)| *m == model)
+        .map(|(_, d)| *d)
+}
+
+/// The index a given dimension count lives in.
+///
+/// The shipped index keeps its historical name so an existing brain is untouched
+/// by this feature; every other size gets a suffixed name. Deriving the name from
+/// the dimensions rather than the model means two models of the same size share
+/// an index, which is correct — the vectors are compatible.
+pub fn index_name_for(base: &str, dimensions: u32, shipped_dimensions: u32) -> String {
+    if dimensions == shipped_dimensions {
+        base.to_string()
+    } else {
+        format!("{base}-{dimensions}")
+    }
+}
+
+fn base(worker_url: &str) -> &str {
+    worker_url.trim_end_matches('/')
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MigrationEstimate {
+    pub entries: u64,
+    /// A lower bound. The chunker's sentence snapping can only produce more, so
+    /// the UI says "at least" rather than implying precision it does not have.
+    pub chunks_at_least: u64,
+    pub current_model: String,
+    /// Model id and dimensions, for the picker.
+    pub models: Vec<(&'static str, u32)>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EstimateBody {
+    entries: u64,
+    #[serde(rename = "chunksAtLeast")]
+    chunks_at_least: u64,
+    model: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchProgress {
+    pub processed: u64,
+    pub failed: u64,
+    pub remaining: u64,
+    pub total: u64,
+    pub done: bool,
+    /// The Worker stopped because a batch achieved nothing — almost always the
+    /// day's model budget. The cursor is kept, so resuming later costs nothing
+    /// already paid for.
+    pub stalled: bool,
+}
+
+async fn get_json<T: serde::de::DeserializeOwned>(
+    worker_url: &str,
+    auth_token: &str,
+    path: &str,
+    locale: Locale,
+) -> Result<T, String> {
+    send_json(reqwest::Client::new().get(format!("{}{path}", base(worker_url))), auth_token, locale)
+        .await
+}
+
+async fn post_json<T: serde::de::DeserializeOwned>(
+    worker_url: &str,
+    auth_token: &str,
+    path: &str,
+    locale: Locale,
+) -> Result<T, String> {
+    send_json(reqwest::Client::new().post(format!("{}{path}", base(worker_url))), auth_token, locale)
+        .await
+}
+
+async fn send_json<T: serde::de::DeserializeOwned>(
+    builder: reqwest::RequestBuilder,
+    auth_token: &str,
+    locale: Locale,
+) -> Result<T, String> {
+    let resp = builder
+        .bearer_auth(auth_token)
+        .timeout(TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| {
+            log::warn!("migration request failed: {e}");
+            i18n::t(locale, Key::ErrorReachBrain).to_string()
+        })?;
+
+    // The app and the Worker update independently, so a brain that predates
+    // these routes is the ordinary state for anyone who updated the app first.
+    // Say what to do, not what happened.
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(i18n::t(locale, Key::ErrorBrainNeedsUpdateForMigration).to_string());
+    }
+    if !resp.status().is_success() {
+        return Err(i18n::t_fmt(
+            locale,
+            Key::ErrorBrainHttpStatus,
+            &[("status", &resp.status().as_u16().to_string())],
+        ));
+    }
+    resp.json::<T>().await.map_err(|e| {
+        log::warn!("migration response was not the expected shape: {e}");
+        i18n::t(locale, Key::ErrorBrainUnexpected).to_string()
+    })
+}
+
+/// What a rebuild would cost, before anything is created.
+pub async fn fetch_estimate(
+    worker_url: &str,
+    auth_token: &str,
+    locale: Locale,
+) -> Result<MigrationEstimate, String> {
+    let body: EstimateBody =
+        get_json(worker_url, auth_token, "/migration/estimate", locale).await?;
+    Ok(MigrationEstimate {
+        entries: body.entries,
+        chunks_at_least: body.chunks_at_least,
+        current_model: body.model,
+        models: EMBEDDING_MODELS.to_vec(),
+    })
+}
+
+/// One re-embed batch. The caller loops while `remaining > 0`, stopping on
+/// `stalled`.
+pub async fn run_batch(
+    worker_url: &str,
+    auth_token: &str,
+    locale: Locale,
+) -> Result<BatchProgress, String> {
+    post_json(worker_url, auth_token, "/migration/reembed", locale).await
+}
+
+/// Where an interrupted rebuild got to, or `None` if this brain has never
+/// migrated.
+pub async fn fetch_status(
+    worker_url: &str,
+    auth_token: &str,
+    locale: Locale,
+) -> Result<serde_json::Value, String> {
+    get_json(worker_url, auth_token, "/migration/status", locale).await
+}
+
+/// Records the new model on the brain.
+///
+/// Lives here rather than in `settings.rs` on purpose. `apply_settings` sends one
+/// merged PATCH when the user clicks Save, and an embedding model in that patch
+/// would take effect the instant it is clicked — before any index exists to hold
+/// vectors of that size. Keeping the write in the migration module means the only
+/// path to it is the sequenced one.
+pub async fn patch_embedding_model(
+    worker_url: &str,
+    auth_token: &str,
+    model: &str,
+    locale: Locale,
+) -> Result<(), String> {
+    let body = serde_json::json!({ "EMBEDDING_MODEL": model });
+    let _: serde_json::Value = send_json(
+        reqwest::Client::new()
+            .patch(format!("{}/config", base(worker_url)))
+            .json(&body),
+        auth_token,
+        locale,
+    )
+    .await?;
+    Ok(())
+}
+
+/// Forget the ledger so the next batch starts from the beginning. Rebuilding is
+/// idempotent, so this costs model calls but cannot corrupt anything.
+pub async fn reset(worker_url: &str, auth_token: &str, locale: Locale) -> Result<(), String> {
+    let _: serde_json::Value =
+        post_json(worker_url, auth_token, "/migration/reset", locale).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_offered_model_declares_its_dimensions() {
+        // A model whose dimension count we had to guess cannot be offered:
+        // guessing wrong creates an index that rejects every vector written to
+        // it, and the index cannot be altered afterwards.
+        for (model, dims) in EMBEDDING_MODELS {
+            assert!(model.starts_with("@cf/"), "{model} is not a Workers AI id");
+            assert!(*dims > 0, "{model} has no dimensions");
+            assert_eq!(dimensions_for(model), Some(*dims));
+        }
+    }
+
+    #[test]
+    fn the_shipped_model_is_offered_so_a_user_can_return_to_it() {
+        // Migration has to be reversible in both directions, or a user who tries
+        // a larger model is stuck with it.
+        assert_eq!(dimensions_for("@cf/baai/bge-small-en-v1.5"), Some(384));
+    }
+
+    #[test]
+    fn an_unknown_model_has_no_dimensions_rather_than_a_guess() {
+        assert_eq!(dimensions_for("@cf/google/embeddinggemma-300m"), None);
+        assert_eq!(dimensions_for(""), None);
+    }
+
+    /// The shipped size keeps the historical index name, so enabling this feature
+    /// does not rename anything under an existing brain.
+    #[test]
+    fn the_shipped_dimension_count_keeps_the_original_index_name() {
+        assert_eq!(
+            index_name_for("second-brain-vectors", 384, 384),
+            "second-brain-vectors"
+        );
+    }
+
+    #[test]
+    fn other_dimension_counts_get_their_own_index() {
+        assert_eq!(
+            index_name_for("second-brain-vectors", 768, 384),
+            "second-brain-vectors-768"
+        );
+        assert_eq!(
+            index_name_for("second-brain-vectors", 1024, 384),
+            "second-brain-vectors-1024"
+        );
+    }
+
+    /// Two models of the same size share an index, which is correct — their
+    /// vectors are compatible, and creating a second index of the same shape
+    /// would double storage for nothing.
+    #[test]
+    fn models_of_the_same_size_share_an_index() {
+        let a = index_name_for("second-brain-vectors", 768, 384);
+        let b = index_name_for("second-brain-vectors", 768, 384);
+        assert_eq!(a, b);
+    }
+
+    // ── HTTP ────────────────────────────────────────────────────────────────
+    //
+    // Against a real tiny_http server, matching the convention in settings.rs
+    // and cf/api.rs: the request path and method select the scenario, so the
+    // assertions cover what the Worker actually receives.
+
+    fn spawn_worker(
+        estimate_status: u16,
+    ) -> (String, std::sync::Arc<std::sync::Mutex<Vec<String>>>) {
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let log = seen.clone();
+        std::thread::spawn(move || loop {
+            let Ok(req) = server.recv() else { return };
+            let method = req.method().as_str().to_string();
+            let url = req.url().to_string();
+            let auth = req
+                .headers()
+                .iter()
+                .find(|h| h.field.equiv("authorization"))
+                .map(|h| h.value.to_string())
+                .unwrap_or_default();
+            log.lock().unwrap().push(format!("{method} {url} auth={auth}"));
+
+            let (status, body) = match (method.as_str(), url.as_str()) {
+                ("GET", "/migration/estimate") => (
+                    estimate_status,
+                    r#"{"ok":true,"entries":1620,"chunksAtLeast":2100,"model":"@cf/baai/bge-small-en-v1.5"}"#,
+                ),
+                ("POST", "/migration/reembed") => (
+                    200,
+                    r#"{"ok":true,"processed":5,"failed":0,"remaining":95,"total":100,"done":false,"stalled":false}"#,
+                ),
+                ("POST", "/migration/reset") => (200, r#"{"ok":true}"#),
+                ("GET", "/migration/status") => (200, r#"{"ok":true,"state":null,"model":"m"}"#),
+                _ => (404, r#"{"ok":false}"#),
+            };
+            let resp = tiny_http::Response::from_string(body)
+                .with_status_code(status)
+                .with_header(
+                    "Content-Type: application/json"
+                        .parse::<tiny_http::Header>()
+                        .unwrap(),
+                );
+            let _ = req.respond(resp);
+        });
+        (format!("http://127.0.0.1:{port}"), seen)
+    }
+
+    #[tokio::test]
+    async fn the_estimate_carries_the_models_the_picker_needs() {
+        let (url, seen) = spawn_worker(200);
+        let est = fetch_estimate(&url, "tok", Locale::En).await.expect("estimate");
+
+        assert_eq!(est.entries, 1620);
+        assert_eq!(est.chunks_at_least, 2100);
+        assert_eq!(est.current_model, "@cf/baai/bge-small-en-v1.5");
+        // Shipped to the UI so the dropdown never hardcodes model ids.
+        assert_eq!(est.models.len(), EMBEDDING_MODELS.len());
+
+        let log = seen.lock().unwrap();
+        assert!(log[0].starts_with("GET /migration/estimate"));
+        assert!(log[0].contains("auth=Bearer tok"));
+    }
+
+    #[tokio::test]
+    async fn a_batch_reports_the_fields_the_loop_needs() {
+        let (url, _) = spawn_worker(200);
+        let p = run_batch(&url, "tok", Locale::En).await.expect("batch");
+        assert_eq!(p.processed, 5);
+        assert_eq!(p.remaining, 95);
+        assert!(!p.done);
+        assert!(!p.stalled);
+    }
+
+    /// A brain that predates these routes 404s. That is the ordinary state for
+    /// someone who updated the app first, so it must say "update your brain"
+    /// rather than surfacing a status code.
+    #[tokio::test]
+    async fn an_older_brain_is_told_to_update_rather_than_shown_a_404() {
+        let (url, _) = spawn_worker(404);
+        let err = fetch_estimate(&url, "tok", Locale::En).await.unwrap_err();
+        assert_eq!(
+            err,
+            i18n::t(Locale::En, Key::ErrorBrainNeedsUpdateForMigration)
+        );
+        assert!(!err.contains("404"), "leaked a status code to the user: {err}");
+    }
+
+    #[tokio::test]
+    async fn a_server_error_does_not_leak_a_raw_body() {
+        let (url, _) = spawn_worker(500);
+        let err = fetch_estimate(&url, "tok", Locale::En).await.unwrap_err();
+        assert!(err.contains("500"), "the status is useful here: {err}");
+        assert!(!err.contains("{"), "leaked a response body: {err}");
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_brain_says_so() {
+        // Nothing is listening on this port.
+        let err = fetch_estimate("http://127.0.0.1:1", "tok", Locale::En)
+            .await
+            .unwrap_err();
+        assert_eq!(err, i18n::t(Locale::En, Key::ErrorReachBrain));
+    }
+
+    #[tokio::test]
+    async fn a_trailing_slash_in_the_stored_address_does_not_double_up() {
+        let (url, seen) = spawn_worker(200);
+        fetch_estimate(&format!("{url}/"), "tok", Locale::En)
+            .await
+            .expect("estimate");
+        let log = seen.lock().unwrap();
+        assert!(
+            log[0].starts_with("GET /migration/estimate"),
+            "path was mangled: {}",
+            log[0]
+        );
+    }
+}

--- a/installer/src-tauri/src/secure_store.rs
+++ b/installer/src-tauri/src/secure_store.rs
@@ -78,9 +78,26 @@ mod backend {
 mod backend {
     use super::StoreError;
     use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     static MAP: Mutex<Option<HashMap<String, String>>> = Mutex::new(None);
+
+    /// Counts reads so a test can assert that a code path never touches the
+    /// keychain at all.
+    ///
+    /// On a real build every read can raise an OS password prompt, and demo mode
+    /// must never do that — but a prompt is not something a unit test can observe,
+    /// and a source scan cannot express "not inside the dry-run branch". Counting
+    /// the reads can.
+    pub static READS: AtomicUsize = AtomicUsize::new(0);
+
+    pub fn reads() -> usize {
+        READS.load(Ordering::SeqCst)
+    }
+    pub fn reset_reads() {
+        READS.store(0, Ordering::SeqCst);
+    }
 
     pub fn set(key: &str, value: &str) -> Result<(), StoreError> {
         MAP.lock()
@@ -91,6 +108,7 @@ mod backend {
     }
 
     pub fn get(key: &str) -> Option<String> {
+        READS.fetch_add(1, Ordering::SeqCst);
         MAP.lock().unwrap().as_ref()?.get(key).cloned()
     }
 
@@ -98,6 +116,17 @@ mod backend {
         if let Some(map) = MAP.lock().unwrap().as_mut() {
             map.remove(key);
         }
+    }
+}
+
+/// Test-only view of how many keychain reads have happened.
+#[cfg(test)]
+pub mod probe {
+    pub fn reads() -> usize {
+        super::backend::reads()
+    }
+    pub fn reset() {
+        super::backend::reset_reads()
     }
 }
 

--- a/installer/src-tauri/src/secure_store.rs
+++ b/installer/src-tauri/src/secure_store.rs
@@ -12,6 +12,17 @@ const KEY_WORKER_URL: &str = "worker-url";
 const KEY_AUTH_TOKEN: &str = "auth-token";
 const KEY_CF_ACCOUNT_ID: &str = "cf-account-id";
 const KEY_CF_SUBDOMAIN: &str = "cf-subdomain";
+/// The vector index a brain was reading *before* an embedding migration.
+///
+/// Read from the live binding at the moment of switching, so it is what
+/// Cloudflare says rather than a name derived from an assumed size. Kept because
+/// after the switch the brain reports the new index as current, and the old one's
+/// name is the only thing that identifies what may safely be freed.
+///
+/// Not a secret: an index name. Stored here rather than in the window because a
+/// browser store is lost on a reset and cannot be trusted to name something whose
+/// deletion is irreversible.
+const KEY_CF_PREVIOUS_INDEX: &str = "cf-previous-index";
 
 #[derive(Debug, Clone)]
 pub struct SetupInfo {
@@ -126,11 +137,29 @@ pub fn load_cf_hints() -> Option<CfHints> {
     })
 }
 
+/// Records what the brain was reading before a migration switched it.
+pub fn save_previous_index(name: &str) -> Result<(), StoreError> {
+    backend::set(KEY_CF_PREVIOUS_INDEX, name)
+}
+
+/// The index left behind by the last migration, if one is outstanding.
+pub fn load_previous_index() -> Option<String> {
+    backend::get(KEY_CF_PREVIOUS_INDEX).filter(|s| !s.is_empty())
+}
+
+/// Called once the old index has actually been freed, so the offer stops being
+/// made. Kept separate from [`clear_setup`]: forgetting the note without deleting
+/// the index would silently orphan it.
+pub fn clear_previous_index() {
+    backend::delete(KEY_CF_PREVIOUS_INDEX);
+}
+
 pub fn clear_setup() {
     backend::delete(KEY_WORKER_URL);
     backend::delete(KEY_AUTH_TOKEN);
     backend::delete(KEY_CF_ACCOUNT_ID);
     backend::delete(KEY_CF_SUBDOMAIN);
+    backend::delete(KEY_CF_PREVIOUS_INDEX);
 }
 
 #[cfg(test)]
@@ -180,6 +209,24 @@ mod tests {
 
         clear_setup();
         assert!(load_cf_hints().is_none(), "disconnect must clear hints too");
+
+        // ── The outstanding-index note ──────────────────────────────────────
+        assert!(load_previous_index().is_none());
+        save_previous_index("second-brain-vectors").unwrap();
+        assert_eq!(load_previous_index().as_deref(), Some("second-brain-vectors"));
+
+        // Freeing the index clears the note without disturbing the setup.
+        save_setup("https://b.workers.dev", "hunter2hunter2").unwrap();
+        clear_previous_index();
+        assert!(load_previous_index().is_none());
+        assert!(load_setup().is_some(), "clearing the note must not log the user out");
+
+        // An empty value reads as absent: it must never name an index to delete.
+        backend::set(super::KEY_CF_PREVIOUS_INDEX, "").unwrap();
+        assert!(load_previous_index().is_none(), "an empty note names nothing");
+
+        clear_setup();
+        assert!(load_previous_index().is_none(), "disconnect clears the note too");
     }
 
     /// The Cloudflare OAuth token is not persisted anywhere.
@@ -187,9 +234,10 @@ mod tests {
     /// Pins the complete set of keys rather than pattern-matching their names: a
     /// future `KEY_CF_TOKEN` or `KEY_BEARER` would slip past a substring check,
     /// but cannot slip past an exact list. Adding a key here is then a deliberate
-    /// act that forces a second look at what is being stored.
+    /// act that forces a second look at what is being stored — as it did for
+    /// `cf-previous-index`, which is an index name and not a credential.
     #[test]
-    fn the_stored_key_set_is_exactly_these_four() {
+    fn the_stored_key_set_is_exactly_these_five() {
         let src = include_str!("secure_store.rs");
         let keys: Vec<&str> = src
             .lines()
@@ -198,7 +246,13 @@ mod tests {
             .collect();
         assert_eq!(
             keys,
-            vec!["worker-url", "auth-token", "cf-account-id", "cf-subdomain"],
+            vec![
+                "worker-url",
+                "auth-token",
+                "cf-account-id",
+                "cf-subdomain",
+                "cf-previous-index",
+            ],
             "secure_store gained or lost a key. A Cloudflare access or refresh \
              token must never be one of them: the AUTH_TOKEN unlocks one brain, \
              a Cloudflare token unlocks the whole account."

--- a/installer/src-tauri/src/settings.rs
+++ b/installer/src-tauri/src/settings.rs
@@ -722,6 +722,66 @@ mod tests {
     }
 
 
+    /// Every `t("…")` the settings window asks for must exist in both locales.
+    ///
+    /// Nothing else checks this. `t`'s parameter type is
+    /// `keyof Messages | \`${keyof Messages}.${string}\``, so *any* dotted
+    /// sub-path type-checks — and on a miss `t` returns the path itself, so a
+    /// mistyped key renders `settingsPanel.migration.pauseButton` to the user as
+    /// though it were a sentence. The migration flow alone added 66 keys referenced
+    /// only by string.
+    #[test]
+    fn every_string_the_settings_window_asks_for_exists_in_both_locales() {
+        let ui = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../src/settings.ts"
+        ))
+        .expect("read settings.ts");
+
+        // Dotted paths the window looks up, e.g. settingsPanel.migration.doneTitle.
+        let mut wanted: Vec<&str> = Vec::new();
+        for (i, _) in ui.match_indices("t(\"") {
+            let rest = &ui[i + 3..];
+            let Some(end) = rest.find('"') else { continue };
+            let path = &rest[..end];
+            if path.starts_with("settingsPanel.") && path.contains('.') {
+                wanted.push(path);
+            }
+        }
+        wanted.sort();
+        wanted.dedup();
+        assert!(
+            wanted.len() > 40,
+            "expected to find the window's string lookups, found {} — the scan broke",
+            wanted.len()
+        );
+
+        for locale in ["en.ts", "it.ts"] {
+            let src = std::fs::read_to_string(format!(
+                "{}/../src/i18n/{}",
+                env!("CARGO_MANIFEST_DIR"),
+                locale
+            ))
+            .expect("read locale");
+
+            let missing: Vec<&&str> = wanted
+                .iter()
+                .filter(|path| {
+                    // The leaf is what is declared; the parent objects are nesting.
+                    let leaf = path.rsplit('.').next().unwrap_or_default();
+                    !src.contains(&format!("{leaf}:"))
+                })
+                .collect();
+
+            assert!(
+                missing.is_empty(),
+                "{locale} is missing {} string(s) the window asks for: {:?}",
+                missing.len(),
+                missing
+            );
+        }
+    }
+
     /// The settings window groups controls into sections with a hardcoded list.
     /// A control missing from it would simply never render — no error, no blank
     /// space, just a setting the user cannot reach.

--- a/installer/src-tauri/src/settings.rs
+++ b/installer/src-tauri/src/settings.rs
@@ -730,7 +730,11 @@ mod tests {
         let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../src/settings.ts");
         let src = std::fs::read_to_string(path).expect("read settings.ts");
         let start = src.find("const SECTIONS").expect("SECTIONS list");
-        let end = src[start..].find("];").expect("end of SECTIONS") + start;
+        // Anchored to a `];` at the start of a line. A bare `find("];")` matched
+        // inside the declaration's own type annotation (`controls: string[];`)
+        // once that was written across several lines, silently truncating the
+        // slice to nothing and failing on a file that was perfectly correct.
+        let end = src[start..].find("\n];").expect("end of SECTIONS") + start;
         let sections = &src[start..end];
         for c in CONTROLS {
             assert!(

--- a/installer/src-tauri/src/worker_url.rs
+++ b/installer/src-tauri/src/worker_url.rs
@@ -1,0 +1,155 @@
+//! Reading a connected brain's own address.
+//!
+//! A workers.dev host carries two facts the app acts on:
+//!
+//! ```text
+//! second-brain . acme . workers.dev
+//! └─ script ──┘  └ subdomain ┘
+//! ```
+//!
+//! The **script name** says which Worker to deploy to. The **subdomain** says
+//! which Cloudflare account it lives in.
+//!
+//! Both must come from the stored address and nowhere else. Taking the script
+//! name from the bundled manifest instead is what #257 was: deploys are a `PUT`,
+//! so updating a brain connected as `my-brain.acme.workers.dev` wrote the bundle
+//! to a script named `second-brain` in that account — creating a Worker the user
+//! never asked for, or overwriting an unrelated one that happened to hold the
+//! name.
+//!
+//! A custom domain yields neither fact, so both accessors return `None` rather
+//! than guessing; callers surface that as "this brain is on its own address".
+
+/// The four labels of a `<script>.<subdomain>.workers.dev` host.
+///
+/// Exactly four: `acme.workers.dev` is not a brain address, and the old
+/// `split('.').nth(1)` read of it returned `"workers"` as the subdomain — a
+/// plausible-looking value that matches no real account.
+fn labels(worker_url: &str) -> Option<[String; 4]> {
+    let parsed = url::Url::parse(worker_url).ok()?;
+    // Match the contract `normalize_worker_url` enforces on the way in: a stored
+    // brain address is always http or https. Anything else is not an address this
+    // app produced, and the script name derived from it would end up in an API
+    // path for a deploy.
+    if parsed.scheme() != "https" && parsed.scheme() != "http" {
+        return None;
+    }
+    let host = parsed.host_str()?.to_ascii_lowercase();
+    if !host.ends_with(".workers.dev") {
+        return None; // custom domain — neither fact is derivable
+    }
+    let parts: Vec<&str> = host.split('.').collect();
+    let [script, subdomain, "workers", "dev"] = parts.as_slice() else {
+        return None;
+    };
+    if script.is_empty() || subdomain.is_empty() {
+        return None;
+    }
+    Some([
+        script.to_string(),
+        subdomain.to_string(),
+        "workers".into(),
+        "dev".into(),
+    ])
+}
+
+/// The Worker script name to deploy to.
+pub fn script_of(worker_url: &str) -> Option<String> {
+    labels(worker_url).map(|l| l[0].clone())
+}
+
+/// The account's workers.dev subdomain, used to resolve which Cloudflare
+/// account holds this brain.
+pub fn subdomain_of(worker_url: &str) -> Option<String> {
+    labels(worker_url).map(|l| l[1].clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_both_halves_of_a_brain_address() {
+        let url = "https://second-brain.acme.workers.dev";
+        assert_eq!(script_of(url).as_deref(), Some("second-brain"));
+        assert_eq!(subdomain_of(url).as_deref(), Some("acme"));
+    }
+
+    /// The case #257 is about: a brain that is not named `second-brain`. The
+    /// script name has to follow the address, or the update deploys elsewhere.
+    #[test]
+    fn reads_a_brain_deployed_under_another_name() {
+        let url = "https://my-brain-2.dad-piranifam-com-s-account.workers.dev";
+        assert_eq!(script_of(url).as_deref(), Some("my-brain-2"));
+        assert_eq!(
+            subdomain_of(url).as_deref(),
+            Some("dad-piranifam-com-s-account")
+        );
+    }
+
+    #[test]
+    fn a_path_or_trailing_slash_does_not_confuse_it() {
+        for url in [
+            "https://second-brain.acme.workers.dev/",
+            "https://second-brain.acme.workers.dev/mcp",
+            "https://second-brain.acme.workers.dev/graph?tab=all",
+        ] {
+            assert_eq!(script_of(url).as_deref(), Some("second-brain"), "{url}");
+            assert_eq!(subdomain_of(url).as_deref(), Some("acme"), "{url}");
+        }
+    }
+
+    /// A custom domain gives up neither fact. Guessing would mean deploying to
+    /// a script name invented from someone's marketing domain.
+    #[test]
+    fn a_custom_domain_yields_nothing() {
+        for url in [
+            "https://brain.example.com",
+            "https://memory.piranifam.com/mcp",
+            "https://workers.dev",
+        ] {
+            assert_eq!(script_of(url), None, "{url}");
+            assert_eq!(subdomain_of(url), None, "{url}");
+        }
+    }
+
+    /// `acme.workers.dev` has no script label. The previous implementation read
+    /// its second label and reported the subdomain as `"workers"`, which matches
+    /// no account and surfaced as a confusing "wrong account" error.
+    #[test]
+    fn an_address_with_no_script_label_is_refused() {
+        assert_eq!(script_of("https://acme.workers.dev"), None);
+        assert_eq!(subdomain_of("https://acme.workers.dev"), None);
+    }
+
+    #[test]
+    fn junk_is_refused_rather_than_half_parsed() {
+        for url in ["", "not a url", "https://", "ftp://x.y.workers.dev"] {
+            assert_eq!(script_of(url), None, "{url}");
+            assert_eq!(subdomain_of(url), None, "{url}");
+        }
+    }
+
+    /// Hosts are case-insensitive, and the script name is used verbatim in an
+    /// API path — so it must come back normalised, not as the user typed it.
+    #[test]
+    fn the_host_is_normalised_to_lowercase() {
+        let url = "https://Second-Brain.ACME.workers.dev";
+        assert_eq!(script_of(url).as_deref(), Some("second-brain"));
+        assert_eq!(subdomain_of(url).as_deref(), Some("acme"));
+    }
+
+    /// The property #248 relies on: an address built from an account's own
+    /// subdomain round-trips back to it, and to the script that was deployed.
+    #[test]
+    fn round_trips_an_address_the_app_itself_built() {
+        for (script, subdomain) in [
+            ("second-brain", "acme"),
+            ("second-brain", "dad-piranifam-com-s-account"),
+        ] {
+            let url = format!("https://{script}.{subdomain}.workers.dev");
+            assert_eq!(script_of(&url).as_deref(), Some(script));
+            assert_eq!(subdomain_of(&url).as_deref(), Some(subdomain));
+        }
+    }
+}

--- a/installer/src/i18n/en.ts
+++ b/installer/src/i18n/en.ts
@@ -36,6 +36,7 @@ export const en: Messages = {
     sectionRecall: "Recall",
     sectionRemember: "Remember",
     sectionAi: "AI",
+    sectionMatching: "Matching",
     custom: "Custom",
     customNote: "These values were set outside the app and don't match a preset. Picking a level below will replace them.",
     reset: "Reset to default",
@@ -140,6 +141,96 @@ export const en: Messages = {
       desc: "Used for sorting, summarizing, and spotting contradictions in your memories — not for the search itself. Every model here runs on your own Cloudflare account.",
       sizeNote: "Larger models write better summaries and cost more neurons. Smaller ones are faster and cheaper.",
       neuronsNote: "Neurons are Cloudflare's usage unit for AI. Your plan includes a daily allowance.",
+    },
+    migration: {
+      lede: "How your Second Brain reads your memories and matches them to what you ask for.",
+      label: "How your memories are read",
+      desc:
+        "Each memory is read once when you save it, and searches are matched against that " +
+        "reading. A different reader can match more precisely, but everything you have " +
+        "already saved has to be read again first.",
+      entries: "{entries} memories saved, in at least {chunks} pieces to read again.",
+      pickLabel: "Read my memories with",
+      inUse: "{name} (in use now)",
+      pickNote:
+        "Options further down the list read your memories in finer detail and use more of " +
+        "your daily AI allowance. All of them run on your own Cloudflare account.",
+      sameAsCurrent: "That's the one in use now — nothing to do.",
+      dirtyNote: "Save or cancel your other changes first.",
+      startButton: "Rebuild with this",
+      confirmTitle: "Before you start",
+      confirmBody:
+        "Your memories are safe. The text of everything you have saved is never touched — " +
+        "only what your Second Brain uses to search gets rebuilt from it.",
+      point1:
+        "Search is incomplete while this runs. Memories that haven't been read again yet " +
+        "won't come back in results.",
+      point2:
+        "It can take a while — {chunks} pieces to read again, and it uses your daily AI " +
+        "allowance. If the allowance runs out, it pauses and picks up where it left off.",
+      point3:
+        "Nothing is deleted along the way. The old search data stays until you choose to " +
+        "free it up at the end, and that last step is the only one that can't be undone.",
+      targetLine: "Switching to: {name}",
+      confirmButton: "Yes, rebuild it",
+      cancelButton: "Not now",
+      startingTitle: "Getting ready",
+      startingBody:
+        "Setting up the new way of reading your memories, then pointing your Second Brain " +
+        "at it. This takes a minute or two — leave this window open.",
+      runningTitle: "Reading your memories again",
+      runningBody:
+        "Search is incomplete until this finishes — anything not read again yet won't show " +
+        "up in results. Leave this window open; closing it pauses the rebuild, and nothing " +
+        "already done is lost.",
+      progress: "{done} of {total} done",
+      progressPending: "Working through them now…",
+      // Label form on purpose: it reads correctly at any count, and it claims
+      // nothing about what the number counts.
+      skipped: "Couldn't be read again: {failed}. Anything missed may not show up in search.",
+      stalledTitle: "Paused for today",
+      stalledBody:
+        "Today's AI allowance is used up. Everything done so far is saved, and picking it " +
+        "up again costs nothing for what's already done. Come back tomorrow, or whenever " +
+        "your allowance resets.",
+      resumeButton: "Carry on",
+      interruptedTitle: "A rebuild was left unfinished",
+      interruptedBody:
+        "A rebuild stopped partway — {done} of {total} done. Search stays incomplete until " +
+        "it finishes, and carrying on costs nothing for what's already done.",
+      failedTitle: "The rebuild stopped",
+      failedBody:
+        "Your memories are untouched and everything done so far is saved. Carrying on " +
+        "won't repeat any of it.",
+      stuck:
+        "The rebuild stopped making progress, so we stopped it. Nothing is lost — try " +
+        "again in a few minutes.",
+      doneTitle: "Your memories have all been read again",
+      doneBody:
+        "Search is complete again, and your Second Brain is now matching memories the new way.",
+      freeLabel: "Free up the old search data",
+      freeDesc:
+        "The search data from before the rebuild is still stored, and your Second Brain " +
+        "could still go back to it. Freeing it up recovers the space it takes, and it is " +
+        "the one step here that can't be undone.",
+      freeButton: "Free up the old data",
+      freeConfirm: "Yes, free it up — I know this can't be undone",
+      freeKeep: "Keep it for now",
+      freeing: "Freeing up the old search data",
+      freeingBody: "This only takes a moment.",
+      freedTitle: "All done",
+      freedBody:
+        "Your Second Brain reads and matches your memories the new way, and the old search " +
+        "data is gone. Nothing else changed.",
+      freeUnknown:
+        "Some search data from before the rebuild is still stored. It doesn't affect " +
+        "anything, and it can be freed up later.",
+      loading: "Checking how your memories are read…",
+      loadFailed: "Couldn't check how your memories are being read right now.",
+      barRunning:
+        "Reading your memories again — {done} of {total} done. Other settings are locked " +
+        "until it finishes.",
+      barWorking: "Working on your Second Brain. Other settings are locked until this finishes.",
     },
   },
   welcome: {

--- a/installer/src/i18n/en.ts
+++ b/installer/src/i18n/en.ts
@@ -157,6 +157,12 @@ export const en: Messages = {
       entriesNone: "No memories saved yet, so there is nothing to read again.",
       pickLabel: "How to read your memories",
       inUse: "{name} (in use now)",
+      storageWarning:
+        "This is more than a free Cloudflare account can hold for a brain your " +
+        "size. While the rebuild runs, both the old and new search data are kept " +
+        "so you can still change your mind — and that is when it would run out. " +
+        "Saving new memories would start failing. A coarser option, or a paid " +
+        "Cloudflare plan, avoids it.",
       pickNote:
         "Reading in more detail matches more precisely and uses more of your daily AI " +
         "allowance. All of these run on your own Cloudflare account.",

--- a/installer/src/i18n/en.ts
+++ b/installer/src/i18n/en.ts
@@ -149,29 +149,61 @@ export const en: Messages = {
         "Each memory is read once when you save it, and searches are matched against that " +
         "reading. A different reader can match more precisely, but everything you have " +
         "already saved has to be read again first.",
-      entries: "{entries} memories saved, in at least {chunks} pieces to read again.",
-      pickLabel: "Read my memories with",
+      // Counted in memories, the same unit the progress line uses. The piece
+      // count appears only where it is about the daily AI allowance, so the two
+      // screens never present the same job in two different units.
+      entries: "{entries} memories saved, all to be read again.",
+      entriesOne: "1 memory saved, to be read again.",
+      entriesNone: "No memories saved yet, so there is nothing to read again.",
+      pickLabel: "How to read your memories",
       inUse: "{name} (in use now)",
       pickNote:
-        "Options further down the list read your memories in finer detail and use more of " +
-        "your daily AI allowance. All of them run on your own Cloudflare account.",
+        "Reading in more detail matches more precisely and uses more of your daily AI " +
+        "allowance. All of these run on your own Cloudflare account.",
+      /**
+       * The picker shows these names and never the model id. This is the last
+       * label read before a one-way operation, and the position of an opaque
+       * string in a list is not something anyone can reason about well.
+       */
+      levels: {
+        standard: {
+          name: "Standard",
+          notice:
+            "Lightest on your daily AI allowance and the quickest to rebuild. Good enough " +
+            "for most searches.",
+        },
+        finer: {
+          name: "Finer detail",
+          notice:
+            "Catches more of what each memory is about, so near-misses sort better. Uses " +
+            "more of your daily AI allowance.",
+        },
+        finest: {
+          name: "Finest detail",
+          notice:
+            "The most precise matching, and the heaviest on both your daily AI allowance " +
+            "and your storage.",
+        },
+      },
       sameAsCurrent: "That's the one in use now — nothing to do.",
       dirtyNote: "Save or cancel your other changes first.",
       startButton: "Rebuild with this",
       confirmTitle: "Before you start",
+      // One full-weight sentence. The rest of this screen is a grey block, and a
+      // grey block before a one-way operation does not get read.
+      confirmLead: "Search will be incomplete until this finishes.",
       confirmBody:
-        "Your memories are safe. The text of everything you have saved is never touched — " +
-        "only what your Second Brain uses to search gets rebuilt from it.",
-      point1:
-        "Search is incomplete while this runs. Memories that haven't been read again yet " +
-        "won't come back in results.",
-      point2:
-        "It can take a while — {chunks} pieces to read again, and it uses your daily AI " +
-        "allowance. If the allowance runs out, it pauses and picks up where it left off.",
-      point3:
-        "Nothing is deleted along the way. The old search data stays until you choose to " +
-        "free it up at the end, and that last step is the only one that can't be undone.",
+        "Your memories are safe — only what your Second Brain uses to search gets rebuilt.",
+      point1: "Memories not read again yet won't come back in results.",
+      point2: "It uses your daily AI allowance, and pauses for the day if that runs out.",
+      // How long, in the only unit the app can honestly promise: batches are
+      // capped by pieces, and the rounds run one after another.
+      point3: "{chunks} pieces to read again — about {rounds} rounds, one after another.",
+      point4: "Nothing is deleted until you choose to free the old search data at the end.",
       targetLine: "Switching to: {name}",
+      // Secondary, and only here: the id earns its place on the screen that
+      // commits, where someone may want to check exactly what they are getting.
+      modelLine: "Model: {name}",
       confirmButton: "Yes, rebuild it",
       cancelButton: "Not now",
       startingTitle: "Getting ready",
@@ -180,39 +212,68 @@ export const en: Messages = {
         "at it. This takes a minute or two — leave this window open.",
       runningTitle: "Reading your memories again",
       runningBody:
-        "Search is incomplete until this finishes — anything not read again yet won't show " +
-        "up in results. Leave this window open; closing it pauses the rebuild, and nothing " +
-        "already done is lost.",
-      progress: "{done} of {total} done",
+        "Search is incomplete until this finishes. Leave this window open, or pause and " +
+        "come back — nothing already read again is lost either way. The total can go up " +
+        "if you save something new while this runs.",
+      pauseButton: "Pause for now",
+      pausing: "Pausing after this round…",
+      pausedTitle: "Paused",
+      pausedBody:
+        "Everything read again so far is saved. Search stays incomplete until you carry " +
+        "on, and carrying on costs nothing for what's already done.",
+      progress: "{done} of {total} memories read again",
       progressPending: "Working through them now…",
-      // Label form on purpose: it reads correctly at any count, and it claims
-      // nothing about what the number counts.
-      skipped: "Couldn't be read again: {failed}. Anything missed may not show up in search.",
+      // Label form on purpose: it reads correctly at any count. Worded as
+      // attempts because a memory that failed stays in front of the cursor and
+      // is tried again, so this is a count of tries and not a count of losses.
+      skipped:
+        "Memories that couldn't be read again yet: {failed}. They get another try as this " +
+        "carries on.",
       stalledTitle: "Paused for today",
       stalledBody:
         "Today's AI allowance is used up. Everything done so far is saved, and picking it " +
         "up again costs nothing for what's already done. Come back tomorrow, or whenever " +
         "your allowance resets.",
+      // The other stall. "Come back tomorrow" is advice that can never work here,
+      // and Carry on alone would rerun the identical failing round forever.
+      stalledFailingTitle: "One memory is blocking the rebuild",
+      stalledFailingBody:
+        "The same memory keeps failing, so the last round got nothing done. Waiting won't " +
+        "change that — the next try would run the identical round. Try again in case it " +
+        "was a blip, or start over to forget where it got to and read everything from the " +
+        "beginning.",
       resumeButton: "Carry on",
+      startOverButton: "Start over instead",
+      startOverNote:
+        "Starting over reads every memory again, including the ones already done, and " +
+        "spends your AI allowance on that work a second time.",
+      resettingTitle: "Starting over",
+      resettingBody:
+        "Clearing the record of what has been read again, then beginning from your first " +
+        "memory.",
       interruptedTitle: "A rebuild was left unfinished",
       interruptedBody:
         "A rebuild stopped partway — {done} of {total} done. Search stays incomplete until " +
         "it finishes, and carrying on costs nothing for what's already done.",
       failedTitle: "The rebuild stopped",
       failedBody:
-        "Your memories are untouched and everything done so far is saved. Carrying on " +
-        "won't repeat any of it.",
+        "Your memories are untouched and everything read again so far is saved. Carrying " +
+        "on picks up where it stopped — it won't start over.",
+      // Its own screen. Stacked under the failed copy this said the same thing
+      // twice, in two voices, the second in red arguing with the first.
+      stuckTitle: "The rebuild stopped making progress",
       stuck:
-        "The rebuild stopped making progress, so we stopped it. Nothing is lost — try " +
-        "again in a few minutes.",
+        "Nothing is lost, and everything read again so far is saved. Trying again in a few " +
+        "minutes often clears it; if it doesn't, start over.",
       doneTitle: "Your memories have all been read again",
       doneBody:
         "Search is complete again, and your Second Brain is now matching memories the new way.",
+      changeAgain: "Change this again",
       freeLabel: "Free up the old search data",
       freeDesc:
-        "The search data from before the rebuild is still stored, and your Second Brain " +
-        "could still go back to it. Freeing it up recovers the space it takes, and it is " +
-        "the one step here that can't be undone.",
+        "The search data from before the rebuild is still taking up space. Your memories " +
+        "aren't touched — this only removes the leftover search data your Second Brain no " +
+        "longer uses. It is the one step here that can't be undone.",
       freeButton: "Free up the old data",
       freeConfirm: "Yes, free it up — I know this can't be undone",
       freeKeep: "Keep it for now",
@@ -222,9 +283,6 @@ export const en: Messages = {
       freedBody:
         "Your Second Brain reads and matches your memories the new way, and the old search " +
         "data is gone. Nothing else changed.",
-      freeUnknown:
-        "Some search data from before the rebuild is still stored. It doesn't affect " +
-        "anything, and it can be freed up later.",
       loading: "Checking how your memories are read…",
       loadFailed: "Couldn't check how your memories are being read right now.",
       barRunning:

--- a/installer/src/i18n/it.ts
+++ b/installer/src/i18n/it.ts
@@ -160,6 +160,13 @@ export const it: Messages = {
       entriesNone: "Non hai ancora salvato ricordi, quindi non c'è nulla da rileggere.",
       pickLabel: "Modo di leggere",
       inUse: "{name} (in uso ora)",
+      storageWarning:
+        "È più di quanto un account Cloudflare gratuito possa contenere per un " +
+        "Second Brain della tua dimensione. Durante la ricostruzione vengono " +
+        "conservati sia i vecchi sia i nuovi dati di ricerca, così puoi ancora " +
+        "cambiare idea — ed è lì che lo spazio finirebbe. Il salvataggio di nuovi " +
+        "ricordi inizierebbe a fallire. Un'opzione meno dettagliata, o un piano " +
+        "Cloudflare a pagamento, lo evita.",
       pickNote:
         "Leggere in modo più dettagliato trova corrispondenze più precise e consuma una " +
         "parte maggiore della tua assegnazione AI giornaliera. Girano tutte sul tuo " +

--- a/installer/src/i18n/it.ts
+++ b/installer/src/i18n/it.ts
@@ -155,74 +155,118 @@ export const it: Messages = {
         "Ogni ricordo viene letto una volta quando lo salvi, e le ricerche vengono " +
         "confrontate con quella lettura. Una lettura diversa può trovare corrispondenze " +
         "più precise, ma prima tutto ciò che hai già salvato va riletto.",
-      entries: "{entries} ricordi salvati, in almeno {chunks} parti da rileggere.",
-      pickLabel: "Leggi i miei ricordi con",
+      entries: "{entries} ricordi salvati, tutti da rileggere.",
+      entriesOne: "1 ricordo salvato, da rileggere.",
+      entriesNone: "Non hai ancora salvato ricordi, quindi non c'è nulla da rileggere.",
+      pickLabel: "Modo di leggere",
       inUse: "{name} (in uso ora)",
       pickNote:
-        "Le opzioni più in basso nell'elenco leggono i tuoi ricordi con più finezza e " +
-        "consumano una parte maggiore della tua assegnazione AI giornaliera. Girano tutte " +
-        "sul tuo account Cloudflare.",
+        "Leggere in modo più dettagliato trova corrispondenze più precise e consuma una " +
+        "parte maggiore della tua assegnazione AI giornaliera. Girano tutte sul tuo " +
+        "account Cloudflare.",
+      levels: {
+        standard: {
+          name: "Standard",
+          notice:
+            "È la più leggera per la tua assegnazione AI giornaliera e la più rapida da " +
+            "ricostruire. Va bene per la maggior parte delle ricerche.",
+        },
+        finer: {
+          name: "Più dettagliato",
+          notice:
+            "Coglie meglio di cosa parla ogni ricordo, così le corrispondenze meno ovvie " +
+            "risalgono nei risultati. Consuma una parte maggiore della tua assegnazione " +
+            "AI giornaliera.",
+        },
+        finest: {
+          name: "Massimo dettaglio",
+          notice:
+            "La corrispondenza più precisa, e la più esigente sia per la tua assegnazione " +
+            "AI giornaliera sia per lo spazio.",
+        },
+      },
       sameAsCurrent: "È già quella in uso — non c'è nulla da fare.",
       dirtyNote: "Salva o annulla prima le altre modifiche.",
-      startButton: "Ricostruisci con questa",
+      startButton: "Ricostruisci con questa opzione",
       confirmTitle: "Prima di iniziare",
+      confirmLead: "Finché non finisce, la ricerca è incompleta.",
       confirmBody:
-        "I tuoi ricordi sono al sicuro. Il testo di ciò che hai salvato non viene mai " +
-        "toccato: viene ricostruito solo ciò che il tuo Second Brain usa per cercare.",
-      point1:
-        "Durante la ricostruzione la ricerca è incompleta. I ricordi non ancora riletti " +
-        "non compaiono tra i risultati.",
+        "I tuoi ricordi sono al sicuro: viene ricostruito solo ciò che il tuo Second Brain " +
+        "usa per cercare.",
+      point1: "I ricordi non ancora riletti non compaiono tra i risultati.",
       point2:
-        "Può richiedere tempo: ci sono {chunks} parti da rileggere e si consuma la tua " +
-        "assegnazione AI giornaliera. Se l'assegnazione finisce, il lavoro si mette in " +
-        "pausa e riprende da dove era arrivato.",
-      point3:
-        "Lungo il percorso non viene cancellato nulla. I vecchi dati di ricerca restano " +
-        "finché non scegli tu di liberarli alla fine, e quell'ultimo passaggio è il solo " +
-        "che non si può annullare.",
-      targetLine: "Si passa a: {name}",
+        "Consuma la tua assegnazione AI giornaliera e, se finisce, si mette in pausa per oggi.",
+      point3: "{chunks} parti da rileggere: circa {rounds} giri, uno dopo l'altro.",
+      point4:
+        "Fino alla fine non viene cancellato nulla: i vecchi dati di ricerca restano finché " +
+        "non scegli tu di liberarli.",
+      targetLine: "Nuovo modo di leggere: {name}",
+      modelLine: "Modello: {name}",
       confirmButton: "Sì, ricostruisci",
       cancelButton: "Non ora",
       startingTitle: "Preparazione",
       startingBody:
-        "Prepariamo il nuovo modo di leggere i tuoi ricordi, poi il tuo Second Brain " +
-        "inizia a usarlo. Ci vuole un minuto o due — lascia aperta questa finestra.",
+        "Il nuovo modo di leggere i tuoi ricordi è quasi pronto; subito dopo il tuo Second " +
+        "Brain inizierà a usarlo. Ci vuole un minuto o due — lascia aperta questa finestra.",
       runningTitle: "Rilettura dei tuoi ricordi",
       runningBody:
-        "Finché non finisce, la ricerca è incompleta: ciò che non è ancora stato riletto " +
-        "non compare tra i risultati. Lascia aperta questa finestra; chiudendola la " +
-        "ricostruzione si mette in pausa e nulla di già fatto va perso.",
-      progress: "{done} di {total} completati",
-      progressPending: "Elaborazione in corso…",
+        "Finché non finisce, la ricerca è incompleta. Lascia aperta questa finestra, " +
+        "oppure metti in pausa e torna più tardi: in ogni caso nulla di già riletto va " +
+        "perso. Il totale può salire se salvi qualcosa di nuovo durante la rilettura.",
+      pauseButton: "Metti in pausa",
+      pausing: "Pausa alla fine di questo giro…",
+      pausedTitle: "In pausa",
+      pausedBody:
+        "Tutto ciò che è stato riletto è salvato. La ricerca resta incompleta finché non " +
+        "continui, e continuare non costa nulla per la parte già completata.",
+      progress: "{done} su {total} ricordi riletti",
+      progressPending: "Rilettura in corso…",
       skipped:
-        "Non è stato possibile rileggere: {failed}. Ciò che manca potrebbe non comparire " +
-        "nelle ricerche.",
+        "Ricordi che non è stato possibile rileggere finora: {failed}. Vengono ritentati " +
+        "mentre la rilettura continua.",
       stalledTitle: "In pausa per oggi",
       stalledBody:
         "L'assegnazione AI di oggi è esaurita. Tutto ciò che è stato fatto è salvato e " +
         "riprendere non costa nulla per la parte già completata. Torna domani, o quando la " +
         "tua assegnazione si rinnova.",
+      stalledFailingTitle: "Un ricordo sta bloccando la ricostruzione",
+      stalledFailingBody:
+        "Lo stesso ricordo continua a non riuscire, così l'ultimo giro non ha concluso " +
+        "nulla. Aspettare non cambia niente: il tentativo successivo rifarebbe esattamente " +
+        "lo stesso giro. Riprova, nel caso fosse un intoppo momentaneo, oppure ricomincia " +
+        "da capo per dimenticare il punto raggiunto e rileggere tutto dall'inizio.",
       resumeButton: "Continua",
+      startOverButton: "Ricomincia da capo",
+      startOverNote:
+        "Ricominciare da capo rilegge tutti i ricordi, anche quelli già fatti, e consuma " +
+        "una seconda volta la tua assegnazione AI per quel lavoro.",
+      resettingTitle: "Riavvio della rilettura",
+      resettingBody:
+        "Il registro di ciò che è già stato riletto viene azzerato, poi la rilettura " +
+        "riparte dal tuo primo ricordo.",
       interruptedTitle: "Una ricostruzione è rimasta a metà",
       interruptedBody:
-        "Una ricostruzione si è fermata a metà: {done} di {total} completati. La ricerca " +
+        "Una ricostruzione si è fermata a metà: {done} su {total} completati. La ricerca " +
         "resta incompleta finché non finisce, e continuare non costa nulla per la parte " +
         "già completata.",
       failedTitle: "La ricostruzione si è fermata",
       failedBody:
-        "I tuoi ricordi non sono stati toccati e tutto ciò che è stato fatto è salvato. " +
-        "Continuando, nulla verrà ripetuto.",
+        "I tuoi ricordi non sono stati toccati e tutto ciò che è stato riletto è salvato. " +
+        "Se riprendi, non si ricomincia da zero.",
+      stuckTitle: "La ricostruzione ha smesso di avanzare",
       stuck:
-        "La ricostruzione ha smesso di avanzare, così l'abbiamo interrotta. Niente è " +
-        "andato perso — riprova tra qualche minuto.",
-      doneTitle: "I tuoi ricordi sono stati riletti tutti",
+        "Niente è andato perso e tutto ciò che è stato riletto è salvato. Riprovare tra " +
+        "qualche minuto spesso basta; se non basta, ricomincia da capo.",
+      doneTitle: "Tutti i tuoi ricordi sono stati riletti.",
       doneBody:
         "La ricerca è di nuovo completa e il tuo Second Brain abbina i ricordi nel modo nuovo.",
+      changeAgain: "Cambia di nuovo",
       freeLabel: "Libera i vecchi dati di ricerca",
       freeDesc:
-        "I dati di ricerca precedenti alla ricostruzione sono ancora conservati e il tuo " +
-        "Second Brain potrebbe ancora tornare a usarli. Liberarli recupera lo spazio che " +
-        "occupano ed è il solo passaggio qui che non si può annullare.",
+        "I dati di ricerca precedenti alla ricostruzione occupano ancora spazio. I tuoi " +
+        "ricordi non vengono toccati: viene rimosso solo ciò che resta dei vecchi dati di " +
+        "ricerca, che il tuo Second Brain non usa più. È il solo passaggio qui che non si " +
+        "può annullare.",
       freeButton: "Libera i vecchi dati",
       freeConfirm: "Sì, liberali — so che non si può annullare",
       freeKeep: "Conservali per ora",
@@ -232,17 +276,14 @@ export const it: Messages = {
       freedBody:
         "Il tuo Second Brain legge e abbina i tuoi ricordi nel modo nuovo, e i vecchi dati " +
         "di ricerca non ci sono più. Nient'altro è cambiato.",
-      freeUnknown:
-        "Sono ancora conservati alcuni dati di ricerca precedenti alla ricostruzione. Non " +
-        "influiscono su nulla e potranno essere liberati più avanti.",
       loading: "Verifica di come vengono letti i tuoi ricordi…",
-      loadFailed: "Non è stato possibile verificare come vengono letti i tuoi ricordi.",
+      loadFailed:
+        "Non è stato possibile verificare come vengono letti i tuoi ricordi in questo momento.",
       barRunning:
-        "Rilettura dei tuoi ricordi — {done} di {total} completati. Le altre impostazioni " +
+        "Rilettura dei tuoi ricordi — {done} su {total} completati. Le altre impostazioni " +
         "sono bloccate fino alla fine.",
       barWorking:
-        "Operazione in corso sul tuo Second Brain. Le altre impostazioni sono bloccate " +
-        "fino alla fine.",
+        "Il tuo Second Brain è al lavoro. Le altre impostazioni sono bloccate fino alla fine.",
     },
   },
   welcome: {

--- a/installer/src/i18n/it.ts
+++ b/installer/src/i18n/it.ts
@@ -36,6 +36,7 @@ export const it: Messages = {
     sectionRecall: "Recupero",
     sectionRemember: "Ricorda",
     sectionAi: "AI",
+    sectionMatching: "Corrispondenze",
     custom: "Personalizzato",
     customNote: "Questi valori sono stati impostati fuori dall'app e non corrispondono a nessun livello. Scegliendo un livello qui sotto verranno sostituiti.",
     reset: "Ripristina il valore predefinito",
@@ -146,6 +147,102 @@ export const it: Messages = {
       desc: "Usato per ordinare, riassumere e individuare contraddizioni nei tuoi ricordi — non per la ricerca in sé. Ogni modello elencato qui gira sul tuo account Cloudflare.",
       sizeNote: "I modelli più grandi scrivono riassunti migliori e costano più Neurons. Quelli più piccoli sono più rapidi ed economici.",
       neuronsNote: "I Neurons sono l'unità di consumo AI di Cloudflare. Il tuo piano include un'assegnazione giornaliera.",
+    },
+    migration: {
+      lede: "Come il tuo Second Brain legge i tuoi ricordi e li abbina a ciò che chiedi.",
+      label: "Come vengono letti i tuoi ricordi",
+      desc:
+        "Ogni ricordo viene letto una volta quando lo salvi, e le ricerche vengono " +
+        "confrontate con quella lettura. Una lettura diversa può trovare corrispondenze " +
+        "più precise, ma prima tutto ciò che hai già salvato va riletto.",
+      entries: "{entries} ricordi salvati, in almeno {chunks} parti da rileggere.",
+      pickLabel: "Leggi i miei ricordi con",
+      inUse: "{name} (in uso ora)",
+      pickNote:
+        "Le opzioni più in basso nell'elenco leggono i tuoi ricordi con più finezza e " +
+        "consumano una parte maggiore della tua assegnazione AI giornaliera. Girano tutte " +
+        "sul tuo account Cloudflare.",
+      sameAsCurrent: "È già quella in uso — non c'è nulla da fare.",
+      dirtyNote: "Salva o annulla prima le altre modifiche.",
+      startButton: "Ricostruisci con questa",
+      confirmTitle: "Prima di iniziare",
+      confirmBody:
+        "I tuoi ricordi sono al sicuro. Il testo di ciò che hai salvato non viene mai " +
+        "toccato: viene ricostruito solo ciò che il tuo Second Brain usa per cercare.",
+      point1:
+        "Durante la ricostruzione la ricerca è incompleta. I ricordi non ancora riletti " +
+        "non compaiono tra i risultati.",
+      point2:
+        "Può richiedere tempo: ci sono {chunks} parti da rileggere e si consuma la tua " +
+        "assegnazione AI giornaliera. Se l'assegnazione finisce, il lavoro si mette in " +
+        "pausa e riprende da dove era arrivato.",
+      point3:
+        "Lungo il percorso non viene cancellato nulla. I vecchi dati di ricerca restano " +
+        "finché non scegli tu di liberarli alla fine, e quell'ultimo passaggio è il solo " +
+        "che non si può annullare.",
+      targetLine: "Si passa a: {name}",
+      confirmButton: "Sì, ricostruisci",
+      cancelButton: "Non ora",
+      startingTitle: "Preparazione",
+      startingBody:
+        "Prepariamo il nuovo modo di leggere i tuoi ricordi, poi il tuo Second Brain " +
+        "inizia a usarlo. Ci vuole un minuto o due — lascia aperta questa finestra.",
+      runningTitle: "Rilettura dei tuoi ricordi",
+      runningBody:
+        "Finché non finisce, la ricerca è incompleta: ciò che non è ancora stato riletto " +
+        "non compare tra i risultati. Lascia aperta questa finestra; chiudendola la " +
+        "ricostruzione si mette in pausa e nulla di già fatto va perso.",
+      progress: "{done} di {total} completati",
+      progressPending: "Elaborazione in corso…",
+      skipped:
+        "Non è stato possibile rileggere: {failed}. Ciò che manca potrebbe non comparire " +
+        "nelle ricerche.",
+      stalledTitle: "In pausa per oggi",
+      stalledBody:
+        "L'assegnazione AI di oggi è esaurita. Tutto ciò che è stato fatto è salvato e " +
+        "riprendere non costa nulla per la parte già completata. Torna domani, o quando la " +
+        "tua assegnazione si rinnova.",
+      resumeButton: "Continua",
+      interruptedTitle: "Una ricostruzione è rimasta a metà",
+      interruptedBody:
+        "Una ricostruzione si è fermata a metà: {done} di {total} completati. La ricerca " +
+        "resta incompleta finché non finisce, e continuare non costa nulla per la parte " +
+        "già completata.",
+      failedTitle: "La ricostruzione si è fermata",
+      failedBody:
+        "I tuoi ricordi non sono stati toccati e tutto ciò che è stato fatto è salvato. " +
+        "Continuando, nulla verrà ripetuto.",
+      stuck:
+        "La ricostruzione ha smesso di avanzare, così l'abbiamo interrotta. Niente è " +
+        "andato perso — riprova tra qualche minuto.",
+      doneTitle: "I tuoi ricordi sono stati riletti tutti",
+      doneBody:
+        "La ricerca è di nuovo completa e il tuo Second Brain abbina i ricordi nel modo nuovo.",
+      freeLabel: "Libera i vecchi dati di ricerca",
+      freeDesc:
+        "I dati di ricerca precedenti alla ricostruzione sono ancora conservati e il tuo " +
+        "Second Brain potrebbe ancora tornare a usarli. Liberarli recupera lo spazio che " +
+        "occupano ed è il solo passaggio qui che non si può annullare.",
+      freeButton: "Libera i vecchi dati",
+      freeConfirm: "Sì, liberali — so che non si può annullare",
+      freeKeep: "Conservali per ora",
+      freeing: "Liberazione dei vecchi dati di ricerca",
+      freeingBody: "Ci vuole solo un momento.",
+      freedTitle: "Tutto fatto",
+      freedBody:
+        "Il tuo Second Brain legge e abbina i tuoi ricordi nel modo nuovo, e i vecchi dati " +
+        "di ricerca non ci sono più. Nient'altro è cambiato.",
+      freeUnknown:
+        "Sono ancora conservati alcuni dati di ricerca precedenti alla ricostruzione. Non " +
+        "influiscono su nulla e potranno essere liberati più avanti.",
+      loading: "Verifica di come vengono letti i tuoi ricordi…",
+      loadFailed: "Non è stato possibile verificare come vengono letti i tuoi ricordi.",
+      barRunning:
+        "Rilettura dei tuoi ricordi — {done} di {total} completati. Le altre impostazioni " +
+        "sono bloccate fino alla fine.",
+      barWorking:
+        "Operazione in corso sul tuo Second Brain. Le altre impostazioni sono bloccate " +
+        "fino alla fine.",
     },
   },
   welcome: {

--- a/installer/src/i18n/types.ts
+++ b/installer/src/i18n/types.ts
@@ -76,6 +76,7 @@ export type Messages = {
       entriesNone: string;
       pickLabel: string;
       inUse: string;
+      storageWarning: string;
       pickNote: string;
       /**
        * Named levels, keyed by the `level` each choice carries. These are the

--- a/installer/src/i18n/types.ts
+++ b/installer/src/i18n/types.ts
@@ -43,6 +43,7 @@ export type Messages = {
     sectionRecall: string;
     sectionRemember: string;
     sectionAi: string;
+    sectionMatching: string;
     custom: string;
     customNote: string;
     reset: string;
@@ -60,6 +61,62 @@ export type Messages = {
     duplicates: { label: string; desc: string; note: string; levels: { permissive: LevelCopy; standard: LevelCopy; strict: LevelCopy } };
     compression: { label: string; desc: string; note: string; levels: { conservative: LevelCopy; standard: LevelCopy; aggressive: LevelCopy } };
     model: { label: string; desc: string; sizeNote: string; neuronsNote: string };
+    /**
+     * Rebuilding how memories are read (#248). The only destructive, multi-step
+     * flow in this window, so it carries a screen's worth of copy per step
+     * rather than one notice per level.
+     */
+    migration: {
+      lede: string;
+      label: string;
+      desc: string;
+      entries: string;
+      pickLabel: string;
+      inUse: string;
+      pickNote: string;
+      sameAsCurrent: string;
+      dirtyNote: string;
+      startButton: string;
+      confirmTitle: string;
+      confirmBody: string;
+      point1: string;
+      point2: string;
+      point3: string;
+      targetLine: string;
+      confirmButton: string;
+      cancelButton: string;
+      startingTitle: string;
+      startingBody: string;
+      runningTitle: string;
+      runningBody: string;
+      progress: string;
+      progressPending: string;
+      skipped: string;
+      stalledTitle: string;
+      stalledBody: string;
+      resumeButton: string;
+      interruptedTitle: string;
+      interruptedBody: string;
+      failedTitle: string;
+      failedBody: string;
+      stuck: string;
+      doneTitle: string;
+      doneBody: string;
+      freeLabel: string;
+      freeDesc: string;
+      freeButton: string;
+      freeConfirm: string;
+      freeKeep: string;
+      freeing: string;
+      freeingBody: string;
+      freedTitle: string;
+      freedBody: string;
+      freeUnknown: string;
+      loading: string;
+      loadFailed: string;
+      barRunning: string;
+      barWorking: string;
+    };
   };
   welcome: {
     title: string;

--- a/installer/src/i18n/types.ts
+++ b/installer/src/i18n/types.ts
@@ -70,38 +70,67 @@ export type Messages = {
       lede: string;
       label: string;
       desc: string;
+      /** Three forms: "1 memory saved" is the count a real new brain shows. */
       entries: string;
+      entriesOne: string;
+      entriesNone: string;
       pickLabel: string;
       inUse: string;
       pickNote: string;
+      /**
+       * Named levels, keyed by the `level` each choice carries. These are the
+       * only labels the picker shows — the model id is secondary text on the
+       * confirm screen and nowhere else, because this is the last thing read
+       * before an operation that cannot be undone.
+       */
+      levels: { standard: LevelCopy; finer: LevelCopy; finest: LevelCopy };
       sameAsCurrent: string;
       dirtyNote: string;
       startButton: string;
       confirmTitle: string;
+      /** The one full-weight sentence on a screen that is otherwise all grey. */
+      confirmLead: string;
       confirmBody: string;
       point1: string;
       point2: string;
+      /** How long, expressed in rounds — the only unit that can be honest. */
       point3: string;
+      point4: string;
       targetLine: string;
+      /** The raw model id, for anyone who wants to audit what they picked. */
+      modelLine: string;
       confirmButton: string;
       cancelButton: string;
       startingTitle: string;
       startingBody: string;
       runningTitle: string;
       runningBody: string;
+      pauseButton: string;
+      pausing: string;
+      pausedTitle: string;
+      pausedBody: string;
       progress: string;
       progressPending: string;
       skipped: string;
       stalledTitle: string;
       stalledBody: string;
+      /** The other stall: one memory keeps failing, so waiting cannot help. */
+      stalledFailingTitle: string;
+      stalledFailingBody: string;
       resumeButton: string;
+      startOverButton: string;
+      startOverNote: string;
+      resettingTitle: string;
+      resettingBody: string;
       interruptedTitle: string;
       interruptedBody: string;
       failedTitle: string;
       failedBody: string;
+      stuckTitle: string;
       stuck: string;
       doneTitle: string;
       doneBody: string;
+      changeAgain: string;
       freeLabel: string;
       freeDesc: string;
       freeButton: string;
@@ -111,7 +140,6 @@ export type Messages = {
       freeingBody: string;
       freedTitle: string;
       freedBody: string;
-      freeUnknown: string;
       loading: string;
       loadFailed: string;
       barRunning: string;

--- a/installer/src/settings.ts
+++ b/installer/src/settings.ts
@@ -13,7 +13,7 @@
 // reaches the Worker until Save, and Cancel discards the batch.
 import { invoke } from "@tauri-apps/api/core";
 import { h } from "./shared";
-import { LOCALE_CHANGE_EVENT, initI18n, t } from "./i18n";
+import { LOCALE_CHANGE_EVENT, getLocale, initI18n, t } from "./i18n";
 import "./style.css";
 
 type ControlView = {
@@ -40,14 +40,21 @@ type Staged = { kind: "level"; id: string } | { kind: "reset" };
  * grouping is what tells a user whether a setting affects recall or capture.
  *
  * "ai" holds the model dropdown rather than level controls, so it has no
- * entry in `controls`.
+ * entry in `controls`; "matching" holds the rebuild flow (#248) the same way.
+ * "matching" is last because it is the only pane that can start something
+ * destructive.
  */
-type SectionId = "recall" | "remember" | "ai";
+type SectionId = "recall" | "remember" | "ai" | "matching";
 
-const SECTIONS: { id: SectionId; labelKey: "sectionRecall" | "sectionRemember" | "sectionAi"; controls: string[] }[] = [
+const SECTIONS: {
+  id: SectionId;
+  labelKey: "sectionRecall" | "sectionRemember" | "sectionAi" | "sectionMatching";
+  controls: string[];
+}[] = [
   { id: "recall", labelKey: "sectionRecall", controls: ["recency", "variety", "connections", "detail"] },
   { id: "remember", labelKey: "sectionRemember", controls: ["duplicates", "compression"] },
   { id: "ai", labelKey: "sectionAi", controls: [] },
+  { id: "matching", labelKey: "sectionMatching", controls: [] },
 ];
 
 /** Recall is the default pane. */
@@ -62,6 +69,25 @@ let staged = new Map<string, Staged>();
 let stagedModel: string | null = null;
 let busy = false;
 let message: { text: string; kind: "ok" | "error" } | null = null;
+
+/** Tauri hands string errors through as strings and everything else as objects. */
+function errorText(e: unknown): string {
+  return typeof e === "string" ? e : String(e);
+}
+
+/** Numbers in copy: 12,480 in English, 12.480 in Italian. */
+function num(n: number): string {
+  return n.toLocaleString(getLocale());
+}
+
+/**
+ * Inputs are frozen both while a Save is in flight and while a rebuild (#248)
+ * is running. Saving other keys mid-rebuild is harmless on the Worker's side,
+ * but a live Cancel button next to a running rebuild reads as "cancel that".
+ */
+function locked(): boolean {
+  return busy || migrationBusy();
+}
 
 /** What a control shows right now: its staged value if edited, else saved. */
 function effectiveLevel(c: ControlView): string | null {
@@ -94,7 +120,7 @@ function discard(): void {
 }
 
 async function save(): Promise<void> {
-  if (busy || !isDirty()) return;
+  if (locked() || !isDirty()) return;
   busy = true;
   message = null;
   render();
@@ -127,6 +153,556 @@ async function save(): Promise<void> {
   }
 }
 
+/* ── Rebuilding how memories are read (#248) ─────────────────────────────────
+ *
+ * Every other control here is a staged radio pick that Save writes. This one is
+ * a sequence of Worker-side operations — create, redeploy, re-read in batches,
+ * then free the old search data — and the last of those cannot be undone. So it
+ * is deliberately NOT part of `staged`/`stagedModel`: Save must not be able to
+ * commit it, Cancel must not look like it can stop it, and the chosen target
+ * must never reach `apply_settings`' patch. Only `begin_embedding_migration`
+ * writes it, after the new search data exists.
+ *
+ * All of it lives at module scope because render() calls app.replaceChildren()
+ * on every state change — a progress bar held by reference would be thrown away
+ * on the next repaint, exactly as `message` and `busy` are handled.
+ */
+
+type MigrationEstimate = {
+  entries: number;
+  chunksAtLeast: number;
+  currentModel: string;
+  /** [id, dimensions]. The number never reaches the screen — it only orders the list. */
+  models: [string, number][];
+};
+
+/** A rebuild the Worker has on record, finished or not. */
+type MigrationRun = {
+  model: string;
+  processed: number;
+  failed: number;
+  totalAtStart: number;
+  cursorId: string | null;
+  finishedAt?: string | null;
+};
+
+type MigrationStatus = { ok: boolean; state: MigrationRun | null; model: string };
+
+type MigrationStep = {
+  processed: number;
+  failed: number;
+  remaining: number;
+  total: number;
+  done: boolean;
+  /** The day's AI allowance is gone. Progress is saved; resuming is free. */
+  stalled: boolean;
+};
+
+type MigrationPhase =
+  /** Pane never opened this session — opening it triggers the first load. */
+  | "unloaded"
+  | "loading"
+  | "loadFailed"
+  /** Estimate shown, nothing created yet. */
+  | "idle"
+  /** Target picked, warning shown, waiting for an explicit yes. */
+  | "confirm"
+  | "starting"
+  | "running"
+  | "stalled"
+  | "failed"
+  /** A rebuild from an earlier session stopped partway. */
+  | "interrupted"
+  /** Re-reading finished; the old search data is still there. */
+  | "done"
+  | "freeing"
+  | "freed";
+
+const migration = {
+  phase: "unloaded" as MigrationPhase,
+  estimate: null as MigrationEstimate | null,
+  /** The picked target. Not staged — see the note above. */
+  target: null as string | null,
+  /** Honest k-of-n, straight from the last step's `total - remaining`. */
+  progress: null as { done: number; total: number; failed: number } | null,
+  error: null as string | null,
+  /** Second half of the two-step confirm on the irreversible last step. */
+  confirmFree: false,
+  /**
+   * What `finish_embedding_migration` needs. Readable from the estimate only
+   * BEFORE the rebuild starts: afterwards the Worker reports the new reader as
+   * the current one, so it is written down at begin time and read back here.
+   */
+  oldDimensions: null as number | null,
+  /** Guards against a second step loop running alongside the first. */
+  looping: false,
+};
+
+function migrationBusy(): boolean {
+  const p = migration.phase;
+  return p === "starting" || p === "running" || p === "freeing";
+}
+
+/**
+ * The old size has to survive an app restart mid-rebuild, or a user who closes
+ * the window before the last step can never free the old search data. It is a
+ * UI bookkeeping detail, so it lives here rather than in the Worker's config.
+ */
+const OLD_DIMENSIONS_KEY = "sb-migration-old-dimensions";
+
+function rememberOldDimensions(model: string, dimensions: number): void {
+  try {
+    localStorage.setItem(OLD_DIMENSIONS_KEY, JSON.stringify({ model, dimensions }));
+  } catch {
+    /* private mode / unavailable */
+  }
+}
+
+function readOldDimensions(model: string): number | null {
+  try {
+    const raw = localStorage.getItem(OLD_DIMENSIONS_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { model?: string; dimensions?: number };
+    // Keyed by model so a note left by an older, different rebuild is ignored
+    // rather than used to delete the wrong search data.
+    if (parsed.model !== model || typeof parsed.dimensions !== "number") return null;
+    return parsed.dimensions;
+  } catch {
+    return null;
+  }
+}
+
+function forgetOldDimensions(): void {
+  try {
+    localStorage.removeItem(OLD_DIMENSIONS_KEY);
+  } catch {
+    /* private mode / unavailable */
+  }
+}
+
+function dimensionsOf(model: string): number | null {
+  const hit = migration.estimate?.models.find(([id]) => id === model);
+  return hit ? hit[1] : null;
+}
+
+/** Estimate before anything is created, and any rebuild already on record. */
+async function loadMigration(): Promise<void> {
+  try {
+    const status = await invoke<MigrationStatus>("migration_status");
+    // A status the Worker itself calls not-ok must not be read as "no rebuild in
+    // progress" — that would offer a fresh start over the top of a live one.
+    if (!status.ok) {
+      migration.phase = "loadFailed";
+      migration.error = null;
+      render();
+      return;
+    }
+    const estimate = await invoke<MigrationEstimate>("migration_estimate");
+    migration.estimate = estimate;
+    migration.error = null;
+    const run = status.state;
+    if (!run) {
+      migration.oldDimensions = dimensionsOf(estimate.currentModel);
+      migration.target = estimate.currentModel;
+      migration.progress = null;
+      migration.phase = "idle";
+    } else {
+      migration.target = run.model;
+      migration.oldDimensions = readOldDimensions(run.model);
+      migration.progress = { done: run.processed, total: run.totalAtStart, failed: run.failed };
+      migration.phase = run.finishedAt ? "done" : "interrupted";
+    }
+  } catch (e) {
+    migration.phase = "loadFailed";
+    migration.error = errorText(e);
+  }
+  render();
+}
+
+async function beginMigration(): Promise<void> {
+  const model = migration.target;
+  if (!model || migrationBusy()) return;
+  const oldDimensions = migration.oldDimensions;
+  migration.phase = "starting";
+  migration.error = null;
+  message = null;
+  render();
+  try {
+    // Creates the new search data, points the brain at it, and redeploys. The
+    // reader is written here and nowhere else.
+    await invoke("begin_embedding_migration", { model });
+  } catch (e) {
+    // The old search data is still bound, so the brain is exactly as it was.
+    // Back to the confirm screen with the target kept, so one click retries.
+    migration.phase = "confirm";
+    migration.error = errorText(e);
+    render();
+    return;
+  }
+  if (oldDimensions !== null) rememberOldDimensions(model, oldDimensions);
+  migration.phase = "running";
+  migration.progress = null;
+  render();
+  await stepLoop();
+}
+
+/**
+ * Batches until the Worker says done. Subrequest limits make one big request
+ * impossible, which is why the app drives the loop rather than the Worker.
+ */
+async function stepLoop(): Promise<void> {
+  if (migration.looping) return;
+  migration.looping = true;
+  let lastRemaining = -1;
+  let idleRounds = 0;
+  try {
+    for (;;) {
+      let step: MigrationStep;
+      try {
+        step = await invoke<MigrationStep>("migration_step");
+      } catch (e) {
+        migration.phase = "failed";
+        migration.error = errorText(e);
+        render();
+        return;
+      }
+      migration.progress = {
+        done: Math.max(0, step.total - step.remaining),
+        total: step.total,
+        failed: step.failed,
+      };
+      if (step.done) {
+        migration.phase = "done";
+        migration.error = null;
+        render();
+        return;
+      }
+      // Stalling is not a failure: the allowance refills. Stop the loop, keep
+      // the progress, and offer to carry on later.
+      if (step.stalled) {
+        migration.phase = "stalled";
+        migration.error = null;
+        render();
+        return;
+      }
+      // A batch that is neither done nor stalled and moves nothing would spin
+      // this loop against the Worker forever. Three identical answers is a stop.
+      idleRounds = step.remaining === lastRemaining ? idleRounds + 1 : 0;
+      lastRemaining = step.remaining;
+      if (idleRounds >= 2) {
+        migration.phase = "failed";
+        migration.error = t("settingsPanel.migration.stuck");
+        render();
+        return;
+      }
+      render();
+    }
+  } finally {
+    migration.looping = false;
+  }
+}
+
+async function resumeMigration(): Promise<void> {
+  if (migrationBusy()) return;
+  migration.phase = "running";
+  migration.error = null;
+  render();
+  await stepLoop();
+}
+
+/** The one irreversible step, always behind its own explicit confirm. */
+async function freeOldSearchData(): Promise<void> {
+  const oldDimensions = migration.oldDimensions;
+  if (oldDimensions === null || migrationBusy()) return;
+  migration.phase = "freeing";
+  migration.error = null;
+  render();
+  try {
+    await invoke("finish_embedding_migration", { oldDimensions });
+    forgetOldDimensions();
+    migration.confirmFree = false;
+    migration.phase = "freed";
+  } catch (e) {
+    // Nothing was freed, so the offer stands.
+    migration.phase = "done";
+    migration.error = errorText(e);
+  }
+  render();
+}
+
+function migrationNote(text: string): HTMLElement {
+  return h("div", { class: "settings-migration-note" }, [text]);
+}
+
+function migrationTitle(text: string): HTMLElement {
+  return h("div", { class: "url-label settings-migration-title" }, [text]);
+}
+
+function migrationActions(...buttons: HTMLElement[]): HTMLElement {
+  return h("div", { class: "row-actions settings-migration-actions" }, buttons);
+}
+
+function migrationButton(cls: string, label: string, onClick: () => void): HTMLElement {
+  const button = h("button", { class: cls, type: "button" }, [label]);
+  (button as HTMLButtonElement).disabled = locked();
+  button.addEventListener("click", onClick);
+  return button;
+}
+
+function migrationProgress(): HTMLElement {
+  const p = migration.progress;
+  const wrap = h("div", { class: "settings-migration-progress" });
+  wrap.append(
+    h("div", { class: "settings-migration-count" }, [
+      p && p.total > 0
+        ? t("settingsPanel.migration.progress", { done: num(p.done), total: num(p.total) })
+        : t("settingsPanel.migration.progressPending"),
+    ]),
+  );
+  if (p && p.total > 0) {
+    const pct = Math.max(0, Math.min(100, Math.round((p.done / p.total) * 100)));
+    // The k-of-n line above says the same thing, so the bar itself is decoration.
+    const track = h("div", { class: "settings-progress", "aria-hidden": "true" });
+    track.append(h("div", { class: "settings-progress-fill", style: `width: ${pct}%` }));
+    wrap.append(track);
+  }
+  if (p && p.failed > 0) {
+    wrap.append(migrationNote(t("settingsPanel.migration.skipped", { failed: num(p.failed) })));
+  }
+  return wrap;
+}
+
+function migrationPicker(e: MigrationEstimate): HTMLElement[] {
+  const select = h("select", { class: "locale-select" }) as HTMLSelectElement;
+  // Ordered by how finely each one reads, which is what the note under the
+  // dropdown explains. The sizes themselves stay out of the copy.
+  const ordered = [...e.models].sort((a, b) => a[1] - b[1]);
+  const label = (id: string) =>
+    id === e.currentModel ? t("settingsPanel.migration.inUse", { name: id }) : id;
+  for (const [id] of ordered) select.append(h("option", { value: id }, [label(id)]));
+  // A reader set outside the app must still show as selected rather than
+  // silently reading as the first entry.
+  if (!ordered.some(([id]) => id === e.currentModel)) {
+    select.append(h("option", { value: e.currentModel }, [label(e.currentModel)]));
+  }
+  select.value = migration.target ?? e.currentModel;
+  select.disabled = locked();
+  select.addEventListener("change", () => {
+    migration.target = select.value;
+    migration.error = null;
+    render();
+  });
+
+  const sameAsCurrent = migration.target === null || migration.target === e.currentModel;
+  // Starting a rebuild locks the action bar, which would strand staged edits
+  // with no way to save them. Ask for a clean slate first, and say so.
+  const blockedByEdits = isDirty();
+  const start = migrationButton("btn-primary", t("settingsPanel.migration.startButton"), () => {
+    migration.phase = "confirm";
+    migration.error = null;
+    render();
+  });
+  (start as HTMLButtonElement).disabled = locked() || sameAsCurrent || blockedByEdits;
+
+  const out: HTMLElement[] = [
+    h("div", { class: "settings-migration-count" }, [
+      t("settingsPanel.migration.entries", {
+        entries: num(e.entries),
+        chunks: num(e.chunksAtLeast),
+      }),
+    ]),
+    h("div", { class: "url-label settings-migration-pick" }, [
+      t("settingsPanel.migration.pickLabel"),
+    ]),
+    select,
+    migrationNote(t("settingsPanel.migration.pickNote")),
+  ];
+  if (sameAsCurrent) out.push(migrationNote(t("settingsPanel.migration.sameAsCurrent")));
+  else if (blockedByEdits) out.push(migrationNote(t("settingsPanel.migration.dirtyNote")));
+  out.push(migrationActions(start));
+  return out;
+}
+
+function migrationConfirm(): HTMLElement[] {
+  const chunks = migration.estimate ? num(migration.estimate.chunksAtLeast) : "—";
+  const points = h("ul", { class: "settings-migration-points" });
+  for (const key of ["point1", "point2", "point3"] as const) {
+    points.append(h("li", {}, [t(`settingsPanel.migration.${key}`, { chunks })]));
+  }
+  const go = migrationButton(
+    "btn-danger",
+    // A failed begin lands back here; the label admits it is a retry.
+    migration.error ? t("common.tryAgain") : t("settingsPanel.migration.confirmButton"),
+    () => void beginMigration(),
+  );
+  // The same block as on the picker, repeated here: this screen stays up while
+  // the user visits another pane, so edits can appear between the two clicks.
+  const blockedByEdits = isDirty();
+  (go as HTMLButtonElement).disabled = locked() || blockedByEdits;
+  const back = migrationButton("btn-ghost", t("settingsPanel.migration.cancelButton"), () => {
+    migration.phase = "idle";
+    migration.error = null;
+    render();
+  });
+  const out = [
+    migrationTitle(t("settingsPanel.migration.confirmTitle")),
+    migrationNote(t("settingsPanel.migration.confirmBody")),
+    points,
+    h("div", { class: "settings-migration-target" }, [
+      t("settingsPanel.migration.targetLine", { name: migration.target ?? "" }),
+    ]),
+  ];
+  if (blockedByEdits) out.push(migrationNote(t("settingsPanel.migration.dirtyNote")));
+  out.push(migrationActions(go, back));
+  return out;
+}
+
+function migrationDone(): HTMLElement[] {
+  const out: HTMLElement[] = [
+    migrationTitle(t("settingsPanel.migration.doneTitle")),
+    migrationNote(t("settingsPanel.migration.doneBody")),
+  ];
+  const p = migration.progress;
+  if (p && p.failed > 0) {
+    out.push(migrationNote(t("settingsPanel.migration.skipped", { failed: num(p.failed) })));
+  }
+  // Without the old size the wrong search data could be deleted, so the offer
+  // is withheld rather than guessed at.
+  if (migration.oldDimensions === null) {
+    out.push(migrationNote(t("settingsPanel.migration.freeUnknown")));
+    return out;
+  }
+  out.push(
+    h("div", { class: "url-label settings-migration-free" }, [
+      t("settingsPanel.migration.freeLabel"),
+    ]),
+    migrationNote(t("settingsPanel.migration.freeDesc")),
+  );
+  if (!migration.confirmFree) {
+    out.push(
+      migrationActions(
+        migrationButton("btn-danger", t("settingsPanel.migration.freeButton"), () => {
+          migration.confirmFree = true;
+          render();
+        }),
+      ),
+    );
+    return out;
+  }
+  out.push(
+    migrationActions(
+      migrationButton("btn-danger", t("settingsPanel.migration.freeConfirm"), () =>
+        void freeOldSearchData(),
+      ),
+      migrationButton("btn-ghost", t("settingsPanel.migration.freeKeep"), () => {
+        migration.confirmFree = false;
+        render();
+      }),
+    ),
+  );
+  return out;
+}
+
+function migrationBody(): HTMLElement[] {
+  const resume = () =>
+    migrationButton("btn-secondary", t("settingsPanel.migration.resumeButton"), () =>
+      void resumeMigration(),
+    );
+  switch (migration.phase) {
+    case "unloaded":
+    case "loading":
+      return [migrationNote(t("settingsPanel.migration.loading"))];
+    case "loadFailed":
+      return [
+        migrationNote(t("settingsPanel.migration.loadFailed")),
+        migrationActions(
+          migrationButton("btn-secondary", t("common.tryAgain"), () => {
+            migration.phase = "unloaded";
+            migration.error = null;
+            render();
+          }),
+        ),
+      ];
+    case "idle":
+      return migration.estimate
+        ? migrationPicker(migration.estimate)
+        : [migrationNote(t("settingsPanel.migration.loadFailed"))];
+    case "confirm":
+      return migrationConfirm();
+    case "starting":
+      return [
+        migrationTitle(t("settingsPanel.migration.startingTitle")),
+        migrationNote(t("settingsPanel.migration.startingBody")),
+      ];
+    case "running":
+      return [
+        migrationTitle(t("settingsPanel.migration.runningTitle")),
+        migrationProgress(),
+        migrationNote(t("settingsPanel.migration.runningBody")),
+      ];
+    case "stalled":
+      return [
+        migrationTitle(t("settingsPanel.migration.stalledTitle")),
+        migrationProgress(),
+        migrationNote(t("settingsPanel.migration.stalledBody")),
+        migrationActions(resume()),
+      ];
+    case "interrupted":
+      return [
+        migrationTitle(t("settingsPanel.migration.interruptedTitle")),
+        migrationProgress(),
+        migrationNote(
+          t("settingsPanel.migration.interruptedBody", {
+            done: num(migration.progress?.done ?? 0),
+            total: num(migration.progress?.total ?? 0),
+          }),
+        ),
+        migrationActions(resume()),
+      ];
+    case "failed":
+      return [
+        migrationTitle(t("settingsPanel.migration.failedTitle")),
+        migrationProgress(),
+        migrationNote(t("settingsPanel.migration.failedBody")),
+        migrationActions(
+          migrationButton("btn-secondary", t("common.tryAgain"), () => void resumeMigration()),
+        ),
+      ];
+    case "done":
+      return migrationDone();
+    case "freeing":
+      return [
+        migrationTitle(t("settingsPanel.migration.freeing")),
+        migrationNote(t("settingsPanel.migration.freeingBody")),
+      ];
+    case "freed":
+      return [
+        migrationTitle(t("settingsPanel.migration.freedTitle")),
+        migrationNote(t("settingsPanel.migration.freedBody")),
+      ];
+  }
+}
+
+function migrationCard(): HTMLElement {
+  if (migration.phase === "unloaded") {
+    // Nothing is fetched until the pane is opened. The phase flips before the
+    // first await, so a re-render cannot start a second load.
+    migration.phase = "loading";
+    void loadMigration();
+  }
+  const card = h("div", { class: "card settings-control settings-migration" });
+  card.append(
+    h("div", { class: "url-label" }, [t("settingsPanel.migration.label")]),
+    h("div", { class: "url-desc" }, [t("settingsPanel.migration.desc")]),
+    ...migrationBody(),
+  );
+  // The Worker's own words: they name what actually went wrong.
+  if (migration.error) {
+    card.append(h("div", { class: "settings-migration-error" }, [migration.error]));
+  }
+  return card;
+}
+
 function controlCard(c: ControlView): HTMLElement {
   // Typed so the dotted keys below still satisfy t()'s Path type rather
   // than widening to a bare string.
@@ -153,7 +729,7 @@ function controlCard(c: ControlView): HTMLElement {
   for (const levelId of c.levels) {
     const input = h("input", { type: "radio", name: `sb-${c.id}`, value: levelId });
     (input as HTMLInputElement).checked = shown === levelId;
-    (input as HTMLInputElement).disabled = busy;
+    (input as HTMLInputElement).disabled = locked();
     input.addEventListener("change", () => stage(c.id, { kind: "level", id: levelId }, c));
     const label = h("label", { class: "settings-level" }, [
       input,
@@ -182,7 +758,7 @@ function controlCard(c: ControlView): HTMLElement {
     t("settingsPanel.reset"),
   ]);
   // Reset is itself staged, so it can be cancelled like any other edit.
-  (reset as HTMLButtonElement).disabled = busy || shown === c.defaultLevel;
+  (reset as HTMLButtonElement).disabled = locked() || shown === c.defaultLevel;
   reset.addEventListener("click", () => stage(c.id, { kind: "reset" }, c));
   card.append(reset);
 
@@ -207,7 +783,7 @@ function modelCard(v: SettingsView): HTMLElement {
     select.append(h("option", { value: current }, [current]));
   }
   select.value = current;
-  select.disabled = busy;
+  select.disabled = locked();
   select.addEventListener("change", () => {
     stagedModel = select.value === v.llmModel ? null : select.value;
     message = null;
@@ -228,7 +804,16 @@ function actionBar(): HTMLElement {
   const bar = h("div", { class: "settings-actions" });
 
   const status = h("div", { class: "settings-actions-status" });
-  if (message) {
+  if (migrationBusy()) {
+    // A rebuild started in one pane greys out every other pane. Say why here,
+    // where the disabled buttons are, rather than only on the pane that owns it.
+    const p = migration.progress;
+    status.textContent =
+      p && p.total > 0
+        ? t("settingsPanel.migration.barRunning", { done: num(p.done), total: num(p.total) })
+        : t("settingsPanel.migration.barWorking");
+    status.classList.add("settings-status-pending");
+  } else if (message) {
     status.textContent = message.text;
     status.classList.add(`settings-status-${message.kind}`);
   } else if (count > 0) {
@@ -242,13 +827,13 @@ function actionBar(): HTMLElement {
   const cancel = h("button", { class: "btn-secondary", type: "button" }, [
     t("settingsPanel.cancel"),
   ]);
-  (cancel as HTMLButtonElement).disabled = busy || !isDirty();
+  (cancel as HTMLButtonElement).disabled = locked() || !isDirty();
   cancel.addEventListener("click", discard);
 
   const saveBtn = h("button", { class: "btn-primary", type: "button" }, [
     busy ? t("settingsPanel.saving") : t("settingsPanel.save"),
   ]);
-  (saveBtn as HTMLButtonElement).disabled = busy || !isDirty();
+  (saveBtn as HTMLButtonElement).disabled = locked() || !isDirty();
   saveBtn.addEventListener("click", () => void save());
 
   bar.append(status, cancel, saveBtn);
@@ -280,7 +865,11 @@ function render(): void {
   const pane = h("section", { class: "pane" });
   pane.append(
     h("h2", { class: "pane-title" }, [t(`settingsPanel.${section.labelKey}`)]),
-    h("p", { class: "settings-lede" }, [t("settingsPanel.lede")]),
+    h("p", { class: "settings-lede" }, [
+      // The shared lede promises "applies to your next search", which is not
+      // what a rebuild does. That pane says what it actually does.
+      active === "matching" ? t("settingsPanel.migration.lede") : t("settingsPanel.lede"),
+    ]),
   );
 
   const byId = new Map(saved.controls.map(c => [c.id, c]));
@@ -291,6 +880,7 @@ function render(): void {
     if (c) pane.append(controlCard(c));
   }
   if (active === "ai") pane.append(modelCard(saved));
+  if (active === "matching") pane.append(migrationCard());
 
   app.append(h("div", { class: "panel" }, [rail, pane]), actionBar());
   // Re-render replaces the whole tree; without this, staging an edit near the
@@ -323,9 +913,11 @@ async function boot(): Promise<void> {
   }
 }
 
-// Closing the window with staged edits would lose them silently.
+// Closing the window with staged edits would lose them silently. Closing it
+// mid-rebuild stops the batch loop, which leaves the brain searchable but
+// incomplete until someone comes back and resumes — also worth a warning.
 window.addEventListener("beforeunload", event => {
-  if (isDirty()) event.preventDefault();
+  if (isDirty() || migrationBusy()) event.preventDefault();
 });
 
 window.addEventListener(LOCALE_CHANGE_EVENT, () => render());

--- a/installer/src/settings.ts
+++ b/installer/src/settings.ts
@@ -181,7 +181,9 @@ async function save(): Promise<void> {
  * picker shows. Dimensions are deliberately not in the payload: a number like
  * 768 on a decision screen is exactly what the named level replaces.
  */
-type EmbeddingChoice = { model: string; level: string };
+/** `exceedsFreeStorage` is computed on the Rust side, because the window
+ *  deliberately never sees dimension counts. */
+type EmbeddingChoice = { model: string; level: string; exceedsFreeStorage: boolean };
 
 type MigrationEstimate = {
   entries: number;
@@ -547,8 +549,12 @@ async function freeOldSearchData(): Promise<void> {
   render();
 }
 
-function migrationNote(text: string): HTMLElement {
-  return h("div", { class: "settings-migration-note" }, [text]);
+function migrationNote(text: string, tone: "plain" | "warn" = "plain"): HTMLElement {
+  const cls =
+    tone === "warn"
+      ? "settings-migration-note settings-migration-warn"
+      : "settings-migration-note";
+  return h("div", { class: cls }, [text]);
 }
 
 function migrationTitle(text: string): HTMLElement {
@@ -630,6 +636,18 @@ function migrationPicker(e: MigrationEstimate): HTMLElement[] {
     select.append(h("option", { value: e.currentModel }, [label(e.currentModel)]));
   }
   select.value = migration.target ?? e.currentModel;
+
+  // The one warning that is about a hard limit rather than a cost. On the free
+  // plan, running out of stored space makes writes fail — there is no billing to
+  // absorb it — and the peak comes during the rebuild, while both the old and new
+  // search data are kept so the change can still be undone.
+  const storageWarning = () => {
+    const target = select.value;
+    const chosen = e.models.find(m => m.model === target);
+    return chosen?.exceedsFreeStorage && target !== e.currentModel
+      ? t("settingsPanel.migration.storageWarning")
+      : null;
+  };
   select.disabled = locked();
   select.addEventListener("change", () => {
     migration.target = select.value;
@@ -667,6 +685,10 @@ function migrationPicker(e: MigrationEstimate): HTMLElement[] {
   const notice = levelNotice(migration.target ?? e.currentModel);
   if (notice) out.push(migrationNote(notice));
   out.push(migrationNote(t("settingsPanel.migration.pickNote")));
+  // Placed with the choice rather than on the warning screen: it is a reason to
+  // pick differently, not a step to acknowledge on the way past.
+  const storage = storageWarning();
+  if (storage) out.push(migrationNote(storage, "warn"));
   if (sameAsCurrent) out.push(migrationNote(t("settingsPanel.migration.sameAsCurrent")));
   else if (blockedByEdits) out.push(migrationNote(t("settingsPanel.migration.dirtyNote")));
   out.push(migrationActions(start));

--- a/installer/src/settings.ts
+++ b/installer/src/settings.ts
@@ -166,14 +166,29 @@ async function save(): Promise<void> {
  * All of it lives at module scope because render() calls app.replaceChildren()
  * on every state change — a progress bar held by reference would be thrown away
  * on the next repaint, exactly as `message` and `busy` are handled.
+ *
+ * Every state has a way out, which is the property the phase list is arranged
+ * around. `running` has Pause. A stall that waiting cannot fix, and a loop that
+ * stops moving, both have Start over. Both terminal screens have a route back to
+ * the picker. A rebuild that leaves search incomplete with no button to press is
+ * the failure mode this flow is designed against.
  */
+
+/**
+ * One offerable way of reading memories.
+ *
+ * `level` is a copy key ("standard" | "finer" | "finest"), and it is what the
+ * picker shows. Dimensions are deliberately not in the payload: a number like
+ * 768 on a decision screen is exactly what the named level replaces.
+ */
+type EmbeddingChoice = { model: string; level: string };
 
 type MigrationEstimate = {
   entries: number;
   chunksAtLeast: number;
   currentModel: string;
-  /** [id, dimensions]. The number never reaches the screen — it only orders the list. */
-  models: [string, number][];
+  /** Already ordered coarsest first by the Worker side; never re-sorted here. */
+  models: EmbeddingChoice[];
 };
 
 /** A rebuild the Worker has on record, finished or not. */
@@ -194,8 +209,14 @@ type MigrationStep = {
   remaining: number;
   total: number;
   done: boolean;
-  /** The day's AI allowance is gone. Progress is saved; resuming is free. */
+  /** The run stopped with its cursor kept, because a batch achieved nothing. */
   stalled: boolean;
+  /**
+   * Why it stopped. `"budget"` refills overnight; `"failing"` never will, so the
+   * two need different screens — "come back tomorrow" is advice that can never
+   * work against a memory that keeps failing.
+   */
+  stalledReason: "budget" | "failing" | null;
 };
 
 type MigrationPhase =
@@ -209,11 +230,20 @@ type MigrationPhase =
   | "confirm"
   | "starting"
   | "running"
-  | "stalled"
+  /** The user asked to stop; progress is kept and resuming is free. */
+  | "paused"
+  /** The day's AI allowance is spent. It comes back. */
+  | "stalledBudget"
+  /** One memory keeps failing. Waiting cannot fix it. */
+  | "stalledFailing"
+  /** Batches keep returning without moving anything. */
+  | "stuck"
   | "failed"
   /** A rebuild from an earlier session stopped partway. */
   | "interrupted"
-  /** Re-reading finished; the old search data is still there. */
+  /** Abandoning a run's record so the next one begins from the first memory. */
+  | "resetting"
+  /** Re-reading finished; the old search data may still be there. */
   | "done"
   | "freeing"
   | "freed";
@@ -229,64 +259,93 @@ const migration = {
   /** Second half of the two-step confirm on the irreversible last step. */
   confirmFree: false,
   /**
-   * What `finish_embedding_migration` needs. Readable from the estimate only
-   * BEFORE the rebuild starts: afterwards the Worker reports the new reader as
-   * the current one, so it is written down at begin time and read back here.
+   * What is left over to free, as the Worker side recorded it from the binding
+   * Cloudflare reported. Nothing here is derived or remembered by this window:
+   * the name of something irreversibly deletable must not depend on browser
+   * storage, which a reset clears and which cannot be trusted to name the right
+   * thing after a restart.
    */
-  oldDimensions: null as number | null,
+  oldIndex: null as string | null,
+  /** Set by Pause. The loop stops after the batch already in flight. */
+  pauseRequested: false,
   /** Guards against a second step loop running alongside the first. */
   looping: false,
 };
 
 function migrationBusy(): boolean {
   const p = migration.phase;
-  return p === "starting" || p === "running" || p === "freeing";
+  return p === "starting" || p === "running" || p === "freeing" || p === "resetting";
 }
 
 /**
- * The old size has to survive an app restart mid-rebuild, or a user who closes
- * the window before the last step can never free the old search data. It is a
- * UI bookkeeping detail, so it lives here rather than in the Worker's config.
+ * Chunks one batch will embed before it stops — the Worker's
+ * MIGRATION_CHUNK_BUDGET. Duplicated here only to turn a piece count into a
+ * number of sequential rounds, which is the one honest answer this window can
+ * give to "how long will this take". It is shown as "about", so a drift in the
+ * Worker's budget changes nothing anyone acts on.
  */
-const OLD_DIMENSIONS_KEY = "sb-migration-old-dimensions";
+const CHUNKS_PER_ROUND = 20;
 
-function rememberOldDimensions(model: string, dimensions: number): void {
+function roundsFor(chunks: number): number {
+  return Math.max(1, Math.round(chunks / CHUNKS_PER_ROUND));
+}
+
+/** The `level` a model is offered under, or null if the Worker doesn't offer it. */
+function levelOf(model: string): string | null {
+  return migration.estimate?.models.find(m => m.model === model)?.level ?? null;
+}
+
+/**
+ * The name a user reads. Never the model id: an id was the last thing read
+ * before a one-way operation, and it asked the reader to reason about the
+ * position of an opaque string in a list.
+ *
+ * Falls back to the id only for a model the Worker does not offer — a reader set
+ * outside the app, which must still show as selected rather than vanish.
+ */
+function levelName(model: string): string {
+  const level = levelOf(model);
+  if (!level) return model;
+  const key = `settingsPanel.migration.levels.${level}.name` as const;
+  const name = t(key);
+  // t() returns the path when a key is missing; a dotted path on screen would be
+  // worse than the id it replaced.
+  return name === key ? model : name;
+}
+
+/** The trade-off, in plain language, for whichever level is selected. */
+function levelNotice(model: string): string | null {
+  const level = levelOf(model);
+  if (!level) return null;
+  const key = `settingsPanel.migration.levels.${level}.notice` as const;
+  const notice = t(key);
+  return notice === key ? null : notice;
+}
+
+/**
+ * Whether there is leftover search data to free, by name.
+ *
+ * Asked of the Worker side rather than tracked here: it is recorded from what
+ * Cloudflare reported as bound, so it survives a restart and cannot name the
+ * wrong thing. A failure reads as "nothing to free" — offering the step without
+ * a name behind it is how the wrong data gets deleted.
+ */
+async function refreshOldIndex(): Promise<void> {
   try {
-    localStorage.setItem(OLD_DIMENSIONS_KEY, JSON.stringify({ model, dimensions }));
+    migration.oldIndex = await invoke<string | null>("outstanding_old_index");
   } catch {
-    /* private mode / unavailable */
+    migration.oldIndex = null;
   }
 }
 
-function readOldDimensions(model: string): number | null {
-  try {
-    const raw = localStorage.getItem(OLD_DIMENSIONS_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as { model?: string; dimensions?: number };
-    // Keyed by model so a note left by an older, different rebuild is ignored
-    // rather than used to delete the wrong search data.
-    if (parsed.model !== model || typeof parsed.dimensions !== "number") return null;
-    return parsed.dimensions;
-  } catch {
-    return null;
-  }
-}
-
-function forgetOldDimensions(): void {
-  try {
-    localStorage.removeItem(OLD_DIMENSIONS_KEY);
-  } catch {
-    /* private mode / unavailable */
-  }
-}
-
-function dimensionsOf(model: string): number | null {
-  const hit = migration.estimate?.models.find(([id]) => id === model);
-  return hit ? hit[1] : null;
-}
-
-/** Estimate before anything is created, and any rebuild already on record. */
-async function loadMigration(): Promise<void> {
+/**
+ * Estimate before anything is created, and any rebuild already on record.
+ *
+ * `forcePicker` is the "Change this again" route: a finished run stays on record,
+ * so re-reading status would land straight back on the done screen and the two
+ * terminal states would have no way out of the window.
+ */
+async function loadMigration(forcePicker = false): Promise<void> {
   try {
     const status = await invoke<MigrationStatus>("migration_status");
     // A status the Worker itself calls not-ok must not be read as "no rebuild in
@@ -301,16 +360,16 @@ async function loadMigration(): Promise<void> {
     migration.estimate = estimate;
     migration.error = null;
     const run = status.state;
-    if (!run) {
-      migration.oldDimensions = dimensionsOf(estimate.currentModel);
+    if (forcePicker || !run) {
       migration.target = estimate.currentModel;
       migration.progress = null;
+      migration.confirmFree = false;
       migration.phase = "idle";
     } else {
       migration.target = run.model;
-      migration.oldDimensions = readOldDimensions(run.model);
       migration.progress = { done: run.processed, total: run.totalAtStart, failed: run.failed };
       migration.phase = run.finishedAt ? "done" : "interrupted";
+      if (run.finishedAt) await refreshOldIndex();
     }
   } catch (e) {
     migration.phase = "loadFailed";
@@ -322,7 +381,9 @@ async function loadMigration(): Promise<void> {
 async function beginMigration(): Promise<void> {
   const model = migration.target;
   if (!model || migrationBusy()) return;
-  const oldDimensions = migration.oldDimensions;
+  // A brain with no memories skips the warning screen, so a failed begin has to
+  // land back on the picker rather than on a screen that was never shown.
+  const back: MigrationPhase = (migration.estimate?.entries ?? 1) === 0 ? "idle" : "confirm";
   migration.phase = "starting";
   migration.error = null;
   message = null;
@@ -333,15 +394,15 @@ async function beginMigration(): Promise<void> {
     await invoke("begin_embedding_migration", { model });
   } catch (e) {
     // The old search data is still bound, so the brain is exactly as it was.
-    // Back to the confirm screen with the target kept, so one click retries.
-    migration.phase = "confirm";
+    // Back with the target kept, so one click retries.
+    migration.phase = back;
     migration.error = errorText(e);
     render();
     return;
   }
-  if (oldDimensions !== null) rememberOldDimensions(model, oldDimensions);
   migration.phase = "running";
   migration.progress = null;
+  migration.pauseRequested = false;
   render();
   await stepLoop();
 }
@@ -374,13 +435,30 @@ async function stepLoop(): Promise<void> {
       if (step.done) {
         migration.phase = "done";
         migration.error = null;
+        migration.confirmFree = false;
+        // Whether there is anything left to free is the Worker side's answer, and
+        // it decides whether the last step is offered at all.
+        await refreshOldIndex();
         render();
         return;
       }
-      // Stalling is not a failure: the allowance refills. Stop the loop, keep
-      // the progress, and offer to carry on later.
+      // Two different stalls behind one flag. A spent allowance refills, so the
+      // advice is "come back tomorrow"; a memory that keeps failing never will,
+      // and telling that user to wait would send them back to Carry on, which
+      // reruns the identical failing batch forever. Anything that is not plainly
+      // a budget stall gets the screen with a way out.
       if (step.stalled) {
-        migration.phase = "stalled";
+        migration.phase = step.stalledReason === "budget" ? "stalledBudget" : "stalledFailing";
+        migration.error = null;
+        render();
+        return;
+      }
+      // An explicit Pause takes effect between batches: the request in flight
+      // cannot be recalled, and throwing away its result would lose work the
+      // allowance has already been spent on.
+      if (migration.pauseRequested) {
+        migration.pauseRequested = false;
+        migration.phase = "paused";
         migration.error = null;
         render();
         return;
@@ -390,8 +468,11 @@ async function stepLoop(): Promise<void> {
       idleRounds = step.remaining === lastRemaining ? idleRounds + 1 : 0;
       lastRemaining = step.remaining;
       if (idleRounds >= 2) {
-        migration.phase = "failed";
-        migration.error = t("settingsPanel.migration.stuck");
+        // Its own phase rather than an error string stacked under the failed
+        // screen, which said the same thing twice in two voices — three lines of
+        // calm grey reassurance and then a red sentence arguing with them.
+        migration.phase = "stuck";
+        migration.error = null;
         render();
         return;
       }
@@ -406,20 +487,56 @@ async function resumeMigration(): Promise<void> {
   if (migrationBusy()) return;
   migration.phase = "running";
   migration.error = null;
+  migration.pauseRequested = false;
+  render();
+  await stepLoop();
+}
+
+/**
+ * The abandon path: forget where the run got to and read everything again from
+ * the first memory.
+ *
+ * Without it, a rebuild whose cursor sits on a permanently failing memory has no
+ * exit at all — every Carry on reruns the same batch. It costs AI allowance for
+ * work already paid for once, which is why the screens that offer it say so.
+ *
+ * It does not land on the picker afterwards. The brain is already reading the new
+ * search data, so stopping here would leave search incomplete with nothing
+ * running to complete it; starting the batches again is what "start over" means.
+ */
+async function restartMigration(): Promise<void> {
+  if (migrationBusy()) return;
+  const back = migration.phase;
+  migration.phase = "resetting";
+  migration.error = null;
+  render();
+  try {
+    await invoke("migration_reset");
+  } catch (e) {
+    // Nothing was forgotten, so the screen that offered this still applies.
+    migration.phase = back;
+    migration.error = errorText(e);
+    render();
+    return;
+  }
+  migration.progress = null;
+  migration.pauseRequested = false;
+  migration.phase = "running";
   render();
   await stepLoop();
 }
 
 /** The one irreversible step, always behind its own explicit confirm. */
 async function freeOldSearchData(): Promise<void> {
-  const oldDimensions = migration.oldDimensions;
-  if (oldDimensions === null || migrationBusy()) return;
+  if (migration.oldIndex === null || migrationBusy()) return;
   migration.phase = "freeing";
   migration.error = null;
   render();
   try {
-    await invoke("finish_embedding_migration", { oldDimensions });
-    forgetOldDimensions();
+    // No argument: the Worker side holds the name of what it recorded as bound,
+    // so nothing deletable is ever named by this window.
+    await invoke("finish_embedding_migration");
+    migration.oldIndex = null;
     migration.confirmFree = false;
     migration.phase = "freed";
   } catch (e) {
@@ -442,13 +559,30 @@ function migrationActions(...buttons: HTMLElement[]): HTMLElement {
   return h("div", { class: "row-actions settings-migration-actions" }, buttons);
 }
 
-function migrationButton(cls: string, label: string, onClick: () => void): HTMLElement {
+/**
+ * `live` is for the one control that must stay usable while a rebuild runs:
+ * Pause. Everything else is disabled for the duration, which is why the default
+ * is the locked one.
+ */
+function migrationButton(
+  cls: string,
+  label: string,
+  onClick: () => void,
+  live = false,
+): HTMLElement {
   const button = h("button", { class: cls, type: "button" }, [label]);
-  (button as HTMLButtonElement).disabled = locked();
+  (button as HTMLButtonElement).disabled = live ? busy : locked();
   button.addEventListener("click", onClick);
   return button;
 }
 
+/**
+ * Not rendered on the done screen at all, which is why `failed` never appears
+ * there. `failed` is cumulative and a memory that failed one batch is retried in
+ * a later one, so finishing with a non-zero count is an ordinary outcome — and
+ * "couldn't be read: 3" under the heading "all your memories have been read
+ * again" would contradict itself, with the alarming half carrying the number.
+ */
 function migrationProgress(): HTMLElement {
   const p = migration.progress;
   const wrap = h("div", { class: "settings-migration-progress" });
@@ -472,17 +606,27 @@ function migrationProgress(): HTMLElement {
   return wrap;
 }
 
+/** Counted in memories, the same unit progress uses, and correct at 0 and 1. */
+function estimateCount(e: MigrationEstimate): string {
+  if (e.entries === 0) return t("settingsPanel.migration.entriesNone");
+  if (e.entries === 1) return t("settingsPanel.migration.entriesOne");
+  return t("settingsPanel.migration.entries", { entries: num(e.entries) });
+}
+
 function migrationPicker(e: MigrationEstimate): HTMLElement[] {
   const select = h("select", { class: "locale-select" }) as HTMLSelectElement;
-  // Ordered by how finely each one reads, which is what the note under the
-  // dropdown explains. The sizes themselves stay out of the copy.
-  const ordered = [...e.models].sort((a, b) => a[1] - b[1]);
-  const label = (id: string) =>
-    id === e.currentModel ? t("settingsPanel.migration.inUse", { name: id }) : id;
-  for (const [id] of ordered) select.append(h("option", { value: id }, [label(id)]));
+  // Already ordered coarsest first, and there is nothing left to sort by:
+  // dimensions no longer reach this window at all.
+  const label = (model: string) =>
+    model === e.currentModel
+      ? t("settingsPanel.migration.inUse", { name: levelName(model) })
+      : levelName(model);
+  for (const choice of e.models) {
+    select.append(h("option", { value: choice.model }, [label(choice.model)]));
+  }
   // A reader set outside the app must still show as selected rather than
   // silently reading as the first entry.
-  if (!ordered.some(([id]) => id === e.currentModel)) {
+  if (!e.models.some(m => m.model === e.currentModel)) {
     select.append(h("option", { value: e.currentModel }, [label(e.currentModel)]));
   }
   select.value = migration.target ?? e.currentModel;
@@ -498,6 +642,13 @@ function migrationPicker(e: MigrationEstimate): HTMLElement[] {
   // with no way to save them. Ask for a clean slate first, and say so.
   const blockedByEdits = isDirty();
   const start = migrationButton("btn-primary", t("settingsPanel.migration.startButton"), () => {
+    // Nothing to warn about on an empty brain: there is no search to go
+    // incomplete and nothing to read again, and the warning copy is nonsense at
+    // zero. The switch itself still has to happen.
+    if (e.entries === 0) {
+      void beginMigration();
+      return;
+    }
     migration.phase = "confirm";
     migration.error = null;
     render();
@@ -505,18 +656,17 @@ function migrationPicker(e: MigrationEstimate): HTMLElement[] {
   (start as HTMLButtonElement).disabled = locked() || sameAsCurrent || blockedByEdits;
 
   const out: HTMLElement[] = [
-    h("div", { class: "settings-migration-count" }, [
-      t("settingsPanel.migration.entries", {
-        entries: num(e.entries),
-        chunks: num(e.chunksAtLeast),
-      }),
-    ]),
+    h("div", { class: "settings-migration-count" }, [estimateCount(e)]),
     h("div", { class: "url-label settings-migration-pick" }, [
       t("settingsPanel.migration.pickLabel"),
     ]),
     select,
-    migrationNote(t("settingsPanel.migration.pickNote")),
   ];
+  // What the selected level actually trades away, so the choice is not made by
+  // reading positions in a list.
+  const notice = levelNotice(migration.target ?? e.currentModel);
+  if (notice) out.push(migrationNote(notice));
+  out.push(migrationNote(t("settingsPanel.migration.pickNote")));
   if (sameAsCurrent) out.push(migrationNote(t("settingsPanel.migration.sameAsCurrent")));
   else if (blockedByEdits) out.push(migrationNote(t("settingsPanel.migration.dirtyNote")));
   out.push(migrationActions(start));
@@ -524,10 +674,12 @@ function migrationPicker(e: MigrationEstimate): HTMLElement[] {
 }
 
 function migrationConfirm(): HTMLElement[] {
-  const chunks = migration.estimate ? num(migration.estimate.chunksAtLeast) : "—";
+  const e = migration.estimate;
+  const chunks = e ? num(e.chunksAtLeast) : "—";
+  const rounds = e ? num(roundsFor(e.chunksAtLeast)) : "—";
   const points = h("ul", { class: "settings-migration-points" });
-  for (const key of ["point1", "point2", "point3"] as const) {
-    points.append(h("li", {}, [t(`settingsPanel.migration.${key}`, { chunks })]));
+  for (const key of ["point1", "point2", "point3", "point4"] as const) {
+    points.append(h("li", {}, [t(`settingsPanel.migration.${key}`, { chunks, rounds })]));
   }
   const go = migrationButton(
     "btn-danger",
@@ -544,17 +696,50 @@ function migrationConfirm(): HTMLElement[] {
     migration.error = null;
     render();
   });
+  const target = migration.target ?? "";
   const out = [
     migrationTitle(t("settingsPanel.migration.confirmTitle")),
+    // One sentence at full weight. Everything under it is grey, and a screen
+    // that is entirely grey before a one-way operation does not get read.
+    h("div", { class: "settings-migration-lead" }, [t("settingsPanel.migration.confirmLead")]),
     migrationNote(t("settingsPanel.migration.confirmBody")),
     points,
+    // The named level, not the id: this is the last label before commitment.
     h("div", { class: "settings-migration-target" }, [
-      t("settingsPanel.migration.targetLine", { name: migration.target ?? "" }),
+      t("settingsPanel.migration.targetLine", { name: levelName(target) }),
     ]),
   ];
+  // The id earns its place only here, as secondary text, for anyone who wants to
+  // check exactly what they are about to be moved onto.
+  if (levelOf(target)) {
+    out.push(
+      h("div", { class: "settings-migration-model" }, [
+        t("settingsPanel.migration.modelLine", { name: target }),
+      ]),
+    );
+  }
   if (blockedByEdits) out.push(migrationNote(t("settingsPanel.migration.dirtyNote")));
   out.push(migrationActions(go, back));
   return out;
+}
+
+/**
+ * Both terminal screens were dead ends inside this window: the only route back
+ * to the picker was closing it and opening it again.
+ */
+function changeAgainButton(): HTMLElement {
+  return migrationButton("btn-ghost", t("settingsPanel.migration.changeAgain"), () => {
+    migration.phase = "loading";
+    migration.error = null;
+    render();
+    void loadMigration(true);
+  });
+}
+
+function startOverButton(): HTMLElement {
+  return migrationButton("btn-secondary", t("settingsPanel.migration.startOverButton"), () =>
+    void restartMigration(),
+  );
 }
 
 function migrationDone(): HTMLElement[] {
@@ -562,14 +747,10 @@ function migrationDone(): HTMLElement[] {
     migrationTitle(t("settingsPanel.migration.doneTitle")),
     migrationNote(t("settingsPanel.migration.doneBody")),
   ];
-  const p = migration.progress;
-  if (p && p.failed > 0) {
-    out.push(migrationNote(t("settingsPanel.migration.skipped", { failed: num(p.failed) })));
-  }
-  // Without the old size the wrong search data could be deleted, so the offer
-  // is withheld rather than guessed at.
-  if (migration.oldDimensions === null) {
-    out.push(migrationNote(t("settingsPanel.migration.freeUnknown")));
+  // Nothing recorded as outstanding means nothing to free. Silently, with no
+  // apology: there is no leftover data and therefore nothing to explain.
+  if (migration.oldIndex === null) {
+    out.push(migrationActions(changeAgainButton()));
     return out;
   }
   out.push(
@@ -585,6 +766,7 @@ function migrationDone(): HTMLElement[] {
           migration.confirmFree = true;
           render();
         }),
+        changeAgainButton(),
       ),
     );
     return out;
@@ -634,18 +816,69 @@ function migrationBody(): HTMLElement[] {
         migrationTitle(t("settingsPanel.migration.startingTitle")),
         migrationNote(t("settingsPanel.migration.startingBody")),
       ];
-    case "running":
+    case "running": {
+      // The copy has always said closing the window is a safe pause, and then
+      // beforeunload argued about closing it. A real Pause is the exit that
+      // settles the contradiction — and it stays enabled while everything else
+      // on the screen is locked.
+      const pause = migrationButton(
+        "btn-ghost",
+        migration.pauseRequested
+          ? t("settingsPanel.migration.pausing")
+          : t("settingsPanel.migration.pauseButton"),
+        () => {
+          migration.pauseRequested = true;
+          render();
+        },
+        true,
+      );
+      (pause as HTMLButtonElement).disabled = migration.pauseRequested;
       return [
         migrationTitle(t("settingsPanel.migration.runningTitle")),
         migrationProgress(),
         migrationNote(t("settingsPanel.migration.runningBody")),
+        migrationActions(pause),
       ];
-    case "stalled":
+    }
+    case "paused":
+      return [
+        migrationTitle(t("settingsPanel.migration.pausedTitle")),
+        migrationProgress(),
+        migrationNote(t("settingsPanel.migration.pausedBody")),
+        migrationActions(resume()),
+      ];
+    case "stalledBudget":
       return [
         migrationTitle(t("settingsPanel.migration.stalledTitle")),
         migrationProgress(),
         migrationNote(t("settingsPanel.migration.stalledBody")),
         migrationActions(resume()),
+      ];
+    case "stalledFailing":
+      // The allowance is not the problem here, so Carry on alone would rerun the
+      // identical failing batch for as long as the user is willing to click it.
+      return [
+        migrationTitle(t("settingsPanel.migration.stalledFailingTitle")),
+        migrationProgress(),
+        migrationNote(t("settingsPanel.migration.stalledFailingBody")),
+        migrationNote(t("settingsPanel.migration.startOverNote")),
+        migrationActions(
+          migrationButton("btn-secondary", t("common.tryAgain"), () => void resumeMigration()),
+          startOverButton(),
+        ),
+      ];
+    case "stuck":
+      // Same trap as stalledFailing, reached by the loop's own no-progress guard
+      // rather than by the Worker admitting it, so it gets the same way out.
+      return [
+        migrationTitle(t("settingsPanel.migration.stuckTitle")),
+        migrationProgress(),
+        migrationNote(t("settingsPanel.migration.stuck")),
+        migrationNote(t("settingsPanel.migration.startOverNote")),
+        migrationActions(
+          migrationButton("btn-secondary", t("common.tryAgain"), () => void resumeMigration()),
+          startOverButton(),
+        ),
       ];
     case "interrupted":
       return [
@@ -657,7 +890,13 @@ function migrationBody(): HTMLElement[] {
             total: num(migration.progress?.total ?? 0),
           }),
         ),
-        migrationActions(resume()),
+        migrationNote(t("settingsPanel.migration.startOverNote")),
+        migrationActions(resume(), startOverButton()),
+      ];
+    case "resetting":
+      return [
+        migrationTitle(t("settingsPanel.migration.resettingTitle")),
+        migrationNote(t("settingsPanel.migration.resettingBody")),
       ];
     case "failed":
       return [
@@ -679,6 +918,7 @@ function migrationBody(): HTMLElement[] {
       return [
         migrationTitle(t("settingsPanel.migration.freedTitle")),
         migrationNote(t("settingsPanel.migration.freedBody")),
+        migrationActions(changeAgainButton()),
       ];
   }
 }

--- a/installer/src/style.css
+++ b/installer/src/style.css
@@ -798,6 +798,96 @@ body.settings-page #app {
   font-size: 0.85rem;
 }
 
+/* ── Rebuilding how memories are read (#248) ─────────────────────────────────
+   One card that becomes a small progress screen, so it needs headings, a bar
+   and a bullet list that the level controls never did. */
+
+.settings-migration-title {
+  margin-top: 0.9rem;
+}
+
+/* .settings-notice reserves two lines to stop level cards reflowing under the
+   cursor. These notices stack several deep, so they get their own class. */
+.settings-migration-note {
+  margin-top: 0.35rem;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.settings-migration-count {
+  margin-top: 0.5rem;
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.settings-migration-pick {
+  margin-top: 0.9rem;
+}
+
+.settings-progress {
+  height: 6px;
+  margin: 0.45rem 0 0.2rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  overflow: hidden;
+}
+
+.settings-progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 0.3s ease;
+}
+
+.settings-migration-points {
+  margin: 0.6rem 0 0;
+  padding-left: 1.1rem;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.settings-migration-points li {
+  margin-bottom: 0.3rem;
+}
+
+.settings-migration-target {
+  margin-top: 0.6rem;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.settings-migration-actions {
+  margin-top: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.settings-migration-error {
+  margin-top: 0.6rem;
+  color: var(--danger);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+/* The step that cannot be undone is fenced off from the finished-rebuild
+   message above it. */
+.settings-migration-free {
+  margin-top: 1rem;
+  padding-top: 0.85rem;
+  border-top: 0.5px solid var(--border);
+}
+
+/* .btn-primary is width:100% for the full-width setup buttons; inside a
+   settings card it has to size to its label like every other button here. */
+.settings-migration .btn-primary {
+  width: auto;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.85rem;
+}
+
 /* Staged edits in a pane the user is not looking at would otherwise be
    invisible until they hit Save. */
 .rail-dot {

--- a/installer/src/style.css
+++ b/installer/src/style.css
@@ -919,3 +919,15 @@ body.settings-page #app {
   font-size: 0.6rem;
   vertical-align: middle;
 }
+
+/* The storage warning in the Matching pane. Every other note there is quiet
+   grey on purpose; this one is the single thing that says "this choice may not
+   work", so it carries the same accent the app uses for other cautions rather
+   than disappearing into the surrounding text. */
+.settings-migration-warn {
+  color: var(--text-primary);
+  background: var(--surface-sunken, rgba(0, 0, 0, 0.03));
+  border-left: 3px solid var(--danger, #c0392b);
+  padding: 8px 10px;
+  border-radius: 6px;
+}

--- a/installer/src/style.css
+++ b/installer/src/style.css
@@ -853,11 +853,34 @@ body.settings-page #app {
   margin-bottom: 0.3rem;
 }
 
+/* The one sentence on the warning screen that carries full weight. The rest of
+   that screen is grey, and a wall of grey before a one-way operation is not
+   read at all. */
+.settings-migration-lead {
+  margin-top: 0.55rem;
+  color: var(--text-primary);
+  font-size: 0.88rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+/* What is being switched to, by its named level. Not monospace any more: it
+   held a model id when it was written, and now it holds a human label. */
 .settings-migration-target {
-  margin-top: 0.6rem;
+  margin-top: 0.7rem;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+/* The raw model id, kept for auditability on the screen that commits and
+   nowhere else. Sized and coloured so it reads as a footnote to the line above
+   rather than as the thing being chosen. */
+.settings-migration-model {
+  margin-top: 0.2rem;
   font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 0.78rem;
-  color: var(--text-secondary);
+  font-size: 0.72rem;
+  color: var(--text-tertiary);
+  word-break: break-all;
 }
 
 .settings-migration-actions {

--- a/scripts/seed-test-brain.mjs
+++ b/scripts/seed-test-brain.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Fills a throwaway Second Brain with enough varied memories to exercise the
+ * embedding migration (#248) end to end.
+ *
+ * WHY THIS EXISTS
+ *
+ * A freshly provisioned brain has no memories, and every interesting failure mode
+ * in a migration is about scale: batch boundaries, the keyset cursor paging across
+ * entries that share a timestamp, the daily allowance running out part-way, and
+ * resuming afterwards. An empty brain proves the plumbing and none of the loop.
+ *
+ * NEVER POINT THIS AT A BRAIN YOU CARE ABOUT. It writes real memories that you
+ * would then have to delete one by one. It is for a scratch account.
+ *
+ * WHAT IT COSTS
+ *
+ * Each capture is not one model call. `captureEntry` embeds the content, runs a
+ * duplicate/contradiction check (another embed, a Vectorize query, and possibly a
+ * streaming LLM call), classifies it (another LLM call), and may infer graph
+ * edges. So seeding 120 memories is a few hundred model calls before the
+ * migration test starts. On a free account that is a real slice of the day's
+ * allowance — seed in the morning, or seed less.
+ *
+ * WHY THE CONTENT IS DELIBERATELY VARIED
+ *
+ * Capture blocks near-duplicates at DUPLICATE_BLOCK_THRESHOLD (0.95). Seeding with
+ * "test entry 1", "test entry 2" … would get most of them rejected as duplicates
+ * of each other, and you would be testing dedupe rather than migration. The
+ * sentences below are built from unrelated subject matter for that reason.
+ *
+ * A few are long enough to split into several chunks, because the migration
+ * budgets its batches in chunks rather than entries — a brain of uniformly short
+ * memories never exercises that.
+ *
+ * USAGE
+ *
+ *   node scripts/seed-test-brain.mjs --url https://second-brain.<sub>.workers.dev \
+ *                                    --token <the brain's password> \
+ *                                    [--count 120]
+ *
+ * Then run the migration from the desktop app's Advanced Settings → Matching.
+ */
+
+const args = process.argv.slice(2);
+function arg(name, fallback = null) {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+}
+
+const url = (arg("url") ?? process.env.SB_URL ?? "").replace(/\/$/, "");
+const token = arg("token") ?? process.env.SB_TOKEN ?? "";
+const count = Number(arg("count", "120"));
+
+if (!url || !token) {
+  console.error(
+    "Need --url and --token (or SB_URL / SB_TOKEN).\n" +
+      "Point this ONLY at a throwaway brain — it writes real memories.",
+  );
+  process.exit(1);
+}
+if (!/^https:\/\/[a-z0-9-]+\.[a-z0-9-]+\.workers\.dev$/.test(url)) {
+  console.error(`Refusing to seed ${url} — expected a plain workers.dev origin.`);
+  process.exit(1);
+}
+
+// Subject matter chosen to be mutually dissimilar, so dedupe does not reject
+// them. Each template is filled with a distinct detail.
+const TEMPLATES = [
+  n => `The sourdough starter doubles in about ${4 + (n % 5)} hours when the kitchen sits near 21 degrees.`,
+  n => `Bus route ${100 + n} stops running after 23:40 on weekdays, so the last useful connection is the 23:12.`,
+  n => `Anna's youngest is called Marek and turns ${3 + (n % 9)} in November — she mentioned wanting a cargo bike.`,
+  n => `The blue oscilloscope drifts about ${n % 7} millivolts after an hour; it needs the warm-up before any calibration run.`,
+  n => `Decided against the ${["oak", "walnut", "birch", "ash"][n % 4]} shelving because the wall studs are 600mm apart, not 400.`,
+  n => `The tomato variety that actually survived last summer was Costoluto, planted in week ${12 + (n % 6)}.`,
+  n => `Reminder: the ${["dentist", "optician", "physio", "vet"][n % 4]} only books ${2 + (n % 3)} weeks ahead, and never on Fridays.`,
+  n => `Rent review lands in month ${1 + (n % 12)}; the lease allows a rise capped at inflation plus one percent.`,
+  n => `That recurring build failure was a stale lockfile, not the compiler — deleting node_modules fixed it in run ${n}.`,
+  n => `The cellar humidity sits around ${55 + (n % 20)} percent, which is fine for the tools but wrong for paper.`,
+];
+
+/** Long entries, so some batches are chunk-bound rather than entry-bound. */
+function longEntry(n) {
+  const paras = [];
+  for (let p = 0; p < 4; p++) {
+    paras.push(
+      `Section ${p + 1} of note ${n}. ` +
+        `The measurements were taken over ${3 + p} consecutive evenings, each time after the room had settled. ` +
+        `What surprised me was how much the reading depended on whether the window had been open earlier in the day, ` +
+        `which is not something the manual mentions anywhere. ` +
+        `The pattern held across all ${5 + p} attempts, so it is unlikely to be noise. ` +
+        `Next time it would be worth logging the outdoor temperature alongside, because the correlation looked stronger ` +
+        `than the one with time of day, and that would change how the schedule should be arranged.`,
+    );
+  }
+  return paras.join("\n\n");
+}
+
+const TAGS = [["kitchen"], ["transport"], ["people"], ["workshop"], ["house"], ["garden"], ["admin"], ["work"]];
+
+let stored = 0;
+let duplicate = 0;
+let failed = 0;
+
+console.log(`Seeding ${count} memories into ${url}\n`);
+
+for (let n = 0; n < count; n++) {
+  // Roughly one in eight is long enough to split into several chunks.
+  const content = n % 8 === 7 ? longEntry(n) : TEMPLATES[n % TEMPLATES.length](n);
+  try {
+    const res = await fetch(`${url}/capture`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ content, tags: TAGS[n % TAGS.length], source: "api" }),
+    });
+    if (!res.ok) {
+      failed++;
+      if (failed <= 3) console.error(`  HTTP ${res.status} on ${n}: ${(await res.text()).slice(0, 120)}`);
+    } else {
+      const body = await res.json();
+      // The route reports a duplicate rather than failing — that is capture
+      // working, not an error, but it means one fewer memory to migrate.
+      if (body.duplicate || body.action === "duplicate") duplicate++;
+      else stored++;
+    }
+  } catch (e) {
+    failed++;
+    if (failed <= 3) console.error(`  ${n}: ${String(e).slice(0, 120)}`);
+  }
+
+  if ((n + 1) % 20 === 0) console.log(`  ${n + 1}/${count} — ${stored} stored, ${duplicate} duplicate, ${failed} failed`);
+  // Gentle, so a free-tier account is not rate-limited into failures that look
+  // like bugs.
+  await new Promise(r => setTimeout(r, 150));
+}
+
+console.log(`\nDone: ${stored} stored, ${duplicate} duplicate, ${failed} failed.`);
+console.log(`Vectors are written out of band, so give it a minute before migrating.\n`);
+
+console.log(`What to check, in order — and what each step proves:
+
+ 1. Advanced Settings → Matching. The estimate should read close to ${stored}
+    memories. If it reads lower, that is the deprecated-entry exclusion, not a bug.
+
+ 2. Pick a finer option and start. WATCH YOUR CLOUDFLARE DASHBOARD:
+    a new index should appear alongside the existing one, NOT replace it.
+    → proves Cloudflare accepts the new size, and that nothing is destroyed.
+
+ 3. While it runs, search the dashboard for something you seeded.
+    → proves the "search is incomplete while this runs" warning is honest.
+
+ 4. Close the settings window mid-rebuild, reopen it.
+    → proves the ledger resumes instead of restarting. Note whether the app
+      warned you before closing; it is supposed to.
+
+ 5. Let it finish, then search again.
+    → proves the rebuild actually populated the new index.
+
+ 6. Do NOT free the old data yet. Check the old index still holds its vectors.
+    → proves the rollback story is real, not just claimed.
+
+ 7. Now free the old data, and confirm the old index disappears.
+    → proves the one irreversible step works, and only when asked.
+
+ 8. Migrate BACK to the standard option.
+    → proves reversibility in both directions, which is the property users
+      will actually lean on.
+
+Report back: the index names you saw, whether the old one kept its vectors,
+how long the rebuild took, and anything the app said that turned out untrue.`);

--- a/src/capture/classify.ts
+++ b/src/capture/classify.ts
@@ -57,9 +57,15 @@ export async function classifyEntry(content: string, env: Env, config: Readonly<
   return parseClassification(text);
 }
 
-export function scheduleClassifyAndTag(entryId: string, content: string, env: Env, ctx: ExecutionContext): void {
+export function scheduleClassifyAndTag(
+  entryId: string,
+  content: string,
+  env: Env,
+  ctx: ExecutionContext,
+  config: Readonly<Config> = DEFAULTS,
+): void {
   ctx.waitUntil(
-    classifyEntry(content, env)
+    classifyEntry(content, env, config)
       .then(async ({ importance, canonical, kind }) => {
         await env.DB.prepare(`UPDATE entries SET importance_score = ? WHERE id = ?`).bind(importance, entryId).run();
         if (!kind && !canonical) return;

--- a/src/capture/entry.ts
+++ b/src/capture/entry.ts
@@ -91,7 +91,7 @@ export async function captureEntry(
           await deleteStaleVectors(env, oldVectorIds, newVectorIds);
         } catch (e) { console.error("Old vector cleanup failed (non-fatal):", e); }
 
-        scheduleClassifyAndTag(targetId, newContent, env, ctx);
+        scheduleClassifyAndTag(targetId, newContent, env, ctx, cfg);
 
         return mergeAction.action === "merge"
           ? { status: "merged", id: targetId }
@@ -114,7 +114,7 @@ export async function captureEntry(
       .catch(e => console.error("Vectorize insert failed (non-fatal):", e))
   );
 
-  scheduleClassifyAndTag(id, c, env, ctx);
+  scheduleClassifyAndTag(id, c, env, ctx, cfg);
 
   if (contradiction.detected && contradiction.conflicting_id) {
     const conflictId = contradiction.conflicting_id;

--- a/src/compression/digest.ts
+++ b/src/compression/digest.ts
@@ -81,7 +81,7 @@ export async function compressTag(
   }
 
   const rows = rawEntries.map(r => ({ id: r.id as string, content: r.content as string }));
-  const text = await synthesizeDigest(tag, rows, env);
+  const text = await synthesizeDigest(tag, rows, env, cfg);
   if (!text) return { synthesizedId: null, entriesUsed: 0, text: "" };
 
   const content = `[Synthesized from ${rows.length} entries tagged "${tag}"]\n\n${text}`;

--- a/src/compression/pattern.ts
+++ b/src/compression/pattern.ts
@@ -49,7 +49,7 @@ If no genuine pattern exists across 3+ memories, respond with exactly: NONE`;
     const validStarters = ["You tend to", "There's a recurring", "Across your memories"];
     if (!validStarters.some(s => trimmed.startsWith(s))) return;
 
-    await captureEntry(trimmed, ["auto-pattern"], "system", env, ctx);
+    await captureEntry(trimmed, ["auto-pattern"], "system", env, ctx, config);
   } catch (e) {
     console.error("derivePattern failed (non-fatal):", String(e));
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,14 @@ export const CONTRADICTION_IMPORTANCE_STEP = 1.0;
 export const EMBEDDING_MODEL = "@cf/baai/bge-small-en-v1.5";
 
 export const CHUNK_MAX_CHARS = 1600;
+// ── Embedding migration (#248) ───────────────────────────────────────────────
+// Budgeted in chunks rather than entries because storeEntry fires one model call
+// per chunk, all concurrently: 25 single-chunk entries is already ~75 binding
+// calls, and a handful of long memories in one batch would be far more. The
+// entry cap is a second ceiling so a page of tiny entries cannot balloon either.
+export const MIGRATION_CHUNK_BUDGET = 20;
+export const MIGRATION_MAX_ENTRIES_PER_BATCH = 25;
+
 export const CHUNK_OVERLAP_CHARS = 200;
 
 export const CLASSIFY_MAX_TOKENS = 80;

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -101,8 +101,8 @@ async function hydrateGraphEntries(ids: string[], env: Env): Promise<Map<string,
   return map;
 }
 
-export async function getConnections(id: string, type: string | undefined, env: Env): Promise<Connection[]> {
-  let neighbors = await expandGraph([id], { hops: 1 }, env);
+export async function getConnections(id: string, type: string | undefined, env: Env, config: Readonly<Config> = DEFAULTS): Promise<Connection[]> {
+  let neighbors = await expandGraph([id], { hops: 1 }, env, config);
   if (type) neighbors = neighbors.filter(n => n.viaType === type);
   if (!neighbors.length) return [];
 
@@ -127,12 +127,12 @@ export async function getConnections(id: string, type: string | undefined, env: 
   return out;
 }
 
-export async function buildGraph(opts: { seed?: string; limit?: number }, env: Env): Promise<GraphView> {
+export async function buildGraph(opts: { seed?: string; limit?: number }, env: Env, config: Readonly<Config> = DEFAULTS): Promise<GraphView> {
   const limit = opts.limit && opts.limit > 0 ? opts.limit : Infinity;
 
   let nodeIds: string[];
   if (opts.seed) {
-    const neighbors = await expandGraph([opts.seed], { hops: 2, maxNodes: limit, includeDeprecated: true }, env);
+    const neighbors = await expandGraph([opts.seed], { hops: 2, maxNodes: limit, includeDeprecated: true }, env, config);
     nodeIds = [opts.seed, ...neighbors.map(n => n.id)].slice(0, limit);
   } else {
     const sql = Number.isFinite(limit)

--- a/src/integrations/mirror.ts
+++ b/src/integrations/mirror.ts
@@ -24,8 +24,12 @@ export function makeMirrorStore(env: Env): MirrorStore {
       // bucket. Non-fatal — a failure just leaves it for the backfill to pick up.
       let finalTags = tags;
       let importance = 0;
+      // Resolved once and used for both the classify and the embed below: they
+      // must agree on the model, and this function previously resolved config
+      // for the embed while classifying with the shipped default.
+      const cfg = await resolveConfig(env);
       try {
-        const c = await classifyEntry(content, env);
+        const c = await classifyEntry(content, env, cfg);
         importance = c.importance;
         if (c.kind) finalTags = withKind(finalTags, c.kind);
         if (c.canonical) finalTags = withStatus(finalTags, "canonical");
@@ -36,7 +40,7 @@ export function makeMirrorStore(env: Env): MirrorStore {
         `INSERT INTO entries (id, content, tags, source, created_at, vector_ids, importance_score) VALUES (?, ?, ?, ?, ?, ?, ?)`
       ).bind(id, content, JSON.stringify(finalTags), source, now, "[]", importance).run();
       try {
-        await storeEntry(env, id, content, finalTags, source, now, await resolveConfig(env));
+        await storeEntry(env, id, content, finalTags, source, now, cfg);
       } catch (e) {
         console.error("Vectorize insert failed (non-fatal):", e);
       }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -356,7 +356,7 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       },
     },
     async ({ id, type }) => {
-      const connections = await getConnections(id, type, env);
+      const connections = await getConnections(id, type, env, await resolveConfig(env));
       if (!connections.length) {
         return { content: [{ type: "text", text: `No connections found for ${id}.` }] };
       }

--- a/src/migration/embedding.ts
+++ b/src/migration/embedding.ts
@@ -1,0 +1,349 @@
+/**
+ * Re-embedding every entry after an embedding-model change.
+ *
+ * Switching models changes the vector dimensions, and a Vectorize index fixes
+ * its dimensions at creation. So a model change means a new index, a redeploy
+ * pointing the binding at it, and every entry re-embedded into it. The desktop
+ * app drives that; this module is the part that runs inside the Worker.
+ *
+ * # D1 is never written destructively
+ *
+ * `entries.content` is the source of truth and migration only reads it. Vectors
+ * are derived data. The worst outcome here is a rebuild that has to be re-run,
+ * never a lost memory.
+ *
+ * # Why this keeps its own ledger
+ *
+ * The obvious progress marker is `entries.vector_ids`, the way
+ * `POST /vectorize-pending` uses it — select the rows that still read `'[]'`.
+ * That does not work here, and the reason is worth stating because it is not
+ * obvious: vector ids are **deterministic**. `storeEntry` derives them from the
+ * entry id and chunk count, so re-embedding unchanged content into a brand new
+ * index produces byte-identical id strings. `vector_ids` was already non-empty
+ * before the migration and stays non-empty throughout.
+ *
+ * An entry the migration never reached therefore reads as "vectorized" in D1
+ * while the live index holds nothing for it. `/vectorize-pending` cannot see it,
+ * `/stats.unvectorized` reports zero, and the dashboard's repair prompt stays
+ * hidden. So this ledger in KV is not merely a convenience for resuming — it is
+ * the only record of what has actually been rebuilt.
+ *
+ * # Why it stops rather than pushing on
+ *
+ * Embedding is the one operation with a daily budget. If that budget runs out
+ * part-way, every remaining entry fails for the same reason, and a loop that
+ * kept going would burn the rest of the run producing identical errors while
+ * reporting hundreds of distinct "failures". So a batch that achieves nothing
+ * stops the run and keeps its cursor. The user is told to resume later, and
+ * resuming costs nothing already paid for.
+ */
+import type { Env } from "../env";
+import { DEFAULTS, type Config } from "../config";
+import { storeEntry } from "../capture/store";
+import { chunkText } from "../text/chunk";
+import {
+  MIGRATION_CHUNK_BUDGET,
+  MIGRATION_MAX_ENTRIES_PER_BATCH,
+} from "../constants";
+
+/**
+ * Prefixed to coexist with workers-oauth-provider's `token:`/`grant:`/`client:`
+ * keys, matching `config:overrides` and `integrations:<provider>`. Singular
+ * because only one migration is ever in flight.
+ */
+export const MIGRATION_KEY = "migration:embedding";
+
+/**
+ * Where the rebuild has got to.
+ *
+ * The cursor is `(created_at, id)` rather than an offset. Capture stays live
+ * during a migration — the nightly cron writes, and recall itself writes via
+ * `derivePattern` — so an offset would skip or repeat rows as the table grows
+ * underneath it. A keyset cursor cannot.
+ */
+export interface MigrationState {
+  /** The model being migrated *to*, recorded so a resumed run can detect that
+   *  the target changed underneath it. */
+  model: string;
+  startedAt: number;
+  /** Last entry successfully processed; null before the first batch. */
+  cursorCreatedAt: number | null;
+  cursorId: string | null;
+  processed: number;
+  failed: number;
+  /** Entry count when the run started, for progress display only. `remaining`
+   *  is always recomputed, because the table changes under us. */
+  totalAtStart: number;
+  finishedAt?: number;
+}
+
+export interface BatchResult {
+  processed: number;
+  failed: number;
+  /** Recomputed every batch — callers loop until it reaches 0, the convention
+   *  `/vectorize-pending` and the integration syncs already use. */
+  remaining: number;
+  total: number;
+  done: boolean;
+  /**
+   * The batch achieved nothing and the run has stopped with its cursor kept.
+   * Almost always the daily embedding budget; possibly a model name the account
+   * cannot serve. Either way, pushing on would only repeat the failure.
+   */
+  stalled: boolean;
+  /** Set when `stalled`, for the message the user sees. Never a raw error. */
+  stalledReason?: string;
+}
+
+/**
+ * Deprecated entries are excluded. Their vectors are deliberately deleted by
+ * `deprecateEntry` and recall filters them out at hydration, so re-embedding
+ * them would spend the scarce resource of the whole operation on rebuilding
+ * something nothing reads.
+ */
+const NOT_DEPRECATED = `tags NOT LIKE '%"status:deprecated"%'`;
+
+export async function readMigration(env: Env): Promise<MigrationState | null> {
+  try {
+    const raw = await env.OAUTH_KV.get(MIGRATION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as MigrationState;
+    // A blob written by an older shape, or hand-edited: treat as absent rather
+    // than trusting a cursor we cannot read. Restarting costs neurons; resuming
+    // from a bad cursor could skip entries silently, which is worse.
+    if (typeof parsed?.model !== "string") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+async function writeMigration(env: Env, state: MigrationState): Promise<void> {
+  await env.OAUTH_KV.put(MIGRATION_KEY, JSON.stringify(state));
+}
+
+export async function clearMigration(env: Env): Promise<void> {
+  await env.OAUTH_KV.delete(MIGRATION_KEY);
+}
+
+/** Entries that would be re-embedded, and the vectors they would produce. */
+export async function estimate(
+  env: Env,
+): Promise<{ entries: number; chunks: number }> {
+  const row = (await env.DB.prepare(
+    `SELECT COUNT(*) AS entries,
+            COALESCE(SUM(MAX(1, (LENGTH(content) + ${
+              CHUNK_STRIDE - 1
+            }) / ${CHUNK_STRIDE})), 0) AS chunks
+       FROM entries
+      WHERE ${NOT_DEPRECATED}`,
+  ).first()) as Record<string, number> | null;
+
+  return {
+    entries: Number(row?.entries ?? 0),
+    chunks: Number(row?.chunks ?? 0),
+  };
+}
+
+/**
+ * How far `chunkText` advances per chunk: `CHUNK_MAX_CHARS - CHUNK_OVERLAP_CHARS`.
+ *
+ * Kept here as the one place the estimate's arithmetic is tied to the chunker,
+ * and asserted against the real `chunkText` in the tests so the two cannot
+ * drift. The projection is a lower bound: sentence-boundary snapping can only
+ * shorten a chunk, never lengthen it, so the real count is sometimes higher.
+ */
+const CHUNK_STRIDE = 1400;
+
+/** Rows after the cursor, oldest first. */
+function pageSql(hasCursor: boolean): string {
+  // Plain `?` placeholders, bound positionally, matching every other query in
+  // this codebase — the created_at value is bound twice rather than reused as
+  // ?1, because that is the style D1 is driven with here and the style the
+  // SQLite-backed tests can exercise.
+  const after = hasCursor
+    ? `AND (created_at > ? OR (created_at = ? AND id > ?))`
+    : "";
+  return `SELECT id, content, tags, source, created_at
+            FROM entries
+           WHERE ${NOT_DEPRECATED} ${after}
+           ORDER BY created_at ASC, id ASC
+           LIMIT ${MIGRATION_MAX_ENTRIES_PER_BATCH}`;
+}
+
+async function countRemaining(
+  env: Env,
+  cursorCreatedAt: number | null,
+  cursorId: string | null,
+): Promise<number> {
+  const sql =
+    cursorCreatedAt === null
+      ? `SELECT COUNT(*) AS count FROM entries WHERE ${NOT_DEPRECATED}`
+      : `SELECT COUNT(*) AS count FROM entries WHERE ${NOT_DEPRECATED}
+           AND (created_at > ? OR (created_at = ? AND id > ?))`;
+  const stmt =
+    cursorCreatedAt === null
+      ? env.DB.prepare(sql)
+      : env.DB.prepare(sql).bind(cursorCreatedAt, cursorCreatedAt, cursorId);
+  const row = (await stmt.first()) as Record<string, number> | null;
+  return Number(row?.count ?? 0);
+}
+
+/**
+ * Best-effort recognition of "the budget ran out" versus "this one entry went
+ * wrong".
+ *
+ * Deliberately not load-bearing. Cloudflare's error text is not a contract, so
+ * the guarantee that actually protects the run is the no-progress stop in
+ * [`runBatch`] — a batch that processed nothing halts whatever the message said.
+ * This only sharpens what the user is told.
+ */
+export function looksLikeBudgetError(e: unknown): boolean {
+  const text = String((e as Error)?.message ?? e).toLowerCase();
+  return (
+    text.includes("4006") ||
+    text.includes("quota") ||
+    text.includes("capacity") ||
+    text.includes("rate limit") ||
+    text.includes("too many requests")
+  );
+}
+
+/**
+ * Re-embeds one batch and advances the cursor.
+ *
+ * Calls `storeEntry` directly rather than going through `captureEntry`, which
+ * would run dedupe (every entry matches itself at ~1.0 and would be blocked or
+ * merged), classification, contradiction handling and edge inference — all of
+ * which cost more model calls and have side effects that are wrong to re-run
+ * over an entire brain.
+ *
+ * It passes each row's real `created_at` rather than now. `reembedOrThrow` looks
+ * like the natural helper but hardcodes `Date.now()`, which would rewrite every
+ * vector's `created_at` metadata to migration time — and recall's keyword fusion
+ * reads that metadata.
+ *
+ * `deleteStaleVectors` is deliberately not called. The old vectors live in the
+ * index being abandoned, so deleting them one by one would cost thousands of
+ * calls to empty something that is about to be dropped whole.
+ */
+export async function runBatch(
+  env: Env,
+  config: Readonly<Config> = DEFAULTS,
+): Promise<BatchResult> {
+  const existing = await readMigration(env);
+
+  // A target change mid-run invalidates the cursor: entries before it hold
+  // vectors from the previous target. Start again rather than finish a rebuild
+  // that would be half one model and half another.
+  const state: MigrationState =
+    existing && existing.model === config.EMBEDDING_MODEL
+      ? existing
+      : {
+          model: config.EMBEDDING_MODEL,
+          startedAt: Date.now(),
+          cursorCreatedAt: null,
+          cursorId: null,
+          processed: 0,
+          failed: 0,
+          totalAtStart: await countRemaining(env, null, null),
+        };
+
+  const page = state.cursorCreatedAt === null
+    ? await env.DB.prepare(pageSql(false)).all()
+    : await env.DB.prepare(pageSql(true))
+        .bind(state.cursorCreatedAt, state.cursorCreatedAt, state.cursorId)
+        .all();
+
+  const rows = (page.results ?? []) as Record<string, unknown>[];
+  if (rows.length === 0) {
+    const finished: MigrationState = { ...state, finishedAt: Date.now() };
+    await writeMigration(env, finished);
+    return {
+      processed: 0,
+      failed: 0,
+      remaining: 0,
+      total: state.totalAtStart,
+      done: true,
+      stalled: false,
+    };
+  }
+
+  let processed = 0;
+  let failed = 0;
+  let chunkBudget = MIGRATION_CHUNK_BUDGET;
+  let lastReached: { created_at: number; id: string } | null = null;
+  let stalledReason: string | undefined;
+
+  for (const row of rows) {
+    const content = row.content as string;
+    const cost = chunkText(content).length;
+    // Always take the first entry even if it alone exceeds the budget, or a
+    // single very long memory would stall the run forever.
+    if (chunkBudget !== MIGRATION_CHUNK_BUDGET && cost > chunkBudget) break;
+    chunkBudget -= cost;
+
+    try {
+      await storeEntry(
+        env,
+        row.id as string,
+        content,
+        JSON.parse((row.tags as string) ?? "[]"),
+        row.source as string,
+        row.created_at as number,
+        config,
+      );
+      processed++;
+      // Only advance past entries that actually succeeded. A failed entry stays
+      // in front of the cursor so a later run retries it.
+      lastReached = { created_at: row.created_at as number, id: row.id as string };
+    } catch (e) {
+      failed++;
+      console.error("Migration re-embed failed for entry", row.id, e);
+      if (looksLikeBudgetError(e)) {
+        stalledReason = "budget";
+        break;
+      }
+      // A single bad entry must not advance the cursor past itself, but it also
+      // must not block the rest of the batch — so stop advancing and keep going
+      // only while something is still succeeding.
+      break;
+    }
+
+    if (chunkBudget <= 0) break;
+  }
+
+  const next: MigrationState = {
+    ...state,
+    cursorCreatedAt: lastReached?.created_at ?? state.cursorCreatedAt,
+    cursorId: lastReached?.id ?? state.cursorId,
+    processed: state.processed + processed,
+    failed: state.failed + failed,
+  };
+
+  const remaining = await countRemaining(
+    env,
+    next.cursorCreatedAt,
+    next.cursorId,
+  );
+
+  // Nothing moved. Keep the cursor, stop the run, and let the caller say so —
+  // continuing would repeat one failure for every entry left.
+  const stalled = processed === 0 && failed > 0;
+  const done = remaining === 0 && !stalled;
+
+  await writeMigration(
+    env,
+    done ? { ...next, finishedAt: Date.now() } : next,
+  );
+
+  return {
+    processed,
+    failed,
+    remaining,
+    total: Math.max(next.totalAtStart, next.processed + remaining),
+    done,
+    stalled,
+    ...(stalled ? { stalledReason: stalledReason ?? "failing" } : {}),
+  };
+}

--- a/src/recall/search.ts
+++ b/src/recall/search.ts
@@ -90,12 +90,12 @@ export async function recallEntries(
     before = parsed.before;
     embedQuery = parsed.cleanQuery;
   }
-  embedQuery = await distillToRareTerms(embedQuery, env);
+  embedQuery = await distillToRareTerms(embedQuery, env, cfg);
 
   const tokens = tokenizeQuery(embedQuery);
   const [values, queryTags] = await Promise.all([
     embed(embedQuery, env, cfg),
-    inferQueryTags(embedQuery, env),
+    inferQueryTags(embedQuery, env, cfg),
   ]);
 
   let keywordRows: KeywordRow[] = [];
@@ -271,12 +271,12 @@ export async function recallEntries(
   if (maxScore > 0) for (const m of matches) m.score = m.score / maxScore;
 
   const insight = synthesize && matches.length > 1
-    ? await synthesizeInsight(embedQuery, matches.map(m => ({ id: m.id, content: m.content })), env)
+    ? await synthesizeInsight(embedQuery, matches.map(m => ({ id: m.id, content: m.content })), env, cfg)
     : "";
 
   if (d1Rows.length >= 5) {
     ctx.waitUntil(
-      derivePattern(d1Rows as { id: string; content: string }[], env, ctx)
+      derivePattern(d1Rows as { id: string; content: string }[], env, ctx, cfg)
         .catch(e => console.error("derivePattern failed (non-fatal):", e))
     );
   }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -138,7 +138,11 @@ export async function handleAdminRoutes(
           row.content as string,
           JSON.parse(row.tags as string),
           row.source as string,
-          row.created_at as number
+          row.created_at as number,
+          // Without this the backfill embeds with DEFAULTS.EMBEDDING_MODEL while
+          // capture and recall use the configured one, writing vectors from the
+          // wrong model into the index — scores go quietly wrong, nothing throws.
+          cfg
         );
         processed++;
       } catch (e) {
@@ -176,7 +180,9 @@ export async function handleAdminRoutes(
 
     for (const row of toProcess as Record<string, any>[]) {
       try {
-        const { canonical, kind } = await classifyEntry(row.content as string, env);
+        // cfg carries the user's LLM_MODEL choice; without it this backfill
+        // classifies with the shipped default and ignores their setting.
+        const { canonical, kind } = await classifyEntry(row.content as string, env, cfg);
         let tags: string[] = JSON.parse(row.tags as string);
         if (kind) tags = withKind(tags, kind);
         if (canonical && getStatus(tags) === null) tags = withStatus(tags, "canonical");

--- a/src/routes/graph.ts
+++ b/src/routes/graph.ts
@@ -3,6 +3,7 @@ import { json, requireAuth } from "../lib/http";
 import { createEdge, deleteEdge, isValidEdgeType } from "../graph/edges";
 import { EDGE_TYPES } from "../graph/types";
 import { buildGraph, getConnections } from "../graph/traverse";
+import { resolveConfig } from "../config";
 
 export async function handleGraphRoutes(
   request: Request,
@@ -60,7 +61,7 @@ export async function handleGraphRoutes(
     if (!id) return json({ ok: false, error: "id is required" }, 400);
     const type = url.searchParams.get("type")?.trim() || undefined;
 
-    const connections = await getConnections(id, type, env);
+    const connections = await getConnections(id, type, env, await resolveConfig(env));
     return json({ ok: true, id, connections });
   }
 
@@ -74,7 +75,7 @@ export async function handleGraphRoutes(
     const limitParam = url.searchParams.get("limit");
     const limit = limitParam ? parseInt(limitParam, 10) : undefined;
 
-    const { nodes, edges } = await buildGraph({ seed, limit }, env);
+    const { nodes, edges } = await buildGraph({ seed, limit }, env, await resolveConfig(env));
     return json({ ok: true, nodes, edges });
   }
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -9,6 +9,7 @@ import { handleGraphRoutes } from "./graph";
 import { handleIntegrationsRoutes } from "./integrations";
 import { handleAdminRoutes } from "./admin";
 import { handleConfigRoutes } from "./config";
+import { handleMigrationRoutes } from "./migration";
 
 type RouteHandler = (
   request: Request,
@@ -25,6 +26,7 @@ const routeHandlers: RouteHandler[] = [
   handleIntegrationsRoutes,
   handleAdminRoutes,
   handleConfigRoutes,
+  handleMigrationRoutes,
 ];
 
 export function createDefaultHandler() {

--- a/src/routes/migration.ts
+++ b/src/routes/migration.ts
@@ -1,0 +1,92 @@
+/**
+ * Embedding-migration surface for the desktop app (#248).
+ *
+ * The app orchestrates a model change — create the new index, redeploy the
+ * binding at it, rebuild every vector, verify, then drop the old index — because
+ * only the app holds Cloudflare credentials. These routes are the parts that
+ * have to run inside the Worker: reading D1 for the estimate, and re-embedding.
+ *
+ * Authenticated with the same AUTH_TOKEN as the rest of the API.
+ *
+ * `POST /migration/reembed` does one bounded batch and returns `remaining`, so
+ * the caller loops until it reaches zero — the same shape as
+ * `POST /vectorize-pending` and the integration syncs. One request cannot do the
+ * whole rebuild: Workers cap subrequests per invocation, and a brain of a few
+ * thousand entries needs thousands of model calls.
+ */
+import type { Env } from "../env";
+import { json, requireAuth } from "../lib/http";
+import { resolveConfig } from "../config";
+import {
+  clearMigration,
+  estimate,
+  readMigration,
+  runBatch,
+} from "../migration/embedding";
+
+export async function handleMigrationRoutes(
+  request: Request,
+  url: URL,
+  env: Env,
+  _ctx: ExecutionContext,
+): Promise<Response | null> {
+  // GET /migration/estimate — what a rebuild would cost, before anything is
+  // created. The app shows this first; the price should be known before
+  // committing, not discovered during.
+  if (url.pathname === "/migration/estimate" && request.method === "GET") {
+    const authErr = requireAuth(request, env);
+    if (authErr) return authErr;
+
+    const cfg = await resolveConfig(env);
+    const { entries, chunks } = await estimate(env);
+    return json({
+      ok: true,
+      entries,
+      // A lower bound — see the note on CHUNK_STRIDE. Named so the app can say
+      // "at least" rather than implying precision it does not have.
+      chunksAtLeast: chunks,
+      model: cfg.EMBEDDING_MODEL,
+    });
+  }
+
+  // GET /migration/status — the ledger. The app reads this to resume an
+  // interrupted rebuild, and to tell the user where it got to.
+  if (url.pathname === "/migration/status" && request.method === "GET") {
+    const authErr = requireAuth(request, env);
+    if (authErr) return authErr;
+
+    const state = await readMigration(env);
+    const cfg = await resolveConfig(env);
+    return json({
+      ok: true,
+      // null means no rebuild has ever been started for this brain.
+      state,
+      // The model currently in force, so the app can spot a ledger left over
+      // from a different target.
+      model: cfg.EMBEDDING_MODEL,
+    });
+  }
+
+  // POST /migration/reembed — one bounded batch.
+  if (url.pathname === "/migration/reembed" && request.method === "POST") {
+    const authErr = requireAuth(request, env);
+    if (authErr) return authErr;
+
+    const cfg = await resolveConfig(env);
+    const result = await runBatch(env, cfg);
+    return json({ ok: true, ...result });
+  }
+
+  // POST /migration/reset — forget the ledger so the next batch starts from the
+  // beginning. Rebuilding is idempotent (vector ids are deterministic, and the
+  // upsert overwrites), so this costs model calls but cannot corrupt anything.
+  if (url.pathname === "/migration/reset" && request.method === "POST") {
+    const authErr = requireAuth(request, env);
+    if (authErr) return authErr;
+
+    await clearMigration(env);
+    return json({ ok: true });
+  }
+
+  return null;
+}

--- a/src/vectorize/health.ts
+++ b/src/vectorize/health.ts
@@ -1,26 +1,43 @@
 import type { Env } from "../env";
 
-export const VECTORIZE_INDEX_NAME = "second-brain-vectors";
+/**
+ * The index name declared in wrangler.jsonc. This is a *last resort* only: it is
+ * what we deployed with, not necessarily what is bound now. Vectorize's two
+ * describe() shapes disagree about whether an index can name itself — the beta
+ * shape (VectorizeIndexDetails) carries `name`, the current V2 shape
+ * (VectorizeIndexInfo) carries no name field at all — so when the binding is
+ * repointed at a differently-named index (e.g. an embedding migration to
+ * second-brain-vectors-768) this constant silently goes stale. Never treat it as
+ * the identity of the live index.
+ */
+export const FALLBACK_VECTORIZE_INDEX_NAME = "second-brain-vectors";
 
 export interface VectorizeHealth {
   ok: boolean;
+  /** The bound index's own name when describe() reports one, else FALLBACK_VECTORIZE_INDEX_NAME. Always a string — the dashboard banner interpolates it. */
   indexName: string;
   dimensions?: number;
+  /** Records containing vectors in the bound index. Omitted when describe() does not report a numeric count. */
+  vectorCount?: number;
   error?: string;
 }
 
 export async function checkVectorizeHealth(env: Env): Promise<VectorizeHealth> {
   try {
     const info = (await env.VECTORIZE.describe()) as any;
+    // `vectorsCount` is the beta spelling of V2's `vectorCount`; accept either.
+    const count = info?.vectorCount ?? info?.vectorsCount;
+    const name = info?.name;
     return {
       ok: true,
-      indexName: VECTORIZE_INDEX_NAME,
+      indexName: typeof name === "string" && name ? name : FALLBACK_VECTORIZE_INDEX_NAME,
       dimensions: info?.dimensions ?? info?.config?.dimensions,
+      vectorCount: typeof count === "number" ? count : undefined,
     };
   } catch (e) {
     return {
       ok: false,
-      indexName: VECTORIZE_INDEX_NAME,
+      indexName: FALLBACK_VECTORIZE_INDEX_NAME,
       error: e instanceof Error ? e.message : String(e),
     };
   }

--- a/test/helpers/sqlite-d1.ts
+++ b/test/helpers/sqlite-d1.ts
@@ -1,0 +1,120 @@
+/**
+ * A D1 facade over real SQLite, for tests whose subject is the SQL itself.
+ *
+ * `test/helpers/d1-mock.ts` matches query strings and returns canned rows. That
+ * is the right tool for most tests — it is fast and it keeps fixtures obvious —
+ * but it cannot evaluate SQL, so anything whose correctness *is* the query is
+ * untestable against it. The embedding migration is exactly that: a keyset
+ * cursor whose comparison decides whether entries are skipped or repeated, and
+ * an aggregate that projects chunk counts with integer division.
+ *
+ * D1 is SQLite, and `node:sqlite` ships with Node, so those queries can be run
+ * for real against the project's own `db/schema.sql`. A wrong comparison then
+ * fails the test instead of passing a string match.
+ *
+ * Only the surface the code under test uses is implemented — `prepare`, `bind`,
+ * `all`, `first`, `run`. Reach for `d1-mock` for everything else.
+ */
+import { DatabaseSync } from "node:sqlite";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SCHEMA = resolve(import.meta.dirname, "../../db/schema.sql");
+
+class SqliteStatement {
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+    private readonly args: unknown[] = [],
+  ) {}
+
+  bind(...args: unknown[]): SqliteStatement {
+    return new SqliteStatement(this.db, this.sql, args);
+  }
+
+  async all(): Promise<{ results: unknown[]; success: true }> {
+    const rows = this.db.prepare(this.sql).all(...(this.args as never[]));
+    return { results: rows, success: true };
+  }
+
+  async first(): Promise<unknown | null> {
+    const row = this.db.prepare(this.sql).get(...(this.args as never[]));
+    return row ?? null;
+  }
+
+  async run(): Promise<{ success: true }> {
+    this.db.prepare(this.sql).run(...(this.args as never[]));
+    return { success: true };
+  }
+}
+
+export interface SqliteD1 {
+  /** Shaped like `env.DB`. */
+  db: { prepare(sql: string): SqliteStatement };
+  /** Insert an entry directly, bypassing the capture pipeline. */
+  seed(entry: {
+    id: string;
+    content: string;
+    createdAt: number;
+    tags?: string[];
+    source?: string;
+    vectorIds?: string[];
+  }): void;
+  /** Every row, for assertions about what the code under test wrote. */
+  rows(): Record<string, unknown>[];
+  close(): void;
+}
+
+/**
+ * A fresh in-memory database with the project's real schema applied.
+ *
+ * Using the shipped schema rather than a hand-written CREATE TABLE means a
+ * column rename breaks these tests, which is the point — the migration's SQL
+ * names columns.
+ */
+export function makeSqliteD1(): SqliteD1 {
+  const raw = new DatabaseSync(":memory:");
+  // The schema uses D1-flavoured DDL; execute it statement by statement so one
+  // unsupported pragma cannot take the whole file down silently.
+  const schema = readFileSync(SCHEMA, "utf8");
+  for (const statement of schema.split(";")) {
+    // Strip comment lines rather than skipping any chunk that starts with one:
+    // splitting on ";" leaves the preceding comment attached to the statement
+    // after it, so a "starts with --" test silently drops real DDL.
+    const sql = statement
+      .split("\n")
+      .filter(line => !line.trim().startsWith("--"))
+      .join("\n")
+      .trim();
+    if (!sql) continue;
+    try {
+      raw.exec(sql);
+    } catch (e) {
+      // Indexes on tables this facade does not need, or D1-only syntax. Fail
+      // loudly for anything touching `entries`, which the migration reads.
+      if (/\bentries\b/i.test(sql)) {
+        throw new Error(`schema.sql statement failed:\n${sql}\n${String(e)}`);
+      }
+    }
+  }
+
+  return {
+    db: { prepare: (sql: string) => new SqliteStatement(raw, sql) },
+    seed({ id, content, createdAt, tags = [], source = "api", vectorIds = [] }) {
+      raw
+        .prepare(
+          `INSERT INTO entries (id, content, tags, source, created_at, vector_ids, recall_count, importance_score)
+           VALUES (?, ?, ?, ?, ?, ?, 0, 0)`,
+        )
+        .run(id, content, JSON.stringify(tags), source, createdAt, JSON.stringify(vectorIds));
+    },
+    rows() {
+      return raw
+        .prepare(`SELECT * FROM entries ORDER BY created_at ASC, id ASC`)
+        .all() as Record<string, unknown>[];
+    },
+    close() {
+      raw.close();
+    },
+  };
+}

--- a/test/integration/embedding-migration.test.ts
+++ b/test/integration/embedding-migration.test.ts
@@ -1,0 +1,412 @@
+/**
+ * #248 — rebuilding every vector after an embedding-model change.
+ *
+ * Driven against real SQLite (`test/helpers/sqlite-d1.ts`) rather than the
+ * string-matching D1 mock, because the correctness of this feature *is* its SQL:
+ * a keyset cursor whose comparison decides whether entries get skipped, and an
+ * aggregate that projects chunk counts. A mock that matched the query text would
+ * pass whatever the comparison said.
+ *
+ * The properties that matter, in order:
+ *
+ * 1. **No entry is ever skipped.** A skipped entry is invisible to every repair
+ *    mechanism the Worker has — vector ids are deterministic, so `vector_ids`
+ *    stays non-empty and `/vectorize-pending` cannot see it.
+ * 2. **An interrupted rebuild resumes** rather than restarting, because restarting
+ *    spends the one budget that runs out.
+ * 3. **A stalled rebuild stops** instead of burning the remaining budget
+ *    reproducing the same failure.
+ * 4. **D1 content is never written.** Vectors are derived; memories are not.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeMemoryKV } from "../helpers/make-env";
+import { chunkText } from "../../src/text/chunk";
+import { DEFAULTS } from "../../src/config";
+import {
+  MIGRATION_KEY,
+  clearMigration,
+  estimate,
+  looksLikeBudgetError,
+  readMigration,
+  runBatch,
+} from "../../src/migration/embedding";
+import type { Env } from "../../src/env";
+
+const NEW_MODEL = "@cf/baai/bge-base-en-v1.5";
+
+/**
+ * An AI binding that records which model it was asked for and can be made to
+ * fail. `makeAIMock` only returns a vector for the shipped model and hands back a
+ * stream for anything else, which is useless here — the whole point is embedding
+ * with a *different* model.
+ */
+function makeAI(opts: { failFrom?: number; error?: string } = {}) {
+  const calls: string[] = [];
+  let n = 0;
+  return {
+    calls,
+    binding: {
+      run: vi.fn(async (model: string) => {
+        n++;
+        calls.push(model);
+        if (opts.failFrom !== undefined && n >= opts.failFrom) {
+          throw new Error(opts.error ?? "boom");
+        }
+        return { data: [[0.1, 0.2, 0.3]] };
+      }),
+    },
+  };
+}
+
+function makeEnv(d1: SqliteD1, ai: ReturnType<typeof makeAI>, kv = makeMemoryKV()) {
+  const upserted: { id: string }[][] = [];
+  const env = {
+    DB: d1.db,
+    OAUTH_KV: kv,
+    AI: ai.binding,
+    VECTORIZE: {
+      upsert: vi.fn(async (vectors: { id: string }[]) => {
+        upserted.push(vectors);
+        return { count: vectors.length };
+      }),
+    },
+  } as unknown as Env;
+  return { env, upserted, kv };
+}
+
+const cfg = { ...DEFAULTS, EMBEDDING_MODEL: NEW_MODEL };
+
+describe("migration estimate", () => {
+  let d1: SqliteD1;
+  beforeEach(() => {
+    d1 = makeSqliteD1();
+  });
+
+  it("counts entries and projects at least as many chunks as the chunker makes", async () => {
+    // One short entry and one long enough to split, so the projection is
+    // exercised rather than trivially 1-per-entry.
+    const long = "word ".repeat(900); // 4500 chars
+    d1.seed({ id: "short", content: "hello", createdAt: 1 });
+    d1.seed({ id: "long", content: long, createdAt: 2 });
+
+    const { env } = makeEnv(d1, makeAI());
+    const { entries, chunks } = await estimate(env);
+
+    expect(entries).toBe(2);
+    // The projection must never promise fewer chunks than the chunker produces,
+    // or the estimate understates the cost the user is agreeing to.
+    const real = chunkText("hello").length + chunkText(long).length;
+    expect(chunks).toBeLessThanOrEqual(real);
+    expect(chunks).toBeGreaterThanOrEqual(2);
+  });
+
+  /** Deprecated entries have had their vectors deliberately deleted and recall
+   *  filters them out, so rebuilding them would spend the scarce resource of the
+   *  whole operation on something nothing reads. */
+  it("excludes deprecated entries from the count", async () => {
+    d1.seed({ id: "live", content: "a", createdAt: 1 });
+    d1.seed({ id: "gone", content: "b", createdAt: 2, tags: ["status:deprecated"] });
+
+    const { env } = makeEnv(d1, makeAI());
+    expect((await estimate(env)).entries).toBe(1);
+  });
+
+  it("reports zero for an empty brain rather than failing", async () => {
+    const { env } = makeEnv(d1, makeAI());
+    expect(await estimate(env)).toEqual({ entries: 0, chunks: 0 });
+  });
+});
+
+describe("migration batches", () => {
+  let d1: SqliteD1;
+  beforeEach(() => {
+    d1 = makeSqliteD1();
+  });
+
+  it("re-embeds with the configured model, not the shipped default", async () => {
+    d1.seed({ id: "a", content: "hello", createdAt: 1 });
+    const ai = makeAI();
+    const { env } = makeEnv(d1, ai);
+
+    await runBatch(env, cfg);
+
+    expect(ai.calls).toEqual([NEW_MODEL]);
+    expect(ai.calls).not.toContain(DEFAULTS.EMBEDDING_MODEL);
+  });
+
+  /**
+   * The load-bearing property. Every entry must be reached exactly once across
+   * however many batches it takes — no gaps, because a gap is undetectable.
+   */
+  it("covers every entry across batches with no gaps and no repeats", async () => {
+    // More entries than one batch will take. Timestamps ascend so this covers
+    // ordinary paging; the tie case has its own test below, because a tie only
+    // exercises the id tie-break when it spans a batch boundary.
+    const ids = Array.from({ length: 40 }, (_, i) => `e${String(i).padStart(2, "0")}`);
+    ids.forEach((id, i) => d1.seed({ id, content: `body ${id}`, createdAt: 100 + i }));
+
+    const ai = makeAI();
+    const { env } = makeEnv(d1, ai);
+
+    const seen: string[] = [];
+    for (let guard = 0; guard < 50; guard++) {
+      const before = await readMigration(env);
+      const r = await runBatch(env, cfg);
+      const after = await readMigration(env);
+      // Record what this batch advanced over.
+      if (after?.cursorId && after.cursorId !== before?.cursorId) seen.push(after.cursorId);
+      if (r.done) break;
+    }
+
+    const state = await readMigration(env);
+    expect(state?.processed).toBe(40);
+    expect(state?.failed).toBe(0);
+    // Every entry embedded exactly once.
+    expect(ai.calls).toHaveLength(40);
+    // And the cursor ended on the last entry in (created_at, id) order.
+    expect(state?.cursorId).toBe("e39");
+    // Strictly increasing cursor — never revisited a position.
+    expect([...seen]).toEqual([...seen].sort());
+  });
+
+  /**
+   * Entries captured in the same millisecond are common — a bulk import gives a
+   * whole brain one timestamp. If the cursor compared `created_at` alone, the
+   * batch boundary would fall inside the tied group and everything after it
+   * would be skipped, silently and permanently.
+   *
+   * Every entry here shares one timestamp, so the boundary is guaranteed to land
+   * inside the tie. An earlier version of this suite tied only the first five of
+   * forty, which never crossed a boundary and left the tie-break untested.
+   */
+  it("does not skip entries that share a created_at across a batch boundary", async () => {
+    const ids = Array.from({ length: 40 }, (_, i) => `e${String(i).padStart(2, "0")}`);
+    ids.forEach(id => d1.seed({ id, content: `body ${id}`, createdAt: 100 }));
+
+    const ai = makeAI();
+    const { env } = makeEnv(d1, ai);
+
+    for (let guard = 0; guard < 50; guard++) {
+      if ((await runBatch(env, cfg)).done) break;
+    }
+
+    const state = await readMigration(env);
+    expect(state?.processed).toBe(40);
+    expect(ai.calls).toHaveLength(40);
+    expect(state?.cursorId).toBe("e39");
+  });
+
+  it("resumes from the cursor instead of starting over", async () => {
+    Array.from({ length: 30 }, (_, i) => `e${i}`).forEach((id, i) =>
+      d1.seed({ id, content: `body ${id}`, createdAt: 100 + i }),
+    );
+
+    const ai = makeAI();
+    const { env, kv } = makeEnv(d1, ai);
+
+    const first = await runBatch(env, cfg);
+    expect(first.processed).toBeGreaterThan(0);
+    expect(first.done).toBe(false);
+    const afterFirst = ai.calls.length;
+
+    // A fresh process, same KV: the ledger is the only thing carried over.
+    const ai2 = makeAI();
+    const { env: env2 } = makeEnv(d1, ai2, kv);
+    await runBatch(env2, cfg);
+
+    // The second run embedded new entries, not the ones already done.
+    expect(ai2.calls.length).toBeLessThanOrEqual(30 - afterFirst);
+    const state = await readMigration(env2);
+    expect(state?.processed).toBe(afterFirst + ai2.calls.length);
+  });
+
+  it("reports done once, with nothing remaining", async () => {
+    d1.seed({ id: "a", content: "one", createdAt: 1 });
+    d1.seed({ id: "b", content: "two", createdAt: 2 });
+    const { env } = makeEnv(d1, makeAI());
+
+    let last = await runBatch(env, cfg);
+    for (let i = 0; i < 5 && !last.done; i++) last = await runBatch(env, cfg);
+
+    expect(last.done).toBe(true);
+    expect(last.remaining).toBe(0);
+    expect((await readMigration(env))?.finishedAt).toBeGreaterThan(0);
+  });
+
+  it("never writes to entries.content", async () => {
+    d1.seed({ id: "a", content: "the original text", createdAt: 1 });
+    const { env } = makeEnv(d1, makeAI());
+
+    await runBatch(env, cfg);
+
+    const rows = d1.rows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe("the original text");
+  });
+
+  /**
+   * `reembedOrThrow` looks like the natural helper for this and is the wrong one:
+   * it hardcodes `Date.now()`, which would stamp every rebuilt vector's metadata
+   * with migration time. Recall's keyword fusion reads that metadata, so a whole
+   * brain would look as though every memory were created the day it migrated.
+   */
+  it("stamps rebuilt vectors with the entry's own created_at, not now", async () => {
+    const originally = 1_600_000_000_000;
+    d1.seed({ id: "a", content: "hello", createdAt: originally });
+    const { env, upserted } = makeEnv(d1, makeAI());
+
+    await runBatch(env, cfg);
+
+    expect(upserted).toHaveLength(1);
+    const [vector] = upserted[0] as unknown as { metadata: Record<string, unknown> }[];
+    expect(vector.metadata.created_at).toBe(originally);
+    expect(vector.metadata.parentId).toBe("a");
+  });
+
+  it("skips deprecated entries when rebuilding", async () => {
+    d1.seed({ id: "live", content: "keep", createdAt: 1 });
+    d1.seed({ id: "gone", content: "drop", createdAt: 2, tags: ["status:deprecated"] });
+    const ai = makeAI();
+    const { env } = makeEnv(d1, ai);
+
+    let r = await runBatch(env, cfg);
+    for (let i = 0; i < 3 && !r.done; i++) r = await runBatch(env, cfg);
+
+    expect(ai.calls).toHaveLength(1);
+    expect((await readMigration(env))?.processed).toBe(1);
+  });
+});
+
+describe("migration under failure", () => {
+  let d1: SqliteD1;
+  beforeEach(() => {
+    d1 = makeSqliteD1();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  /**
+   * Property 3. When the budget runs out every remaining entry fails for the
+   * same reason, so a loop that kept going would spend the rest of the run
+   * producing identical errors and report hundreds of distinct "failures".
+   */
+  it("stops the run when a batch achieves nothing", async () => {
+    Array.from({ length: 20 }, (_, i) => `e${i}`).forEach((id, i) =>
+      d1.seed({ id, content: `body ${id}`, createdAt: 100 + i }),
+    );
+    // Fails from the very first embed.
+    const ai = makeAI({ failFrom: 1, error: "AiError: 4006 out of neurons" });
+    const { env } = makeEnv(d1, ai);
+
+    const r = await runBatch(env, cfg);
+
+    expect(r.stalled).toBe(true);
+    expect(r.processed).toBe(0);
+    expect(r.done).toBe(false);
+    // One attempt, not twenty.
+    expect(ai.calls).toHaveLength(1);
+  });
+
+  it("keeps the cursor when it stalls, so a resume does not redo paid work", async () => {
+    Array.from({ length: 20 }, (_, i) => `e${i}`).forEach((id, i) =>
+      d1.seed({ id, content: `body ${id}`, createdAt: 100 + i }),
+    );
+
+    // Succeeds for a while, then the budget goes.
+    const ai = makeAI({ failFrom: 4, error: "4006 quota exceeded" });
+    const { env, kv } = makeEnv(d1, ai);
+
+    const first = await runBatch(env, cfg);
+    expect(first.processed).toBe(3);
+    const cursor = (await readMigration(env))?.cursorId;
+    expect(cursor).toBe("e2");
+
+    // Resume with budget restored: picks up after e2, does not redo e0–e2.
+    const ai2 = makeAI();
+    const { env: env2 } = makeEnv(d1, ai2, kv);
+    await runBatch(env2, cfg);
+    expect((await readMigration(env2))?.cursorId).not.toBe("e0");
+    expect((await readMigration(env2))?.processed).toBeGreaterThan(3);
+  });
+
+  /** A failed entry must stay in front of the cursor so a later run retries it,
+   *  rather than being stepped over and lost. */
+  it("does not advance the cursor past an entry that failed", async () => {
+    d1.seed({ id: "a", content: "ok", createdAt: 1 });
+    d1.seed({ id: "b", content: "bad", createdAt: 2 });
+    d1.seed({ id: "c", content: "ok", createdAt: 3 });
+
+    const ai = makeAI({ failFrom: 2, error: "single entry problem" });
+    const { env } = makeEnv(d1, ai);
+
+    await runBatch(env, cfg);
+
+    // Advanced to a, stopped at b. c has not been passed over.
+    expect((await readMigration(env))?.cursorId).toBe("a");
+  });
+
+  it("starts over when the target model changed under a half-finished run", async () => {
+    d1.seed({ id: "a", content: "one", createdAt: 1 });
+    d1.seed({ id: "b", content: "two", createdAt: 2 });
+    const { env, kv } = makeEnv(d1, makeAI());
+
+    await runBatch(env, cfg);
+    expect((await readMigration(env))?.cursorId).toBeTruthy();
+
+    // A different target: finishing the old run would leave the index half one
+    // model and half another.
+    const ai2 = makeAI();
+    const { env: env2 } = makeEnv(d1, ai2, kv);
+    await runBatch(env2, { ...DEFAULTS, EMBEDDING_MODEL: "@cf/baai/bge-large-en-v1.5" });
+
+    const state = await readMigration(env2);
+    expect(state?.model).toBe("@cf/baai/bge-large-en-v1.5");
+    // Cursor restarted from the beginning of the table.
+    expect(state?.processed).toBeLessThanOrEqual(2);
+    expect(ai2.calls[0]).toBe("@cf/baai/bge-large-en-v1.5");
+  });
+
+  it("treats an unreadable ledger as absent rather than trusting its cursor", async () => {
+    d1.seed({ id: "a", content: "one", createdAt: 1 });
+    const kv = makeMemoryKV();
+    await kv.put(MIGRATION_KEY, "{not json");
+    const { env } = makeEnv(d1, makeAI(), kv);
+
+    expect(await readMigration(env)).toBeNull();
+    // And a batch still runs, from the start.
+    const r = await runBatch(env, cfg);
+    expect(r.processed).toBe(1);
+  });
+
+  it("clears the ledger on reset", async () => {
+    d1.seed({ id: "a", content: "one", createdAt: 1 });
+    const { env } = makeEnv(d1, makeAI());
+    await runBatch(env, cfg);
+    expect(await readMigration(env)).not.toBeNull();
+
+    await clearMigration(env);
+    expect(await readMigration(env)).toBeNull();
+  });
+});
+
+describe("budget-error recognition", () => {
+  /** Best-effort and deliberately not load-bearing — the no-progress stop is
+   *  what actually protects the run. These cases document the intent. */
+  it("recognises the shapes Cloudflare uses for a spent budget", () => {
+    for (const message of [
+      "AiError: 4006: out of neurons",
+      "Quota exceeded for this account",
+      "Insufficient capacity",
+      "Rate limit exceeded",
+      "429 Too Many Requests",
+    ]) {
+      expect(looksLikeBudgetError(new Error(message)), message).toBe(true);
+    }
+  });
+
+  it("does not mistake an ordinary failure for a spent budget", () => {
+    for (const message of ["network unreachable", "invalid model", "boom"]) {
+      expect(looksLikeBudgetError(new Error(message)), message).toBe(false);
+    }
+  });
+});

--- a/test/integration/migration-routes.test.ts
+++ b/test/integration/migration-routes.test.ts
@@ -1,0 +1,126 @@
+/**
+ * #248 — the migration surface the desktop app drives.
+ *
+ * These go through the real default handler, the same path a request from the
+ * Tauri app takes, rather than calling the route functions directly. That is what
+ * catches a handler that was never registered in `routeHandlers` — the feature
+ * would be complete, tested, and unreachable.
+ *
+ * The re-embed logic itself is covered in `embedding-migration.test.ts` against
+ * real SQLite. This file is about the HTTP contract: auth, shapes, and the fields
+ * the app loops on.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createDefaultHandler } from "../../src/routes/index";
+import { makeMemoryKV, makeTestDb, makeTestEnv } from "../helpers/make-env";
+import { CONFIG_KEY } from "../../src/config";
+import { MIGRATION_KEY } from "../../src/migration/embedding";
+import type { Env } from "../../src/env";
+
+const ctx = { waitUntil: () => {} } as unknown as ExecutionContext;
+const TOKEN = "test-token";
+
+function req(path: string, init: RequestInit = {}, auth = true) {
+  return new Request(`http://localhost${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(auth ? { Authorization: `Bearer ${TOKEN}` } : {}),
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+describe("migration routes", () => {
+  let env: Env;
+  let kv: KVNamespace;
+  let handler: ReturnType<typeof createDefaultHandler>;
+
+  beforeEach(() => {
+    kv = makeMemoryKV();
+    env = makeTestEnv(makeTestDb(), { OAUTH_KV: kv, AUTH_TOKEN: TOKEN });
+    handler = createDefaultHandler();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  /**
+   * Every route here reads or rewrites the whole brain's vectors, so an
+   * unauthenticated one would let anyone burn a stranger's model budget.
+   */
+  it("refuses every route without a token", async () => {
+    const calls: [string, string][] = [
+      ["GET", "/migration/estimate"],
+      ["GET", "/migration/status"],
+      ["POST", "/migration/reembed"],
+      ["POST", "/migration/reset"],
+    ];
+    for (const [method, path] of calls) {
+      const res = await handler.fetch(req(path, { method }, false), env, ctx);
+      expect(res.status, `${method} ${path}`).toBe(401);
+    }
+  });
+
+  it("is reachable through the real handler, not just registered in a module", async () => {
+    // A handler missing from routeHandlers falls through to the 404 at the end
+    // of createDefaultHandler, which is exactly the failure this catches.
+    const res = await handler.fetch(req("/migration/status"), env, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it("estimates before anything has been created", async () => {
+    const res = await handler.fetch(req("/migration/estimate"), env, ctx);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(typeof body.entries).toBe("number");
+    // Named "at least" because the projection is a lower bound — the chunker's
+    // sentence snapping can only produce more.
+    expect(typeof body.chunksAtLeast).toBe("number");
+    expect(body.model).toBe("@cf/baai/bge-small-en-v1.5");
+  });
+
+  it("reports the configured model, so the app can spot a stale ledger", async () => {
+    await kv.put(CONFIG_KEY, JSON.stringify({ EMBEDDING_MODEL: "@cf/baai/bge-base-en-v1.5" }));
+
+    const res = await handler.fetch(req("/migration/status"), env, ctx);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.model).toBe("@cf/baai/bge-base-en-v1.5");
+  });
+
+  it("reports no ledger for a brain that has never migrated", async () => {
+    const res = await handler.fetch(req("/migration/status"), env, ctx);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.state).toBeNull();
+  });
+
+  it("returns the fields the app loops on", async () => {
+    const res = await handler.fetch(req("/migration/reembed", { method: "POST" }), env, ctx);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    // `remaining` is the field the caller loops until zero — the convention
+    // /vectorize-pending and the integration syncs already use.
+    for (const field of ["processed", "failed", "remaining", "total", "done", "stalled"]) {
+      expect(body, `missing ${field}`).toHaveProperty(field);
+    }
+  });
+
+  it("forgets the ledger on reset", async () => {
+    await kv.put(
+      MIGRATION_KEY,
+      JSON.stringify({ model: "x", startedAt: 1, cursorCreatedAt: 5, cursorId: "a", processed: 3, failed: 0, totalAtStart: 9 }),
+    );
+    expect(await kv.get(MIGRATION_KEY)).not.toBeNull();
+
+    const res = await handler.fetch(req("/migration/reset", { method: "POST" }), env, ctx);
+    expect(res.status).toBe(200);
+    expect(await kv.get(MIGRATION_KEY)).toBeNull();
+  });
+
+  it("does not answer the wrong method on a migration path", async () => {
+    // A GET that fell through to POST handling would re-embed on a page load.
+    const res = await handler.fetch(req("/migration/reembed"), env, ctx);
+    expect(res.status).toBe(404);
+  });
+});

--- a/test/unit/config-passed-not-defaulted.test.ts
+++ b/test/unit/config-passed-not-defaulted.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Every caller of a config-taking function must pass config explicitly.
+ *
+ * `config: Readonly<Config> = DEFAULTS` is a convenient signature and a
+ * dangerous one: forget the argument and the call silently uses the shipped
+ * default instead of the user's setting. Nothing throws, nothing fails a type
+ * check, and the wrong value is indistinguishable from the right one until
+ * someone changes a setting and notices it did nothing.
+ *
+ * Four call sites had already drifted when this test was written:
+ *
+ * - `POST /vectorize-pending` embedded with `DEFAULTS.EMBEDDING_MODEL` while
+ *   capture and recall used the configured one, writing vectors from the wrong
+ *   model into the index. Scores go quietly wrong; nothing throws. This is the
+ *   exact failure `config-embedding-consistency.test.ts` exists to prevent, on a
+ *   route that test does not reach.
+ * - `POST /classify-pending` and `scheduleClassifyAndTag` classified with
+ *   `DEFAULTS.LLM_MODEL`, ignoring the model the user picked in the desktop app.
+ * - `mirror.createEntry` resolved config for its embed and then classified with
+ *   the default, so one function used two different models.
+ *
+ * `config-threading-complete.test.ts` cannot catch any of these: it looks for
+ * module-scope *reads* of tunables, and an omitted argument reads nothing.
+ *
+ * Passing `DEFAULTS` explicitly is allowed — it documents the intent at the call
+ * site, which is the whole point.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const SRC = resolve(import.meta.dirname, "../../src");
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...sourceFiles(path));
+    else if (entry.name.endsWith(".ts")) out.push(path);
+  }
+  return out;
+}
+
+const FILES = sourceFiles(SRC).map(path => ({
+  path,
+  rel: path.slice(SRC.length + 1),
+  text: readFileSync(path, "utf8"),
+}));
+
+/** Functions declaring a defaulted config parameter, by name. */
+function configTakingFunctions(): Map<string, string> {
+  const found = new Map<string, string>();
+  const decl = /export\s+(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)/gs;
+  for (const { rel, text } of FILES) {
+    for (const m of text.matchAll(decl)) {
+      const [, name, params] = m;
+      if (/config\s*:\s*Readonly<Config>\s*=/.test(params)) found.set(name, rel);
+    }
+  }
+  return found;
+}
+
+/**
+ * Argument list of each call to `name`, found by matching parentheses so nested
+ * calls and object literals are not truncated.
+ */
+function callsTo(name: string, text: string): string[] {
+  const calls: string[] = [];
+  const needle = new RegExp(`\\b${name}\\s*\\(`, "g");
+  for (const m of text.matchAll(needle)) {
+    // Skip the declaration itself.
+    const before = text.slice(Math.max(0, m.index - 30), m.index);
+    if (/function\s+$/.test(before)) continue;
+
+    let depth = 1;
+    let i = m.index + m[0].length;
+    while (i < text.length && depth > 0) {
+      const c = text[i];
+      if (c === "(") depth++;
+      else if (c === ")") depth--;
+      i++;
+    }
+    calls.push(text.slice(m.index + m[0].length, i - 1));
+  }
+  return calls;
+}
+
+describe("config is passed, never left to the default", () => {
+  const functions = configTakingFunctions();
+
+  it("finds the config-taking functions it is meant to guard", () => {
+    // A rename that broke the detector would otherwise make this whole file
+    // pass by testing nothing.
+    expect(functions.size).toBeGreaterThanOrEqual(5);
+    for (const expected of ["storeEntry", "embed", "classifyEntry"]) {
+      expect([...functions.keys()], `${expected} should be detected`).toContain(expected);
+    }
+  });
+
+  it("every call inside src/ passes config explicitly", () => {
+    const offenders: string[] = [];
+
+    for (const [fn, declaredIn] of functions) {
+      for (const { rel, text } of FILES) {
+        for (const args of callsTo(fn, text)) {
+          // The recursive call inside the function's own file is its business —
+          // e.g. reembedOrThrow forwarding to storeEntry — but it still has to
+          // name config, which the check below covers.
+          const passesConfig = /\b(cfg|config|DEFAULTS|resolveConfig)\b/.test(args);
+          if (!passesConfig) {
+            offenders.push(
+              `${rel}: ${fn}(…) omits config (declared in ${declaredIn})\n      args: ${args
+                .replace(/\s+/g, " ")
+                .trim()
+                .slice(0, 120)}`,
+            );
+          }
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      `these calls fall back to DEFAULTS instead of the user's settings:\n  ${offenders.join(
+        "\n  ",
+      )}\n\nPass the resolved config, or pass DEFAULTS explicitly to say you meant it.`,
+    ).toEqual([]);
+  });
+});

--- a/test/unit/vectorize-health.test.ts
+++ b/test/unit/vectorize-health.test.ts
@@ -1,40 +1,113 @@
 import { describe, it, expect, vi } from "vitest";
-import { checkVectorizeHealth } from "../../src/vectorize/health";
+import { checkVectorizeHealth, FALLBACK_VECTORIZE_INDEX_NAME } from "../../src/vectorize/health";
 import { makeTestEnv, makeTestDb, makeVectorizeMock } from "../helpers/make-env";
 
+function envDescribing(value: unknown) {
+  return makeTestEnv(makeTestDb(), {
+    VECTORIZE: makeVectorizeMock({ describe: vi.fn().mockResolvedValue(value) }),
+  });
+}
+
+function envFailing(error: unknown) {
+  return makeTestEnv(makeTestDb(), {
+    VECTORIZE: makeVectorizeMock({ describe: vi.fn().mockRejectedValue(error) }),
+  });
+}
+
 describe("checkVectorizeHealth", () => {
-  it("returns ok with the index name and dimensions when describe() resolves", async () => {
-    const env = makeTestEnv(makeTestDb(), {
-      VECTORIZE: makeVectorizeMock({
-        describe: vi.fn().mockResolvedValue({ dimensions: 384, metric: "cosine" }),
-      }),
+  it("reports the name the bound index gives, not the compile-time fallback", async () => {
+    // The migration case: the binding has been repointed at a 768-dim index, so
+    // reporting FALLBACK_VECTORIZE_INDEX_NAME here would name the wrong index on
+    // the dashboard banner during the migration the user is watching.
+    const health = await checkVectorizeHealth(
+      envDescribing({ name: "second-brain-vectors-768", dimensions: 768, vectorCount: 12 }),
+    );
+    expect(health.indexName).toBe("second-brain-vectors-768");
+    expect(health.indexName).not.toBe(FALLBACK_VECTORIZE_INDEX_NAME);
+  });
+
+  it("returns the full healthy shape GET /health serialises", async () => {
+    const health = await checkVectorizeHealth(
+      envDescribing({ name: "second-brain-vectors-768", dimensions: 768, vectorCount: 12 }),
+    );
+    expect(health).toEqual({
+      ok: true,
+      indexName: "second-brain-vectors-768",
+      dimensions: 768,
+      vectorCount: 12,
     });
-    const health = await checkVectorizeHealth(env);
+  });
+
+  it("reports the vector count from the V2 describe() shape", async () => {
+    const health = await checkVectorizeHealth(envDescribing({ dimensions: 768, vectorCount: 41 }));
     expect(health.ok).toBe(true);
-    expect(health.indexName).toBe("second-brain-vectors");
+    expect(health.vectorCount).toBe(41);
+  });
+
+  it("reports the vector count from the beta describe() shape (vectorsCount)", async () => {
+    const health = await checkVectorizeHealth(
+      envDescribing({ name: "second-brain-vectors", config: { dimensions: 384, metric: "cosine" }, vectorsCount: 7 }),
+    );
+    expect(health.vectorCount).toBe(7);
+  });
+
+  it("reports a zero vector count as 0, not as missing (an empty index is a fact)", async () => {
+    const health = await checkVectorizeHealth(envDescribing({ dimensions: 384, vectorCount: 0 }));
+    expect(health.vectorCount).toBe(0);
+  });
+
+  it("omits the vector count when describe() does not report one", async () => {
+    const health = await checkVectorizeHealth(envDescribing({ dimensions: 384, metric: "cosine" }));
+    expect(health.ok).toBe(true);
     expect(health.dimensions).toBe(384);
+    expect(health.vectorCount).toBeUndefined();
+    // undefined must not survive into the /health body as an explicit null.
+    expect(JSON.parse(JSON.stringify(health))).not.toHaveProperty("vectorCount");
+  });
+
+  it("omits the vector count when describe() reports a non-numeric one", async () => {
+    const health = await checkVectorizeHealth(envDescribing({ dimensions: 384, vectorCount: "41" }));
+    expect(health.vectorCount).toBeUndefined();
+  });
+
+  it("falls back to the configured index name when describe() reports no name", async () => {
+    // The V2 describe() shape has no `name` field at all, so this is the live path
+    // today — the fallback must still be the wrangler.jsonc name that public/utils.js
+    // and the README verify step expect.
+    const health = await checkVectorizeHealth(envDescribing({ dimensions: 384 }));
+    expect(health.indexName).toBe(FALLBACK_VECTORIZE_INDEX_NAME);
+    expect(health.indexName).toBe("second-brain-vectors");
+  });
+
+  it("falls back when describe() reports an empty or non-string name", async () => {
+    expect((await checkVectorizeHealth(envDescribing({ name: "", dimensions: 384 }))).indexName)
+      .toBe(FALLBACK_VECTORIZE_INDEX_NAME);
+    expect((await checkVectorizeHealth(envDescribing({ name: 123, dimensions: 384 }))).indexName)
+      .toBe(FALLBACK_VECTORIZE_INDEX_NAME);
   });
 
   it("reads dimensions from a beta-shaped config object", async () => {
-    const env = makeTestEnv(makeTestDb(), {
-      VECTORIZE: makeVectorizeMock({
-        describe: vi.fn().mockResolvedValue({ config: { dimensions: 384, metric: "cosine" } }),
-      }),
-    });
-    const health = await checkVectorizeHealth(env);
+    const health = await checkVectorizeHealth(
+      envDescribing({ config: { dimensions: 384, metric: "cosine" } }),
+    );
     expect(health.ok).toBe(true);
     expect(health.dimensions).toBe(384);
   });
 
   it("returns not-ok with the error message when describe() rejects", async () => {
-    const env = makeTestEnv(makeTestDb(), {
-      VECTORIZE: makeVectorizeMock({
-        describe: vi.fn().mockRejectedValue(new Error("index not found")),
-      }),
-    });
-    const health = await checkVectorizeHealth(env);
+    const health = await checkVectorizeHealth(envFailing(new Error("index not found")));
     expect(health.ok).toBe(false);
-    expect(health.indexName).toBe("second-brain-vectors");
     expect(health.error).toContain("index not found");
+    // The banner interpolates indexName, so it stays a non-empty string even when
+    // we could not ask the index its name.
+    expect(health.indexName).toBe(FALLBACK_VECTORIZE_INDEX_NAME);
+    expect(typeof health.indexName).toBe("string");
+    expect(health.vectorCount).toBeUndefined();
+  });
+
+  it("stringifies a non-Error rejection", async () => {
+    const health = await checkVectorizeHealth(envFailing("boom"));
+    expect(health.ok).toBe(false);
+    expect(health.error).toBe("boom");
   });
 });


### PR DESCRIPTION
Closes #257. Closes #248.

Two features plus the correctness work they depended on. 40 files, +5,842.

## #257 — updates go to the right Worker

`update_worker` took its script name from the bundled manifest while deploys are a `PUT`. A brain connected as `my-brain.acme.workers.dev` was therefore "updated" by writing the bundle to a script called `second-brain` in that account: failing forever if none existed, or **silently overwriting an unrelated Worker** that happened to hold the name. The account was resolved correctly from the address; only the script name ignored it.

Both halves of a workers.dev host now live in one strict parse (`worker_url.rs`), which also fixed a latent bug — `split('.').nth(1)` on the 3-label host `acme.workers.dev` returned `"workers"` as the subdomain, a plausible value matching no account.

## #248 — changing how memories are read

Switching embedding model changes the vector dimensions, and a Vectorize index fixes those at creation. So it is: create a second index, repoint the binding, rebuild every vector, verify, and only then drop the first — with rollback available at every step before the last.

**The rebuild keeps its own ledger, and that is not a convenience.** Vector ids are deterministic, so re-embedding unchanged content into a new index produces byte-identical id strings. `vector_ids` stays non-empty throughout, which means `/vectorize-pending` and `/stats.unvectorized` are *structurally blind* to entries a stalled rebuild never reached. The KV ledger is the only record of what was actually rebuilt.

**A batch that achieves nothing stops the run.** When the daily allowance goes, every remaining entry fails identically; a loop that continued would spend the rest of the run reproducing one failure and report hundreds. The Worker distinguishes "budget spent" from "one entry failing" and the window shows different screens, because telling the second user to come back tomorrow is advice that can never work.

Only models with documented dimensions are offered — guessing wrong creates an index that rejects every vector and cannot be altered. Choices are presented as named levels, matching the other six controls in that window; dimensions never reach the screen.

## Correctness work these depended on

**Eleven call sites ignored the user's settings.** `config: Readonly<Config> = DEFAULTS` is a convenient signature and a dangerous one — omit the argument and the call silently uses shipped defaults. `POST /vectorize-pending` embedded with the *default* model while capture and recall used the configured one, writing wrong-model vectors into the index; that would corrupt a brain immediately after a migration. `derivePattern` does the same from the *recall* path. The rest meant the model and hops controls shipped in #246 did nothing on several paths. `config-threading-complete.test.ts` cannot catch these: it looks for module-scope *reads*, and an omitted argument reads nothing.

**`/health` reported a compile-time index name** rather than the bound one — actively misleading during exactly the operation where a user watches that banner.

## Testing without the live brain

Demo mode previously could not reach a brain at all, so the entire Advanced Settings window failed in it — a pre-existing #246 gap. It now runs a real HTTP server on loopback, and the app's own functions execute **unchanged** against it: real requests, real parsing, real error mapping. A demo run is evidence about the shipping code path.

It behaves like a brain with data: 1,620 memories, a rebuild that takes 81 batches, a config that records overrides and reads them back, and an env var to reach the "paused for today" screen.

That immediately exposed three keychain reads in demo mode — including one at startup, which is why the window never worked — plus two bugs in the migration commands. All fixed.

`scripts/seed-test-brain.mjs` fills a throwaway brain for an end-to-end pass, refusing any target that is not a plain workers.dev origin.

## Verification

- **172 Rust tests, 903 Worker tests**, both typechecks clean, installer builds, `wrangler deploy --dry-run` builds
- The migration's SQL is tested against **real SQLite** via the project's own `db/schema.sql`, because the correctness of a keyset cursor *is* its SQL and a string-matching mock would pass whatever the comparison said
- **~90 mutations** run across the new logic, all caught. Several only after fixing the tests first — a tie-break case where the fixture could not reach the code path, and guards that matched their own source
- Demo mode driven end to end: full rebuild, `/health` following the repoint, settings window rendering every control

## What is not proven

**No test here creates a real Vectorize index or performs a real redeploy.** The demo proves orchestration, error handling and every screen; it cannot prove Cloudflare accepts a 768-dimension index or that the binding repoints. That closes on a throwaway account — worth doing before anyone migrates a brain they care about.