### PR TITLE
Change your Second Brain's password, or set a new one when it's lost (#235)

### DIFF
--- a/installer/src-tauri/src/cf/api.rs
+++ b/installer/src-tauri/src/cf/api.rs
@@ -535,6 +535,47 @@ pub async fn worker_health_ok(worker_url: &str, auth_token: &str) -> Result<bool
     Ok(body["ok"] == true && body["vectorize"]["ok"] == true)
 }
 
+/// GET /health, asking one question only: **does this password open this
+/// brain?**
+///
+/// Every answer other than a 401 is a pass — a 500, a 404, a body that is not
+/// JSON at all. That is the whole difference from [`worker_health_ok`], and it
+/// is deliberate: the Worker runs `requireAuth` before any route body
+/// (`src/lib/http.ts`), so anything that is not a 401 is proof the token was
+/// accepted, whatever went wrong afterwards.
+///
+/// This exists for [`super::provision::rotate_secret`], whose gate is "has the
+/// new password taken effect", not "is this brain healthy". Gating a rotation on
+/// full health makes a brain with a degraded vector index **permanently
+/// unrotatable**: `vectorize.ok` is false, so the poll can never go green, so
+/// nothing local is ever written — the keychain keeps the old password while the
+/// brain is already on the new one, and "Try again" lands on the identical
+/// screen forever. The password change succeeded on the first attempt and
+/// nothing in the app is able to say so.
+///
+/// [`worker_health_ok`] stays as it is, and `provision`/`update_worker` keep
+/// using it. There a 401 means a secret was dropped and a degraded index means
+/// the deploy is not finished, so both legitimately want the whole contract.
+///
+/// Never answers `Ok(false)`. A refusal comes back as `Unauthorized` because the
+/// caller has to tell "the edge is still serving the old secret" apart from a
+/// network error, and a bool cannot carry that; the `bool` is here so the
+/// [`super::provision::Backend`] method mirrors `health_ok` and a dry run can
+/// wave through an address with no server behind it.
+pub async fn worker_auth_ok(worker_url: &str, auth_token: &str) -> Result<bool, CfApiError> {
+    let http = reqwest::Client::new();
+    let resp = http
+        .get(format!("{worker_url}/health"))
+        .bearer_auth(auth_token)
+        .timeout(Duration::from_secs(20))
+        .send()
+        .await?;
+    if resp.status().as_u16() == 401 {
+        return Err(CfApiError::Unauthorized);
+    }
+    Ok(true)
+}
+
 /// GET /health and return the Worker's reported `version` (None if the field
 /// is absent — e.g. a deployment predating the version echo).
 pub async fn worker_version(
@@ -1129,6 +1170,148 @@ mod tests {
                 "type": "secret_text"
             }),
             "exact body shape, not a superset"
+        );
+    }
+
+    /// The three ways the write can be refused, which a rotation has to tell
+    /// apart. Until now the stub only ever answered `200 {"success":true}`, so
+    /// the whole error mapping was unexercised — and `commands::rotation_failure`
+    /// routes `Unauthorized` to a different screen ("sign in to Cloudflare
+    /// again") from everything else, so getting it wrong sends a user to fix a
+    /// problem they do not have.
+    ///
+    /// The 403 is not a duplicate of the 401. Cloudflare answers 403 for a
+    /// session that is signed in but whose token lacks Workers Scripts:Edit, and
+    /// re-authorising is the fix for both — so both must reach the same screen.
+    ///
+    /// The 500 pins the other half: a server error must *not* look like an auth
+    /// problem, or a Cloudflare incident tells the user their sign-in expired.
+    /// It costs the retry ladder's ~4s of backoff, which is the price of
+    /// asserting that a 5xx really is retried and a 4xx really is not.
+    #[tokio::test]
+    async fn put_secret_maps_the_refusals_a_rotation_has_to_tell_apart() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::sync::Arc;
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let hits = Arc::new(AtomicU32::new(0));
+        let hits_bg = hits.clone();
+        std::thread::spawn(move || loop {
+            let Ok(req) = server.recv() else { return };
+            hits_bg.fetch_add(1, Ordering::SeqCst);
+            // The account id selects the scenario; the path is otherwise the
+            // one real path, so nothing here passes by hitting a stub route.
+            let (status, body) = match req.url() {
+                u if u.starts_with("/accounts/expired/") => (
+                    401,
+                    r#"{"success":false,"errors":[{"code":10000,"message":"Authentication error"}]}"#,
+                ),
+                u if u.starts_with("/accounts/scopeless/") => (
+                    403,
+                    r#"{"success":false,"errors":[{"code":10000,"message":"Authentication error"}]}"#,
+                ),
+                _ => (
+                    500,
+                    r#"{"success":false,"errors":[{"code":10013,"message":"workers.api.error.internal"}]}"#,
+                ),
+            };
+            let _ = req.respond(tiny_http::Response::from_string(body).with_status_code(status));
+        });
+        let base = format!("http://127.0.0.1:{port}");
+        let client_for = |account: &str| {
+            CfClient::with_base("tok".into(), account.to_string(), base.clone())
+        };
+
+        for account in ["expired", "scopeless"] {
+            match client_for(account).put_secret("my-brain", "AUTH_TOKEN", "pw").await {
+                Err(CfApiError::Unauthorized) => {}
+                other => panic!("{account} must route to the re-authorise screen: {other:?}"),
+            }
+        }
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            2,
+            "a refusal is not transient — retrying it only delays the truth"
+        );
+
+        match client_for("outage").put_secret("my-brain", "AUTH_TOKEN", "pw").await {
+            Err(CfApiError::Api { code, message }) => {
+                assert_eq!(code, 10013);
+                assert!(message.contains("internal"), "lost the message: {message}");
+            }
+            other => panic!("a server error must not read as an auth problem: {other:?}"),
+        }
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            2 + MAX_ATTEMPTS,
+            "a 5xx is transient and must be retried before it is believed"
+        );
+    }
+
+    /// The probe a rotation is gated on, asserted next to the one it must *not*
+    /// be gated on.
+    ///
+    /// A brain whose vector index is degraded answers 200 with
+    /// `vectorize.ok: false`. `worker_health_ok` calls that unhealthy, which is
+    /// right for a deploy. If a rotation asked the same question the poll could
+    /// never go green: the secret would be written, the confirmation would fail
+    /// on every one of its twelve attempts, nothing local would be written, and
+    /// the user would be locked out of their own brain by an index problem that
+    /// has nothing to do with their password — with "Try again" landing on the
+    /// same screen forever.
+    ///
+    /// The last case is what keeps the probe from being vacuous: a connection
+    /// that never reached a server is not a pass. "Any non-401 answer" means an
+    /// answer.
+    #[tokio::test]
+    async fn the_auth_probe_passes_everything_that_is_not_a_refusal() {
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        std::thread::spawn(move || loop {
+            let Ok(req) = server.recv() else { return };
+            let (status, body) = match req.url() {
+                // Live, authenticating, vector index broken.
+                u if u.starts_with("/degraded") => (
+                    200,
+                    r#"{"ok":false,"version":"2.2.0","vectorize":{"ok":false,"error":"index not found"}}"#,
+                ),
+                // Authenticated, then fell over inside the route.
+                u if u.starts_with("/broken") => (500, r#"{"ok":false,"error":"boom"}"#),
+                // Something that is not the health contract at all.
+                u if u.starts_with("/html") => (200, "<html>gateway</html>"),
+                _ => (401, r#"{"ok":false,"error":"Unauthorized"}"#),
+            };
+            let _ = req.respond(tiny_http::Response::from_string(body).with_status_code(status));
+        });
+        let base = format!("http://127.0.0.1:{port}");
+
+        assert!(
+            matches!(worker_auth_ok(&format!("{base}/degraded"), "pw").await, Ok(true)),
+            "a degraded index is not a wrong password"
+        );
+        // …and the difference from the full check is the point of having two.
+        assert!(
+            matches!(worker_health_ok(&format!("{base}/degraded"), "pw").await, Ok(false)),
+            "worker_health_ok must keep failing a degraded index — provision and \
+             update_worker are gated on it"
+        );
+        for path in ["/broken", "/html"] {
+            assert!(
+                matches!(worker_auth_ok(&format!("{base}{path}"), "pw").await, Ok(true)),
+                "{path}: the token was accepted, whatever happened next"
+            );
+        }
+        assert!(
+            matches!(
+                worker_auth_ok(&format!("{base}/refused"), "pw").await,
+                Err(CfApiError::Unauthorized)
+            ),
+            "only a 401 means the new secret has not landed yet"
+        );
+        assert!(
+            worker_auth_ok("http://127.0.0.1:1/nothing", "pw").await.is_err(),
+            "nothing answered, so nothing accepted the password"
         );
     }
 }

--- a/installer/src-tauri/src/cf/api.rs
+++ b/installer/src-tauri/src/cf/api.rs
@@ -400,6 +400,30 @@ impl CfClient {
         Ok(())
     }
 
+    /// Writes one secret on a deployed script, leaving everything else alone.
+    ///
+    /// The whole of a password change (#235) is this request. The obvious
+    /// alternative — redeploy with the new `AUTH_TOKEN` in the upload metadata —
+    /// re-uploads every asset and rewrites every binding to change one field, and
+    /// it forces a question nobody has an answer to: whether an explicit
+    /// `secret_text` binding beats `keep_bindings` when a deploy carries both. A
+    /// wrong answer there either drops a secret the user added by hand or keeps
+    /// the old password while reporting success, and the second failure stays
+    /// invisible until they are locked out.
+    ///
+    /// An upsert, not an update: the same request sets a secret that was never
+    /// there. Cloudflare applies it to the live deployment asynchronously, so the
+    /// Worker can still be serving the previous value for a few seconds after
+    /// this returns — callers that need the new value to be in force must verify
+    /// it themselves (see `provision::rotate_secret`).
+    pub async fn put_secret(&self, script: &str, name: &str, text: &str) -> Result<(), CfApiError> {
+        let url = self.url(&self.account_path(&format!("/workers/scripts/{script}/secrets")));
+        let body = serde_json::json!({ "name": name, "text": text, "type": "secret_text" });
+        self.send::<serde_json::Value>(|h| h.put(&url).json(&body))
+            .await?;
+        Ok(())
+    }
+
     // ── workers.dev subdomain ───────────────────────────────────────────────
 
     /// Every Worker script in the account, by deploy name.
@@ -1029,5 +1053,82 @@ mod tests {
                 "vectorize_info swallowed the {name} failure"
             );
         }
+    }
+
+    /// The body shape is the whole risk here. Cloudflare accepts the request and
+    /// answers `success: true` for a payload that names the wrong field, and the
+    /// only symptom is that the user's password did not change — discovered the
+    /// next time they try to sign in, from a machine that no longer works. A
+    /// compiler cannot check a `json!` literal, so the assertion is an exact
+    /// value comparison: an extra key or a renamed one fails it.
+    ///
+    /// The method matters as much: `POST` to the same path is a different
+    /// operation, and the account bearer proves this went through `send` rather
+    /// than the JWT-authenticated `send_no_auth` used for asset uploads.
+    #[tokio::test]
+    async fn put_secret_sends_the_documented_body_to_the_script_secrets_path() {
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Debug)]
+        struct Seen {
+            method: String,
+            path: String,
+            auth: String,
+            body: String,
+        }
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let seen: Arc<Mutex<Vec<Seen>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_bg = seen.clone();
+        std::thread::spawn(move || loop {
+            let Ok(mut req) = server.recv() else { return };
+            let mut body = String::new();
+            let _ = req.as_reader().read_to_string(&mut body);
+            let auth = req
+                .headers()
+                .iter()
+                .find(|h| h.field.equiv("Authorization"))
+                .map(|h| h.value.as_str().to_string())
+                .unwrap_or_default();
+            seen_bg.lock().unwrap().push(Seen {
+                method: req.method().as_str().to_string(),
+                path: req.url().to_string(),
+                auth,
+                body,
+            });
+            // What Cloudflare answers: the secret it stored, never its value.
+            let _ = req.respond(
+                tiny_http::Response::from_string(
+                    r#"{"success":true,"errors":[],"messages":[],"result":{"name":"AUTH_TOKEN","type":"secret_text"}}"#,
+                )
+                .with_status_code(200),
+            );
+        });
+
+        let client = CfClient::with_base(
+            "tok".into(),
+            "acct".into(),
+            format!("http://127.0.0.1:{port}"),
+        );
+        client
+            .put_secret("my-brain", "AUTH_TOKEN", "correct horse battery staple")
+            .await
+            .unwrap();
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 1, "one write, not a retry loop: {seen:?}");
+        assert_eq!(seen[0].method, "PUT");
+        assert_eq!(seen[0].path, "/accounts/acct/workers/scripts/my-brain/secrets");
+        assert_eq!(seen[0].auth, "Bearer tok");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&seen[0].body).unwrap(),
+            serde_json::json!({
+                "name": "AUTH_TOKEN",
+                "text": "correct horse battery staple",
+                "type": "secret_text"
+            }),
+            "exact body shape, not a superset"
+        );
     }
 }

--- a/installer/src-tauri/src/cf/backend.rs
+++ b/installer/src-tauri/src/cf/backend.rs
@@ -71,6 +71,9 @@ impl Backend for LiveBackend {
     async fn health_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError> {
         api::worker_health_ok(worker_url, auth_token).await
     }
+    async fn auth_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError> {
+        api::worker_auth_ok(worker_url, auth_token).await
+    }
     async fn capture_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError> {
         api::worker_capture_ok(worker_url, auth_token).await
     }
@@ -236,7 +239,13 @@ impl Backend for DryRunBackend {
             .and_then(|b| b.get("text"))
             .and_then(|t| t.as_str())
         {
-            crate::demo_brain::rotate_to(token);
+            // `deployed_with`, not `rotate_to`: the secret rides along with this
+            // upload, so the Worker comes up already holding it and there is no
+            // propagation window to model. Routing a deploy through the rotation
+            // path instead pointed `SECOND_BRAIN_DEMO_ROTATE_AFTER` at
+            // `provision`'s health poll — where a 401 is terminal — and killed
+            // demo setup outright whenever the variable was exported.
+            crate::demo_brain::deployed_with(token);
         }
         Ok(())
     }
@@ -282,6 +291,21 @@ impl Backend for DryRunBackend {
             None => Ok(true),
         }
     }
+    /// The rotation gate's probe, resolved through exactly the same addresses as
+    /// [`Self::health_ok`] — see [`demo_health_target`]. A dry run that waved
+    /// this one through unconditionally would put the demo back to proving the
+    /// opposite of what it is run to prove, and this is the check a rotation
+    /// actually turns on.
+    async fn auth_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError> {
+        self.pause().await;
+        match demo_health_target(worker_url) {
+            // `worker_auth_ok` maps a 401 — and only a 401 — to `Unauthorized`,
+            // which `rotate_secret`'s loop reads as "the new secret has not
+            // propagated yet" and retries.
+            Some(url) => api::worker_auth_ok(&url, auth_token).await,
+            None => Ok(true),
+        }
+    }
     async fn capture_ok(&self, _worker_url: &str, _auth_token: &str) -> Result<bool, CfApiError> {
         Ok(true)
     }
@@ -306,7 +330,7 @@ impl Backend for DryRunBackend {
 mod tests {
     use super::*;
 
-    use crate::demo_brain::{self, DEFAULT_TOKEN};
+    use crate::demo_brain;
 
     /// A dry run must not quietly skip the password write. Demo mode exists to
     /// walk the real flow, so a rotation that never reached the backend has to
@@ -318,36 +342,30 @@ mod tests {
     /// gate `rotate_secret` exists for passes against a server that accepts
     /// anything.
     ///
-    /// The password it settles on is [`DEFAULT_TOKEN`]. The demo brain is
-    /// process-wide and outlives this test, so leaving it on anything else would
-    /// start 401ing whatever else in the suite is mid-request against it — the
-    /// same reasoning `demo_brain`'s own
-    /// `rotate_to_reaches_the_brain_the_app_is_handed` sets out.
-    ///
-    /// It does pass through a distinct value first, and then puts it straight
-    /// back. Settling on the default alone would prove nothing: another test
-    /// leaves the brain on that password too, so this would pass with the
-    /// rotation deleted. A value nothing else uses is the only thing that can
-    /// only have come from this call. The window it is held for is two statements
-    /// with no request in between.
+    /// **The brain is bound for this test alone.** It used to rotate the
+    /// process-wide one and hand the password straight back, on the grounds that
+    /// the window was "two statements with no request in between" — true read
+    /// down the page, false under a parallel harness, where three other tests are
+    /// reading that same global. At `RUST_TEST_THREADS=64` it failed 10 runs out
+    /// of 15, and CI's thread count follows the runner's cores. A scoped brain
+    /// removes the shared state instead of narrowing the window, which also frees
+    /// the test to settle on a password nothing else uses — the only value that
+    /// can *only* have come from this call.
     #[tokio::test]
     async fn dry_run_records_the_secret_write_and_the_demo_brain_starts_enforcing_it() {
+        let brain = demo_brain::scoped_brain();
         probe::reset_secret_puts();
 
         DryRunBackend
             .put_secret("my-brain", "AUTH_TOKEN", "a-password-only-this-test-sets")
             .await
             .unwrap();
-        let taken = demo_brain::auth_token();
-        DryRunBackend
-            .put_secret("my-brain", "AUTH_TOKEN", DEFAULT_TOKEN)
-            .await
-            .unwrap();
         assert_eq!(
-            taken, "a-password-only-this-test-sets",
+            demo_brain::auth_token(),
+            "a-password-only-this-test-sets",
             "setting AUTH_TOKEN must move the demo brain onto it. Without that, \
-             `rotate_secret`'s health gate polls a server that accepts anything, \
-             passes on the first attempt, and a demo rotation flips nothing while \
+             `rotate_secret`'s gate polls a server that accepts anything, passes \
+             on the first attempt, and a demo rotation flips nothing while \
              reporting success"
         );
         // `contains`, not equality. The record is a process-global static and the
@@ -360,44 +378,75 @@ mod tests {
             probe::secret_puts()
         );
 
-        assert_eq!(
-            demo_brain::auth_token(),
-            DEFAULT_TOKEN,
-            "the demo brain must be holding the password that was just set"
-        );
-
         // A secret that is not the brain's password must not retire the one that
-        // is. In this test rather than its own, because the brain is process-wide
-        // and two tests reading its password concurrently are reading each
-        // other's writes.
+        // is.
         DryRunBackend
             .put_secret("my-brain", "SOME_OTHER_SECRET", "not-a-password")
             .await
             .unwrap();
         assert_eq!(
             demo_brain::auth_token(),
-            DEFAULT_TOKEN,
+            "a-password-only-this-test-sets",
             "a secret under another name is not the brain's password"
         );
-        assert!(
-            matches!(
-                DryRunBackend
-                    .health_ok(&demo_brain::base_url(), DEFAULT_TOKEN)
-                    .await,
-                Ok(true)
+
+        // Both probes: `auth_ok` is what a rotation is gated on, `health_ok` is
+        // what every other flow asks, and a dry run has to route them both at the
+        // demo brain rather than answer either from a constant.
+        let set = "a-password-only-this-test-sets";
+        let url = brain.base_url();
+        for (name, accepted, refused) in [
+            (
+                "auth_ok",
+                DryRunBackend.auth_ok(url, set).await,
+                DryRunBackend.auth_ok(url, "not-the-demo-password").await,
             ),
-            "the password that was set must open the demo brain"
-        );
-        assert!(
-            matches!(
-                DryRunBackend
-                    .health_ok(&demo_brain::base_url(), "not-the-demo-password")
-                    .await,
-                Err(CfApiError::Unauthorized)
+            (
+                "health_ok",
+                DryRunBackend.health_ok(url, set).await,
+                DryRunBackend.health_ok(url, "not-the-demo-password").await,
             ),
-            "setting the secret must retire every other password, or a demo \
-             rotation flips nothing and the health gate proves nothing"
-        );
+        ] {
+            assert!(
+                matches!(accepted, Ok(true)),
+                "{name}: the password that was set must open the demo brain, got {accepted:?}"
+            );
+            assert!(
+                matches!(refused, Err(CfApiError::Unauthorized)),
+                "{name}: setting the secret must retire every other password, or \
+                 a demo rotation flips nothing and the gate proves nothing. Got \
+                 {refused:?}"
+            );
+        }
+    }
+
+    /// Demo setup, end to end against the demo brain, with the rotation delay
+    /// exported.
+    ///
+    /// The knob is for rotation's retry loop. It used to reach the deploy as
+    /// well, and `provision`'s health poll treats a 401 as terminal — so with
+    /// `SECOND_BRAIN_DEMO_ROTATE_AFTER` set, the very first thing a demo user
+    /// does died on "Something went wrong", with no way to reach the screen the
+    /// variable was exported to see.
+    ///
+    /// A scoped brain, so the fresh password this provisions with cannot 401 the
+    /// rest of the suite.
+    #[tokio::test]
+    async fn a_dry_run_setup_completes_even_with_the_rotation_delay_exported() {
+        let _brain = demo_brain::scoped_brain_with(demo_brain::Options {
+            rotate_after: Some(3),
+            ..demo_brain::test_options()
+        });
+
+        crate::cf::provision::provision(
+            &DryRunBackend,
+            &crate::worker_bundle::manifest(),
+            "Demo Account",
+            "a-password-only-this-test-sets",
+            |_| {},
+        )
+        .await
+        .expect("a demo setup must not be broken by a knob meant for rotation");
     }
 
     /// The dry-run health check has to be capable of saying no.

--- a/installer/src-tauri/src/cf/backend.rs
+++ b/installer/src-tauri/src/cf/backend.rs
@@ -6,6 +6,7 @@ use super::api::{self, CfClient};
 use super::provision::Backend;
 use super::types::CfApiError;
 use crate::worker_bundle;
+use std::sync::Mutex;
 use std::time::Duration;
 
 pub struct LiveBackend {
@@ -64,6 +65,9 @@ impl Backend for LiveBackend {
     async fn enable_script_subdomain(&self, script: &str) -> Result<(), CfApiError> {
         self.client.enable_script_subdomain(script).await
     }
+    async fn put_secret(&self, script: &str, name: &str, text: &str) -> Result<(), CfApiError> {
+        self.client.put_secret(script, name, text).await
+    }
     async fn health_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError> {
         api::worker_health_ok(worker_url, auth_token).await
     }
@@ -84,6 +88,30 @@ impl Backend for LiveBackend {
 /// Answers everything successfully after a short pause, so the setup flow can
 /// be demoed end-to-end. Never touches the network or the keychain.
 pub struct DryRunBackend;
+
+/// Every secret write a dry run has made, as `(script, name)` pairs.
+///
+/// [`DryRunBackend`] is a unit struct constructed inline at every call site
+/// (`&DryRunBackend`), so there is nowhere on the value to hang a record, and
+/// giving it state would mean editing every caller to make one test possible. A
+/// module static is the cheap way to make "the rotation really did reach the
+/// backend" observable — the same shape as `secure_store`'s read counter.
+///
+/// The secret's text is deliberately not kept. Nothing here has a reason to hold
+/// the user's new password after the call returns, and a demo password is still
+/// a password.
+static DRY_RUN_SECRET_PUTS: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
+
+/// Test-only view of the secret writes a dry run has made.
+#[cfg(test)]
+pub mod probe {
+    pub fn secret_puts() -> Vec<(String, String)> {
+        super::DRY_RUN_SECRET_PUTS.lock().unwrap().clone()
+    }
+    pub fn reset_secret_puts() {
+        super::DRY_RUN_SECRET_PUTS.lock().unwrap().clear();
+    }
+}
 
 impl DryRunBackend {
     async fn pause(&self) {
@@ -150,6 +178,18 @@ impl Backend for DryRunBackend {
         self.pause().await;
         Ok(())
     }
+    /// Records the write and succeeds. Flipping the password the demo brain
+    /// actually accepts is `demo_brain`'s half of the job: it is the thing
+    /// serving `/health`, and a rotation is only worth demoing if the old
+    /// password starts failing afterwards.
+    async fn put_secret(&self, script: &str, name: &str, _text: &str) -> Result<(), CfApiError> {
+        self.pause().await;
+        DRY_RUN_SECRET_PUTS
+            .lock()
+            .unwrap()
+            .push((script.to_string(), name.to_string()));
+        Ok(())
+    }
     async fn health_ok(&self, _worker_url: &str, _auth_token: &str) -> Result<bool, CfApiError> {
         self.pause().await;
         Ok(true)
@@ -172,4 +212,26 @@ impl Backend for DryRunBackend {
         ])
     }
     async fn sleep(&self, _duration: Duration) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A dry run must not quietly skip the password write. Demo mode exists to
+    /// walk the real flow, so a rotation that never reached the backend has to
+    /// look different from one that did — otherwise the demo proves nothing about
+    /// the thing it is demonstrating.
+    #[tokio::test]
+    async fn dry_run_records_the_secret_write() {
+        probe::reset_secret_puts();
+        DryRunBackend
+            .put_secret("my-brain", "AUTH_TOKEN", "demo-password")
+            .await
+            .unwrap();
+        assert_eq!(
+            probe::secret_puts(),
+            vec![("my-brain".to_string(), "AUTH_TOKEN".to_string())]
+        );
+    }
 }

--- a/installer/src-tauri/src/cf/backend.rs
+++ b/installer/src-tauri/src/cf/backend.rs
@@ -114,9 +114,56 @@ pub mod probe {
 }
 
 impl DryRunBackend {
+    /// The pacing that makes a demo look like work being done.
+    ///
+    /// Zero under test. It is a UI affordance and nothing asserts on it, while a
+    /// suite that sleeps through it holds every dry-run path open for a second
+    /// at a time — long enough for a process-global counter (`secure_store`'s
+    /// read probe) to pick up whatever else the suite is doing and report it
+    /// against the path being measured.
     async fn pause(&self) {
-        tokio::time::sleep(Duration::from_millis(450)).await;
+        let delay = if cfg!(test) {
+            Duration::ZERO
+        } else {
+            Duration::from_millis(450)
+        };
+        tokio::time::sleep(delay).await;
     }
+}
+
+/// The address of the demo brain a dry run's health check should actually talk
+/// to, or `None` when nothing is listening at `worker_url` and the check has to
+/// be waved through.
+///
+/// Two addresses reach the same server, and both have to be recognised:
+///
+/// * **Loopback.** `dashboard_credentials` hands every Worker-backed screen
+///   `http://127.0.0.1:PORT` in dry-run, because that is where the demo brain is
+///   and a screen pointed anywhere else has nothing to read.
+/// * **`*.demo.workers.dev`.** The stand-in address, used wherever a real
+///   workers.dev *shape* is required. `rotate_secret` (and `update_worker`)
+///   derive the Worker's script name from the address it is given — #257, and
+///   non-negotiable — and loopback has no script label at all, so a dry-run
+///   rotation has no choice but to pass the stand-in. `DryRunBackend::get_account_subdomain`
+///   answers `"demo"`, so this is exactly the set of addresses a dry run invents.
+///
+/// Anything else has no server behind it and gets the unconditional pass below.
+///
+/// Do not simplify this back to `Ok(true)`. A rotation's entire safety property
+/// is that nothing local is written until the Worker authenticates the *new*
+/// password; against a backend that reports health without asking anyone, that
+/// gate passes trivially and demo mode proves the opposite of what it is run to
+/// prove — which is how the last arc shipped five bugs past 170 unit tests.
+fn demo_health_target(worker_url: &str) -> Option<String> {
+    let parsed = url::Url::parse(worker_url).ok()?;
+    let host = parsed.host_str()?.to_ascii_lowercase();
+    if host == "127.0.0.1" || host == "localhost" || host == "[::1]" || host == "::1" {
+        return Some(worker_url.to_string());
+    }
+    if host.ends_with(".demo.workers.dev") {
+        return Some(crate::demo_brain::base_url());
+    }
+    None
 }
 
 impl Backend for DryRunBackend {
@@ -163,12 +210,34 @@ impl Backend for DryRunBackend {
         self.pause().await;
         Ok("dryrun-jwt".into())
     }
+    /// A fresh deploy carries the password as a `secret_text` binding, so the
+    /// demo brain has to take it the same way a real Worker would.
+    ///
+    /// Without this, running setup again after a demo rotation fails: the health
+    /// poll now genuinely asks the demo brain, the brain is still enforcing the
+    /// rotated password, and `provision`'s poll treats a 401 as terminal. An
+    /// *update* is unaffected and must be — its metadata carries `keep_bindings`
+    /// and no secret, exactly because the app does not know the password then.
     async fn deploy_worker(
         &self,
         _script: &str,
-        _metadata: &serde_json::Value,
+        metadata: &serde_json::Value,
     ) -> Result<(), CfApiError> {
         self.pause().await;
+        if let Some(token) = metadata
+            .get("bindings")
+            .and_then(|b| b.as_array())
+            .and_then(|bindings| {
+                bindings.iter().find(|b| {
+                    b.get("type").and_then(|t| t.as_str()) == Some("secret_text")
+                        && b.get("name").and_then(|n| n.as_str()) == Some("AUTH_TOKEN")
+                })
+            })
+            .and_then(|b| b.get("text"))
+            .and_then(|t| t.as_str())
+        {
+            crate::demo_brain::rotate_to(token);
+        }
         Ok(())
     }
     async fn set_cron(&self, _script: &str, _crons: &[String]) -> Result<(), CfApiError> {
@@ -178,21 +247,40 @@ impl Backend for DryRunBackend {
         self.pause().await;
         Ok(())
     }
-    /// Records the write and succeeds. Flipping the password the demo brain
-    /// actually accepts is `demo_brain`'s half of the job: it is the thing
-    /// serving `/health`, and a rotation is only worth demoing if the old
-    /// password starts failing afterwards.
-    async fn put_secret(&self, script: &str, name: &str, _text: &str) -> Result<(), CfApiError> {
+    /// Records the write, then makes it true.
+    ///
+    /// This backend stands in for Cloudflare's control plane and the demo brain
+    /// stands in for the Worker, so when the fake control plane sets `AUTH_TOKEN`
+    /// the fake Worker has to start honouring it — otherwise `rotate_secret`'s
+    /// health gate polls a server that accepts anything, passes on the first
+    /// attempt, and a demo rotation flips nothing while reporting success. The
+    /// old password would go on working for the rest of the run.
+    ///
+    /// Only `AUTH_TOKEN`. A future secret under another name is not the brain's
+    /// password and must not retire it.
+    async fn put_secret(&self, script: &str, name: &str, text: &str) -> Result<(), CfApiError> {
         self.pause().await;
         DRY_RUN_SECRET_PUTS
             .lock()
             .unwrap()
             .push((script.to_string(), name.to_string()));
+        if name == "AUTH_TOKEN" {
+            crate::demo_brain::rotate_to(text);
+        }
         Ok(())
     }
-    async fn health_ok(&self, _worker_url: &str, _auth_token: &str) -> Result<bool, CfApiError> {
+    /// Probes the demo brain for real when there is one behind this address; see
+    /// [`demo_health_target`] for which addresses those are and why an
+    /// unconditional pass is wrong.
+    async fn health_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError> {
         self.pause().await;
-        Ok(true)
+        match demo_health_target(worker_url) {
+            // `worker_health_ok` already maps a 401 to `Unauthorized`, which
+            // `rotate_secret`'s loop reads as "the new secret has not propagated
+            // yet" and retries — the same shape the live path has.
+            Some(url) => api::worker_health_ok(&url, auth_token).await,
+            None => Ok(true),
+        }
     }
     async fn capture_ok(&self, _worker_url: &str, _auth_token: &str) -> Result<bool, CfApiError> {
         Ok(true)
@@ -218,20 +306,129 @@ impl Backend for DryRunBackend {
 mod tests {
     use super::*;
 
+    use crate::demo_brain::{self, DEFAULT_TOKEN};
+
     /// A dry run must not quietly skip the password write. Demo mode exists to
     /// walk the real flow, so a rotation that never reached the backend has to
     /// look different from one that did — otherwise the demo proves nothing about
     /// the thing it is demonstrating.
+    ///
+    /// The second half is the wiring that makes the demo real: setting the secret
+    /// has to retire the old password on the brain that serves `/health`, or the
+    /// gate `rotate_secret` exists for passes against a server that accepts
+    /// anything.
+    ///
+    /// The password it settles on is [`DEFAULT_TOKEN`]. The demo brain is
+    /// process-wide and outlives this test, so leaving it on anything else would
+    /// start 401ing whatever else in the suite is mid-request against it — the
+    /// same reasoning `demo_brain`'s own
+    /// `rotate_to_reaches_the_brain_the_app_is_handed` sets out.
+    ///
+    /// It does pass through a distinct value first, and then puts it straight
+    /// back. Settling on the default alone would prove nothing: another test
+    /// leaves the brain on that password too, so this would pass with the
+    /// rotation deleted. A value nothing else uses is the only thing that can
+    /// only have come from this call. The window it is held for is two statements
+    /// with no request in between.
     #[tokio::test]
-    async fn dry_run_records_the_secret_write() {
+    async fn dry_run_records_the_secret_write_and_the_demo_brain_starts_enforcing_it() {
         probe::reset_secret_puts();
+
         DryRunBackend
-            .put_secret("my-brain", "AUTH_TOKEN", "demo-password")
+            .put_secret("my-brain", "AUTH_TOKEN", "a-password-only-this-test-sets")
+            .await
+            .unwrap();
+        let taken = demo_brain::auth_token();
+        DryRunBackend
+            .put_secret("my-brain", "AUTH_TOKEN", DEFAULT_TOKEN)
             .await
             .unwrap();
         assert_eq!(
-            probe::secret_puts(),
-            vec![("my-brain".to_string(), "AUTH_TOKEN".to_string())]
+            taken, "a-password-only-this-test-sets",
+            "setting AUTH_TOKEN must move the demo brain onto it. Without that, \
+             `rotate_secret`'s health gate polls a server that accepts anything, \
+             passes on the first attempt, and a demo rotation flips nothing while \
+             reporting success"
         );
+        // `contains`, not equality. The record is a process-global static and the
+        // suite runs in parallel, so pinning the whole vector makes this test
+        // fail whenever another one happens to rotate at the same moment — which
+        // says nothing about either.
+        assert!(
+            probe::secret_puts().contains(&("my-brain".to_string(), "AUTH_TOKEN".to_string())),
+            "the write must be recorded against the script it targeted: {:?}",
+            probe::secret_puts()
+        );
+
+        assert_eq!(
+            demo_brain::auth_token(),
+            DEFAULT_TOKEN,
+            "the demo brain must be holding the password that was just set"
+        );
+
+        // A secret that is not the brain's password must not retire the one that
+        // is. In this test rather than its own, because the brain is process-wide
+        // and two tests reading its password concurrently are reading each
+        // other's writes.
+        DryRunBackend
+            .put_secret("my-brain", "SOME_OTHER_SECRET", "not-a-password")
+            .await
+            .unwrap();
+        assert_eq!(
+            demo_brain::auth_token(),
+            DEFAULT_TOKEN,
+            "a secret under another name is not the brain's password"
+        );
+        assert!(
+            matches!(
+                DryRunBackend
+                    .health_ok(&demo_brain::base_url(), DEFAULT_TOKEN)
+                    .await,
+                Ok(true)
+            ),
+            "the password that was set must open the demo brain"
+        );
+        assert!(
+            matches!(
+                DryRunBackend
+                    .health_ok(&demo_brain::base_url(), "not-the-demo-password")
+                    .await,
+                Err(CfApiError::Unauthorized)
+            ),
+            "setting the secret must retire every other password, or a demo \
+             rotation flips nothing and the health gate proves nothing"
+        );
+    }
+
+    /// The dry-run health check has to be capable of saying no.
+    ///
+    /// Port 1 has nothing listening, and it is loopback, so this is the shortest
+    /// proof that the check makes a real request instead of answering from a
+    /// constant. If this ever reports `Ok(true)`, `rotate_secret`'s gate is
+    /// vacuous in demo mode and a demo rotation "succeeds" against a brain that
+    /// never received it.
+    #[tokio::test]
+    async fn the_dry_run_health_check_fails_when_nothing_is_listening() {
+        let result = DryRunBackend.health_ok("http://127.0.0.1:1", "demo").await;
+        assert!(
+            !matches!(result, Ok(true)),
+            "a dry-run health check answered yes for an address with no server \
+             behind it: {result:?}"
+        );
+    }
+
+    /// …and still waves through the addresses no demo server stands behind, so
+    /// the flows that invent a plausible remote address keep working offline.
+    #[tokio::test]
+    async fn an_address_with_no_demo_server_behind_it_still_passes() {
+        assert!(matches!(
+            DryRunBackend
+                .health_ok("https://second-brain.acme.workers.dev", "demo")
+                .await,
+            Ok(true)
+        ));
+        assert!(demo_health_target("https://second-brain.acme.workers.dev").is_none());
+        assert!(demo_health_target("https://second-brain.demo.workers.dev").is_some());
+        assert!(demo_health_target("http://127.0.0.1:8787").is_some());
     }
 }

--- a/installer/src-tauri/src/cf/provision.rs
+++ b/installer/src-tauri/src/cf/provision.rs
@@ -46,7 +46,6 @@ pub enum Step {
     /// Emitted by `commands::rotate_password` around `rotate::persist`, never
     /// from here: nothing local may be written until [`rotate_secret`] has
     /// returned, so the step does not exist inside it.
-    #[allow(dead_code)] // constructed outside this module, by the command
     Local,
 }
 

--- a/installer/src-tauri/src/cf/provision.rs
+++ b/installer/src-tauri/src/cf/provision.rs
@@ -28,6 +28,26 @@ pub enum Step {
     Recall,
     /// Assets + Worker + schedule + smoke tests — "Finishing up"
     Finish,
+    // The three below belong to a password change (#235) and to nothing else.
+    // A rotation is not a shortened setup: it writes one secret and then waits,
+    // and the wait is the part the user is being asked to sit through — up to
+    // `HEALTH_ATTEMPTS × HEALTH_WAIT`, on a screen that says "Leave this window
+    // open". Reusing `Finish` for all of it was tried and is wrong twice over:
+    // the rotation screen's checklist is keyed by these ids, so every row would
+    // stay a static bullet for the whole run, and "Finishing up" describes the
+    // last stage of a deploy rather than the two distinct things that can fail
+    // here — the write going out, and the brain accepting what was written.
+    /// The secret PUT — "Sending the change to your Second Brain"
+    Secret,
+    /// Polling `/health` with the new password — "Waiting for it to take effect"
+    Confirm,
+    /// The local stores — "Updating this computer".
+    ///
+    /// Emitted by `commands::rotate_password` around `rotate::persist`, never
+    /// from here: nothing local may be written until [`rotate_secret`] has
+    /// returned, so the step does not exist inside it.
+    #[allow(dead_code)] // constructed outside this module, by the command
+    Local,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -103,7 +123,13 @@ pub trait Backend {
     /// effect at the edge a little after it returns — see [`rotate_secret`],
     /// which is the only caller that may treat it as done.
     async fn put_secret(&self, script: &str, name: &str, text: &str) -> Result<(), CfApiError>;
+    /// The full health contract: live *and* its vector index wired. What a
+    /// deploy has to wait for.
     async fn health_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError>;
+    /// Does this password open this brain — and nothing else. What a *rotation*
+    /// has to wait for; see [`super::api::worker_auth_ok`] for why the two must
+    /// not be merged, and [`rotate_secret`] for what merging them costs.
+    async fn auth_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError>;
     async fn capture_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError>;
     /// The deployed script's current bindings (for a preserve-everything update).
     async fn get_script_bindings(&self, script: &str)
@@ -497,7 +523,8 @@ pub async fn update_worker<B: Backend>(
 ///
 /// The deployment is otherwise untouched: no assets are re-uploaded, no bindings
 /// are rewritten, and no code is redeployed. Progress is reported as
-/// [`Step::Finish`] — see the note on the emit below.
+/// [`Step::Secret`] then [`Step::Confirm`] — the two things that can fail, and
+/// the two rows the rotation screen draws.
 ///
 /// A failure here is *not* proof that the password is unchanged. The write and
 /// the confirmation are two separate operations, and only the second one can
@@ -510,16 +537,7 @@ pub async fn rotate_secret<B: Backend>(
     new_token: &str,
     progress: impl Fn(StepEvent),
 ) -> Result<(), ProvisionError> {
-    // One step for the whole rotation, and an existing one. A new `Step` variant
-    // would need copy in every locale and a case in the progress UI to describe a
-    // single API call and a wait; `Finish` already means "the remote change is
-    // going in, and we are verifying it", which is exactly this.
-    let emit = |status: StepStatus| {
-        progress(StepEvent {
-            step: Step::Finish,
-            status,
-        })
-    };
+    let emit = |step: Step, status: StepStatus| progress(StepEvent { step, status });
 
     // #257, and it bites harder here than it did there. The script name comes
     // from the address the user is actually connected to, never from the bundled
@@ -534,51 +552,61 @@ pub async fn rotate_secret<B: Backend>(
     let script =
         crate::worker_url::script_of(worker_url).ok_or(ProvisionError::NotAWorkersDevAddress)?;
 
-    emit(StepStatus::Running);
-    let result = async {
-        backend.put_secret(&script, "AUTH_TOKEN", new_token).await?;
-
-        // The write is asynchronous at the edge, so the point of this loop is to
-        // wait out the propagation with the *new* token. The secret is PUT once,
-        // above: re-sending it on every attempt would be a second write racing
-        // the first, and would tell us nothing new.
-        for attempt in 0..HEALTH_ATTEMPTS {
-            match backend.health_ok(worker_url, new_token).await {
-                Ok(true) => return Ok(()),
-                // Read this next to `update_worker`'s health poll before changing
-                // it: the two treat a 401 in opposite ways, on purpose.
-                //
-                // There, the poll uses the token the app already had, so a 401
-                // means the redeploy dropped the secret — retrying would only
-                // delay telling the user they are locked out, and it is terminal.
-                //
-                // Here the poll uses the token that was just written, so a 401
-                // means the edge is still serving the *old* secret and the change
-                // has not landed yet. It is the expected answer for the first few
-                // seconds of every rotation. Making it terminal turns any deploy
-                // slower than one probe into a reported failure — of a rotation
-                // that then succeeds seconds later, leaving the user with a
-                // password the app told them was not applied.
-                Err(CfApiError::Unauthorized) => {}
-                // Not live yet, or DNS/network still catching up.
-                Ok(false) | Err(_) => {}
-            }
-            if attempt + 1 < HEALTH_ATTEMPTS {
-                backend.sleep(HEALTH_WAIT).await;
-            }
-        }
-        // Every attempt used up. The password may still be in force — see the
-        // note on this function.
-        Err(ProvisionError::HealthCheckFailed)
+    emit(Step::Secret, StepStatus::Running);
+    if let Err(e) = backend.put_secret(&script, "AUTH_TOKEN", new_token).await {
+        emit(Step::Secret, StepStatus::Error);
+        return Err(e.into());
     }
-    .await;
+    emit(Step::Secret, StepStatus::Done);
 
-    emit(if result.is_ok() {
-        StepStatus::Done
-    } else {
-        StepStatus::Error
-    });
-    result
+    // The write is asynchronous at the edge, so the point of this loop is to wait
+    // out the propagation with the *new* token. The secret is PUT once, above:
+    // re-sending it on every attempt would be a second write racing the first,
+    // and would tell us nothing new.
+    emit(Step::Confirm, StepStatus::Running);
+    for attempt in 0..HEALTH_ATTEMPTS {
+        // `auth_ok`, not `health_ok`, and the difference is the difference
+        // between a recoverable rotation and an unrecoverable one.
+        //
+        // The full health check requires `ok && vectorize.ok`. A brain whose
+        // vector index is degraded fails it on every attempt forever — so a
+        // rotation gated on it writes the secret, never confirms, never persists,
+        // and leaves the keychain on the old password while the brain is on the
+        // new one. "Try again" then repeats that exact sequence for as long as
+        // the index stays broken. All this gate has to establish is that the new
+        // password opens the brain; the dashboard is where a degraded index gets
+        // reported, and it is not this flow's business.
+        match backend.auth_ok(worker_url, new_token).await {
+            Ok(true) => {
+                emit(Step::Confirm, StepStatus::Done);
+                return Ok(());
+            }
+            // Read this next to `update_worker`'s health poll before changing
+            // it: the two treat a 401 in opposite ways, on purpose.
+            //
+            // There, the poll uses the token the app already had, so a 401
+            // means the redeploy dropped the secret — retrying would only
+            // delay telling the user they are locked out, and it is terminal.
+            //
+            // Here the poll uses the token that was just written, so a 401
+            // means the edge is still serving the *old* secret and the change
+            // has not landed yet. It is the expected answer for the first few
+            // seconds of every rotation. Making it terminal turns any deploy
+            // slower than one probe into a reported failure — of a rotation
+            // that then succeeds seconds later, leaving the user with a
+            // password the app told them was not applied.
+            Err(CfApiError::Unauthorized) => {}
+            // Nothing answered yet — DNS/network still catching up.
+            Ok(false) | Err(_) => {}
+        }
+        if attempt + 1 < HEALTH_ATTEMPTS {
+            backend.sleep(HEALTH_WAIT).await;
+        }
+    }
+    // Every attempt used up. The password may still be in force — see the note on
+    // this function.
+    emit(Step::Confirm, StepStatus::Error);
+    Err(ProvisionError::HealthCheckFailed)
 }
 
 #[cfg(test)]
@@ -615,12 +643,17 @@ mod tests {
         existing_vectorize: bool,
         subdomain_rejections: Mutex<u32>,
         health_failures: Mutex<u32>,
-        /// Health probes to answer with a 401 before anything else, standing in
-        /// for a secret that has not propagated to the edge yet.
+        /// Probes to answer with a 401 before anything else, standing in for a
+        /// secret that has not propagated to the edge yet.
         health_unauthorized: Mutex<u32>,
-        /// Every health probe, answered or not — a count the log cannot give,
-        /// since the log only records the ones that pass.
-        health_calls: Mutex<u32>,
+        /// Every probe of either kind, answered or not — a count the log cannot
+        /// give, since the log only records the ones that pass.
+        probe_calls: Mutex<u32>,
+        /// A brain that is up and authenticating with a broken vector index:
+        /// `health_ok` answers no for as long as it lasts, `auth_ok` still says
+        /// the password is good. This is the state that made a rotation gated on
+        /// full health permanently unrecoverable.
+        degraded_vector_index: bool,
         script_bindings: Vec<serde_json::Value>,
         last_deploy_metadata: Mutex<Option<serde_json::Value>>,
     }
@@ -631,6 +664,23 @@ mod tests {
         }
         fn entries(&self) -> Vec<String> {
             self.log.lock().unwrap().clone()
+        }
+        /// The half both probes share: the scripted refusals, spent in order, and
+        /// the call count. `None` means nothing was scripted and the probe is
+        /// free to answer for itself.
+        fn scripted_probe(&self) -> Option<Result<bool, CfApiError>> {
+            *self.probe_calls.lock().unwrap() += 1;
+            let mut unauthorized = self.health_unauthorized.lock().unwrap();
+            if *unauthorized > 0 {
+                *unauthorized -= 1;
+                return Some(Err(CfApiError::Unauthorized));
+            }
+            let mut failures = self.health_failures.lock().unwrap();
+            if *failures > 0 {
+                *failures -= 1;
+                return Some(Ok(false));
+            }
+            None
         }
     }
 
@@ -714,18 +764,24 @@ mod tests {
             Ok(())
         }
         async fn health_ok(&self, _url: &str, _token: &str) -> Result<bool, CfApiError> {
-            *self.health_calls.lock().unwrap() += 1;
-            let mut unauthorized = self.health_unauthorized.lock().unwrap();
-            if *unauthorized > 0 {
-                *unauthorized -= 1;
-                return Err(CfApiError::Unauthorized);
+            if let Some(scripted) = self.scripted_probe() {
+                return scripted;
             }
-            let mut failures = self.health_failures.lock().unwrap();
-            if *failures > 0 {
-                *failures -= 1;
+            if self.degraded_vector_index {
+                // `ok && vectorize.ok` is what the real check requires, and this
+                // half of it never recovers on its own.
                 return Ok(false);
             }
             self.log("health_ok");
+            Ok(true)
+        }
+        async fn auth_ok(&self, _url: &str, _token: &str) -> Result<bool, CfApiError> {
+            if let Some(scripted) = self.scripted_probe() {
+                return scripted;
+            }
+            // Deliberately blind to `degraded_vector_index`: the only question
+            // this probe answers is whether the password was accepted.
+            self.log("auth_ok");
             Ok(true)
         }
         async fn put_secret(
@@ -1096,15 +1152,122 @@ mod tests {
         );
         // Confirmed against the Worker, not just written. Success is the caller's
         // signal that the new password is safe to store locally.
-        assert!(fake.entries().contains(&"health_ok".to_string()));
+        assert!(fake.entries().contains(&"auth_ok".to_string()));
 
+        // The two things that can fail, reported as two steps, in order. The
+        // rotation screen draws a row per step id and moves it on each status, so
+        // this sequence is the screen: collapsing it back to one event leaves the
+        // user watching static bullets for up to
+        // `HEALTH_ATTEMPTS × HEALTH_WAIT`.
         let events = events.into_inner().unwrap();
         assert_eq!(
             events,
             vec![
-                (Step::Finish, StepStatus::Running),
-                (Step::Finish, StepStatus::Done)
+                (Step::Secret, StepStatus::Running),
+                (Step::Secret, StepStatus::Done),
+                (Step::Confirm, StepStatus::Running),
+                (Step::Confirm, StepStatus::Done),
             ]
+        );
+    }
+
+    /// What actually crosses the IPC boundary. `installer/src/main.ts` keys the
+    /// rotation checklist by these exact strings, and until now nothing asserted
+    /// any of them — which is how a rotation shipped emitting `"finish"` at a
+    /// screen listening for `"secret"`, `"confirm"` and `"local"`, leaving every
+    /// row a static bullet for the whole run under copy reading "Leave this
+    /// window open".
+    ///
+    /// Renaming a variant or dropping the `rename_all` is a silent break: Rust
+    /// stays happy, the front end still compiles, and the only symptom is a
+    /// progress screen that never moves.
+    #[test]
+    fn the_step_ids_on_the_wire_are_the_ones_the_screens_key_on() {
+        assert_eq!(
+            serde_json::to_value(StepEvent {
+                step: Step::Secret,
+                status: StepStatus::Running,
+            })
+            .unwrap(),
+            serde_json::json!({ "step": "secret", "status": "running" }),
+            "the whole event shape, field names included"
+        );
+
+        for (step, id) in [
+            (Step::Space, "space"),
+            (Step::Memory, "memory"),
+            (Step::Recall, "recall"),
+            (Step::Finish, "finish"),
+            (Step::Secret, "secret"),
+            (Step::Confirm, "confirm"),
+            // Emitted by `commands::rotate_password`, not by this module — the
+            // string still has to be right, and this is where the wire format is
+            // pinned.
+            (Step::Local, "local"),
+        ] {
+            let event = StepEvent { step, status: StepStatus::Done };
+            assert_eq!(
+                serde_json::to_value(&event).unwrap()["step"],
+                serde_json::json!(id),
+                "{step:?} must reach the front end as {id:?}"
+            );
+        }
+
+        for (status, id) in [
+            (StepStatus::Running, "running"),
+            (StepStatus::Done, "done"),
+            (StepStatus::Error, "error"),
+        ] {
+            let event = StepEvent { step: Step::Secret, status };
+            assert_eq!(
+                serde_json::to_value(&event).unwrap()["status"],
+                serde_json::json!(id),
+                "{status:?} must reach the front end as {id:?}"
+            );
+        }
+    }
+
+    /// A brain whose vector index is broken must still be rotatable.
+    ///
+    /// This is the unrecoverable one. `health_ok` requires `ok && vectorize.ok`,
+    /// so against a degraded index the confirmation can *never* go green: the
+    /// secret is written on the first attempt and accepted, the poll fails twelve
+    /// times, `persist` never runs, and the keychain keeps the old password while
+    /// the brain is already on the new one. Every "Try again" repeats exactly
+    /// that, and nothing in the app can tell the user their password did change.
+    ///
+    /// So the gate asks the only question it needs answered — does the new
+    /// password open the brain — and this fake answers the two questions
+    /// differently to prove which one it asked.
+    #[tokio::test]
+    async fn a_rotation_completes_against_a_brain_whose_vector_index_is_unhealthy() {
+        let fake = Fake {
+            degraded_vector_index: true,
+            ..Default::default()
+        };
+        rotate_secret(
+            &&fake,
+            "https://second-brain.acme.workers.dev",
+            "new-pw-123456789",
+            |_| {},
+        )
+        .await
+        .expect("a broken vector index is not a wrong password");
+
+        assert_eq!(
+            *fake.probe_calls.lock().unwrap(),
+            1,
+            "the auth probe passed first time — there was nothing to retry"
+        );
+        assert!(
+            fake.entries().contains(&"auth_ok".to_string()),
+            "the gate must be the auth-only probe: {:?}",
+            fake.entries()
+        );
+        assert!(
+            !fake.entries().contains(&"health_ok".to_string()),
+            "the full health check would never go green here: {:?}",
+            fake.entries()
         );
     }
 
@@ -1129,7 +1292,7 @@ mod tests {
         .await
         .expect("a 401 while the secret propagates is not a failed rotation");
 
-        assert_eq!(*fake.health_calls.lock().unwrap(), 4, "3 × 401, then green");
+        assert_eq!(*fake.probe_calls.lock().unwrap(), 4, "3 × 401, then green");
         // Waiting is what fixes a 401 here — re-writing the secret would be a
         // second write racing the first and would tell us nothing new.
         assert_eq!(secret_writes(&fake).len(), 1);
@@ -1159,26 +1322,46 @@ mod tests {
             "expected HealthCheckFailed, got {err:?}"
         );
         assert_eq!(
-            *fake.health_calls.lock().unwrap(),
+            *fake.probe_calls.lock().unwrap(),
             HEALTH_ATTEMPTS,
             "every attempt is used, and no more"
         );
         assert_eq!(secret_writes(&fake).len(), 1, "one PUT, not one per poll");
-        assert!(events
-            .into_inner()
-            .unwrap()
-            .contains(&(Step::Finish, StepStatus::Error)));
+
+        // The write succeeded and the confirmation did not, and the screen has to
+        // show exactly that: it is the difference between "nothing happened" and
+        // "your new password may already be live", which are opposite
+        // instructions to the person reading them.
+        let events = events.into_inner().unwrap();
+        assert!(
+            events.contains(&(Step::Secret, StepStatus::Done)),
+            "the change did go out: {events:?}"
+        );
+        assert!(
+            events.contains(&(Step::Confirm, StepStatus::Error)),
+            "the confirmation is what failed: {events:?}"
+        );
     }
 
     /// A brain on its own domain yields no script name, so there is nothing to
     /// write the secret to. The refusal has to come *before* the write: guessing
     /// at a name would set AUTH_TOKEN on some other Worker in the account.
+    ///
+    /// And before any progress is reported, which is the half the events are
+    /// captured for. The documented property is that this is refused "without a
+    /// half-started progress screen"; with the callback thrown away, moving the
+    /// first emit above the refusal left this test green while the user got a
+    /// checklist that starts, stops on a spinner and is then replaced by an error
+    /// screen — the flicker that makes people believe something was written.
     #[tokio::test]
     async fn rotation_refuses_a_custom_domain_before_touching_the_password() {
         let fake = Fake::default();
-        let err = rotate_secret(&&fake, "https://brain.example.com", "new-pw-123456789", |_| {})
-            .await
-            .unwrap_err();
+        let events = Mutex::new(Vec::new());
+        let err = rotate_secret(&&fake, "https://brain.example.com", "new-pw-123456789", |e| {
+            events.lock().unwrap().push((e.step, e.status))
+        })
+        .await
+        .unwrap_err();
 
         assert!(
             matches!(err, ProvisionError::NotAWorkersDevAddress),
@@ -1188,6 +1371,11 @@ mod tests {
             fake.entries().is_empty(),
             "a refused rotation must not call Cloudflare at all: {:?}",
             fake.entries()
+        );
+        let events = events.into_inner().unwrap();
+        assert!(
+            events.is_empty(),
+            "a refusal must not start a progress screen it cannot finish: {events:?}"
         );
     }
 

--- a/installer/src-tauri/src/cf/provision.rs
+++ b/installer/src-tauri/src/cf/provision.rs
@@ -99,6 +99,10 @@ pub trait Backend {
     ) -> Result<(), CfApiError>;
     async fn set_cron(&self, script: &str, crons: &[String]) -> Result<(), CfApiError>;
     async fn enable_script_subdomain(&self, script: &str) -> Result<(), CfApiError>;
+    /// Writes one secret on a deployed script without redeploying it. Takes
+    /// effect at the edge a little after it returns — see [`rotate_secret`],
+    /// which is the only caller that may treat it as done.
+    async fn put_secret(&self, script: &str, name: &str, text: &str) -> Result<(), CfApiError>;
     async fn health_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError>;
     async fn capture_ok(&self, worker_url: &str, auth_token: &str) -> Result<bool, CfApiError>;
     /// The deployed script's current bindings (for a preserve-everything update).
@@ -486,6 +490,97 @@ pub async fn update_worker<B: Backend>(
     Ok(())
 }
 
+/// Replaces the brain's password and waits for it to take effect.
+///
+/// Returns only once the Worker authenticates the NEW token, so a caller may
+/// treat success as "safe to persist locally".
+///
+/// The deployment is otherwise untouched: no assets are re-uploaded, no bindings
+/// are rewritten, and no code is redeployed. Progress is reported as
+/// [`Step::Finish`] — see the note on the emit below.
+///
+/// A failure here is *not* proof that the password is unchanged. The write and
+/// the confirmation are two separate operations, and only the second one can
+/// time out, so a caller must present the failure as "your new password may
+/// already be live" rather than "nothing happened".
+#[allow(dead_code)] // called by the #235 rotation flow landing alongside this
+pub async fn rotate_secret<B: Backend>(
+    backend: &B,
+    worker_url: &str,
+    new_token: &str,
+    progress: impl Fn(StepEvent),
+) -> Result<(), ProvisionError> {
+    // One step for the whole rotation, and an existing one. A new `Step` variant
+    // would need copy in every locale and a case in the progress UI to describe a
+    // single API call and a wait; `Finish` already means "the remote change is
+    // going in, and we are verifying it", which is exactly this.
+    let emit = |status: StepStatus| {
+        progress(StepEvent {
+            step: Step::Finish,
+            status,
+        })
+    };
+
+    // #257, and it bites harder here than it did there. The script name comes
+    // from the address the user is actually connected to, never from the bundled
+    // manifest: a brain reached at `my-brain.acme.workers.dev` would otherwise
+    // have its password "changed" by writing AUTH_TOKEN onto a script called
+    // `second-brain` — leaving the real brain on the old password (the user is
+    // then locked out of nothing, but believes they rotated) while handing an
+    // unrelated Worker a secret it never asked for.
+    //
+    // Derived before anything is emitted or written, so a brain on a custom
+    // domain is refused without a half-started progress screen.
+    let script =
+        crate::worker_url::script_of(worker_url).ok_or(ProvisionError::NotAWorkersDevAddress)?;
+
+    emit(StepStatus::Running);
+    let result = async {
+        backend.put_secret(&script, "AUTH_TOKEN", new_token).await?;
+
+        // The write is asynchronous at the edge, so the point of this loop is to
+        // wait out the propagation with the *new* token. The secret is PUT once,
+        // above: re-sending it on every attempt would be a second write racing
+        // the first, and would tell us nothing new.
+        for attempt in 0..HEALTH_ATTEMPTS {
+            match backend.health_ok(worker_url, new_token).await {
+                Ok(true) => return Ok(()),
+                // Read this next to `update_worker`'s health poll before changing
+                // it: the two treat a 401 in opposite ways, on purpose.
+                //
+                // There, the poll uses the token the app already had, so a 401
+                // means the redeploy dropped the secret — retrying would only
+                // delay telling the user they are locked out, and it is terminal.
+                //
+                // Here the poll uses the token that was just written, so a 401
+                // means the edge is still serving the *old* secret and the change
+                // has not landed yet. It is the expected answer for the first few
+                // seconds of every rotation. Making it terminal turns any deploy
+                // slower than one probe into a reported failure — of a rotation
+                // that then succeeds seconds later, leaving the user with a
+                // password the app told them was not applied.
+                Err(CfApiError::Unauthorized) => {}
+                // Not live yet, or DNS/network still catching up.
+                Ok(false) | Err(_) => {}
+            }
+            if attempt + 1 < HEALTH_ATTEMPTS {
+                backend.sleep(HEALTH_WAIT).await;
+            }
+        }
+        // Every attempt used up. The password may still be in force — see the
+        // note on this function.
+        Err(ProvisionError::HealthCheckFailed)
+    }
+    .await;
+
+    emit(if result.is_ok() {
+        StepStatus::Done
+    } else {
+        StepStatus::Error
+    });
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -520,6 +615,12 @@ mod tests {
         existing_vectorize: bool,
         subdomain_rejections: Mutex<u32>,
         health_failures: Mutex<u32>,
+        /// Health probes to answer with a 401 before anything else, standing in
+        /// for a secret that has not propagated to the edge yet.
+        health_unauthorized: Mutex<u32>,
+        /// Every health probe, answered or not — a count the log cannot give,
+        /// since the log only records the ones that pass.
+        health_calls: Mutex<u32>,
         script_bindings: Vec<serde_json::Value>,
         last_deploy_metadata: Mutex<Option<serde_json::Value>>,
     }
@@ -613,6 +714,12 @@ mod tests {
             Ok(())
         }
         async fn health_ok(&self, _url: &str, _token: &str) -> Result<bool, CfApiError> {
+            *self.health_calls.lock().unwrap() += 1;
+            let mut unauthorized = self.health_unauthorized.lock().unwrap();
+            if *unauthorized > 0 {
+                *unauthorized -= 1;
+                return Err(CfApiError::Unauthorized);
+            }
             let mut failures = self.health_failures.lock().unwrap();
             if *failures > 0 {
                 *failures -= 1;
@@ -620,6 +727,15 @@ mod tests {
             }
             self.log("health_ok");
             Ok(true)
+        }
+        async fn put_secret(
+            &self,
+            script: &str,
+            name: &str,
+            text: &str,
+        ) -> Result<(), CfApiError> {
+            self.log(format!("put_secret:{script}:{name}:{text}"));
+            Ok(())
         }
         async fn capture_ok(&self, _url: &str, _token: &str) -> Result<bool, CfApiError> {
             self.log("capture_ok");
@@ -950,6 +1066,155 @@ mod tests {
         let find = |ty: &str| bindings.iter().find(|b| b["type"] == ty).unwrap();
         assert_eq!(find("d1")["database_id"], "found-d1");
         assert_eq!(find("kv_namespace")["namespace_id"], "found-kv");
+    }
+
+    /// Counts the secret writes in a fake's log — a rotation is one PUT, and
+    /// several of the tests below are about how many times it happened.
+    fn secret_writes(fake: &Fake) -> Vec<String> {
+        fake.entries()
+            .into_iter()
+            .filter(|l| l.starts_with("put_secret:"))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn rotation_writes_the_password_and_confirms_it() {
+        let fake = Fake::default();
+        let events = Mutex::new(Vec::new());
+        rotate_secret(
+            &&fake,
+            "https://second-brain.acme.workers.dev",
+            "new-pw-123456789",
+            |e| events.lock().unwrap().push((e.step, e.status)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            secret_writes(&fake),
+            vec!["put_secret:second-brain:AUTH_TOKEN:new-pw-123456789".to_string()]
+        );
+        // Confirmed against the Worker, not just written. Success is the caller's
+        // signal that the new password is safe to store locally.
+        assert!(fake.entries().contains(&"health_ok".to_string()));
+
+        let events = events.into_inner().unwrap();
+        assert_eq!(
+            events,
+            vec![
+                (Step::Finish, StepStatus::Running),
+                (Step::Finish, StepStatus::Done)
+            ]
+        );
+    }
+
+    /// The inversion guard. In `update_worker` a 401 during the health poll means
+    /// the redeploy dropped the secret and is terminal; here it means the new
+    /// secret has not reached the edge yet, which is the *normal* answer for the
+    /// first seconds of a rotation.
+    ///
+    /// This test fails the moment someone "fixes" the two functions to agree.
+    #[tokio::test]
+    async fn rotation_retries_through_unauthorized_until_the_secret_propagates() {
+        let fake = Fake {
+            health_unauthorized: Mutex::new(3),
+            ..Default::default()
+        };
+        rotate_secret(
+            &&fake,
+            "https://second-brain.acme.workers.dev",
+            "new-pw-123456789",
+            |_| {},
+        )
+        .await
+        .expect("a 401 while the secret propagates is not a failed rotation");
+
+        assert_eq!(*fake.health_calls.lock().unwrap(), 4, "3 × 401, then green");
+        // Waiting is what fixes a 401 here — re-writing the secret would be a
+        // second write racing the first and would tell us nothing new.
+        assert_eq!(secret_writes(&fake).len(), 1);
+    }
+
+    /// A rotation that never confirms fails, rather than waiting forever — but it
+    /// still only ever wrote once, so the caller's "your new password may already
+    /// be live" message stays true.
+    #[tokio::test]
+    async fn rotation_gives_up_after_health_attempts_and_writes_only_once() {
+        let fake = Fake {
+            health_unauthorized: Mutex::new(HEALTH_ATTEMPTS + 5),
+            ..Default::default()
+        };
+        let events = Mutex::new(Vec::new());
+        let err = rotate_secret(
+            &&fake,
+            "https://second-brain.acme.workers.dev",
+            "new-pw-123456789",
+            |e| events.lock().unwrap().push((e.step, e.status)),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ProvisionError::HealthCheckFailed),
+            "expected HealthCheckFailed, got {err:?}"
+        );
+        assert_eq!(
+            *fake.health_calls.lock().unwrap(),
+            HEALTH_ATTEMPTS,
+            "every attempt is used, and no more"
+        );
+        assert_eq!(secret_writes(&fake).len(), 1, "one PUT, not one per poll");
+        assert!(events
+            .into_inner()
+            .unwrap()
+            .contains(&(Step::Finish, StepStatus::Error)));
+    }
+
+    /// A brain on its own domain yields no script name, so there is nothing to
+    /// write the secret to. The refusal has to come *before* the write: guessing
+    /// at a name would set AUTH_TOKEN on some other Worker in the account.
+    #[tokio::test]
+    async fn rotation_refuses_a_custom_domain_before_touching_the_password() {
+        let fake = Fake::default();
+        let err = rotate_secret(&&fake, "https://brain.example.com", "new-pw-123456789", |_| {})
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, ProvisionError::NotAWorkersDevAddress),
+            "expected NotAWorkersDevAddress, got {err:?}"
+        );
+        assert!(
+            fake.entries().is_empty(),
+            "a refused rotation must not call Cloudflare at all: {:?}",
+            fake.entries()
+        );
+    }
+
+    /// #257, applied to the password. The secret goes to the script named by the
+    /// address the user is connected to, never to the bundled manifest's name —
+    /// which here is `second-brain` and would be a different Worker entirely.
+    ///
+    /// Getting this wrong is worse than the update bug it mirrors: the real brain
+    /// would keep the old password while the app reported a successful change,
+    /// and an unrelated script would quietly gain an AUTH_TOKEN.
+    #[tokio::test]
+    async fn rotation_writes_to_the_script_named_by_the_address() {
+        let fake = Fake::default();
+        rotate_secret(
+            &&fake,
+            "https://my-brain.acme.workers.dev",
+            "new-pw-123456789",
+            |_| {},
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            secret_writes(&fake),
+            vec!["put_secret:my-brain:AUTH_TOKEN:new-pw-123456789".to_string()],
+            "the manifest's script name must never be reached for"
+        );
     }
 
     #[test]

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -10,6 +10,7 @@ use crate::cf::provision::{self, ProvisionError, ProvisionOutcome};
 use crate::cf::types::{Account, CfApiError};
 use crate::app_menus::AppMenus;
 use crate::i18n::{self, AppLocale, Key, Locale};
+use crate::rotate::{self, RotateOutcome};
 use crate::worker_url::subdomain_of;
 use crate::{cli_config, mcp_config, password_check, secure_store, windows, worker_bundle};
 use std::sync::Mutex;
@@ -29,6 +30,14 @@ pub struct SetupSession {
     /// Set when the main window should boot straight into the Worker-update
     /// flow instead of the normal setup flow.
     pending_worker_update: Mutex<bool>,
+    /// Set when the main window should boot into the change-your-password flow
+    /// (#235, Door A). Mirrors `pending_worker_update` exactly, including being
+    /// read before any keychain access — see [`get_app_state`].
+    pending_rotation: Mutex<bool>,
+    /// Set at launch when the brain refused the password this computer has
+    /// stored, which means it was changed somewhere else. The window then asks
+    /// for the new one instead of opening a dashboard that only 401s.
+    stale_password: Mutex<bool>,
     /// Account id + workers.dev subdomain from the most recent scan, held until
     /// a brain is actually connected. Non-secret, but pointless — and possibly
     /// wrong — to persist for a scan the user abandoned.
@@ -49,6 +58,8 @@ impl SetupSession {
             accounts: Mutex::new(Vec::new()),
             outcome: Mutex::new(None),
             pending_worker_update: Mutex::new(false),
+            pending_rotation: Mutex::new(false),
+            stale_password: Mutex::new(false),
             cf_hints: Mutex::new(None),
             demo_previous_index: Mutex::new(None),
         }
@@ -60,6 +71,8 @@ impl SetupSession {
         self.accounts.lock().unwrap().clear();
         *self.outcome.lock().unwrap() = None;
         *self.pending_worker_update.lock().unwrap() = false;
+        *self.pending_rotation.lock().unwrap() = false;
+        *self.stale_password.lock().unwrap() = false;
         *self.cf_hints.lock().unwrap() = None;
         *self.demo_previous_index.lock().unwrap() = None;
     }
@@ -89,7 +102,16 @@ pub fn get_app_state(session: State<'_, SetupSession>) -> AppState {
     // Dry-run is checked before the keychain read so demo mode never touches
     // secure storage (each read can raise a macOS permission prompt for
     // unsigned dev builds, which would block the setup UI's first paint).
-    let mode = if *session.pending_worker_update.lock().unwrap() {
+    //
+    // Every in-memory flag has to be tested before that read for the same
+    // reason, which is why the two #235 modes sit up here with the Worker
+    // update rather than beside the branch they most resemble. A demo run
+    // reaching `load_setup()` at all is the bug — see #252.
+    let mode = if *session.pending_rotation.lock().unwrap() {
+        "change-password"
+    } else if *session.stale_password.lock().unwrap() {
+        "stale-password"
+    } else if *session.pending_worker_update.lock().unwrap() {
         "worker-update"
     } else if !session.dry_run && secure_store::load_setup().is_some() {
         "wrapper"
@@ -774,7 +796,15 @@ fn dashboard_credentials(
         // does not resolve, so every Worker-backed screen failed with "Couldn't
         // reach your Second Brain". Pointing at a real server on loopback means
         // settings and migration run their actual HTTP paths against real data.
-        Ok((crate::demo_brain::base_url(), "demo".to_string()))
+        //
+        // The password is asked of the brain rather than written here as a
+        // literal. A real run re-reads it from the keychain, which a rotation has
+        // just updated; demo mode has no keychain, so the equivalent is to ask
+        // the demo brain what it currently answers to. With the literal in place
+        // every settings and dashboard window 401s for the rest of the run the
+        // moment a demo rotation happens — which is the whole flow this is meant
+        // to make demonstrable.
+        Ok((crate::demo_brain::base_url(), crate::demo_brain::auth_token()))
     } else {
         let info = secure_store::load_setup()
             .ok_or_else(|| user_err(locale, Key::OpenDashboardNotSetup))?;
@@ -835,22 +865,69 @@ pub struct WorkerUpdateInfo {
     pub available_version: String,
 }
 
+/// What the one authenticated request the app makes at launch found out.
+enum LaunchCheck {
+    /// Nothing worth interrupting the user for: up to date, unknown, offline,
+    /// on a custom domain, in dry-run, or not set up.
+    Nothing,
+    Update(WorkerUpdateInfo),
+    /// The brain refused the password this computer has stored, which means it
+    /// was changed somewhere else (#235 §5). Until now this was discarded, and
+    /// the user got a dashboard that silently 401ed with no route back except
+    /// Disconnect.
+    StalePassword,
+}
+
+/// The launch-time probe. One authenticated `GET /health`, and both facts come
+/// out of it — the deployed version, and whether this computer's password still
+/// opens the brain at all.
+async fn launch_check(dry_run: bool) -> LaunchCheck {
+    if dry_run {
+        return LaunchCheck::Nothing;
+    }
+    let Some(info) = secure_store::load_setup() else {
+        return LaunchCheck::Nothing;
+    };
+
+    // The request is made before the workers.dev check, not after.
+    //
+    // The custom-domain early-out exists because such a brain cannot be updated
+    // from here — but it can certainly have had its password changed on another
+    // computer, and its owner deserves the same screen. The cost is one GET at
+    // launch for custom-domain users, who previously skipped it.
+    let deployed = match crate::cf::api::worker_version(&info.worker_url, &info.auth_token).await {
+        Ok(version) => version,
+        Err(CfApiError::Unauthorized) => return LaunchCheck::StalePassword,
+        // Offline, or a brain having a moment. Neither is a password problem, and
+        // telling someone their password changed because their wifi dropped is
+        // worse than saying nothing at all.
+        Err(e) => {
+            log::debug!("launch health check could not reach the brain: {e}");
+            return LaunchCheck::Nothing;
+        }
+    };
+
+    if subdomain_of(&info.worker_url).is_none() {
+        return LaunchCheck::Nothing;
+    }
+    let bundled = worker_bundle::manifest().worker_version.clone();
+    if crate::version::is_behind(deployed.as_deref(), &bundled) {
+        LaunchCheck::Update(WorkerUpdateInfo {
+            deployed_version: deployed,
+            available_version: bundled,
+        })
+    } else {
+        LaunchCheck::Nothing
+    }
+}
+
 /// Core check, usable outside a command context (the launch-time offer). None
 /// when up to date, unknown, on a custom domain, in dry-run, or not set up.
 async fn compute_worker_update(dry_run: bool) -> Option<WorkerUpdateInfo> {
-    if dry_run {
-        return None;
+    match launch_check(dry_run).await {
+        LaunchCheck::Update(info) => Some(info),
+        LaunchCheck::Nothing | LaunchCheck::StalePassword => None,
     }
-    let info = secure_store::load_setup()?;
-    subdomain_of(&info.worker_url)?;
-    let bundled = worker_bundle::manifest().worker_version.clone();
-    let deployed = crate::cf::api::worker_version(&info.worker_url, &info.auth_token)
-        .await
-        .unwrap_or(None);
-    crate::version::is_behind(deployed.as_deref(), &bundled).then_some(WorkerUpdateInfo {
-        deployed_version: deployed,
-        available_version: bundled,
-    })
 }
 
 /// Checks whether the deployed Worker is behind the version this app bundles.
@@ -861,15 +938,23 @@ pub async fn worker_update_available(
     Ok(compute_worker_update(session.dry_run).await)
 }
 
-/// Launch-time offer: quietly check, and if the Worker is behind, ask with a
-/// native dialog. On accept, drop into the Worker-update flow.
-pub fn maybe_offer_worker_update(app: &AppHandle) {
+/// Launch-time check on the brain this computer is connected to.
+///
+/// Two outcomes are worth interrupting for: the Worker is behind the bundled
+/// version (ask, with a native dialog), or the stored password no longer opens
+/// the brain (#235 §5 — show the screen that asks for the new one).
+pub fn check_brain_at_launch(app: &AppHandle) {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
         let locale = locale_of(&app);
         let dry_run = app.state::<SetupSession>().dry_run;
-        let Some(update) = compute_worker_update(dry_run).await else {
-            return;
+        let update = match launch_check(dry_run).await {
+            LaunchCheck::Nothing => return,
+            LaunchCheck::StalePassword => {
+                show_stale_password(&app);
+                return;
+            }
+            LaunchCheck::Update(update) => update,
         };
         let message = i18n::t_fmt(
             locale,
@@ -893,6 +978,22 @@ pub fn maybe_offer_worker_update(app: &AppHandle) {
             let _ = windows::open_setup_window(&app);
         }
     });
+}
+
+/// Routes a launch that found a dead password to the screen that asks for the
+/// new one.
+///
+/// In place of the wrapper window, not beside it. The dashboard behind it can
+/// only 401, and leaving it up would mean explaining the problem through a broken
+/// page — which until now was the entire experience of having your password
+/// changed on another computer: a silently failing window and no route back
+/// except Disconnect.
+fn show_stale_password(app: &AppHandle) {
+    *app.state::<SetupSession>().stale_password.lock().unwrap() = true;
+    if let Some(window) = app.get_webview_window("brain") {
+        let _ = window.close();
+    }
+    let _ = windows::open_setup_window(app);
 }
 
 /// Puts the main window into Worker-update mode and shows it. Called from the
@@ -929,7 +1030,12 @@ pub async fn start_worker_update(
             &DryRunBackend,
             manifest,
             &outcome.worker_url,
-            "demo",
+            // Not the literal "demo": an update's health poll is made with the
+            // password the app already holds, and after a demo rotation that is
+            // no longer the default. A 401 there is terminal (it means a redeploy
+            // dropped the secret), so a hard-coded token turns every demo update
+            // after a demo rotation into a reported failure.
+            &crate::demo_brain::auth_token(),
             provision::VectorizeTarget::shipped(manifest),
             progress,
         )
@@ -943,38 +1049,13 @@ pub async fn start_worker_update(
     }
 
     let info = secure_store::load_setup().ok_or_else(|| user_err(locale, Key::ErrorComputerNotSetup))?;
-    let expected_sub = subdomain_of(&info.worker_url)
-        .ok_or_else(|| user_err(locale, Key::ErrorCustomDomain))?;
-    let mut tokens = session
-        .tokens
-        .lock()
-        .unwrap()
-        .clone()
-        .ok_or_else(|| user_err(locale, Key::ErrorCfSignInFirst))?;
-    if tokens.expires_at <= std::time::Instant::now() {
-        tokens = oauth::refresh(&tokens).await.map_err(|e| {
-            log::warn!("token refresh failed: {e}");
-            user_err(locale, Key::ErrorCfSignInExpired)
-        })?;
-        *session.tokens.lock().unwrap() = Some(tokens.clone());
-    }
-    let accounts = session.accounts.lock().unwrap().clone();
 
-    // Find the account whose workers.dev subdomain matches the Worker's URL.
-    let mut matched: Option<String> = None;
-    for account in &accounts {
-        let client = CfClient::new(tokens.access_token.clone(), account.id.clone());
-        if let Ok(Some(sub)) = client.get_account_subdomain().await {
-            if sub == expected_sub {
-                matched = Some(account.id.clone());
-                break;
-            }
-        }
-    }
-    let account_id = matched.ok_or_else(|| user_err(locale, Key::ErrorWrongCfAccount))?;
-
+    // Resolving which Cloudflare account holds this brain used to be written out
+    // here as well as in `cloudflare_client_for_brain`. It now has a third caller
+    // (`rotate_password`), and three copies of "match the address's subdomain
+    // against every signed-in account" is three places for #257 to come back.
     let backend = LiveBackend {
-        client: CfClient::new(tokens.access_token.clone(), account_id),
+        client: cloudflare_client_for_brain(&info.worker_url, &session, locale).await?,
     };
     // A routine update stays on whatever index this build ships with. Only an
     // embedding migration moves it, and that goes through its own command.
@@ -1002,6 +1083,474 @@ pub async fn start_worker_update(
     Ok(ProvisionOutcome {
         mcp_url: format!("{}/mcp", info.worker_url.trim_end_matches('/')),
         worker_url: info.worker_url,
+    })
+}
+
+// ── Changing the password (#235) ─────────────────────────────────────────────
+
+/// Why a password change did not finish, in the only three shapes that differ in
+/// what may honestly be said afterwards.
+///
+/// `Result<(), String>` is not sufficient here, and that is load-bearing rather
+/// than fastidious. A string cannot separate "the change never reached
+/// Cloudflare, so your old password still works" from "the change was accepted
+/// and never confirmed, so your new password may already be the only one that
+/// opens your brain". Those are opposite instructions. With one string every
+/// failure has to hedge — so a user whose Cloudflare sign-in merely expired is
+/// told their password may already have changed, which teaches people to
+/// disbelieve that warning on the one occasion it is real.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RotateError {
+    /// Selects the screen, and with it what may be claimed:
+    ///   `"notSent"`     — nothing reached Cloudflare; the old password still works.
+    ///   `"unconfirmed"` — the secret was accepted; health never went green. Never
+    ///                     tell the user the old password still works.
+    ///   `"local"`       — the brain has the new password; a local write failed.
+    pub stage: &'static str,
+    /// Already localised; rendered into the failure screen's detail slot rather
+    /// than being the screen. Bare text — the "What went wrong: …" framing is the
+    /// front end's.
+    pub detail: String,
+}
+
+impl RotateError {
+    fn not_sent(detail: String) -> Self {
+        Self { stage: "notSent", detail }
+    }
+    fn unconfirmed(detail: String) -> Self {
+        Self { stage: "unconfirmed", detail }
+    }
+    fn local(detail: String) -> Self {
+        Self { stage: "local", detail }
+    }
+}
+
+/// Maps a `rotate_secret` failure onto what the user may be told.
+///
+/// `HealthCheckFailed` is the only variant that means the secret was accepted.
+/// `rotate_secret` PUTs once and then polls, so it is the only error raised
+/// *after* the write; everything else is raised before it or by it.
+///
+/// One honest caveat, and it is why `notSent` claims no more than "nothing
+/// reached Cloudflare": a PUT that dies on the wire may still have been applied
+/// at the far end. That is rare, indistinguishable from here, and the retry the
+/// screen offers settles it either way — `PUT …/secrets` on one name is
+/// idempotent.
+fn rotation_failure(error: ProvisionError, locale: Locale) -> RotateError {
+    match error {
+        ProvisionError::HealthCheckFailed => {
+            RotateError::unconfirmed(user_err(locale, Key::ErrorRotateNotConfirmed))
+        }
+        // Refused before the PUT, by the same #257 guard the update path uses.
+        ProvisionError::NotAWorkersDevAddress => {
+            RotateError::not_sent(user_err(locale, Key::ErrorCustomDomain))
+        }
+        // The case the three-way split exists for: an expired Cloudflare sign-in
+        // must read as "nothing happened", not as a hedge.
+        ProvisionError::Api(CfApiError::Unauthorized) => {
+            RotateError::not_sent(user_err(locale, Key::ErrorCfSignInExpired))
+        }
+        _ => RotateError::not_sent(user_err(locale, Key::ErrorFriendlyRetry)),
+    }
+}
+
+/// The address a rotation should act on, and the password this computer already
+/// holds for it — `None` when it holds none.
+///
+/// `address` is Door B: the user has lost their password, so there may be nothing
+/// in secure storage to resolve and the address comes from Cloudflare discovery
+/// instead. There is then no current password, which is precisely why every check
+/// that needs one is skipped for that door rather than failed.
+///
+/// Absent, this is Door A on a computer that is already connected, and the
+/// address is resolved the way every other settings command resolves it: through
+/// `dashboard_credentials`, never `secure_store::load_setup()` directly, because
+/// that ignores dry-run and raises a Keychain prompt (#252).
+fn rotation_target(
+    app: &AppHandle,
+    address: Option<String>,
+) -> Result<(String, Option<String>, Locale), String> {
+    let locale = locale_of(app);
+    match address {
+        Some(address) => Ok((normalize_worker_url(&address, locale)?, None, locale)),
+        None => {
+            let (url, token, locale) = settings_target(app)?;
+            Ok((url, Some(token), locale))
+        }
+    }
+}
+
+/// Every Vectorize index name a brain built by this app could legitimately be
+/// bound to.
+///
+/// The shipped name, plus the one an embedding migration would have moved it to
+/// for each reading this build knows about (#248 names indexes by dimension
+/// count). Without the migrated names a user who has changed how their brain
+/// reads would be told their own brain is not a brain.
+fn brain_index_names() -> Vec<String> {
+    let manifest = worker_bundle::manifest();
+    let mut names = vec![manifest.vectorize_name.clone()];
+    for choice in crate::migration::EMBEDDING_MODELS {
+        let name = crate::migration::index_name_for(
+            &manifest.vectorize_name,
+            choice.dimensions,
+            manifest.vectorize_dimensions,
+        );
+        if !names.contains(&name) {
+            names.push(name);
+        }
+    }
+    names
+}
+
+/// Confirms the Worker at `worker_url` really is a Second Brain, from its
+/// Cloudflare bindings rather than from anything it says over HTTP.
+///
+/// This is the #247 rule, and rotation needs it more sharply than discovery did.
+/// In lost mode the user types an address, and the Cloudflare account match
+/// cannot catch a typo that lands on a *different Worker of their own* — that
+/// script is in the right account, so the only thing left to check is what it is.
+/// Getting it wrong would overwrite an unrelated Worker's `AUTH_TOKEN` secret
+/// while telling the user their brain's password had changed: the brain stays on
+/// the old password, and something they did not name has been altered.
+///
+/// Bindings and not a probe, for the reason `cf/discover.rs` sets out at length:
+/// a Worker authors every byte of its own HTTP responses and can forge whatever
+/// a probe looks for, but it cannot forge account state.
+async fn confirm_target_is_a_brain(
+    worker_url: &str,
+    session: &SetupSession,
+    locale: Locale,
+) -> Result<(), String> {
+    use provision::Backend;
+
+    let script = crate::worker_url::script_of(worker_url)
+        .ok_or_else(|| user_err(locale, Key::ErrorCustomDomain))?;
+
+    let bindings = if session.dry_run {
+        DryRunBackend.get_script_bindings(&script).await
+    } else {
+        cloudflare_client_for_brain(worker_url, session, locale)
+            .await?
+            .get_script_bindings(&script)
+            .await
+    }
+    .map_err(|e| {
+        // A script that does not exist answers the same way as one that cannot
+        // be read. Both mean "there is no brain of yours at that address", which
+        // is what the user needs to know and can act on.
+        log::warn!("could not read the bindings for {script}: {e}");
+        user_err(locale, Key::ErrorNotABrain)
+    })?;
+
+    brain_index_names()
+        .iter()
+        .any(|name| discover::bindings_look_like_a_brain(&bindings, name))
+        .then_some(())
+        .ok_or_else(|| user_err(locale, Key::ErrorNotABrain))
+}
+
+/// Checks an address typed in lost mode before anything is done to it.
+///
+/// Exists so §2.4's screen can report a bad address where it was entered instead
+/// of failing several screens later, and it is the same check `rotate_password`
+/// runs on an explicit address — one implementation, two callers, so the screen
+/// cannot pass something the command would then refuse.
+#[tauri::command]
+pub async fn validate_brain_address(
+    address: String,
+    app: AppHandle,
+    session: State<'_, SetupSession>,
+) -> Result<(), String> {
+    let locale = locale_of(&app);
+    let worker_url = normalize_worker_url(&address, locale)?;
+    confirm_target_is_a_brain(&worker_url, &session, locale).await
+}
+
+/// Revokes every access an AI tool was granted through `/oauth/authorize`.
+///
+/// Deliberately separate from rotation rather than part of it. Those tools hold
+/// provider-issued tokens validated against KV, not the brain's password, so a
+/// rotation genuinely does not reach them — which is right for a hygiene change
+/// and wrong for a leak. Making it explicit is what lets the done screen tell the
+/// truth about what a rotation did and did not close.
+///
+/// The Worker's `{ ok, revoked, failed }` is passed straight through: `failed` is
+/// the case this control exists for, and summarising it away would hide a tool
+/// that kept its access.
+#[tauri::command]
+pub async fn disconnect_ai_tools(app: AppHandle) -> Result<serde_json::Value, String> {
+    let (worker_url, token, locale) = settings_target(&app)?;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/oauth/revoke-all", worker_url.trim_end_matches('/')))
+        .bearer_auth(&token)
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await
+        .map_err(|e| {
+            log::warn!("revoke-all failed: {e}");
+            user_err(locale, Key::ErrorReachBrain)
+        })?;
+    if !resp.status().is_success() {
+        return Err(i18n::t_fmt(
+            locale,
+            Key::ErrorBrainHttpStatus,
+            &[("status", &resp.status().as_u16().to_string())],
+        ));
+    }
+    resp.json()
+        .await
+        .map_err(|_| user_err(locale, Key::ErrorBrainUnexpected))
+}
+
+/// Applies the ledger rule to a `GET /migration/status` body.
+///
+/// Three states, because the ledger is rewritten with `finishedAt` when a
+/// rebuild completes rather than deleted:
+///
+/// | `state`            | meaning                       | rotation |
+/// |--------------------|-------------------------------|----------|
+/// | `null`             | never migrated                | allowed  |
+/// | `finishedAt` set   | rebuild complete              | allowed  |
+/// | `finishedAt` absent| in progress **or abandoned**  | blocked  |
+///
+/// The block is not about session contention — every batch re-reads the token,
+/// so a rotation would technically survive one. It is about the failure mode: a
+/// rotation caught half-way leaves the next batch 401ing and the ledger stalling
+/// with `failed` climbing, so a recoverable password problem presents as a failed
+/// rebuild. That is the more frightening of the two and the one that invites a
+/// destructive "fix".
+///
+/// An outstanding old index is deliberately not consulted. That is the ordinary
+/// post-rebuild state, users sit in it for weeks, and rotation touches no
+/// Vectorize binding.
+fn blocked_by_migration(status: &serde_json::Value) -> bool {
+    match status.get("state") {
+        None | Some(serde_json::Value::Null) => false,
+        Some(state) => !state
+            .get("finishedAt")
+            .is_some_and(|finished| !finished.is_null()),
+    }
+}
+
+/// Whether a rebuild is in flight (or was abandoned) and rotation must wait.
+///
+/// Door A only. Door B cannot ask — checking needs a working password, which is
+/// by definition what that user does not have — and gating their only way back
+/// in on a check they cannot perform would be backwards. Someone who has lost
+/// their password is not driving a rebuild from that machine anyway.
+#[tauri::command]
+pub async fn rotation_blocked(app: AppHandle) -> Result<bool, String> {
+    let (url, token, locale) = settings_target(&app)?;
+    let status = crate::migration::fetch_status(&url, &token, locale).await?;
+    Ok(blocked_by_migration(&status))
+}
+
+/// Read-only re-probe of `/health` with a password, for the "it may already be
+/// live" screen.
+///
+/// Writes nothing, which is what makes it safe to offer as a button on the one
+/// screen where the user does not know what happened. A wrong password is a
+/// `false`, not an error: on that screen "no" is an answer, not a fault.
+#[tauri::command]
+pub async fn recheck_password(
+    password: String,
+    address: Option<String>,
+    app: AppHandle,
+) -> Result<bool, String> {
+    let (worker_url, _, locale) = rotation_target(&app, address)?;
+    match crate::cf::api::worker_health_ok(&worker_url, password.trim()).await {
+        Ok(ok) => Ok(ok),
+        Err(CfApiError::Unauthorized) => Ok(false),
+        Err(e) => {
+            log::warn!("password re-check could not reach the brain: {e}");
+            Err(user_err(locale, Key::ErrorReachBrain))
+        }
+    }
+}
+
+/// Puts the main window into change-your-password mode and shows it. Door A,
+/// from the Connection pane — the same shape as `begin_worker_update`.
+#[tauri::command]
+pub fn begin_password_change(
+    app: AppHandle,
+    session: State<'_, SetupSession>,
+) -> Result<(), String> {
+    *session.pending_rotation.lock().unwrap() = true;
+    windows::open_setup_window(&app)
+        .map_err(|_| user_err(locale_of(&app), Key::ErrorOpenWindowFailed))
+}
+
+/// Replaces the brain's password, then writes the new one everywhere this
+/// computer keeps it.
+///
+/// The order is not negotiable. The remote change goes first and is confirmed
+/// against the *new* password before anything local is touched, so a failure
+/// before that point leaves this computer able to open its own brain. Reversing
+/// it would produce the one outcome with no recovery inside the app: local
+/// stores holding a password the brain never accepted.
+#[tauri::command]
+pub async fn rotate_password(
+    new_password: String,
+    address: Option<String>,
+    app: AppHandle,
+    session: State<'_, SetupSession>,
+) -> Result<RotateOutcome, RotateError> {
+    let locale = locale_of(&app);
+    let new_password = new_password.trim().to_string();
+    if new_password.len() < MIN_PASSWORD_LEN {
+        return Err(RotateError::not_sent(i18n::t_fmt(
+            locale,
+            Key::ErrorPasswordTooShort,
+            &[("min", &MIN_PASSWORD_LEN.to_string())],
+        )));
+    }
+
+    let progress_app = app.clone();
+    let progress = move |event: provision::StepEvent| {
+        let _ = progress_app.emit("setup-progress", &event);
+    };
+
+    if session.dry_run {
+        return rotate_demo_password(&new_password, &session, locale, progress).await;
+    }
+
+    // 1. Which brain. Through the session-aware helper, never the keychain
+    //    directly — see `rotation_target`.
+    let door_b = address.is_some();
+    let (worker_url, current_password, locale) =
+        rotation_target(&app, address).map_err(RotateError::not_sent)?;
+
+    // 1a. On Door B the address was typed or picked rather than read back from
+    //     this computer's own store, so confirm it is a brain before writing a
+    //     secret to it. Door A's address came from secure storage, which this app
+    //     wrote itself after a successful connection.
+    if door_b {
+        confirm_target_is_a_brain(&worker_url, &session, locale)
+            .await
+            .map_err(RotateError::not_sent)?;
+    }
+
+    // 2. Refuse defensively if a rebuild is under way. The Connection pane
+    //    already hides the door, but the flow can be open across the moment a
+    //    rebuild starts on another machine.
+    //
+    //    Only a check that *succeeds* and says "blocked" refuses. Door B has no
+    //    password to ask with, and a check that cannot be made is not a block: a
+    //    user who has lost their password must not be turned away by a question
+    //    they are unable to answer. A network blip must not either.
+    if let Some(password) = &current_password {
+        if let Ok(status) = crate::migration::fetch_status(&worker_url, password, locale).await {
+            if blocked_by_migration(&status) {
+                return Err(RotateError::not_sent(user_err(
+                    locale,
+                    Key::ErrorRotateBlocked,
+                )));
+            }
+        }
+    }
+
+    // 3. The Cloudflare account that holds this brain, matched by the subdomain
+    //    in its address rather than assumed.
+    let client = cloudflare_client_for_brain(&worker_url, &session, locale)
+        .await
+        .map_err(RotateError::not_sent)?;
+
+    // 4. The remote change, health-gated against the new password.
+    provision::rotate_secret(
+        &LiveBackend { client },
+        &worker_url,
+        &new_password,
+        progress,
+    )
+    .await
+    .map_err(|e| {
+        log::warn!("password rotation failed: {e}");
+        rotation_failure(e, locale)
+    })?;
+
+    // 5. Only now is it safe to write anything locally.
+    //
+    // Without a home directory there is nowhere for `persist` to look, so it
+    // cannot run at all and there is no outcome to report — which is what the
+    // `"local"` stage is for. `ErrorRotateSecureStore` reads correctly here: the
+    // password was changed and nothing on this computer was told, which is what
+    // the user needs to act on. Deliberately not `ErrorSecureStoreConnect`, which
+    // opens "Connected, but…" — nothing was connected, a working password was
+    // replaced.
+    let home = dirs::home_dir()
+        .ok_or_else(|| RotateError::local(user_err(locale, Key::ErrorRotateSecureStore)))?;
+    let refresh_app = app.clone();
+    let refresh_url = worker_url.clone();
+    let outcome = rotate::persist(&home, &worker_url, &new_password, move |token| {
+        windows::refresh_wrapper_token(&refresh_app, &refresh_url, token)
+    });
+
+    *session.pending_rotation.lock().unwrap() = false;
+    // A rotation is also the answer to "your password was changed elsewhere".
+    *session.stale_password.lock().unwrap() = false;
+
+    // Reported, not raised. The rotation itself succeeded — the brain is on the
+    // new password — so turning a failed local write into an `Err` would throw
+    // away the outcome that tells the screen *which* store to name, and would
+    // describe a change that did happen as one that did not. The `"local"` stage
+    // is for a local step that produced no outcome at all (above), and the front
+    // end renders the same screen from either arrival.
+    Ok(outcome)
+}
+
+/// The demo half of [`rotate_password`], split out so it can be driven by a test.
+///
+/// A Tauri `State`/`AppHandle` cannot be constructed in a unit test, and the
+/// property that matters most here — that a demo rotation reaches the keychain
+/// exactly zero times — is only observable by calling the thing that does the
+/// work. `previous_index_for` is split for the same reason.
+///
+/// This runs the real pipeline: `rotate_secret` against `DryRunBackend`, whose
+/// `put_secret` moves the demo brain onto the new password and whose `health_ok`
+/// then has to get a real 200 back from it. What it must never do is write to
+/// secure storage — demo state lives in the session and in the demo brain, per
+/// the `demo_previous_index` precedent.
+async fn rotate_demo_password(
+    new_password: &str,
+    session: &SetupSession,
+    locale: Locale,
+    progress: impl Fn(provision::StepEvent),
+) -> Result<RotateOutcome, RotateError> {
+    // Resolved the same way every other demo screen resolves it, so this path
+    // shares the no-keychain guarantee rather than restating it.
+    let (_demo_url, _demo_token) =
+        dashboard_credentials(session, locale).map_err(RotateError::not_sent)?;
+
+    // The address handed to `rotate_secret` is the `.demo.workers.dev` stand-in,
+    // not the loopback address above. `rotate_secret` derives the Worker's script
+    // name from the address it is given (#257) and loopback has no script label,
+    // so it would refuse a demo rotation before doing anything.
+    // `DryRunBackend::health_ok` resolves the stand-in back to the brain on
+    // loopback, so the gate is still a real request against a real server.
+    let worker_url = "https://second-brain.demo.workers.dev";
+
+    provision::rotate_secret(&DryRunBackend, worker_url, new_password, progress)
+        .await
+        .map_err(|e| {
+            log::warn!("demo password rotation failed: {e}");
+            rotation_failure(e, locale)
+        })?;
+
+    *session.pending_rotation.lock().unwrap() = false;
+    *session.stale_password.lock().unwrap() = false;
+
+    // No `rotate::persist`. Its first act is `secure_store::save_setup`, and a
+    // demo run must not write a demo password into the user's real keychain —
+    // nor a plaintext demo credential into their real CLI config. The demo brain
+    // is now answering to the new password, and `dashboard_credentials` asks it
+    // rather than remembering, so demo mode is genuinely on the new password
+    // from here without anything having been stored.
+    Ok(RotateOutcome {
+        keychain: true,
+        cli_config: None,
+        dashboard: true,
     })
 }
 
@@ -1152,14 +1701,18 @@ pub async fn begin_embedding_migration(
     if session.dry_run {
         // The demo brain runs on a loopback address, which has no script or
         // subdomain to derive — `update_worker` would refuse it before doing
-        // anything. DryRunBackend ignores the URL entirely (its health check is
-        // stubbed), so a synthetic workers.dev address exercises the same code
-        // path while the real loopback address keeps serving the HTTP calls.
+        // anything. The `.demo.workers.dev` stand-in exercises the same code path,
+        // and `DryRunBackend::health_ok` resolves it back to the brain on
+        // loopback, so the health poll is a real request against a real server
+        // while the deploy stays a no-op.
         provision::update_worker(
             &DryRunBackend,
             manifest,
             "https://second-brain.demo.workers.dev",
-            "demo",
+            // The live password, for the same reason as `start_worker_update`'s
+            // dry-run branch: the health poll is authenticated, and a demo
+            // rotation has already moved this.
+            &auth_token,
             provision::VectorizeTarget { name: &target_index, dimensions },
             progress,
         )
@@ -1387,9 +1940,15 @@ pub fn open_settings_window(app: AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::{dashboard_credentials, normalize_worker_url, previous_index_for, SetupSession};
-    use crate::cf::provision::ProvisionOutcome;
-    use crate::i18n::Locale;
+    use super::{
+        blocked_by_migration, cloudflare_client_for_brain, dashboard_credentials,
+        normalize_worker_url, previous_index_for, rotate_demo_password, rotation_failure,
+        RotateError, SetupSession,
+    };
+    use crate::cf::oauth::Tokens;
+    use crate::cf::provision::{ProvisionError, ProvisionOutcome};
+    use crate::cf::types::{Account, CfApiError};
+    use crate::i18n::{self, Key, Locale};
 
     #[test]
     fn normalizes_pasted_addresses() {
@@ -1507,6 +2066,339 @@ mod tests {
             crate::secure_store::probe::reads(),
             0,
             "an unconnected demo session fell back to the keychain"
+        );
+    }
+
+    // ── Changing the password (#235) ─────────────────────────────────────────
+
+    /// The three failure shapes are three different things to tell the user, and
+    /// the copy on each screen is only true for one of them.
+    ///
+    /// "notSent" says the old password still works. "unconfirmed" must never say
+    /// that: the secret was accepted and only the confirmation timed out, so the
+    /// new password may already be the only one that opens the brain. Collapsing
+    /// them means every failure has to hedge — and a user whose Cloudflare
+    /// sign-in merely expired is told their password may have changed, which
+    /// teaches people to ignore that warning on the one occasion it is real.
+    #[test]
+    fn each_failure_shape_selects_the_screen_that_can_tell_the_truth() {
+        assert_eq!(
+            rotation_failure(ProvisionError::HealthCheckFailed, Locale::En).stage,
+            "unconfirmed",
+            "the only error raised after the secret was accepted"
+        );
+        assert_eq!(
+            rotation_failure(
+                ProvisionError::Api(CfApiError::Unauthorized),
+                Locale::En
+            )
+            .stage,
+            "notSent",
+            "an expired Cloudflare sign-in never reached the brain"
+        );
+        assert_eq!(
+            rotation_failure(ProvisionError::NotAWorkersDevAddress, Locale::En).stage,
+            "notSent",
+            "refused by the #257 guard before the write"
+        );
+        assert_eq!(
+            rotation_failure(ProvisionError::CaptureFailed, Locale::En).stage,
+            "notSent",
+        );
+        assert_eq!(RotateError::local(String::new()).stage, "local");
+
+        // Distinct strings, checked as a set: two stages that happen to be spelled
+        // the same select the same screen no matter how carefully the match arms
+        // above are written.
+        let stages = [
+            RotateError::not_sent(String::new()).stage,
+            RotateError::unconfirmed(String::new()).stage,
+            RotateError::local(String::new()).stage,
+        ];
+        let mut unique = stages.to_vec();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), 3, "two stages collapsed into one: {stages:?}");
+    }
+
+    /// The detail is what the front end drops into "What went wrong: …", so it
+    /// has to be localised rather than a Rust error's `Display`.
+    #[test]
+    fn the_failure_detail_is_localised_and_not_a_rust_error_string() {
+        let english = rotation_failure(
+            ProvisionError::Api(CfApiError::Unauthorized),
+            Locale::En,
+        );
+        assert_eq!(english.detail, i18n::t(Locale::En, Key::ErrorCfSignInExpired));
+
+        let italian = rotation_failure(
+            ProvisionError::Api(CfApiError::Unauthorized),
+            Locale::It,
+        );
+        assert_ne!(
+            italian.detail, english.detail,
+            "the detail must follow the app's locale"
+        );
+        assert!(
+            !rotation_failure(ProvisionError::HealthCheckFailed, Locale::En)
+                .detail
+                .is_empty(),
+            "an empty detail renders as an empty sentence on the screen"
+        );
+    }
+
+    /// The ledger has three states, not two: a finished rebuild leaves its record
+    /// behind with `finishedAt` set rather than deleting it.
+    #[test]
+    fn rotation_waits_only_while_a_rebuild_is_actually_outstanding() {
+        let never = serde_json::json!({ "ok": true, "state": null });
+        let finished = serde_json::json!({
+            "ok": true,
+            "state": { "model": "m", "processed": 10, "finishedAt": 1_753_000_000_000i64 }
+        });
+        let running = serde_json::json!({
+            "ok": true,
+            "state": { "model": "m", "processed": 3, "totalAtStart": 100 }
+        });
+
+        assert!(!blocked_by_migration(&never), "a brain that never migrated");
+        assert!(!blocked_by_migration(&finished), "a rebuild that completed");
+        assert!(
+            blocked_by_migration(&running),
+            "in progress, or abandoned — both block, and Advanced Settings is the \
+             escape the message points at"
+        );
+
+        // A ledger with the key present but null is not a finished one. Reading
+        // `is_some()` alone would let a half-written record unblock rotation.
+        let null_finish = serde_json::json!({ "state": { "finishedAt": null } });
+        assert!(blocked_by_migration(&null_finish));
+
+        // And a body with no `state` key at all — an older Worker — is not a
+        // reason to refuse.
+        assert!(!blocked_by_migration(&serde_json::json!({ "ok": true })));
+    }
+
+    /// An outstanding old index is the ordinary post-rebuild state. Users sit in
+    /// it for weeks, rotation touches no Vectorize binding, and treating it as a
+    /// block would make the password unchangeable until they freed an index they
+    /// were told they could keep.
+    ///
+    /// Asserted on the source rather than by planting a note: the note lives in
+    /// process-global test state that other tests clear, so a behavioural version
+    /// of this would be racing them. What is checkable is that neither function
+    /// can consult it. Scans only the function bodies, so this test's own text
+    /// cannot satisfy it.
+    #[test]
+    fn an_outstanding_old_index_is_not_a_reason_to_block_rotation() {
+        let src = include_str!("commands.rs");
+        for name in ["fn blocked_by_migration", "pub async fn rotation_blocked"] {
+            let start = src.find(name).unwrap_or_else(|| panic!("{name} exists"));
+            let body = &src[start..];
+            let body = &body[..body.find("\n}").expect("end of fn")];
+            assert!(
+                !body.contains("previous_index"),
+                "{name} consults the outstanding-index note. That note means a \
+                 rebuild finished and the old index has not been freed — which is \
+                 a state users stay in deliberately, and rotation does not care."
+            );
+        }
+    }
+
+    /// Every in-memory mode is decided before secure storage is consulted.
+    ///
+    /// `get_app_state` takes a Tauri `State`, which cannot be built in a unit
+    /// test, so this reads the source — but the rule it protects is not a style
+    /// preference. `&&`/`else if` are short-circuiting, and each of these
+    /// branches returns without falling through, so a mode moved below the
+    /// `load_setup()` branch performs a keychain read on the way past. That read
+    /// raises an OS password prompt on an unsigned dev build, before the setup
+    /// UI's first paint, which is #252 — and demo mode, which must never see one,
+    /// reaches this function on every launch.
+    ///
+    /// Scans only the function body, so the names written in this test cannot
+    /// satisfy it.
+    #[test]
+    fn every_in_memory_mode_is_decided_before_the_keychain_is_touched() {
+        let src = include_str!("commands.rs");
+        let start = src.find("pub fn get_app_state").expect("the command");
+        let body = &src[start..];
+        let body = &body[..body.find("\n}").expect("end of fn")];
+
+        let keychain = body
+            .find("secure_store::load_setup")
+            .expect("get_app_state still reads the keychain somewhere");
+        for flag in ["pending_rotation", "stale_password", "pending_worker_update"] {
+            let at = body
+                .find(flag)
+                .unwrap_or_else(|| panic!("{flag} is not consulted at all"));
+            assert!(
+                at < keychain,
+                "{flag} is checked after the keychain read, so reaching that mode \
+                 costs an OS password prompt — and in demo mode there is nothing \
+                 in the keychain to have prompted for"
+            );
+        }
+    }
+
+    /// A demo rotation runs the real pipeline and reaches the keychain zero times.
+    ///
+    /// Counted rather than grepped, for the reason `demo_mode_never_reads_the_keychain`
+    /// sets out: every read can raise an OS password prompt on an unsigned dev
+    /// build, a source scan cannot express "not inside the dry-run branch", and a
+    /// guard written that way passed while the bug was reintroduced.
+    ///
+    /// The password is [`DEFAULT_TOKEN`] on purpose. The demo brain is
+    /// process-wide and outlives this test, so rotating it to anything else would
+    /// start 401ing whatever else in the suite is mid-request against it — the
+    /// reasoning `demo_brain`'s own rotation test sets out. Rotating it to the
+    /// token every other caller already sends changes nothing for them while
+    /// still driving the whole path: the secret write is recorded, the demo brain
+    /// takes the password, and `rotate_secret`'s health gate has to get a real
+    /// 200 back from it before this returns.
+    #[tokio::test]
+    async fn a_demo_rotation_runs_the_real_path_and_never_reads_the_keychain() {
+        let session = SetupSession::new(true);
+        *session.pending_rotation.lock().unwrap() = true;
+
+        // Sampled rather than counted once. The read probe is a process-global
+        // counter and the suite runs in parallel, so a single sample can pick up
+        // another test's keychain access and report it against this path. A
+        // sample that caught someone else proves nothing either way — but a path
+        // that reads the keychain contaminates *every* sample, so one clean
+        // sample is the proof and repeated dirty ones are the failure.
+        let mut outcome = None;
+        let mut dirty = Vec::new();
+        for _ in 0..8 {
+            let before = crate::secure_store::probe::reads();
+            let attempt = rotate_demo_password(
+                crate::demo_brain::DEFAULT_TOKEN,
+                &session,
+                Locale::En,
+                |_| {},
+            )
+            .await
+            .expect("the demo brain must accept the password the demo just set");
+            let reads = crate::secure_store::probe::reads() - before;
+            if reads == 0 {
+                outcome = Some(attempt);
+                break;
+            }
+            dirty.push(reads);
+        }
+        let outcome = outcome.unwrap_or_else(|| {
+            panic!(
+                "every sample of a demo rotation touched the keychain ({dirty:?}) — \
+                 that is the OS password prompt users see, and a demo password has \
+                 no business in a real keychain"
+            )
+        });
+
+        assert!(
+            crate::cf::backend::probe::secret_puts()
+                .contains(&("second-brain".to_string(), "AUTH_TOKEN".to_string())),
+            "the rotation never reached the backend, so the demo proves nothing \
+             about the thing it is demonstrating"
+        );
+        assert_eq!(
+            crate::demo_brain::auth_token(),
+            crate::demo_brain::DEFAULT_TOKEN,
+            "the demo brain must be holding the password the rotation set"
+        );
+        assert!(outcome.keychain);
+        assert_eq!(
+            outcome.cli_config, None,
+            "a demo run must not write a plaintext credential file"
+        );
+        assert!(
+            !*session.pending_rotation.lock().unwrap(),
+            "a finished rotation must leave the flow"
+        );
+    }
+
+    /// Resolving which Cloudflare account holds a brain was written out twice —
+    /// once in `start_worker_update` and once in `cloudflare_client_for_brain`.
+    /// Rotation is the third caller, so the copy went. This pins the errors the
+    /// shared helper raises and the order it raises them in, which is what
+    /// `start_worker_update` used to do inline.
+    ///
+    /// Every case here returns before any network call: a custom domain and a
+    /// missing sign-in are refused up front, and an empty account list never
+    /// enters the loop.
+    #[tokio::test]
+    async fn the_shared_account_lookup_refuses_in_the_same_order_the_inline_copy_did() {
+        let session = SetupSession::new(false);
+
+        assert_eq!(
+            cloudflare_client_for_brain("https://brain.example.com", &session, Locale::En)
+                .await
+                .map(|_| ())
+                .unwrap_err(),
+            i18n::t(Locale::En, Key::ErrorCustomDomain),
+            "a custom domain yields no subdomain to match, and retrying cannot help"
+        );
+
+        assert_eq!(
+            cloudflare_client_for_brain(
+                "https://second-brain.acme.workers.dev",
+                &session,
+                Locale::En
+            )
+            .await
+            .map(|_| ())
+            .unwrap_err(),
+            i18n::t(Locale::En, Key::ErrorCfSignInFirst),
+            "no Cloudflare session yet"
+        );
+
+        *session.tokens.lock().unwrap() = Some(Tokens {
+            access_token: "cf-access-token".into(),
+            refresh_token: None,
+            expires_at: std::time::Instant::now() + std::time::Duration::from_secs(3600),
+        });
+        session.accounts.lock().unwrap().push(Account {
+            id: "acct-1".into(),
+            name: "Some other space".into(),
+        });
+        // The account list is scanned, nothing matches `acme`, and the message
+        // names the real problem rather than a generic failure.
+        //
+        // Left un-run against the network deliberately: with one account this
+        // would make a live request, so the assertion below is the empty-list
+        // case, which is the same branch.
+        session.accounts.lock().unwrap().clear();
+        assert_eq!(
+            cloudflare_client_for_brain(
+                "https://second-brain.acme.workers.dev",
+                &session,
+                Locale::En
+            )
+            .await
+            .map(|_| ())
+            .unwrap_err(),
+            i18n::t(Locale::En, Key::ErrorWrongCfAccount),
+        );
+    }
+
+    /// …and that `start_worker_update` actually calls it. The behavioural test
+    /// above pins the helper; this pins that the inline copy is gone, because a
+    /// second copy left behind would keep passing every test while quietly
+    /// drifting.
+    #[test]
+    fn the_worker_update_resolves_its_account_through_the_shared_helper() {
+        let src = include_str!("commands.rs");
+        let start = src.find("pub async fn start_worker_update").expect("the command");
+        let body = &src[start..];
+        let body = &body[..body.find("\n}\n").expect("end of fn")];
+
+        assert!(
+            body.contains("cloudflare_client_for_brain"),
+            "start_worker_update must resolve its account through the shared helper"
+        );
+        assert!(
+            !body.contains("get_account_subdomain"),
+            "start_worker_update still enumerates accounts itself — that is the \
+             copy rotation was meant to remove"
         );
     }
 

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -1400,9 +1400,27 @@ async fn confirm_target_is_a_brain(
         user_err(locale, Key::ErrorNotABrain)
     })?;
 
+    bindings_are_a_brains(&bindings, locale)
+}
+
+/// The #247 decision itself, over bindings that have already been read.
+///
+/// Split from the fetch above so a test can drive it, on the
+/// `blocked_by_migration` precedent. Every backend reachable from a test answers
+/// `get_script_bindings` with a brain's bindings — the live one needs a real
+/// Cloudflare account, and the dry-run one describes the demo brain — so with
+/// the decision inline the *refusal* had no way of being exercised at all, and
+/// replacing the whole of it with `Ok(())` passed the entire suite.
+///
+/// What that mutation ships is the harm the caller's doc describes: a Door B
+/// typo that lands on a different Worker of the user's own is in the right
+/// Cloudflare account, so nothing else in the flow can catch it, and it has its
+/// `AUTH_TOKEN` overwritten while the user is told their brain's password
+/// changed.
+fn bindings_are_a_brains(bindings: &[serde_json::Value], locale: Locale) -> Result<(), String> {
     brain_index_names()
         .iter()
-        .any(|name| discover::bindings_look_like_a_brain(&bindings, name))
+        .any(|name| discover::bindings_look_like_a_brain(bindings, name))
         .then_some(())
         .ok_or_else(|| user_err(locale, Key::ErrorNotABrain))
 }
@@ -1442,9 +1460,26 @@ pub async fn validate_brain_address(
 #[tauri::command]
 pub async fn disconnect_ai_tools(app: AppHandle) -> Result<serde_json::Value, String> {
     let (worker_url, token, locale) = settings_target(&app)?;
+    revoke_all_tools(&worker_url, &token, locale).await
+}
+
+/// The request [`disconnect_ai_tools`] makes, split out so it can be driven by a
+/// test — the command takes an `AppHandle`, which no unit test can construct, and
+/// this is the whole of what it does.
+///
+/// `bearer_auth` is not decoration. `/oauth/revoke-all` is guarded like every
+/// other route on the brain, so without the brain's password the Worker answers
+/// 401 and the button reports a failure for a door it never asked to close. It
+/// fails safe, which is why it had no test and why it is the last thing here
+/// nothing was watching.
+async fn revoke_all_tools(
+    worker_url: &str,
+    token: &str,
+    locale: Locale,
+) -> Result<serde_json::Value, String> {
     let resp = reqwest::Client::new()
         .post(format!("{}/oauth/revoke-all", worker_url.trim_end_matches('/')))
-        .bearer_auth(&token)
+        .bearer_auth(token)
         .timeout(std::time::Duration::from_secs(30))
         .send()
         .await
@@ -1508,12 +1543,55 @@ fn rotation_block(locale: Locale) -> RotateError {
     RotateError::blocked(user_err(locale, Key::ErrorRotateBlocked))
 }
 
+/// Whether a rebuild is under way — or was abandoned — and a rotation has to
+/// wait for it, asked of the brain itself.
+///
+/// **Fails open, twice over, and both are the rule rather than an oversight.**
+///
+/// Door B has no password to ask with, so `current_password` is `None` and the
+/// answer is "not blocked" without a request: gating someone's only way back in
+/// on a question they are by definition unable to answer would be backwards.
+///
+/// And a check that could not be *made* is not a block either. A rebuild is a
+/// rare state; an unreachable brain is a Tuesday. Refusing on a failed
+/// `fetch_status` presents a network blip as "you may not change your password"
+/// on the one screen whose entire job is to change it, and leaves a Door A user
+/// with no connection unable to change theirs at all — while the block screen
+/// points them at Advanced Settings, which they cannot reach either.
+///
+/// So only a check that succeeded *and* came back blocked refuses. Split out of
+/// [`rotate_password`] so that rule can be driven by a test: that command takes
+/// an `AppHandle` and a Tauri `State`, and inverting this gate to refuse on
+/// failure compiled and passed the whole suite.
+async fn rebuild_blocks_rotation(
+    worker_url: &str,
+    current_password: Option<&str>,
+    locale: Locale,
+) -> bool {
+    let Some(password) = current_password else {
+        return false;
+    };
+    match crate::migration::fetch_status(worker_url, password, locale).await {
+        Ok(status) => blocked_by_migration(&status),
+        Err(e) => {
+            log::warn!("could not ask whether a rebuild is under way, so it is not a block: {e}");
+            false
+        }
+    }
+}
+
 /// Whether a rebuild is in flight (or was abandoned) and rotation must wait.
 ///
 /// Door A only. Door B cannot ask — checking needs a working password, which is
 /// by definition what that user does not have — and gating their only way back
 /// in on a check they cannot perform would be backwards. Someone who has lost
 /// their password is not driving a rebuild from that machine anyway.
+///
+/// Deliberately *not* [`rebuild_blocks_rotation`]: this one is the Connection
+/// pane asking in advance whether to offer the door, and a failure there has to
+/// reach the pane rather than be flattened into "no". The defensive gate inside
+/// the flow answers a different question — may this rotation proceed — where the
+/// same failure must never refuse.
 #[tauri::command]
 pub async fn rotation_blocked(app: AppHandle) -> Result<bool, String> {
     let (url, token, locale) = settings_target(&app)?;
@@ -1539,13 +1617,34 @@ pub async fn recheck_password(
         let session = app.state::<SetupSession>();
         rotation_target(&session, locale, address)?.0
     };
-    // `worker_auth_ok`, not `worker_health_ok`, for the same reason the rotation
-    // gate uses it: `/health` reports `ok` as the *vector index's* health, and
-    // this screen is asking one question only — does the brain let this password
-    // in? A brain whose index is degraded would answer "no" about a password that
-    // is live and is now the only one that opens it. That is the worst answer
-    // this button can give, on the one screen that exists to end the doubt.
-    match crate::cf::api::worker_auth_ok(&worker_url, password.trim()).await {
+    password_opens_brain(&worker_url, &password, locale).await
+}
+
+/// Does this password open this brain? The whole of [`recheck_password`], split
+/// out so it can be driven by a test — the command takes an `AppHandle`.
+///
+/// **Three answers, and the screen renders three different things.** Yes, no,
+/// and could-not-ask: `recheckUnreachable` exists to carry that third one, and
+/// it only has something to carry while the three stay distinct. A wrong
+/// password is `Ok(false)` and not an error, because on the screen this serves
+/// "no" is an answer rather than a fault; collapsing it into the error arm makes
+/// a refused password look like a broken connection and sends the user off
+/// checking their network instead of trying the other password. Collapsing the
+/// other way is worse still — an unreachable brain reported as `Ok(false)` tells
+/// someone their new password does not work when nothing was ever asked.
+///
+/// `worker_auth_ok`, not `worker_health_ok`, for the same reason the rotation
+/// gate uses it: `/health` reports `ok` as the *vector index's* health, and this
+/// screen is asking one question only. A brain whose index is degraded would
+/// answer "no" about a password that is live and is now the only one that opens
+/// it — the worst answer this button can give, on the one screen that exists to
+/// end the doubt.
+async fn password_opens_brain(
+    worker_url: &str,
+    password: &str,
+    locale: Locale,
+) -> Result<bool, String> {
+    match crate::cf::api::worker_auth_ok(worker_url, password.trim()).await {
         Ok(ok) => Ok(ok),
         Err(CfApiError::Unauthorized) => Ok(false),
         Err(e) => {
@@ -1629,16 +1728,11 @@ pub async fn rotate_password(
     //    already hides the door, but the flow can be open across the moment a
     //    rebuild starts on another machine.
     //
-    //    Only a check that *succeeds* and says "blocked" refuses. Door B has no
-    //    password to ask with, and a check that cannot be made is not a block: a
-    //    user who has lost their password must not be turned away by a question
-    //    they are unable to answer. A network blip must not either.
-    if let Some(password) = &current_password {
-        if let Ok(status) = crate::migration::fetch_status(&worker_url, password, locale).await {
-            if blocked_by_migration(&status) {
-                return Err(rotation_block(locale));
-            }
-        }
+    //    Only a check that *succeeds* and says "blocked" refuses — both halves of
+    //    that live in `rebuild_blocks_rotation`, which is where the reasoning is
+    //    and where a test can reach them.
+    if rebuild_blocks_rotation(&worker_url, current_password.as_deref(), locale).await {
+        return Err(rotation_block(locale));
     }
 
     // 3. The Cloudflare account that holds this brain, matched by the subdomain
@@ -2188,10 +2282,12 @@ pub fn open_settings_window(app: AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::{
-        app_mode, blocked_by_migration, clear_pending_rotation, cloudflare_client_for_brain,
-        confirm_target_is_a_brain, dashboard_credentials, for_log, normalize_worker_url,
-        previous_index_for, rotate_demo_password, rotation_address, rotation_block,
-        rotation_failure, rotation_target, RotateError, SetupSession, LOG_DETAIL_MAX,
+        app_mode, bindings_are_a_brains, blocked_by_migration, brain_index_names,
+        clear_pending_rotation, cloudflare_client_for_brain, confirm_target_is_a_brain,
+        dashboard_credentials, for_log, normalize_worker_url, password_opens_brain,
+        previous_index_for, rebuild_blocks_rotation, revoke_all_tools, rotate_demo_password,
+        rotation_address, rotation_block, rotation_failure, rotation_target, RotateError,
+        SetupSession, LOG_DETAIL_MAX,
     };
     use crate::cf::oauth::Tokens;
     use crate::cf::provision::{ProvisionError, ProvisionOutcome};
@@ -2666,6 +2762,78 @@ mod tests {
         }
     }
 
+    /// A rebuild that could not be asked about is not a rebuild in progress.
+    ///
+    /// The gate has to fail **open**, and the only reason to state that as a rule
+    /// is that failing closed is the natural way to write it. A rebuild is a rare
+    /// state; a brain that cannot be reached for a moment is a Tuesday. Refusing
+    /// on a failed `fetch_status` turns every blip into "you may not change your
+    /// password" on the one screen that exists to change it, and hands an offline
+    /// Door A user a permanent refusal whose suggested escape — Advanced
+    /// Settings — is behind the same connection that just failed.
+    ///
+    /// Inverting that arm compiled and passed all 237 tests: the gate lived
+    /// inside `rotate_password`, which takes an `AppHandle` and a Tauri `State`,
+    /// so nothing could call it. It is its own function now for that reason.
+    #[tokio::test]
+    async fn a_rebuild_that_could_not_be_asked_about_does_not_block_a_rotation() {
+        // A brain of its own: this rotates its password, and the process-wide one
+        // is what every other test in the suite is mid-request against.
+        let brain = crate::demo_brain::scoped_brain();
+        const PASSWORD: &str = "the-password-this-rebuild-test-sets";
+        crate::demo_brain::rotate_to(PASSWORD);
+
+        // Asked and answered: a brain that has never been rebuilt does not block.
+        assert!(
+            !rebuild_blocks_rotation(brain.base_url(), Some(PASSWORD), Locale::En).await,
+            "a brain with no ledger at all was treated as mid-rebuild"
+        );
+
+        // The one that matters. Nothing is listening on port 1, so the request
+        // fails outright — and a question that could not be put is not a "yes".
+        assert!(
+            !rebuild_blocks_rotation("http://127.0.0.1:1", Some(PASSWORD), Locale::En).await,
+            "a brain that could not be reached was reported as mid-rebuild, so a \
+             network blip presents as a refusal to change a password and an \
+             offline user can never change theirs"
+        );
+
+        // The same rule for a password the brain refuses: `fetch_status` comes
+        // back as an error, and this computer holding a stale password is a
+        // reason to change it rather than grounds to forbid changing it.
+        assert!(
+            !rebuild_blocks_rotation(brain.base_url(), Some("not-this-brains-password"), Locale::En)
+                .await,
+            "a 401 from the rebuild check locked the user out of the flow that \
+             fixes exactly that"
+        );
+
+        // Door B has no password to ask with, so there is no question to put.
+        assert!(
+            !rebuild_blocks_rotation(brain.base_url(), None, Locale::En).await,
+            "someone who has lost their password was turned away by a check that \
+             needs the password they have lost"
+        );
+
+        // …and a rebuild that genuinely is outstanding still blocks, or the gate
+        // above is satisfied by a function that always says no. One batch of the
+        // demo brain's 1,620 entries leaves a ledger with no `finishedAt`, which
+        // is the in-progress state.
+        crate::migration::run_batch(brain.base_url(), PASSWORD, Locale::En)
+            .await
+            .expect("one re-embed batch against the demo brain");
+        assert!(
+            rebuild_blocks_rotation(brain.base_url(), Some(PASSWORD), Locale::En).await,
+            "a rebuild is under way and the rotation was allowed through. Caught \
+             half-way it leaves the next batch 401ing and the ledger stalling, so \
+             a recoverable password problem presents as a failed rebuild — the \
+             more frightening of the two, and the one that invites a destructive fix"
+        );
+
+        // Which Door B still cannot be asked about, rebuild or no rebuild.
+        assert!(!rebuild_blocks_rotation(brain.base_url(), None, Locale::En).await);
+    }
+
     /// Every in-memory mode is decided before secure storage is consulted.
     ///
     /// The rule this protects is not a style preference. `&&` and `else if` are
@@ -2984,6 +3152,89 @@ mod tests {
             .expect("the demo account's bindings look like a brain");
     }
 
+    /// …and a Worker that is not a brain is refused, however right its account is.
+    ///
+    /// The negative half of the test above, and the half that was missing. Both
+    /// cases it covered — a custom domain, and the app's own brain — are decided
+    /// before this check or by it saying yes, so replacing the decision itself
+    /// with `Ok(())` left all 237 tests green while removing the only thing
+    /// standing between a mistyped address and someone else's Worker.
+    ///
+    /// The account match cannot help here, which is the whole point: every script
+    /// listed below is in the user's *own* Cloudflare account, reached at their
+    /// own `workers.dev` subdomain, and a Door B typo — one letter of a script
+    /// name — is how a user lands on one. Accepted, the flow writes `AUTH_TOKEN`
+    /// onto it and reports that the brain's password has changed: the brain is
+    /// untouched and still on the old password, and something the user never
+    /// named has been altered.
+    ///
+    /// Driven through `bindings_are_a_brains` rather than
+    /// `confirm_target_is_a_brain` because there is no backend a test can reach
+    /// that answers with anything but a brain's bindings — the wire between the
+    /// two is asserted at the bottom.
+    #[test]
+    fn a_worker_that_is_not_a_brain_is_refused_however_right_its_account_is() {
+        let vectorize = |index: &str| {
+            serde_json::json!({ "type": "vectorize", "name": "VECTORIZE", "index_name": index })
+        };
+        let d1 = || serde_json::json!({ "type": "d1", "name": "DB", "database_id": "abc" });
+        let kv = || serde_json::json!({ "type": "kv_namespace", "name": "OAUTH_KV" });
+        let a_brains_index = brain_index_names()
+            .first()
+            .expect("this build knows what index its own brains are on")
+            .clone();
+
+        for (what, bindings) in [
+            ("a Worker with no bindings at all", vec![]),
+            ("their own API, with a database and no vector index", vec![d1(), kv()]),
+            (
+                "their own search Worker, on an index of its own",
+                vec![d1(), vectorize("acme-docs-vectors")],
+            ),
+            (
+                "a brain's index name with no database behind it",
+                vec![vectorize(&a_brains_index), kv()],
+            ),
+            (
+                "a database and a vector index that is not one a brain uses",
+                vec![d1(), vectorize("second-brain-vectors-backup")],
+            ),
+        ] {
+            assert_eq!(
+                bindings_are_a_brains(&bindings, Locale::En).unwrap_err(),
+                i18n::t(Locale::En, Key::ErrorNotABrain),
+                "{what} was accepted as a brain. A Door B typo then overwrites its \
+                 AUTH_TOKEN while telling the user their brain's password changed."
+            );
+        }
+
+        // …and every index one of this build's own brains could legitimately be
+        // on is accepted, including the ones an embedding migration moved it to.
+        // Refusing those tells a user who changed how their brain reads that
+        // their own brain is not a brain.
+        for name in brain_index_names() {
+            assert!(
+                bindings_are_a_brains(&[d1(), vectorize(&name), kv()], Locale::En).is_ok(),
+                "{name} is an index this app's own brains are on, and it was refused"
+            );
+        }
+
+        // The wire. The decision is only worth pinning while the command that
+        // reads the bindings still ends in it, and that is exactly what a test
+        // driving the decision directly cannot see.
+        let src = include_str!("commands.rs");
+        let body = fn_body(src, "async fn confirm_target_is_a_brain(");
+        assert!(
+            at(body, "get_script_bindings") < at(body, "bindings_are_a_brains(&bindings, locale)"),
+            "the brain check no longer decides on the bindings it just read"
+        );
+        assert!(
+            !body.contains("\n    Ok(())"),
+            "confirm_target_is_a_brain reports success without consulting anything \
+             — which is the mutation this whole test exists for"
+        );
+    }
+
     /// The order of `rotate_password`, which is the whole of its safety argument.
     ///
     /// Three mutations of this function compiled with all 208 tests passing:
@@ -3005,7 +3256,12 @@ mod tests {
 
         let door_b = at(body, "if door_b {");
         let confirm = at(body, "confirm_target_is_a_brain");
-        let blocked = at(body, "blocked_by_migration");
+        // The gate moved into `rebuild_blocks_rotation` so that its fail-open
+        // rule could be exercised at all — see
+        // `a_rebuild_that_could_not_be_asked_about_does_not_block_a_rotation`.
+        // The ordering it has to keep is unchanged, and this is still the only
+        // thing that can see it.
+        let blocked = at(body, "rebuild_blocks_rotation");
         let remote = at(body, "provision::rotate_secret");
         let persist = at(body, "rotate::persist");
 
@@ -3132,6 +3388,46 @@ mod tests {
         assert!(
             call.contains("windows::refresh_wrapper_token"),
             "…and the open dashboard window is no longer told either"
+        );
+    }
+
+    /// A finished rotation leaves the change-your-password flow — on the live
+    /// path as well as the demo one.
+    ///
+    /// `a_demo_rotation_runs_the_real_path_and_never_reads_the_keychain` asserts
+    /// this of `rotate_demo_password`, which a test can call. The live half
+    /// cannot be called at all: it takes an `AppHandle` and a Tauri `State`, and
+    /// reaching its last lines needs a real Cloudflare account. So deleting the
+    /// clear from *that* half left every test green, and what it ships is
+    /// `app_mode` returning `"change-password"` for the rest of the session and
+    /// the next launch reopening the password-change screen over a password that
+    /// has just been successfully changed. That is the wedge
+    /// `walking_away_from_a_password_change_does_not_wedge_the_next_flow`
+    /// exists to prevent, reached through the door that *worked* — and the user
+    /// has no way to tell that their change did land.
+    ///
+    /// Source-scanned for that reason, and both anchors are `expect`ed: an
+    /// ordering assertion whose landmark has been deleted must fail rather than
+    /// quietly compare a missing position against something.
+    #[test]
+    fn a_finished_rotation_leaves_the_password_change_flow_on_the_live_path_too() {
+        let src = include_str!("commands.rs");
+        let body = fn_body(src, "pub async fn rotate_password(");
+
+        let persist = at(body, "rotate::persist");
+        let cleared = at(body, "clear_pending_rotation");
+        let ok = at(body, "Ok(outcome)");
+
+        assert!(
+            persist < cleared && cleared < ok,
+            "the flow is left before the rotation has finished doing its work, or \
+             not at all — it has to be cleared on the way out of the success path"
+        );
+        assert!(
+            persist < at(body, "*session.stale_password.lock().unwrap() = false"),
+            "a rotation is also the answer to \"your password was changed \
+             elsewhere\", and a flag nothing clears keeps telling the user that \
+             about the password they have just set themselves"
         );
     }
 
@@ -3278,6 +3574,145 @@ mod tests {
             !body.contains("get_account_subdomain"),
             "start_worker_update still enumerates accounts itself — that is the \
              copy rotation was meant to remove"
+        );
+    }
+
+    /// The re-check has three answers, and the screen renders three things.
+    ///
+    /// Yes, no, and could-not-ask. `recheckUnreachable` is copy written for that
+    /// third one, and it only has something to carry while the three stay apart —
+    /// turning the `Unauthorized` arm into an error compiled and passed
+    /// everything, which merges "your password is not the one that works" into
+    /// "we could not reach your brain" and sends a user who only had to try their
+    /// other password off to check their network instead.
+    ///
+    /// The last section is the probe itself, which was `worker_health_ok` until
+    /// this branch changed it. `/health` reports `ok` as the *vector index's*
+    /// health, so that call answered a question about Vectorize on the one screen
+    /// that exists to tell someone whether their password changed — and a brain
+    /// with a degraded index says "no" about a password that is live and is now
+    /// the only one that opens it.
+    #[tokio::test]
+    async fn the_password_recheck_has_three_answers_and_asks_only_about_the_password() {
+        let brain = crate::demo_brain::scoped_brain();
+        const PASSWORD: &str = "the-password-this-recheck-test-sets";
+        crate::demo_brain::rotate_to(PASSWORD);
+
+        assert_eq!(
+            password_opens_brain(brain.base_url(), PASSWORD, Locale::En).await,
+            Ok(true),
+            "the brain's own password did not open it"
+        );
+        assert_eq!(
+            password_opens_brain(brain.base_url(), "not-this-brains-password", Locale::En).await,
+            Ok(false),
+            "a refused password must come back as an answer, not a fault: this \
+             screen is asking a yes/no question and \"no\" is one of the answers \
+             it was opened to receive"
+        );
+        assert_eq!(
+            password_opens_brain("http://127.0.0.1:1", PASSWORD, Locale::En).await,
+            Err(i18n::t(Locale::En, Key::ErrorReachBrain).to_string()),
+            "\"could not ask\" is the third answer, and reporting it as `false` \
+             tells someone their new password does not work when nothing was ever \
+             asked — on the screen they opened because they did not know"
+        );
+
+        // Surrounding whitespace is not a wrong password. The field is one a user
+        // pastes into.
+        assert_eq!(
+            password_opens_brain(brain.base_url(), &format!("  {PASSWORD}\n"), Locale::En).await,
+            Ok(true),
+            "a pasted password with whitespace around it was reported as refused"
+        );
+
+        // The probe asks about the password and nothing else. A path the brain
+        // does not serve answers 404 *after* authenticating, so the password was
+        // accepted and the answer is still yes — where `worker_health_ok` would
+        // say no, because it reads any non-200 (and any `vectorize.ok: false`) as
+        // a refusal. Those are the same branch of the same function; the degraded
+        // index is the case that matters and no demo brain here can be made to
+        // report one, so this is the reachable half of it.
+        assert_eq!(
+            password_opens_brain(&format!("{}/not-a-route", brain.base_url()), PASSWORD, Locale::En)
+                .await,
+            Ok(true),
+            "the re-check answered \"your password does not work\" about a brain \
+             that had just accepted it, because it asked whether the brain was \
+             well rather than whether it was open"
+        );
+
+        // …and the probe named, because the case above is a stand-in for the one
+        // that cannot be staged.
+        let src = include_str!("commands.rs");
+        let body = fn_body(src, "async fn password_opens_brain(");
+        assert!(
+            body.contains("worker_auth_ok"),
+            "the re-check no longer asks whether the password is accepted"
+        );
+        assert!(
+            !body.contains("worker_health_ok"),
+            "the re-check is back on the full health contract, so a brain with a \
+             degraded vector index tells its owner their password did not change"
+        );
+    }
+
+    /// Disconnecting the AI tools: the one action whose whole value is that its
+    /// report can be believed, and the one command in this module that had no
+    /// test of any kind.
+    ///
+    /// Rotation deliberately does not reach these tools — they hold
+    /// provider-issued tokens validated against KV, not the brain's password —
+    /// which is why this is offered separately, and why what it reports is the
+    /// only evidence the user gets that a door was closed.
+    #[tokio::test]
+    async fn disconnecting_ai_tools_sends_the_password_and_passes_the_count_through() {
+        let brain = crate::demo_brain::scoped_brain();
+        const PASSWORD: &str = "the-password-this-revoke-test-sets";
+        crate::demo_brain::rotate_to(PASSWORD);
+
+        let body = revoke_all_tools(brain.base_url(), PASSWORD, Locale::En)
+            .await
+            .expect("the brain's own password opens the route that closes the tools");
+        assert_eq!(body["ok"], true);
+        assert_eq!(
+            body["revoked"], 2,
+            "the Worker's own count, passed through rather than summarised: it is \
+             what tells the user how many tools were holding access"
+        );
+        assert_eq!(
+            body["failed"], 0,
+            "`failed` is the case this control exists for — a tool that kept its \
+             access — so it has to survive the trip to the screen"
+        );
+
+        // Pressing it a second time reports nothing left, rather than closing the
+        // same two again. The pass-through is only worth anything if the number
+        // moves.
+        let again = revoke_all_tools(brain.base_url(), PASSWORD, Locale::En)
+            .await
+            .expect("nothing left to close is still a success");
+        assert_eq!(again["revoked"], 0);
+
+        // The brain's password is what makes the request. Without it this route
+        // 401s like every other, and the user is shown a failure for a door that
+        // was never even asked to close — which fails safe, and is why nothing
+        // noticed the token was gone.
+        let refused = revoke_all_tools(brain.base_url(), "not-this-brains-password", Locale::En)
+            .await
+            .expect_err("a brain must not revoke anything for a password it refuses");
+        assert!(
+            refused.contains("401"),
+            "the status the brain gave is what makes this diagnosable: {refused}"
+        );
+
+        // …and a brain that could not be reached at all says something else
+        // again, because the two send the user to different places.
+        assert_eq!(
+            revoke_all_tools("http://127.0.0.1:1", PASSWORD, Locale::En)
+                .await
+                .unwrap_err(),
+            i18n::t(Locale::En, Key::ErrorReachBrain),
         );
     }
 

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -99,6 +99,25 @@ pub struct AppState {
 
 #[tauri::command]
 pub fn get_app_state(session: State<'_, SetupSession>) -> AppState {
+    AppState {
+        mode: app_mode(&session),
+        dry_run: session.dry_run,
+    }
+}
+
+/// Which screen the main window opens on.
+///
+/// Split out of the command so it can be *run* by a test rather than described
+/// by one. A Tauri `State` cannot be constructed in a unit test, and the property
+/// this function has to hold — that a demo launch performs zero keychain reads —
+/// is only observable by calling the thing that does the work. The source-scanning
+/// guard that used to stand in for that ordered three flag names against
+/// `load_setup` and said nothing at all about the `dry_run` term, so swapping
+/// `!session.dry_run && load_setup().is_some()` for
+/// `load_setup().is_some() && !session.dry_run` passed it — and that swap is #252
+/// exactly: `&&` short-circuits left to right, so the second form reads the
+/// keychain on every demo launch.
+fn app_mode(session: &SetupSession) -> &'static str {
     // Dry-run is checked before the keychain read so demo mode never touches
     // secure storage (each read can raise a macOS permission prompt for
     // unsigned dev builds, which would block the setup UI's first paint).
@@ -107,7 +126,7 @@ pub fn get_app_state(session: State<'_, SetupSession>) -> AppState {
     // reason, which is why the two #235 modes sit up here with the Worker
     // update rather than beside the branch they most resemble. A demo run
     // reaching `load_setup()` at all is the bug — see #252.
-    let mode = if *session.pending_rotation.lock().unwrap() {
+    if *session.pending_rotation.lock().unwrap() {
         "change-password"
     } else if *session.stale_password.lock().unwrap() {
         "stale-password"
@@ -117,10 +136,6 @@ pub fn get_app_state(session: State<'_, SetupSession>) -> AppState {
         "wrapper"
     } else {
         "setup"
-    };
-    AppState {
-        mode,
-        dry_run: session.dry_run,
     }
 }
 
@@ -452,6 +467,15 @@ pub async fn connect_existing(
             }
         }
     }
+
+    // This *is* the answer to "your password was changed on another computer"
+    // (#235 §5): the stale-password screen's first offer is to enter the new one,
+    // and it arrives here. Leaving the flag set means `get_app_state` keeps
+    // returning `"stale-password"` after the fix has landed, so the next
+    // `begin_worker_update` — or the next launch, before the health check has had
+    // a chance to disagree — tells the user again that their password was changed
+    // elsewhere, about a password that now works. Only a restart cleared it.
+    *session.stale_password.lock().unwrap() = false;
 
     let outcome = ProvisionOutcome {
         mcp_url: format!("{worker_url}/mcp"),
@@ -818,8 +842,32 @@ pub fn open_dashboard_impl(app: &AppHandle, session: &SetupSession) -> Result<()
     let (worker_url, token) = dashboard_credentials(session, locale)?;
     windows::open_wrapper_window(app, &worker_url, &token)
         .map_err(|_| user_err(locale, Key::OpenDashboardFailed))?;
+    // Reaching the dashboard is how a password change is abandoned — "Not now"
+    // on the change-password screen lands exactly here, and the setup window is
+    // closed on the next line.
+    //
+    // Cleared because `pending_rotation` was otherwise only unset on success or
+    // on logout, and `get_app_state` consults it first: the flag survived, so the
+    // next "Update your Second Brain" opened the *password-change* flow instead
+    // of the update, and nothing short of restarting the app put it right.
+    //
+    // `stale_password` is deliberately not cleared here. That flag records
+    // something about the brain — that the password this computer holds no longer
+    // opens it — and walking over to the dashboard does not make it untrue. It is
+    // cleared where it is actually resolved: `connect_existing` and a completed
+    // rotation.
+    clear_pending_rotation(session);
     close_setup_windows(app);
     Ok(())
+}
+
+/// Leaves the change-your-password flow without having changed anything.
+///
+/// One function rather than an assignment at each exit, because the flag is read
+/// by `app_mode` ahead of every other mode: an exit that forgets to clear it does
+/// not fail, it silently redirects the *next* thing the user asks for.
+fn clear_pending_rotation(session: &SetupSession) {
+    *session.pending_rotation.lock().unwrap() = false;
 }
 
 fn close_setup_windows(app: &AppHandle) {
@@ -1088,8 +1136,8 @@ pub async fn start_worker_update(
 
 // ── Changing the password (#235) ─────────────────────────────────────────────
 
-/// Why a password change did not finish, in the only three shapes that differ in
-/// what may honestly be said afterwards.
+/// Why a password change did not finish, in the only shapes that differ in what
+/// may honestly be said afterwards.
 ///
 /// `Result<(), String>` is not sufficient here, and that is load-bearing rather
 /// than fastidious. A string cannot separate "the change never reached
@@ -1104,8 +1152,10 @@ pub async fn start_worker_update(
 pub struct RotateError {
     /// Selects the screen, and with it what may be claimed:
     ///   `"notSent"`     — nothing reached Cloudflare; the old password still works.
-    ///   `"unconfirmed"` — the secret was accepted; health never went green. Never
-    ///                     tell the user the old password still works.
+    ///   `"unconfirmed"` — the secret may have been accepted; health never went
+    ///                     green. Never tell the user the old password still works.
+    ///   `"blocked"`     — refused on purpose, with somewhere to go. Nothing was
+    ///                     sent, but "try again" is the wrong offer.
     ///   `"local"`       — the brain has the new password; a local write failed.
     pub stage: &'static str,
     /// Already localised; rendered into the failure screen's detail slot rather
@@ -1121,38 +1171,140 @@ impl RotateError {
     fn unconfirmed(detail: String) -> Self {
         Self { stage: "unconfirmed", detail }
     }
+    /// A refusal this app made on purpose, with a route out of it.
+    ///
+    /// Its own stage rather than a `notSent` with an unusual detail. `notSent`'s
+    /// screen is "Nothing was changed / Try again", and for a rebuild that is in
+    /// flight *every part of that is wrong*: trying again in ten seconds fails the
+    /// same way, the real instruction (wait, or reset the rebuild from Advanced
+    /// Settings) arrives as a footnote under a button that will not work, and an
+    /// abandoned ledger blocks rotation permanently with no escape offered at all.
+    fn blocked(detail: String) -> Self {
+        Self { stage: "blocked", detail }
+    }
     fn local(detail: String) -> Self {
         Self { stage: "local", detail }
     }
 }
 
-/// Maps a `rotate_secret` failure onto what the user may be told.
+/// Maps a `rotate_secret` failure onto what the user may honestly be told.
 ///
-/// `HealthCheckFailed` is the only variant that means the secret was accepted.
-/// `rotate_secret` PUTs once and then polls, so it is the only error raised
-/// *after* the write; everything else is raised before it or by it.
+/// The dividing line is `put_secret`, not the error's variant, and every caller
+/// of this function is downstream of `rotate_secret` — so the question is only
+/// ever "was the PUT entered before this was raised?".
 ///
-/// One honest caveat, and it is why `notSent` claims no more than "nothing
-/// reached Cloudflare": a PUT that dies on the wire may still have been applied
-/// at the far end. That is rare, indistinguishable from here, and the retry the
-/// screen offers settles it either way — `PUT …/secrets` on one name is
-/// idempotent.
+/// `NotAWorkersDevAddress` is the one failure raised before it: the script name is
+/// derived from the address first, precisely so a custom-domain brain is refused
+/// without a half-started progress screen. Everything else comes out of
+/// `put_secret` or the health poll that follows it.
+///
+/// **Which is why the old catch-all was wrong.** It sent `CfApiError::Network`
+/// and `Http` to `notSent`, whose screen states in as many words that the old
+/// password still works and everything is exactly as it was. `send_impl` returns
+/// `Network` only after exhausting its retries, which includes the case where the
+/// PUT reached Cloudflare and only the *response* was lost — and `Http` is an
+/// unparseable body, which can arrive with any status at all. Neither supports a
+/// positive claim about remote state.
+///
+/// `Unauthorized` is the one that looks safe and is not. A 401 is an authorization
+/// decision made before the secrets handler runs, so *that attempt* changed
+/// nothing — but `send_impl` retries, and a first attempt that died on the wire
+/// with the PUT already applied, followed by a retry that 401s on an access token
+/// that expired in between, produces exactly this error over a brain whose
+/// password has already moved.
+///
+/// The asymmetry decides the doubtful cases. A wrong `unconfirmed` shows the
+/// password with "this may already be live, save it" and a re-check button that
+/// settles it in one request. A wrong `notSent` tells someone their old password
+/// still works, so they close the window without saving the new one, and the next
+/// launch locks them out of their own brain with nothing left to recover from.
+///
+/// Matched exhaustively on purpose. A new `ProvisionError` variant should not
+/// quietly inherit a default here; it should stop the build until someone decides
+/// which side of the PUT it is raised on.
 fn rotation_failure(error: ProvisionError, locale: Locale) -> RotateError {
     match error {
-        ProvisionError::HealthCheckFailed => {
-            RotateError::unconfirmed(user_err(locale, Key::ErrorRotateNotConfirmed))
-        }
-        // Refused before the PUT, by the same #257 guard the update path uses.
+        // Refused before the PUT, by the same #257 guard the update path uses —
+        // and the only failure in `rotate_secret` that is.
         ProvisionError::NotAWorkersDevAddress => {
             RotateError::not_sent(user_err(locale, Key::ErrorCustomDomain))
         }
-        // The case the three-way split exists for: an expired Cloudflare sign-in
-        // must read as "nothing happened", not as a hedge.
-        ProvisionError::Api(CfApiError::Unauthorized) => {
-            RotateError::not_sent(user_err(locale, Key::ErrorCfSignInExpired))
+        ProvisionError::HealthCheckFailed => {
+            RotateError::unconfirmed(user_err(locale, Key::ErrorRotateNotConfirmed))
         }
-        _ => RotateError::not_sent(user_err(locale, Key::ErrorFriendlyRetry)),
+        // From `put_secret`. The detail still names the real cause — the stage
+        // says what may be claimed, the detail says what went wrong, and those
+        // are different questions.
+        ProvisionError::Api(CfApiError::Unauthorized) => {
+            RotateError::unconfirmed(user_err(locale, Key::ErrorCfSignInExpired))
+        }
+        ProvisionError::Api(_) => {
+            RotateError::unconfirmed(user_err(locale, Key::ErrorRotateNotConfirmed))
+        }
+        // Not reachable from `rotate_secret`, which neither captures nor registers
+        // a subdomain. Listed rather than swept into a `_` so the exhaustiveness
+        // above is real, and sent to `unconfirmed` because an unreachable arm that
+        // becomes reachable should fail towards the claim that cannot lock anyone
+        // out.
+        ProvisionError::CaptureFailed | ProvisionError::SubdomainUnavailable => {
+            RotateError::unconfirmed(user_err(locale, Key::ErrorRotateNotConfirmed))
+        }
     }
+}
+
+/// How much of a failure a log line is allowed to carry.
+///
+/// `CfApiError::Http` holds up to 600 characters of whatever Cloudflare returned
+/// when the body would not parse, and `{e}` on a `ProvisionError` renders all of
+/// it. A password change is exactly the moment a user is likeliest to be asked
+/// for their log, so one failure pasting most of an edge error page — request
+/// ids, ray ids, whatever else the response echoed — into it is both unreadable
+/// and more than they meant to share.
+const LOG_DETAIL_MAX: usize = 160;
+
+/// Trims a diagnostic to [`LOG_DETAIL_MAX`] characters, on a character boundary,
+/// and says how much it dropped so a truncated line is never mistaken for the
+/// whole story.
+fn for_log(detail: impl std::fmt::Display) -> String {
+    let text = detail.to_string();
+    match text.char_indices().nth(LOG_DETAIL_MAX) {
+        None => text,
+        Some((cut, _)) => {
+            let dropped = text.chars().count() - LOG_DETAIL_MAX;
+            format!("{}… (+{dropped} more characters)", &text[..cut])
+        }
+    }
+}
+
+/// Normalises an address typed into the rotation flow, and refuses cleartext.
+///
+/// `normalize_worker_url` keeps a scheme the user typed, and `worker_url::labels`
+/// accepts `http` — both on purpose, for `http://localhost:8787` dev setups, and
+/// both wrong on this path. A rotation is the one operation that sends a password
+/// the user has never used before as a bearer token, and then *stores* the origin
+/// it sent it to: the keychain and the plaintext CLI config both take it, so a
+/// single mistyped `http://` makes every later request from the app and from the
+/// `brain` command cleartext too, indefinitely. `reqwest` does no HSTS, so nothing
+/// downstream will upgrade it.
+///
+/// Only the typed address goes through here. A Door A address came out of this
+/// app's own secure storage, where it was written after a successful connection,
+/// and demo mode runs against a loopback brain that has no certificate — neither
+/// is a user typing a scheme they did not think about.
+fn rotation_address(input: &str, locale: Locale) -> Result<String, String> {
+    let normalized = normalize_worker_url(input, locale)?;
+    let scheme = url::Url::parse(&normalized)
+        .map(|u| u.scheme().to_string())
+        .unwrap_or_default();
+    if scheme != "https" {
+        // Not ErrorBadUrl: `http://my-brain.acme.workers.dev` is a perfectly good
+        // address, and telling someone it does not look like one sends them
+        // hunting for a typo that is not there. The problem is the scheme, and
+        // the reason is worth stating — this is the one path that would put a
+        // brand-new password on the wire in the clear.
+        return Err(user_err(locale, Key::ErrorRotateNeedsHttps));
+    }
+    Ok(normalized)
 }
 
 /// The address a rotation should act on, and the password this computer already
@@ -1167,16 +1319,20 @@ fn rotation_failure(error: ProvisionError, locale: Locale) -> RotateError {
 /// address is resolved the way every other settings command resolves it: through
 /// `dashboard_credentials`, never `secure_store::load_setup()` directly, because
 /// that ignores dry-run and raises a Keychain prompt (#252).
+///
+/// Takes the session rather than the `AppHandle` it could pull the session out
+/// of, so it can be driven by a test — the cleartext refusal above is the sort of
+/// rule that is easy to write and easy to delete.
 fn rotation_target(
-    app: &AppHandle,
+    session: &SetupSession,
+    locale: Locale,
     address: Option<String>,
-) -> Result<(String, Option<String>, Locale), String> {
-    let locale = locale_of(app);
+) -> Result<(String, Option<String>), String> {
     match address {
-        Some(address) => Ok((normalize_worker_url(&address, locale)?, None, locale)),
+        Some(address) => Ok((rotation_address(&address, locale)?, None)),
         None => {
-            let (url, token, locale) = settings_target(app)?;
-            Ok((url, Some(token), locale))
+            let (url, token) = dashboard_credentials(session, locale)?;
+            Ok((url, Some(token)))
         }
     }
 }
@@ -1264,7 +1420,11 @@ pub async fn validate_brain_address(
     session: State<'_, SetupSession>,
 ) -> Result<(), String> {
     let locale = locale_of(&app);
-    let worker_url = normalize_worker_url(&address, locale)?;
+    // Through `rotation_address`, which is the general normaliser plus this
+    // path's refusal of cleartext. The screen has to refuse exactly what the
+    // command would refuse, or it waves an address through to the place where
+    // the user has already committed to it.
+    let worker_url = rotation_address(&address, locale)?;
     confirm_target_is_a_brain(&worker_url, &session, locale).await
 }
 
@@ -1334,6 +1494,20 @@ fn blocked_by_migration(status: &serde_json::Value) -> bool {
     }
 }
 
+/// The refusal [`blocked_by_migration`] produces, as its own screen.
+///
+/// Split out so the stage and the wording travel together and can be asserted
+/// without a `rotate_password` in the way. A rebuild that starts mid-flow — which
+/// is the only way this is reached, since the Connection pane already hides the
+/// door — used to come back as `notSent`, whose screen reads "Nothing was
+/// changed" over a "Try again" button, with the actual reason in the detail
+/// slot. Every word of that is unhelpful here: the retry fails identically, the
+/// instruction that would work (wait for the rebuild, or reset it from Advanced
+/// Settings) reads as a footnote, and an abandoned ledger blocks forever.
+fn rotation_block(locale: Locale) -> RotateError {
+    RotateError::blocked(user_err(locale, Key::ErrorRotateBlocked))
+}
+
 /// Whether a rebuild is in flight (or was abandoned) and rotation must wait.
 ///
 /// Door A only. Door B cannot ask — checking needs a working password, which is
@@ -1359,7 +1533,12 @@ pub async fn recheck_password(
     address: Option<String>,
     app: AppHandle,
 ) -> Result<bool, String> {
-    let (worker_url, _, locale) = rotation_target(&app, address)?;
+    let locale = locale_of(&app);
+    // Scoped so the `State` borrow is dropped before the await below.
+    let worker_url = {
+        let session = app.state::<SetupSession>();
+        rotation_target(&session, locale, address)?.0
+    };
     match crate::cf::api::worker_health_ok(&worker_url, password.trim()).await {
         Ok(ok) => Ok(ok),
         Err(CfApiError::Unauthorized) => Ok(false),
@@ -1413,14 +1592,22 @@ pub async fn rotate_password(
     };
 
     if session.dry_run {
-        return rotate_demo_password(&new_password, &session, locale, progress).await;
+        let refresh_app = app.clone();
+        return rotate_demo_password(&new_password, &session, locale, progress, move |token| {
+            // The demo brain's own address, for the same reason the live path
+            // uses the brain's: `refresh_wrapper_token` only writes where the
+            // window's origin matches, and demo mode's window is on loopback.
+            let url = crate::demo_brain::base_url();
+            windows::refresh_wrapper_token(&refresh_app, &url, token)
+        })
+        .await;
     }
 
     // 1. Which brain. Through the session-aware helper, never the keychain
     //    directly — see `rotation_target`.
     let door_b = address.is_some();
-    let (worker_url, current_password, locale) =
-        rotation_target(&app, address).map_err(RotateError::not_sent)?;
+    let (worker_url, current_password) =
+        rotation_target(&session, locale, address).map_err(RotateError::not_sent)?;
 
     // 1a. On Door B the address was typed or picked rather than read back from
     //     this computer's own store, so confirm it is a brain before writing a
@@ -1443,10 +1630,7 @@ pub async fn rotate_password(
     if let Some(password) = &current_password {
         if let Ok(status) = crate::migration::fetch_status(&worker_url, password, locale).await {
             if blocked_by_migration(&status) {
-                return Err(RotateError::not_sent(user_err(
-                    locale,
-                    Key::ErrorRotateBlocked,
-                )));
+                return Err(rotation_block(locale));
             }
         }
     }
@@ -1458,6 +1642,12 @@ pub async fn rotate_password(
         .map_err(RotateError::not_sent)?;
 
     // 4. The remote change, health-gated against the new password.
+    //
+    // `?`, not `.ok()`. Everything below writes the new password into stores this
+    // computer reads at launch, and doing that after a remote change that did not
+    // land is the one outcome #235 has no recovery for: the brain still answers to
+    // the old password, nothing here holds it any more, and the app has no way to
+    // ask for it back. That mutation compiled and passed the whole suite.
     provision::rotate_secret(
         &LiveBackend { client },
         &worker_url,
@@ -1466,12 +1656,26 @@ pub async fn rotate_password(
     )
     .await
     .map_err(|e| {
-        log::warn!("password rotation failed: {e}");
+        log::warn!("password rotation failed: {}", for_log(&e));
         rotation_failure(e, locale)
     })?;
 
     // 5. Only now is it safe to write anything locally.
     //
+    // The third row of the rotation screen's checklist, and the only one emitted
+    // from outside `rotate_secret` — which is not an oversight but the ordering
+    // itself. Nothing local may be written until the remote change has been
+    // confirmed, so the step cannot exist inside the function that does the
+    // confirming, and a row that nobody emits is a row that sits as a static
+    // bullet for the whole run.
+    let emit_local = |status: provision::StepStatus| {
+        let _ = app.emit(
+            "setup-progress",
+            provision::StepEvent { step: provision::Step::Local, status },
+        );
+    };
+    emit_local(provision::StepStatus::Running);
+
     // Without a home directory there is nowhere for `persist` to look, so it
     // cannot run at all and there is no outcome to report — which is what the
     // `"local"` stage is for. `ErrorRotateSecureStore` reads correctly here: the
@@ -1479,15 +1683,40 @@ pub async fn rotate_password(
     // the user needs to act on. Deliberately not `ErrorSecureStoreConnect`, which
     // opens "Connected, but…" — nothing was connected, a working password was
     // replaced.
-    let home = dirs::home_dir()
-        .ok_or_else(|| RotateError::local(user_err(locale, Key::ErrorRotateSecureStore)))?;
+    //
+    // The one hard failure this step has, and so the one place it ends in
+    // `Error`. Everything `persist` itself can get wrong comes back as a flag on
+    // the outcome instead — see below.
+    let Some(home) = dirs::home_dir() else {
+        emit_local(provision::StepStatus::Error);
+        return Err(RotateError::local(user_err(locale, Key::ErrorRotateSecureStore)));
+    };
     let refresh_app = app.clone();
     let refresh_url = worker_url.clone();
-    let outcome = rotate::persist(&home, &worker_url, &new_password, move |token| {
-        windows::refresh_wrapper_token(&refresh_app, &refresh_url, token)
-    });
+    let outcome = rotate::persist(
+        &home,
+        &worker_url,
+        &new_password,
+        // The one caller that supplies the real secure store. `persist` takes it
+        // as a seam so its own tests never write the process-global test map (and
+        // so the failure branch is reachable at all) — which means this line is
+        // the whole of "the keychain is actually written", and the guard below
+        // holds it in place.
+        |url, token| secure_store::save_setup(url, token).map_err(|e| e.to_string()),
+        move |token| windows::refresh_wrapper_token(&refresh_app, &refresh_url, token),
+    );
 
-    *session.pending_rotation.lock().unwrap() = false;
+    // `Done`, not a status derived from the outcome, and the distinction is the
+    // one the checklist is for. `persist` never fails as a whole — it writes each
+    // store independently and reports which ones took — so the *step* completed
+    // whatever the flags say. An `Error` row here would also contradict the screen
+    // it appears on: this returns `Ok`, the done screen renders, and it names any
+    // store that did not take in a sentence of its own. A red row above a
+    // successful screen tells the user two different things at once, and the one
+    // that is wrong is the one with no detail attached.
+    emit_local(provision::StepStatus::Done);
+
+    clear_pending_rotation(&session);
     // A rotation is also the answer to "your password was changed elsewhere".
     *session.stale_password.lock().unwrap() = false;
 
@@ -1517,6 +1746,7 @@ async fn rotate_demo_password(
     session: &SetupSession,
     locale: Locale,
     progress: impl Fn(provision::StepEvent),
+    refresh_dashboard: impl FnOnce(&str) -> bool,
 ) -> Result<RotateOutcome, RotateError> {
     // Resolved the same way every other demo screen resolves it, so this path
     // shares the no-keychain guarantee rather than restating it.
@@ -1534,23 +1764,34 @@ async fn rotate_demo_password(
     provision::rotate_secret(&DryRunBackend, worker_url, new_password, progress)
         .await
         .map_err(|e| {
-            log::warn!("demo password rotation failed: {e}");
+            log::warn!("demo password rotation failed: {}", for_log(&e));
             rotation_failure(e, locale)
         })?;
 
-    *session.pending_rotation.lock().unwrap() = false;
+    clear_pending_rotation(session);
     *session.stale_password.lock().unwrap() = false;
 
-    // No `rotate::persist`. Its first act is `secure_store::save_setup`, and a
-    // demo run must not write a demo password into the user's real keychain —
-    // nor a plaintext demo credential into their real CLI config. The demo brain
-    // is now answering to the new password, and `dashboard_credentials` asks it
-    // rather than remembering, so demo mode is genuinely on the new password
-    // from here without anything having been stored.
+    // No `rotate::persist`. Its first act is a secure-storage write, and a demo
+    // run must not put a demo password into the user's real keychain — nor a
+    // plaintext demo credential into their real CLI config. The demo brain is now
+    // answering to the new password, and `dashboard_credentials` asks it rather
+    // than remembering, so demo mode is genuinely on the new password from here
+    // without anything having been stored.
+    //
+    // The dashboard is the exception, and it is called rather than assumed. An
+    // open wrapper window holds the token it was created with in `localStorage`,
+    // which is true of the demo window exactly as it is of a real one — and it is
+    // the single behaviour the whole dry-run-fidelity argument exists to make
+    // demonstrable, since it is the one place a rotation can leave something
+    // visibly stale. Hard-coding `dashboard: true` here skipped it, so a demo
+    // rotation left the dashboard window 401ing against the demo brain and the
+    // done screen said it had not.
+    let dashboard = refresh_dashboard(new_password);
+
     Ok(RotateOutcome {
         keychain: true,
         cli_config: None,
-        dashboard: true,
+        dashboard,
     })
 }
 
@@ -1941,14 +2182,86 @@ pub fn open_settings_window(app: AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::{
-        blocked_by_migration, cloudflare_client_for_brain, dashboard_credentials,
-        normalize_worker_url, previous_index_for, rotate_demo_password, rotation_failure,
-        RotateError, SetupSession,
+        app_mode, blocked_by_migration, clear_pending_rotation, cloudflare_client_for_brain,
+        confirm_target_is_a_brain, dashboard_credentials, for_log, normalize_worker_url,
+        previous_index_for, rotate_demo_password, rotation_address, rotation_block,
+        rotation_failure, rotation_target, RotateError, SetupSession, LOG_DETAIL_MAX,
     };
     use crate::cf::oauth::Tokens;
     use crate::cf::provision::{ProvisionError, ProvisionOutcome};
     use crate::cf::types::{Account, CfApiError};
     use crate::i18n::{self, Key, Locale};
+
+    /// The body of a top-level `fn`, read from the source *above* the test module.
+    ///
+    /// Both halves of that sentence are load-bearing, and both were learned by
+    /// this repo the expensive way. Reading only the code means a guard can never
+    /// be satisfied by the assertion text written to describe it — that has
+    /// silently disabled four guards here so far, including one that passed with
+    /// the thing it was guarding deleted. And every anchor is `expect`ed rather
+    /// than defaulted to "the rest of the file": a scan that fails open finds
+    /// whatever it is looking for and reports success.
+    fn fn_body<'a>(src: &'a str, signature: &str) -> &'a str {
+        let code = &src[..src
+            .find("\n#[cfg(test)]\nmod tests {")
+            .expect("the test module is the boundary of the scannable source")];
+        let start = code
+            .find(signature)
+            .unwrap_or_else(|| panic!("`{signature}` is not in this file any more"));
+        let body = &code[start..];
+        let end = body
+            .find("\n}\n")
+            .unwrap_or_else(|| panic!("`{signature}` has no closing brace in column zero"));
+        &body[..end]
+    }
+
+    /// Where `needle` appears in `body`, or a failure naming what was being
+    /// looked for. Never `unwrap_or(0)`: a missing anchor that sorts first
+    /// satisfies every ordering assertion made about it.
+    fn at(body: &str, needle: &str) -> usize {
+        body.find(needle)
+            .unwrap_or_else(|| panic!("`{needle}` is gone from the function this test guards"))
+    }
+
+    /// How many keychain reads `run` performed, or `None` when another test
+    /// reset the counter mid-sample and the answer is unknowable.
+    ///
+    /// The counter is process-global and the suite runs in parallel, so a single
+    /// sample can pick up someone else's access — or, if they reset in between,
+    /// go backwards. The old form of this subtracted regardless, which underflows
+    /// on a decrease (a panic in debug) and, with `saturating_sub`, reports the
+    /// false zero that would make this whole check pass while the bug was live.
+    fn keychain_reads_during(run: impl FnOnce()) -> Option<usize> {
+        let before = crate::secure_store::probe::reads();
+        run();
+        let after = crate::secure_store::probe::reads();
+        after.checked_sub(before)
+    }
+
+    /// Asserts `run` never touches the keychain, sampling to survive the suite.
+    ///
+    /// A sample that caught another test's read proves nothing either way — but a
+    /// path that reads the keychain contaminates *every* sample, so one clean
+    /// sample is the proof and repeated dirty ones are the failure.
+    fn assert_never_reads_the_keychain(what: &str, mut run: impl FnMut()) {
+        // Reset once, outside the sampling loop: the counter is a `usize` that
+        // nothing else zeroes, and every reader here tolerates a decrease.
+        crate::secure_store::probe::reset();
+        let mut dirty = Vec::new();
+        let mut inconclusive = 0;
+        for _ in 0..8 {
+            match keychain_reads_during(&mut run) {
+                Some(0) => return,
+                Some(n) => dirty.push(n),
+                None => inconclusive += 1,
+            }
+        }
+        panic!(
+            "no sample of {what} came back clean (reads: {dirty:?}, {inconclusive} \
+             inconclusive) — a keychain read here is the OS password prompt users \
+             see, raised before the setup UI's first paint"
+        );
+    }
 
     #[test]
     fn normalizes_pasted_addresses() {
@@ -2031,42 +2344,34 @@ mod tests {
     /// countable, so this counts.
     #[test]
     fn demo_mode_never_reads_the_keychain() {
+        // A brain of its own. The token assertion below is about what a demo
+        // session is handed, not about what some other test happened to leave the
+        // process-wide brain answering to.
+        let _brain = crate::demo_brain::scoped_brain();
         let session = SetupSession::new(true);
         *session.outcome.lock().unwrap() = Some(ProvisionOutcome {
             worker_url: "https://second-brain.demo.workers.dev".into(),
             mcp_url: "https://second-brain.demo.workers.dev/mcp".into(),
         });
 
-        crate::secure_store::probe::reset();
+        assert_never_reads_the_keychain("dashboard_credentials in demo mode", || {
+            let _ = dashboard_credentials(&session, Locale::En);
+        });
         let (url, token) = dashboard_credentials(&session, Locale::En).expect("demo credentials");
-        assert_eq!(
-            crate::secure_store::probe::reads(),
-            0,
-            "dashboard_credentials touched the keychain in demo mode — that is the \
-             prompt users see when they open the settings window"
-        );
         assert!(url.starts_with("http://127.0.0.1:"), "demo must use the local brain: {url}");
         assert_eq!(token, "demo");
 
         // The outstanding-index note is the other path that reached the keychain.
-        crate::secure_store::probe::reset();
-        let _ = previous_index_for(&session);
-        assert_eq!(
-            crate::secure_store::probe::reads(),
-            0,
-            "the outstanding-index note was read from the keychain in demo mode"
-        );
+        assert_never_reads_the_keychain("the outstanding-index note in demo mode", || {
+            let _ = previous_index_for(&session);
+        });
 
         // And with no session outcome either: the fallback is exactly where the
         // keychain read used to hide.
         let fresh = SetupSession::new(true);
-        crate::secure_store::probe::reset();
-        let _ = dashboard_credentials(&fresh, Locale::En);
-        assert_eq!(
-            crate::secure_store::probe::reads(),
-            0,
-            "an unconnected demo session fell back to the keychain"
-        );
+        assert_never_reads_the_keychain("an unconnected demo session", || {
+            let _ = dashboard_credentials(&fresh, Locale::En);
+        });
     }
 
     // ── Changing the password (#235) ─────────────────────────────────────────
@@ -2085,26 +2390,15 @@ mod tests {
         assert_eq!(
             rotation_failure(ProvisionError::HealthCheckFailed, Locale::En).stage,
             "unconfirmed",
-            "the only error raised after the secret was accepted"
-        );
-        assert_eq!(
-            rotation_failure(
-                ProvisionError::Api(CfApiError::Unauthorized),
-                Locale::En
-            )
-            .stage,
-            "notSent",
-            "an expired Cloudflare sign-in never reached the brain"
+            "the secret was accepted and only the confirmation ran out of attempts"
         );
         assert_eq!(
             rotation_failure(ProvisionError::NotAWorkersDevAddress, Locale::En).stage,
             "notSent",
-            "refused by the #257 guard before the write"
+            "refused by the #257 guard before the write — the script name is derived \
+             from the address before anything is emitted or sent"
         );
-        assert_eq!(
-            rotation_failure(ProvisionError::CaptureFailed, Locale::En).stage,
-            "notSent",
-        );
+        assert_eq!(rotation_block(Locale::En).stage, "blocked");
         assert_eq!(RotateError::local(String::new()).stage, "local");
 
         // Distinct strings, checked as a set: two stages that happen to be spelled
@@ -2113,12 +2407,173 @@ mod tests {
         let stages = [
             RotateError::not_sent(String::new()).stage,
             RotateError::unconfirmed(String::new()).stage,
+            RotateError::blocked(String::new()).stage,
             RotateError::local(String::new()).stage,
         ];
         let mut unique = stages.to_vec();
         unique.sort_unstable();
         unique.dedup();
-        assert_eq!(unique.len(), 3, "two stages collapsed into one: {stages:?}");
+        assert_eq!(unique.len(), 4, "two stages collapsed into one: {stages:?}");
+    }
+
+    /// Nothing raised from `put_secret` onwards may claim the old password still
+    /// works.
+    ///
+    /// `notSent`'s screen states, in as many words, that the old password still
+    /// works and everything is exactly as it was. That is a positive claim about
+    /// *remote* state, and there are only two errors this app can make it from:
+    /// one it raised itself before sending anything, and one Cloudflare raised
+    /// before the secrets handler ran. Everything else out of `rotate_secret`
+    /// comes from a request that was already in flight.
+    ///
+    /// The `_` arm that used to sit at the bottom of `rotation_failure` sent
+    /// `Network` and `Http` to `notSent`. `send_impl` returns `Network` only after
+    /// exhausting its retries — which includes a PUT that reached Cloudflare and
+    /// whose *response* was lost — and `Http` is an unparseable body that can
+    /// arrive with any status. Both were being reported as "nothing happened" over
+    /// a brain whose password may have already moved, and a user who believes that
+    /// closes the window without saving the password they now need.
+    #[test]
+    fn a_failure_after_the_put_never_claims_the_old_password_still_works() {
+        // `reqwest::Error` has no public constructor, so a request that cannot
+        // even be built stands in for the one `send_impl` returns after every
+        // attempt died on the wire — the case where the PUT may have been applied
+        // on any of them and only the response was lost.
+        let on_the_wire = CfApiError::Network(
+            reqwest::Client::new()
+                .get("http://[not a host]/")
+                .build()
+                .expect_err("an unparseable URL cannot be built into a request"),
+        );
+
+        let after_the_put = [
+            ProvisionError::Api(on_the_wire),
+            ProvisionError::Api(CfApiError::Http {
+                status: 200,
+                body: "[unparseable response] <html>…".into(),
+            }),
+            ProvisionError::Api(CfApiError::Api {
+                code: 10021,
+                message: "workers.api.error".into(),
+            }),
+            ProvisionError::Api(CfApiError::Other("Cloudflare returned no result".into())),
+            // The one that looks safe and is not. A 401 is decided before the
+            // secrets handler runs, so *that attempt* wrote nothing — but
+            // `send_impl` retries, and a first attempt that died on the wire with
+            // the PUT already applied, followed by a retry that 401s on a token
+            // that expired in between, arrives here over a brain that has moved.
+            ProvisionError::Api(CfApiError::Unauthorized),
+            ProvisionError::HealthCheckFailed,
+            // Unreachable from `rotate_secret`, and classified so that becoming
+            // reachable fails towards the claim that cannot lock anyone out.
+            ProvisionError::CaptureFailed,
+            ProvisionError::SubdomainUnavailable,
+        ];
+        for error in after_the_put {
+            let described = error.to_string();
+            assert_eq!(
+                rotation_failure(error, Locale::En).stage,
+                "unconfirmed",
+                "`{described}` was reported as notSent, whose screen tells the user \
+                 their old password still works — which this app cannot know"
+            );
+        }
+    }
+
+    /// A rebuild in flight is refused on purpose, and gets a screen that says so.
+    ///
+    /// As `notSent` it arrived as "Nothing was changed" over a "Try again" button,
+    /// with the real reason — and the only instruction that works — in the detail
+    /// slot underneath. Retrying fails identically, and an abandoned ledger blocks
+    /// rotation forever, so that screen offered a user in a permanent state a
+    /// button that could never get them out of it.
+    #[test]
+    fn a_deliberate_refusal_is_not_dressed_up_as_nothing_having_happened() {
+        let blocked = rotation_block(Locale::En);
+        assert_eq!(blocked.stage, "blocked");
+        assert_ne!(
+            blocked.stage,
+            RotateError::not_sent(String::new()).stage,
+            "a block is not a failure to send: the retry the notSent screen offers \
+             fails the same way, and an abandoned ledger never stops blocking"
+        );
+        assert_eq!(blocked.detail, i18n::t(Locale::En, Key::ErrorRotateBlocked));
+        assert_ne!(
+            rotation_block(Locale::It).detail,
+            blocked.detail,
+            "the detail must follow the app's locale"
+        );
+    }
+
+    /// The wire shape the failure screens read, pinned by name.
+    ///
+    /// `#[serde(rename_all = "camelCase")]` is one line and deleting it compiles.
+    /// Both fields here happen to be single words, so the rename is invisible
+    /// today — which is exactly why it is worth pinning before a third field
+    /// arrives and the front end starts reading `undefined` for it.
+    #[test]
+    fn the_failure_reaches_the_screen_under_the_names_it_reads() {
+        assert_eq!(
+            serde_json::to_value(RotateError::unconfirmed("nope".into()))
+                .expect("RotateError serializes"),
+            serde_json::json!({ "stage": "unconfirmed", "detail": "nope" })
+        );
+
+        // …and the attribute itself, which the assertion above genuinely cannot
+        // see. `stage` and `detail` are single lowercase words, so the rename is a
+        // no-op *today*: deleting it changes no byte of the JSON and no test can
+        // notice. The next field added will not be so lucky — `RotateOutcome`
+        // already carries `cli_config`/`cliConfig` — and the way that failure
+        // presents is a screen quietly rendering `undefined`, which nothing here
+        // would catch either. So the attribute is pinned, not inferred.
+        let src = include_str!("commands.rs");
+        let code = &src[..src
+            .find("\n#[cfg(test)]\nmod tests {")
+            .expect("the test module is the boundary of the scannable source")];
+        let decl = code
+            .find("pub struct RotateError {")
+            .expect("RotateError is declared above the tests");
+        let attrs = &code[code[..decl]
+            .rfind("#[derive(")
+            .expect("RotateError still derives its traits")..decl];
+        assert!(
+            attrs.contains(r#"rename_all = "camelCase""#),
+            "RotateError no longer renames its fields. Harmless while every field \
+             is one word, and a field the front end reads as `undefined` the moment \
+             one is not — with nothing on either side of the bridge to say so."
+        );
+    }
+
+    /// A rotation failure is the moment a user is likeliest to be asked for their
+    /// log, and `CfApiError::Http` carries up to 600 characters of whatever
+    /// Cloudflare returned when the body would not parse. One failure used to put
+    /// most of an edge error page into the log — unreadable, and more than anyone
+    /// meant to share.
+    #[test]
+    fn a_logged_failure_is_bounded_and_says_when_it_was_cut() {
+        let short = "Cloudflare sign-in expired";
+        assert_eq!(for_log(short), short, "a short detail is left alone");
+
+        let long = "x".repeat(600);
+        let logged = for_log(&long);
+        assert!(
+            logged.chars().count() < long.chars().count(),
+            "a 600-character response body reached the log intact"
+        );
+        assert!(
+            logged.starts_with(&"x".repeat(LOG_DETAIL_MAX)),
+            "the kept part must be the beginning, where the useful diagnostic is"
+        );
+        assert!(
+            logged.contains("+440 more"),
+            "a truncated line that does not say it was truncated reads as the whole \
+             story: {logged}"
+        );
+
+        // Cut on a character boundary, not a byte one — Cloudflare's messages are
+        // UTF-8 and slicing one in half panics.
+        let multibyte = "é".repeat(600);
+        assert!(for_log(&multibyte).starts_with(&"é".repeat(LOG_DETAIL_MAX)));
     }
 
     /// The detail is what the front end drops into "What went wrong: …", so it
@@ -2207,37 +2662,49 @@ mod tests {
 
     /// Every in-memory mode is decided before secure storage is consulted.
     ///
-    /// `get_app_state` takes a Tauri `State`, which cannot be built in a unit
-    /// test, so this reads the source — but the rule it protects is not a style
-    /// preference. `&&`/`else if` are short-circuiting, and each of these
-    /// branches returns without falling through, so a mode moved below the
-    /// `load_setup()` branch performs a keychain read on the way past. That read
-    /// raises an OS password prompt on an unsigned dev build, before the setup
-    /// UI's first paint, which is #252 — and demo mode, which must never see one,
+    /// The rule this protects is not a style preference. `&&` and `else if` are
+    /// short-circuiting, so a term evaluated before `load_setup()` is a term that
+    /// costs no keychain read, and one evaluated after it is a term that costs an
+    /// OS password prompt on an unsigned dev build — raised before the setup UI's
+    /// first paint. That is #252, and demo mode, which must never see a prompt,
     /// reaches this function on every launch.
     ///
-    /// Scans only the function body, so the names written in this test cannot
-    /// satisfy it.
+    /// The previous version of this test ordered three flag *names* against
+    /// `load_setup` in the source, and never constrained the `dry_run` term at
+    /// all — so rewriting `!session.dry_run && load_setup().is_some()` as
+    /// `load_setup().is_some() && !session.dry_run` passed it while reintroducing
+    /// the exact bug the last release fixed. `app_mode` was split out of the
+    /// command so the counter can answer instead of a substring search: the
+    /// prompt is an OS dialog no test can see, but the read that causes it is
+    /// countable.
     #[test]
     fn every_in_memory_mode_is_decided_before_the_keychain_is_touched() {
-        let src = include_str!("commands.rs");
-        let start = src.find("pub fn get_app_state").expect("the command");
-        let body = &src[start..];
-        let body = &body[..body.find("\n}").expect("end of fn")];
+        // The plain demo launch: no flags, nothing stored, and the `dry_run` term
+        // is the only thing standing between it and the keychain.
+        let demo = SetupSession::new(true);
+        assert_never_reads_the_keychain("a demo launch deciding its mode", || {
+            assert_eq!(app_mode(&demo), "setup");
+        });
 
-        let keychain = body
-            .find("secure_store::load_setup")
-            .expect("get_app_state still reads the keychain somewhere");
-        for flag in ["pending_rotation", "stale_password", "pending_worker_update"] {
-            let at = body
-                .find(flag)
-                .unwrap_or_else(|| panic!("{flag} is not consulted at all"));
-            assert!(
-                at < keychain,
-                "{flag} is checked after the keychain read, so reaching that mode \
-                 costs an OS password prompt — and in demo mode there is nothing \
-                 in the keychain to have prompted for"
-            );
+        // And each in-memory mode, on a *real* session, where the flag is the only
+        // thing standing between it and the keychain. A mode moved below the
+        // `load_setup()` branch still returns the right string — it just charges
+        // the user a password prompt to get there, which no assertion on the
+        // returned mode can see.
+        fn flag_of<'a>(session: &'a SetupSession, mode: &str) -> &'a std::sync::Mutex<bool> {
+            match mode {
+                "change-password" => &session.pending_rotation,
+                "stale-password" => &session.stale_password,
+                "worker-update" => &session.pending_worker_update,
+                other => panic!("no in-memory flag selects {other}"),
+            }
+        }
+        for mode in ["change-password", "stale-password", "worker-update"] {
+            let live = SetupSession::new(false);
+            *flag_of(&live, mode).lock().unwrap() = true;
+            assert_never_reads_the_keychain(mode, || {
+                assert_eq!(app_mode(&live), mode);
+            });
         }
     }
 
@@ -2248,16 +2715,20 @@ mod tests {
     /// build, a source scan cannot express "not inside the dry-run branch", and a
     /// guard written that way passed while the bug was reintroduced.
     ///
-    /// The password is [`DEFAULT_TOKEN`] on purpose. The demo brain is
-    /// process-wide and outlives this test, so rotating it to anything else would
-    /// start 401ing whatever else in the suite is mid-request against it — the
-    /// reasoning `demo_brain`'s own rotation test sets out. Rotating it to the
-    /// token every other caller already sends changes nothing for them while
-    /// still driving the whole path: the secret write is recorded, the demo brain
-    /// takes the password, and `rotate_secret`'s health gate has to get a real
-    /// 200 back from it before this returns.
+    /// The brain is scoped to this test, which is what lets the password be a
+    /// real one. The process-wide demo brain outlives every test, so rotating
+    /// *that* to anything other than the token everyone else sends starts 401ing
+    /// whatever is mid-request against it — measured at 10 failures in 15 runs at
+    /// `RUST_TEST_THREADS=64`. Rotating it to `DEFAULT_TOKEN` was the way round
+    /// that, and it cost the assertion that matters most: a rotation that flipped
+    /// nothing looked identical to one that worked. With a brain of its own this
+    /// can set a password no other test has ever sent and then insist the brain is
+    /// holding it.
     #[tokio::test]
     async fn a_demo_rotation_runs_the_real_path_and_never_reads_the_keychain() {
+        let _brain = crate::demo_brain::scoped_brain();
+        const NEW: &str = "a-password-only-this-test-sets";
+
         let session = SetupSession::new(true);
         *session.pending_rotation.lock().unwrap() = true;
 
@@ -2267,30 +2738,44 @@ mod tests {
         // sample that caught someone else proves nothing either way — but a path
         // that reads the keychain contaminates *every* sample, so one clean
         // sample is the proof and repeated dirty ones are the failure.
+        //
+        // `checked_sub`, because another test resetting the counter mid-sample
+        // makes `after` smaller than `before`: the plain subtraction underflowed
+        // and panicked, and a saturating one would have reported the false zero
+        // that passes this test no matter what the code does.
+        crate::secure_store::probe::reset();
+        let refreshed_with = std::sync::Mutex::new(Vec::new());
         let mut outcome = None;
         let mut dirty = Vec::new();
+        let mut inconclusive = 0;
         for _ in 0..8 {
             let before = crate::secure_store::probe::reads();
             let attempt = rotate_demo_password(
-                crate::demo_brain::DEFAULT_TOKEN,
+                NEW,
                 &session,
                 Locale::En,
                 |_| {},
+                |token| {
+                    refreshed_with.lock().unwrap().push(token.to_string());
+                    true
+                },
             )
             .await
             .expect("the demo brain must accept the password the demo just set");
-            let reads = crate::secure_store::probe::reads() - before;
-            if reads == 0 {
-                outcome = Some(attempt);
-                break;
+            match crate::secure_store::probe::reads().checked_sub(before) {
+                Some(0) => {
+                    outcome = Some(attempt);
+                    break;
+                }
+                Some(n) => dirty.push(n),
+                None => inconclusive += 1,
             }
-            dirty.push(reads);
         }
         let outcome = outcome.unwrap_or_else(|| {
             panic!(
-                "every sample of a demo rotation touched the keychain ({dirty:?}) — \
-                 that is the OS password prompt users see, and a demo password has \
-                 no business in a real keychain"
+                "no sample of a demo rotation came back clean (reads: {dirty:?}, \
+                 {inconclusive} inconclusive) — that is the OS password prompt users \
+                 see, and a demo password has no business in a real keychain"
             )
         });
 
@@ -2302,17 +2787,405 @@ mod tests {
         );
         assert_eq!(
             crate::demo_brain::auth_token(),
+            NEW,
+            "the demo brain is still on the password it started with, so the \
+             rotation reported a change that did not happen — which is the one \
+             thing a demo of a password change has to get right"
+        );
+        assert_ne!(
+            NEW,
             crate::demo_brain::DEFAULT_TOKEN,
-            "the demo brain must be holding the password the rotation set"
+            "the assertion above is only worth making about a password no other \
+             caller in this suite already sends"
         );
         assert!(outcome.keychain);
         assert_eq!(
             outcome.cli_config, None,
             "a demo run must not write a plaintext credential file"
         );
+        // The dashboard is the one store a demo rotation genuinely has to touch,
+        // and it used to be hard-coded to `true` without anything being called.
+        // An open wrapper window keeps the token it was created with, in demo mode
+        // exactly as in a real one — so skipping it left the demo window 401ing
+        // against the demo brain while the done screen said it was fine, which is
+        // the single behaviour the dry-run-fidelity argument exists to demonstrate.
+        assert_eq!(
+            refreshed_with.lock().unwrap().last().map(String::as_str),
+            Some(NEW),
+            "the open dashboard window was never handed the new password"
+        );
+        assert!(outcome.dashboard, "…and the result is reported, not assumed");
         assert!(
             !*session.pending_rotation.lock().unwrap(),
             "a finished rotation must leave the flow"
+        );
+    }
+
+    /// A refused refresh is reported as refused, in demo mode too. The `true` that
+    /// used to be written here was a constant, so nothing could have told the
+    /// difference.
+    #[tokio::test]
+    async fn a_demo_rotation_reports_a_dashboard_it_could_not_reach() {
+        let _brain = crate::demo_brain::scoped_brain();
+        let session = SetupSession::new(true);
+        let outcome = rotate_demo_password(
+            "another-password-only-this-test-sets",
+            &session,
+            Locale::En,
+            |_| {},
+            |_| false,
+        )
+        .await
+        .expect("the demo brain must accept the password the demo just set");
+        assert!(!outcome.dashboard);
+    }
+
+    // ── The doors, the guards, and the order they run in ─────────────────────
+
+    /// A rotation is the one operation that sends a password the user has never
+    /// used before, as a bearer token, to an address they just typed — and then
+    /// *stores* that address. `http://` there is not a dev convenience, it is a
+    /// password in cleartext on the wire and an origin that makes every later
+    /// request from the app and from the `brain` command cleartext as well.
+    /// `reqwest` performs no HSTS upgrade, so nothing downstream corrects it.
+    #[test]
+    fn a_typed_rotation_address_may_not_be_cleartext() {
+        for input in [
+            "http://second-brain.acme.workers.dev",
+            "HTTP://second-brain.acme.workers.dev",
+            "http://localhost:8787",
+            "http://second-brain.acme.workers.dev/mcp",
+        ] {
+            assert!(
+                rotation_address(input, Locale::En).is_err(),
+                "{input} was accepted, so the new password goes out unprotected and \
+                 an http:// origin is written to the keychain and the plaintext CLI \
+                 config for every request after it"
+            );
+        }
+
+        // …and the ordinary case still works, including the bare host the manual
+        // entry screen invites.
+        for input in [
+            "https://second-brain.acme.workers.dev",
+            "second-brain.acme.workers.dev",
+            "  second-brain.acme.workers.dev/mcp  ",
+        ] {
+            assert_eq!(
+                rotation_address(input, Locale::En).unwrap(),
+                "https://second-brain.acme.workers.dev",
+                "input: {input:?}"
+            );
+        }
+
+        // The general normaliser still keeps http for the dev setups that need it,
+        // so this refusal has to live on the rotation path and cannot be delegated.
+        assert_eq!(
+            normalize_worker_url("http://localhost:8787/mcp", Locale::En).unwrap(),
+            "http://localhost:8787"
+        );
+    }
+
+    /// The two doors resolve their address from different places, and the typed
+    /// one carries the cleartext refusal with it.
+    ///
+    /// Door A goes through `dashboard_credentials`, never `secure_store` directly
+    /// (#252), and comes back with the password this computer already holds —
+    /// which is what the migration check below needs and Door B does not have.
+    #[test]
+    fn each_door_resolves_the_brain_it_is_allowed_to_resolve() {
+        // Door A resolves through the demo brain, so this needs one whose password
+        // no other test can move underneath it.
+        let _brain = crate::demo_brain::scoped_brain();
+        let session = SetupSession::new(true);
+
+        // Door B: the address is typed, so there is no current password…
+        let (url, current) =
+            rotation_target(&session, Locale::En, Some("second-brain.acme.workers.dev".into()))
+                .expect("a typed https address resolves");
+        assert_eq!(url, "https://second-brain.acme.workers.dev");
+        assert_eq!(
+            current, None,
+            "someone who has lost their password has none to offer, which is why \
+             every check that needs one is skipped for this door rather than failed"
+        );
+
+        // …and cleartext is refused here too, not only in the screen's validator.
+        assert!(
+            rotation_target(&session, Locale::En, Some("http://second-brain.acme.workers.dev".into()))
+                .is_err()
+        );
+
+        // Door A: resolved from the session, with the password this computer holds.
+        let (url, current) =
+            rotation_target(&session, Locale::En, None).expect("a connected computer resolves");
+        assert_eq!(url, crate::demo_brain::base_url());
+        assert_eq!(current.as_deref(), Some("demo"));
+    }
+
+    /// The screen that checks an address must refuse exactly what the command
+    /// would refuse.
+    ///
+    /// One implementation, two callers, is the whole point of `validate_brain_address`
+    /// — a screen that waves something through only moves the refusal several
+    /// screens later, to the place where the user has already committed. Pointing
+    /// it back at `normalize_worker_url` compiles, passes every behavioural test
+    /// here, and quietly re-opens the cleartext door on the one path where the
+    /// address is typed by hand.
+    #[test]
+    fn the_address_screen_refuses_exactly_what_the_command_refuses() {
+        let src = include_str!("commands.rs");
+        let body = fn_body(src, "pub async fn validate_brain_address(");
+        assert!(
+            body.contains("rotation_address"),
+            "the screen's validator no longer shares the command's check"
+        );
+        assert!(
+            !body.contains("normalize_worker_url"),
+            "the screen normalises the address itself, so it accepts the `http://` \
+             the command would refuse — and reports the problem several screens \
+             after the one that could have prevented it"
+        );
+        assert!(
+            body.contains("confirm_target_is_a_brain"),
+            "…and it must still be the same brain check, not merely a URL parse"
+        );
+    }
+
+    /// Door B's address was typed or picked, so it is confirmed to be a brain from
+    /// Cloudflare's own record of the account before a secret is written to it.
+    ///
+    /// The Cloudflare account match cannot catch a typo that lands on a *different
+    /// Worker of the user's own* — that script is in the right account, so the only
+    /// thing left to check is what it is. Getting it wrong overwrites an unrelated
+    /// Worker's `AUTH_TOKEN` while telling the user their brain's password changed.
+    #[tokio::test]
+    async fn an_address_with_no_script_to_name_is_refused_before_any_secret_is_written() {
+        let session = SetupSession::new(true);
+
+        assert_eq!(
+            confirm_target_is_a_brain("https://brain.example.com", &session, Locale::En)
+                .await
+                .unwrap_err(),
+            i18n::t(Locale::En, Key::ErrorCustomDomain),
+            "a custom domain yields no script name, and #257 says the script name \
+             comes from the address or not at all"
+        );
+
+        // A real workers.dev address goes on to read the account's bindings.
+        confirm_target_is_a_brain("https://second-brain.demo.workers.dev", &session, Locale::En)
+            .await
+            .expect("the demo account's bindings look like a brain");
+    }
+
+    /// The order of `rotate_password`, which is the whole of its safety argument.
+    ///
+    /// Three mutations of this function compiled with all 208 tests passing:
+    /// deleting the Door B brain check, deleting the migration gate, and turning
+    /// the remote change's `?` into `.ok()` so the local writes ran even when the
+    /// remote change had failed. That last one is the outcome this module's own
+    /// doc calls unrecoverable — the brain keeps the old password, nothing on this
+    /// computer holds it, and the app has no way to ask for it back.
+    ///
+    /// Asserted on the source because the function takes an `AppHandle` and a
+    /// Tauri `State`, neither of which a unit test can construct, and because
+    /// reaching step 4 needs a live Cloudflare account. What each step *does* is
+    /// tested behaviourally elsewhere in this module; what nothing else can see is
+    /// that they are still wired together in this order.
+    #[test]
+    fn the_rotation_does_the_remote_change_first_and_only_persists_if_it_worked() {
+        let src = include_str!("commands.rs");
+        let body = fn_body(src, "pub async fn rotate_password(");
+
+        let door_b = at(body, "if door_b {");
+        let confirm = at(body, "confirm_target_is_a_brain");
+        let blocked = at(body, "blocked_by_migration");
+        let remote = at(body, "provision::rotate_secret");
+        let persist = at(body, "rotate::persist");
+
+        assert!(
+            door_b < confirm && confirm < remote,
+            "the Door B brain check must run, and must run before the secret is \
+             written — a typo that lands on another Worker of the user's own is in \
+             the right Cloudflare account and passes every other check"
+        );
+        assert!(
+            blocked < remote,
+            "the rebuild gate must refuse before the secret is written: a rotation \
+             caught half-way leaves the next batch 401ing and a recoverable password \
+             problem presenting as a failed migration"
+        );
+        assert!(
+            at(body, "return Err(rotation_block") < remote,
+            "the rebuild gate no longer returns — it computes a block and carries on"
+        );
+        assert!(
+            remote < persist,
+            "the local stores are written before the brain has taken the new \
+             password. Reversing this is the one failure #235 cannot recover from."
+        );
+
+        // The `?` itself. `.ok()` here compiles, keeps the ordering above intact,
+        // and runs every local write over a remote change that failed.
+        //
+        // Read as one statement, bounded by the blank line that ends it, rather
+        // than as everything between the call and `persist`: the local step's
+        // progress emit sits in that gap and discards its own result on purpose,
+        // which a looser scan reads as the remote failure being swallowed.
+        let call = {
+            let tail = &body[remote..];
+            &tail[..tail
+                .find("\n\n")
+                .expect("the remote change is one statement, ending in a blank line")]
+        };
+        assert!(
+            call.contains("})?;"),
+            "the remote change's failure is no longer propagated, so `persist` runs \
+             whether or not the brain took the new password"
+        );
+        for swallowed in [".ok()", ".unwrap_or", "let _ ="] {
+            assert!(
+                !call.contains(swallowed),
+                "the remote change's failure is discarded with `{swallowed}`"
+            );
+        }
+    }
+
+    /// The checklist's third row is reported by this command or by nobody.
+    ///
+    /// `rotate_secret` emits `Secret` and `Confirm` itself; `Local` cannot live
+    /// there, because nothing local may be written until that function has
+    /// returned. So the emit sits here, and an emit that only one caller can make
+    /// is an emit that goes missing quietly: the row renders as a static bullet
+    /// for the whole run, on the screen whose entire job is to show the user which
+    /// part of a password change they are waiting on.
+    ///
+    /// `Step::Local` no longer carries an `#[allow(dead_code)]`, so deleting the
+    /// emit is also a warning — this pins the ordering, which the compiler cannot
+    /// see.
+    #[test]
+    fn the_local_writes_report_themselves_to_the_checklist() {
+        let src = include_str!("commands.rs");
+        let body = fn_body(src, "pub async fn rotate_password(");
+
+        assert!(
+            at(body, "provision::Step::Local") < at(body, "rotate::persist"),
+            "the local step is declared after the writes it is meant to announce"
+        );
+        let running = at(body, "emit_local(provision::StepStatus::Running)");
+        let persist = at(body, "rotate::persist");
+        let done = at(body, "emit_local(provision::StepStatus::Done)");
+        assert!(
+            running < persist && persist < done,
+            "the row has to go Running *before* the writes and Done *after* them, \
+             or it reports a step the user has already sat through"
+        );
+
+        // The same channel as every other step. A different event name drops the
+        // row silently — the window is listening on one name and nothing errors.
+        assert!(
+            body[..running].contains(r#"app.emit(
+            "setup-progress","#),
+            "the local step is emitted on a channel the rotation screen is not \
+             listening to"
+        );
+
+        // And the one hard failure ends in `Error` rather than an unreported
+        // early return: `persist` cannot run at all without a home directory.
+        let hard_failure = at(body, "dirs::home_dir()");
+        assert!(
+            body[hard_failure..persist].contains("emit_local(provision::StepStatus::Error)"),
+            "a rotation that cannot write anything locally leaves the row spinning \
+             forever while the failure screen renders behind it"
+        );
+    }
+
+    /// `persist` takes its secure-storage write as a seam, so that one line in
+    /// `rotate_password` is the entire connection between a password change and
+    /// the store the app reads at every launch.
+    ///
+    /// The seam is what makes `persist`'s own failure branch reachable — the test
+    /// backend cannot fail — and what stops its tests writing the process-global
+    /// map that `secure_store`'s end-to-end test asserts on. The cost is this one
+    /// wire, which nothing else can see.
+    #[test]
+    fn the_rotation_hands_persist_the_real_secure_store() {
+        let src = include_str!("commands.rs");
+        let body = fn_body(src, "pub async fn rotate_password(");
+        let persist = at(body, "rotate::persist");
+        let call = &body[persist..];
+        assert!(
+            call.contains("secure_store::save_setup"),
+            "`persist` is no longer given the real store, so `keychain: true` would \
+             tell the user their computer holds a password it does not have"
+        );
+        // Searched in the tail after `persist`, not in the whole body: the
+        // dry-run branch at the top of this function refreshes a window too, and
+        // an unanchored search would find that one and prove nothing about this
+        // call.
+        assert!(
+            call.contains("windows::refresh_wrapper_token"),
+            "…and the open dashboard window is no longer told either"
+        );
+    }
+
+    /// Abandoning a password change leaves the flow.
+    ///
+    /// `pending_rotation` was cleared only on success and on logout, and
+    /// `app_mode` consults it before everything else — so "Not now" left it set,
+    /// and the next "Update your Second Brain" opened the *password-change* screen
+    /// instead of the update. Nothing short of restarting the app put it right.
+    #[test]
+    fn walking_away_from_a_password_change_does_not_wedge_the_next_flow() {
+        let session = SetupSession::new(true);
+        *session.pending_rotation.lock().unwrap() = true;
+        assert_eq!(app_mode(&session), "change-password");
+
+        clear_pending_rotation(&session);
+        assert_eq!(
+            app_mode(&session),
+            "setup",
+            "the abandoned flow still owns the window"
+        );
+
+        // …and the exit the front end actually takes is wired to it. "Not now"
+        // opens the dashboard, which closes the setup window on the next line —
+        // `open_dashboard_impl` needs an `AppHandle`, so the wiring is what is
+        // checkable here and the clearing itself is asserted above.
+        let src = include_str!("commands.rs");
+        let body = fn_body(src, "pub fn open_dashboard_impl(");
+        assert!(
+            at(body, "clear_pending_rotation") < at(body, "close_setup_windows"),
+            "leaving for the dashboard must drop the password-change flow before the \
+             window that was running it is closed"
+        );
+    }
+
+    /// Fixing a stale password has to *fix* it.
+    ///
+    /// `stale_password` is set at launch when the brain refuses the password this
+    /// computer holds, and `connect_existing` is the screen's first offer — enter
+    /// the new one. Nothing cleared the flag, so after a successful reconnection
+    /// `app_mode` still returned `"stale-password"` and the next
+    /// `begin_worker_update` told the user again that their password had been
+    /// changed elsewhere, about a password that now works.
+    ///
+    /// Source-scanned because `connect_existing` takes an `AppHandle` and probes a
+    /// live Worker; what is checkable is that the clear happens on the success
+    /// path — after the probe and the store write, not before them.
+    #[test]
+    fn a_reconnection_clears_the_password_changed_elsewhere_flag() {
+        let src = include_str!("commands.rs");
+        let body = fn_body(src, "pub async fn connect_existing(");
+        let cleared = at(body, "stale_password");
+        assert!(
+            at(body, "probe_worker") < cleared && at(body, "secure_store::save_setup") < cleared,
+            "the flag is cleared before the new password has been shown to work, so \
+             a wrong one would silently dismiss the screen that was asking for it"
+        );
+        assert!(
+            cleared < at(body, "*session.outcome.lock()"),
+            "the flag must be cleared on the way out of the success path"
         );
     }
 
@@ -2404,6 +3277,7 @@ mod tests {
 
     #[test]
     fn dashboard_credentials_dry_run_uses_the_local_demo_brain() {
+        let _brain = crate::demo_brain::scoped_brain();
         let session = SetupSession::new(true);
         *session.outcome.lock().unwrap() = Some(ProvisionOutcome {
             worker_url: "https://second-brain.demo.workers.dev".into(),

--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -1539,7 +1539,13 @@ pub async fn recheck_password(
         let session = app.state::<SetupSession>();
         rotation_target(&session, locale, address)?.0
     };
-    match crate::cf::api::worker_health_ok(&worker_url, password.trim()).await {
+    // `worker_auth_ok`, not `worker_health_ok`, for the same reason the rotation
+    // gate uses it: `/health` reports `ok` as the *vector index's* health, and
+    // this screen is asking one question only — does the brain let this password
+    // in? A brain whose index is degraded would answer "no" about a password that
+    // is live and is now the only one that opens it. That is the worst answer
+    // this button can give, on the one screen that exists to end the doubt.
+    match crate::cf::api::worker_auth_ok(&worker_url, password.trim()).await {
         Ok(ok) => Ok(ok),
         Err(CfApiError::Unauthorized) => Ok(false),
         Err(e) => {

--- a/installer/src-tauri/src/demo_brain.rs
+++ b/installer/src-tauri/src/demo_brain.rs
@@ -55,6 +55,18 @@ const BATCH_PAUSE: Duration = Duration::from_millis(250);
 /// otherwise unreachable in a demo.
 const STALL_ENV: &str = "SECOND_BRAIN_DEMO_STALL_AFTER";
 
+/// Set to an attempt count to make a rotated password take that many refusals
+/// before it works, the way a Cloudflare secret takes time to propagate.
+///
+/// A demo brain that switches instantly never exercises the health gate's retry
+/// loop, and that loop is the one thing rotation does differently from
+/// `update_worker`: there a 401 during the health poll is terminal, here it
+/// means "not landed yet, keep asking". A brain that lands the new password on
+/// the first request would pass either implementation, so the difference the
+/// gate exists for would go untested. Off by default, because every other demo
+/// flow wants the rotation over with.
+const ROTATE_ENV: &str = "SECOND_BRAIN_DEMO_ROTATE_AFTER";
+
 /// Shipped in `src/config.ts` DEFAULTS. Both must be values the pickers offer,
 /// or the settings window shows a model that is not in its own dropdown and the
 /// migration pane cannot read the current dimensions — asserted in tests.
@@ -65,6 +77,11 @@ const DEMO_EMBEDDING_MODEL: &str = "@cf/baai/bge-small-en-v1.5";
 /// the app reports "Couldn't reach your Second Brain" — the truth — rather than
 /// hanging.
 const UNREACHABLE: &str = "http://127.0.0.1:1";
+
+/// What demo mode hands the windows as the brain's password until a rotation
+/// sets another one. Only a default: an unrotated brain accepts anything
+/// non-empty, so nothing breaks if a caller uses a different string.
+pub const DEFAULT_TOKEN: &str = "demo";
 
 const THREADS: usize = 3;
 
@@ -79,6 +96,9 @@ pub struct Options {
     pub batch_pause: Duration,
     /// Pause the rebuild once, after this many batches.
     pub stall_after: Option<u64>,
+    /// Refuse a newly rotated password this many times before honouring it, so
+    /// the health gate's retry loop has something to retry through.
+    pub rotate_after: Option<u64>,
 }
 
 impl Default for Options {
@@ -89,6 +109,7 @@ impl Default for Options {
             batch_entries: BATCH_ENTRIES,
             batch_pause: BATCH_PAUSE,
             stall_after: parse_stall_after(std::env::var(STALL_ENV).ok().as_deref()),
+            rotate_after: parse_rotate_after(std::env::var(ROTATE_ENV).ok().as_deref()),
         }
     }
 }
@@ -96,9 +117,22 @@ impl Default for Options {
 /// Split out from the env read so it can be tested without `set_var`, which
 /// races every other test in the process.
 fn parse_stall_after(raw: Option<&str>) -> Option<u64> {
-    let n = raw?.trim().parse::<u64>().ok()?;
     // 0 would stall before the first batch, leaving no progress to resume from —
     // which is not the state the paused screen is for.
+    positive_count(raw)
+}
+
+/// Split out from the env read for the same reason as [`parse_stall_after`].
+fn parse_rotate_after(raw: Option<&str>) -> Option<u64> {
+    // 0 refusals is the default behaviour — the new password lands at once — so
+    // it reads as "off" rather than as a delay of no length.
+    positive_count(raw)
+}
+
+/// A count read from the environment. Absent, unparseable and zero all mean the
+/// gate is off: a demo must never be made stranger by a typo in a variable.
+fn positive_count(raw: Option<&str>) -> Option<u64> {
+    let n = raw?.trim().parse::<u64>().ok()?;
     (n > 0).then_some(n)
 }
 
@@ -196,11 +230,44 @@ impl Ledger {
     }
 }
 
+/// The `AUTH_TOKEN` secret, once a rotation has set one.
+///
+/// A real secret is not swapped atomically: the PUT returns before every edge
+/// running the Worker has the new value, which is why the health gate polls
+/// instead of trusting the write. `pending` models that window — until it
+/// reaches zero the new password is refused and whatever it replaced still
+/// works, exactly the order a rotation has to survive.
+struct Password {
+    /// The value the brain will accept once the write has propagated.
+    value: String,
+    /// What it replaced, still live while `pending` lasts. `None` means the
+    /// brain was in its permissive state before this rotation.
+    previous: Option<String>,
+    /// Attempts with `value` left to refuse before it takes effect.
+    pending: u64,
+}
+
+impl Password {
+    /// What this brain accepts *right now*: the new value once it has landed,
+    /// and whatever it replaced until then. `None` means "any non-empty token",
+    /// the state a brain that has never been rotated is in.
+    fn accepted_now(&self) -> Option<&str> {
+        if self.pending > 0 {
+            self.previous.as_deref()
+        } else {
+            Some(&self.value)
+        }
+    }
+}
+
 #[derive(Default)]
 struct State {
     /// Sparse, exactly like `config:overrides` in KV.
     overrides: Map<String, Value>,
     ledger: Option<Ledger>,
+    /// `None` until something rotates this brain — see [`is_authenticated`] for
+    /// why the default is permissive.
+    password: Option<Password>,
 }
 
 struct Demo {
@@ -408,6 +475,63 @@ fn now_ms() -> u64 {
         .unwrap_or_default()
 }
 
+// ── Password ────────────────────────────────────────────────────────────────
+
+impl Demo {
+    /// Whether `token` — already known to be non-empty — opens this brain.
+    /// [`is_authenticated`] carries the reasoning for the two states.
+    ///
+    /// Takes the lock for writing because the check *is* a write while a
+    /// rotation is propagating: spending the pending counter is what makes the
+    /// new password land after N refusals rather than never.
+    fn accepts(&self, token: &str) -> bool {
+        let mut state = self.state.lock().unwrap();
+        let Some(password) = state.password.as_mut() else {
+            return true;
+        };
+        // The new value, still propagating: refuse it and spend one attempt.
+        if password.pending > 0 && token == password.value {
+            password.pending -= 1;
+            return false;
+        }
+        match password.accepted_now() {
+            Some(accepted) => token == accepted,
+            None => true,
+        }
+    }
+
+    /// Makes `token` the only password this brain accepts, once any configured
+    /// propagation delay has been spent.
+    fn rotate_to(&self, token: &str) {
+        let mut state = self.state.lock().unwrap();
+        // What is live now, not what was written last: rotating again while an
+        // earlier rotation is still propagating must not resurrect a password
+        // that never worked.
+        let previous = state
+            .password
+            .as_ref()
+            .and_then(|p| p.accepted_now().map(str::to_string));
+        state.password = Some(Password {
+            value: token.to_string(),
+            previous,
+            pending: self.options.rotate_after.unwrap_or(0),
+        });
+    }
+
+    /// The password that works against this brain at this moment, for callers
+    /// that have to hand one to a window.
+    fn auth_token(&self) -> String {
+        self.state
+            .lock()
+            .unwrap()
+            .password
+            .as_ref()
+            .and_then(Password::accepted_now)
+            .unwrap_or(DEFAULT_TOKEN)
+            .to_string()
+    }
+}
+
 // ── Server ──────────────────────────────────────────────────────────────────
 
 /// Shown when demo mode opens the dashboard. The wrapper window would otherwise
@@ -434,19 +558,53 @@ fn json_response(status: u16, payload: &Value) -> tiny_http::Response<std::io::C
 /// Every route the real Worker guards with `requireAuth` is guarded here, so a
 /// demo run is also evidence the app sends its token.
 ///
-/// Any non-empty bearer token is accepted rather than one literal string: what
-/// is worth proving is that the app authenticates at all, and pinning the value
-/// would turn an unrelated change of the demo token into a window full of 401s.
-fn is_authenticated(req: &tiny_http::Request) -> bool {
+/// There are two states, because rotation needs both:
+///
+/// * **No password set — the default.** Any non-empty bearer token is accepted
+///   rather than one literal string: what is worth proving is that the app
+///   authenticates at all, and pinning the value would turn an unrelated change
+///   of the demo token into a window full of 401s. Every demo flow that is not
+///   about rotation stays in this state.
+/// * **A password set by [`rotate_to`].** Only that value is accepted, and
+///   everything else gets the 401 an unauthenticated request already gets. The
+///   whole safety property of a rotation is a health check that passes *only*
+///   once the new password is live, and against a brain that accepts anything
+///   that check passes trivially and proves nothing. It is also the only way to
+///   reach the "your password was changed on another computer" screen, which
+///   needs the old token to genuinely stop working.
+///
+/// The header is read once and checked once rather than folded over every
+/// authorization header: the check has a side effect while a rotation is
+/// propagating, and a request carrying two of them must not spend two attempts.
+fn is_authenticated(demo: &Demo, req: &tiny_http::Request) -> bool {
+    let Some(token) = bearer_token(req) else {
+        return false;
+    };
+    demo.accepts(&token)
+}
+
+/// The first non-empty bearer token a request carries.
+fn bearer_token(req: &tiny_http::Request) -> Option<String> {
     req.headers()
         .iter()
         .filter(|h| h.field.equiv("authorization"))
-        .any(|h| {
-            let value = h.value.to_string();
-            value
-                .strip_prefix("Bearer ")
-                .is_some_and(|token| !token.trim().is_empty())
-        })
+        .find_map(|h| bearer_of(&h.value.to_string()).map(str::to_string))
+}
+
+/// The token inside one `Authorization` value, if it carries a bearer one.
+///
+/// Case-sensitive, because `src/lib/http.ts` compares the whole header against
+/// `Bearer ${env.AUTH_TOKEN}` and nothing else — a demo brain that accepted
+/// `bearer` would pass a request the real Worker refuses.
+///
+/// Split out from the header walk because it is the only part that can be
+/// tested for what it rejects: both hyper and `tiny_http` strip surrounding
+/// whitespace from a header value, so a scheme with nothing after it cannot be
+/// put on the wire at all, and the empty-token guard is reachable only from
+/// here.
+fn bearer_of(value: &str) -> Option<&str> {
+    let token = value.strip_prefix("Bearer ")?.trim();
+    (!token.is_empty()).then_some(token)
 }
 
 fn serve(server: &tiny_http::Server, demo: &Demo) {
@@ -455,7 +613,7 @@ fn serve(server: &tiny_http::Server, demo: &Demo) {
         let method = req.method().as_str().to_string();
         let raw = req.url().to_string();
         let path = raw.split('?').next().unwrap_or_default().to_string();
-        let authed = is_authenticated(&req);
+        let authed = is_authenticated(demo, &req);
         let mut body = String::new();
         let _ = std::io::Read::read_to_string(req.as_reader(), &mut body);
 
@@ -478,11 +636,12 @@ fn serve(server: &tiny_http::Server, demo: &Demo) {
     }
 }
 
-/// Binds a demo brain on an ephemeral loopback port and returns its base URL.
+/// Binds a demo brain on an ephemeral loopback port, returning its address and
+/// the state behind it.
 ///
 /// A small pool rather than one thread: a re-embed batch sleeps, and a single
 /// handler would hold an unrelated /config read behind it.
-pub fn spawn(options: Options) -> Option<String> {
+fn bind(options: Options) -> Option<(String, Arc<Demo>)> {
     let server = tiny_http::Server::http("127.0.0.1:0").ok()?;
     let port = server.server_addr().to_ip()?.port();
     let server = Arc::new(server);
@@ -492,28 +651,72 @@ pub fn spawn(options: Options) -> Option<String> {
         let demo = demo.clone();
         std::thread::spawn(move || serve(&server, &demo));
     }
-    Some(format!("http://127.0.0.1:{port}"))
+    Some((format!("http://127.0.0.1:{port}"), demo))
 }
 
-static RUNNING: OnceLock<String> = OnceLock::new();
+/// The demo brain this process serves: the address to hand out, and the handle
+/// a rotation needs to reach in and change the password.
+struct Running {
+    base_url: String,
+    /// `None` when loopback could not be bound at all — there is then nothing
+    /// listening, so there is also nothing to rotate.
+    demo: Option<Arc<Demo>>,
+}
+
+static RUNNING: OnceLock<Running> = OnceLock::new();
+
+/// The one demo brain, started if it is not already up.
+fn running() -> &'static Running {
+    RUNNING.get_or_init(|| match bind(Options::default()) {
+        Some((url, demo)) => {
+            log::info!("demo brain listening on {url}");
+            Running { base_url: url, demo: Some(demo) }
+        }
+        None => {
+            log::warn!("could not bind the demo brain to loopback");
+            Running { base_url: UNREACHABLE.to_string(), demo: None }
+        }
+    })
+}
 
 /// The demo brain's address, starting it if it is not already up.
 ///
 /// Lazy as well as started at launch so no caller can be handed a dead address:
 /// the port is chosen by the OS, so it cannot be a constant.
 pub fn base_url() -> String {
-    RUNNING
-        .get_or_init(|| match spawn(Options::default()) {
-            Some(url) => {
-                log::info!("demo brain listening on {url}");
-                url
-            }
-            None => {
-                log::warn!("could not bind the demo brain to loopback");
-                UNREACHABLE.to_string()
-            }
-        })
-        .clone()
+    running().base_url.clone()
+}
+
+/// The password the demo brain accepts right now — [`DEFAULT_TOKEN`] until a
+/// rotation has set one, and during propagation still the one being replaced.
+///
+/// Demo mode has no keychain to read a rotated password back out of, so anything
+/// that hands a token to a window has to ask the brain what it currently
+/// answers to, or the window 401s for the rest of the run.
+pub fn auth_token() -> String {
+    running()
+        .demo
+        .as_ref()
+        .map(|demo| demo.auth_token())
+        .unwrap_or_else(|| DEFAULT_TOKEN.to_string())
+}
+
+/// Makes `token` the only password this demo brain accepts.
+///
+/// The dry-run branch of a rotation calls this: `DryRunBackend::put_secret`
+/// records that the write happened, and this is the half that makes it true,
+/// because the demo brain — not Cloudflare — is what `/health` is polled
+/// against. Without it the health gate would pass against a server that accepts
+/// anything, which is the one thing that gate exists to rule out, and the old
+/// password would go on working forever.
+///
+/// Starts the brain if it is not up yet, so no ordering of a flow's calls can
+/// leave a rotation writing to a brain nobody is serving.
+pub fn rotate_to(token: &str) {
+    match &running().demo {
+        Some(demo) => demo.rotate_to(token),
+        None => log::warn!("no demo brain is listening, so there is no password to rotate"),
+    }
 }
 
 /// Brings the demo brain up at launch, before any window can ask for it.
@@ -527,15 +730,34 @@ mod tests {
     use crate::i18n::Locale;
     use crate::settings::{self, CONTROLS, DEFAULT_LEVELS};
 
-    /// A demo brain with the delay removed. Everything else is what a real demo
-    /// run uses, so the tests exercise the shipped numbers.
+    /// A demo brain with the delays removed. Everything else is what a real demo
+    /// run uses, so the tests exercise the shipped numbers. The two gates are
+    /// named rather than inherited: both read the environment, and a variable
+    /// left exported in a developer's shell must not change what the suite
+    /// proves.
     fn brain() -> String {
-        spawn(Options { batch_pause: Duration::ZERO, stall_after: None, ..Options::default() })
-            .expect("bind loopback")
+        brain_with(Options {
+            batch_pause: Duration::ZERO,
+            stall_after: None,
+            rotate_after: None,
+            ..Options::default()
+        })
     }
 
     fn brain_with(options: Options) -> String {
-        spawn(options).expect("bind loopback")
+        bind(options).expect("bind loopback").0
+    }
+
+    /// A brain plus the handle a rotation goes through. Most tests need only an
+    /// address; these have to reach the state behind it.
+    fn brain_and_handle(rotate_after: Option<u64>) -> (String, Arc<Demo>) {
+        bind(Options {
+            batch_pause: Duration::ZERO,
+            stall_after: None,
+            rotate_after,
+            ..Options::default()
+        })
+        .expect("bind loopback")
     }
 
     async fn get(url: &str, path: &str) -> (u16, Value) {
@@ -547,6 +769,21 @@ mod tests {
             .expect("request");
         let status = resp.status().as_u16();
         (status, resp.json().await.unwrap_or(Value::Null))
+    }
+
+    /// The status of a `/config` read carrying exactly this `Authorization`
+    /// header, or none at all. Deliberately not `bearer_auth`: what these tests
+    /// are about is what the header itself carries, down to an empty one.
+    async fn config_status(url: &str, authorization: Option<&str>) -> u16 {
+        let mut req = reqwest::Client::new().get(format!("{url}/config"));
+        if let Some(value) = authorization {
+            req = req.header("Authorization", value);
+        }
+        req.send().await.expect("request").status().as_u16()
+    }
+
+    async fn bearer_status(url: &str, token: &str) -> u16 {
+        config_status(url, Some(&format!("Bearer {token}"))).await
     }
 
     async fn post(url: &str, path: &str) -> (u16, Value) {
@@ -764,6 +1001,184 @@ mod tests {
             .await
             .expect("request");
         assert_eq!(resp.status().as_u16(), 401, "the real Worker requires auth on /config");
+    }
+
+    // ── The password ────────────────────────────────────────────────────────
+
+    /// The load-bearing test of this set, and it is about what did *not*
+    /// change. Settings, migration, the dashboard window and every future demo
+    /// flow send whatever token their caller happens to hold, so a brain that
+    /// insisted on one literal value by default would answer all of them with
+    /// 401s — the failure this permissive default was chosen to avoid.
+    #[tokio::test]
+    async fn a_brain_that_has_never_been_rotated_accepts_any_non_empty_token() {
+        let url = brain();
+        for token in [DEFAULT_TOKEN, "something-else-entirely", "hunter2hunter2"] {
+            assert_eq!(
+                bearer_status(&url, token).await,
+                200,
+                "{token} was refused by a brain with no password set"
+            );
+        }
+
+        // Non-empty is still the floor: an absent, blank or non-bearer header is
+        // not a credential, and the real Worker refuses all of them.
+        for header in [None, Some(""), Some("Bearer "), Some("Bearer    "), Some("Bearer"), Some("Basic demo")] {
+            assert_eq!(
+                config_status(&url, header).await,
+                401,
+                "{header:?} must not authenticate"
+            );
+        }
+    }
+
+    /// What counts as a credential at all, checked here rather than over HTTP:
+    /// hyper and `tiny_http` both strip whitespace around a header value, so a
+    /// bearer scheme followed by nothing cannot be put on the wire, and the
+    /// guard against an empty token has no other way of being exercised.
+    #[test]
+    fn only_a_bearer_scheme_with_something_after_it_is_a_token() {
+        assert_eq!(bearer_of("Bearer demo"), Some("demo"));
+        assert_eq!(bearer_of("Bearer  padded  "), Some("padded"));
+        assert_eq!(bearer_of("Bearer "), None, "the scheme alone is not a credential");
+        assert_eq!(bearer_of("Bearer \t "), None);
+        assert_eq!(bearer_of("Bearer"), None);
+        assert_eq!(bearer_of(""), None);
+        assert_eq!(bearer_of("Basic demo"), None);
+        // `src/lib/http.ts` matches `Bearer ${env.AUTH_TOKEN}` exactly, so a
+        // lowercased scheme is a request the real Worker would refuse.
+        assert_eq!(bearer_of("bearer demo"), None);
+    }
+
+    /// One test walking the whole sequence rather than one per scenario: a brain
+    /// is shared state for as long as it is bound, and two tests rotating it
+    /// would race over which password is live.
+    #[tokio::test]
+    async fn rotating_leaves_the_newest_password_the_only_one_that_opens_the_brain() {
+        let (url, demo) = brain_and_handle(None);
+        assert_eq!(bearer_status(&url, DEFAULT_TOKEN).await, 200);
+        assert_eq!(demo.auth_token(), DEFAULT_TOKEN, "an unrotated brain answers to the default");
+
+        demo.rotate_to("first-new-password");
+        assert_eq!(bearer_status(&url, "first-new-password").await, 200);
+        assert_eq!(
+            bearer_status(&url, DEFAULT_TOKEN).await,
+            401,
+            "the password the brain was opened with must stop working"
+        );
+        assert_eq!(
+            bearer_status(&url, "something-else-entirely").await,
+            401,
+            "once a password is set the brain must stop accepting anything non-empty"
+        );
+        assert_eq!(config_status(&url, Some("Bearer ")).await, 401);
+        assert_eq!(demo.auth_token(), "first-new-password");
+
+        // Rotating again: only the newest survives, or a leaked password would
+        // be re-usable after the user changed it a second time.
+        demo.rotate_to("second-new-password");
+        assert_eq!(bearer_status(&url, "second-new-password").await, 200);
+        assert_eq!(bearer_status(&url, "first-new-password").await, 401);
+        assert_eq!(bearer_status(&url, DEFAULT_TOKEN).await, 401);
+        assert_eq!(demo.auth_token(), "second-new-password");
+    }
+
+    /// The propagation window the health gate exists for. A real secret is not
+    /// live when the PUT returns, so `rotate_secret` must retry through 401s
+    /// rather than treat the first one as terminal the way `update_worker` does
+    /// — and against a brain that switches instantly, both implementations pass.
+    #[tokio::test]
+    async fn a_delayed_rotation_keeps_the_old_password_working_until_the_new_one_lands() {
+        const REFUSALS: u64 = 3;
+        let (url, demo) = brain_and_handle(Some(REFUSALS));
+
+        // The first rotation has nothing live to fall back to, so the brain stays
+        // permissive — except for the password that has not landed yet.
+        demo.rotate_to("old-password");
+        for attempt in 1..=REFUSALS {
+            assert_eq!(
+                bearer_status(&url, "old-password").await,
+                401,
+                "attempt {attempt} of {REFUSALS} must still be refused"
+            );
+        }
+        assert_eq!(
+            bearer_status(&url, "old-password").await,
+            200,
+            "the password must land once the refusals are spent"
+        );
+
+        // The second rotation replaces a live password, which is the case the
+        // app is actually in: the old one carries it through the window the
+        // health gate spends polling.
+        demo.rotate_to("new-password");
+        for attempt in 1..=REFUSALS {
+            // Checked before the refusal, not after: the attempt that spends the
+            // last refusal is the one that lands the new password, so the old one
+            // is already retired by the time that call returns.
+            assert_eq!(
+                bearer_status(&url, "old-password").await,
+                200,
+                "the old password must keep working while the new one is in flight"
+            );
+            assert_eq!(demo.auth_token(), "old-password");
+            assert_eq!(
+                bearer_status(&url, "new-password").await,
+                401,
+                "attempt {attempt} of {REFUSALS} must still be refused"
+            );
+        }
+
+        assert_eq!(bearer_status(&url, "new-password").await, 200);
+        assert_eq!(
+            bearer_status(&url, "old-password").await,
+            401,
+            "landing must retire the password it replaced"
+        );
+        assert_eq!(demo.auth_token(), "new-password");
+    }
+
+    #[test]
+    fn the_rotation_delay_is_off_unless_the_env_var_names_an_attempt_count() {
+        assert_eq!(parse_rotate_after(None), None);
+        assert_eq!(parse_rotate_after(Some("")), None);
+        assert_eq!(parse_rotate_after(Some("nonsense")), None);
+        // Landing at once is the default, not a delay of no length.
+        assert_eq!(parse_rotate_after(Some("0")), None);
+        assert_eq!(parse_rotate_after(Some("2")), Some(2));
+        assert_eq!(parse_rotate_after(Some(" 2 ")), Some(2));
+    }
+
+    /// `rotate_to` has to reach the brain the app is talking to, not an instance
+    /// a test happened to bind: a dry-run rotation calls the free function and
+    /// then polls `base_url()`, and a rotation that missed would look like a
+    /// clean pass.
+    ///
+    /// It rotates to [`DEFAULT_TOKEN`] deliberately. This brain is process-wide
+    /// and outlives the test, so rotating it to anything else would start 401ing
+    /// whatever else is mid-request against it; rotating it to the token every
+    /// caller already sends changes nothing for them while still proving the
+    /// enforcement is now on.
+    #[tokio::test]
+    async fn rotate_to_reaches_the_brain_the_app_is_handed() {
+        let url = base_url();
+        rotate_to(DEFAULT_TOKEN);
+
+        // The shape of the health gate itself: poll with the new password until
+        // it authenticates, bounded so a rotation that never lands fails the
+        // test rather than hanging it. More than one attempt only when the
+        // propagation delay is exported into the test run.
+        let mut attempts = 0;
+        while bearer_status(&url, DEFAULT_TOKEN).await != 200 {
+            attempts += 1;
+            assert!(attempts < 20, "the rotated password never took effect");
+        }
+        assert_eq!(auth_token(), DEFAULT_TOKEN);
+        assert_eq!(
+            bearer_status(&url, "not-the-demo-password").await,
+            401,
+            "the process-wide brain must enforce the password it was rotated to"
+        );
     }
 
     // ── Migration ───────────────────────────────────────────────────────────

--- a/installer/src-tauri/src/demo_brain.rs
+++ b/installer/src-tauri/src/demo_brain.rs
@@ -65,6 +65,11 @@ const STALL_ENV: &str = "SECOND_BRAIN_DEMO_STALL_AFTER";
 /// the first request would pass either implementation, so the difference the
 /// gate exists for would go untested. Off by default, because every other demo
 /// flow wants the rotation over with.
+///
+/// **Rotation only** — see [`Demo::deployed_with`]. A password that arrives with
+/// a deploy has nothing to propagate, and delaying that one instead pointed the
+/// knob at `provision`'s health poll, where a 401 is terminal: exporting this
+/// variable made first-time demo setup die with "Something went wrong".
 const ROTATE_ENV: &str = "SECOND_BRAIN_DEMO_ROTATE_AFTER";
 
 /// Shipped in `src/config.ts` DEFAULTS. Both must be values the pickers offer,
@@ -539,6 +544,25 @@ impl Demo {
     /// Makes `token` the only password this brain accepts, once any configured
     /// propagation delay has been spent.
     fn rotate_to(&self, token: &str) {
+        self.set_password(token, self.options.rotate_after.unwrap_or(0));
+    }
+
+    /// Makes `token` the only password this brain accepts, **now**.
+    ///
+    /// A fresh deploy carries `AUTH_TOKEN` as a binding in its upload metadata,
+    /// so the Worker comes up already holding it: there is no propagation window
+    /// because there was no separate secret write to propagate.
+    ///
+    /// Split from [`Self::rotate_to`] because [`ROTATE_ENV`] must reach one and
+    /// not the other. Applying the delay to a deploy aims it at `provision`'s
+    /// health poll, which treats a 401 as terminal — so with the variable
+    /// exported, first-time demo setup failed with "Something went wrong" and
+    /// the retry loop the variable exists to exercise was never reached.
+    fn deployed_with(&self, token: &str) {
+        self.set_password(token, 0);
+    }
+
+    fn set_password(&self, token: &str, pending: u64) {
         let mut state = self.state.lock().unwrap();
         // What is live now, not what was written last: rotating again while an
         // earlier rotation is still propagating must not resurrect a password
@@ -550,7 +574,7 @@ impl Demo {
         state.password = Some(Password {
             value: token.to_string(),
             previous,
-            pending: self.options.rotate_after.unwrap_or(0),
+            pending,
         });
     }
 
@@ -649,10 +673,13 @@ fn serve(server: &tiny_http::Server, demo: &Demo) {
         let method = req.method().as_str().to_string();
         let raw = req.url().to_string();
         let path = raw.split('?').next().unwrap_or_default().to_string();
-        let authed = is_authenticated(demo, &req);
-        let mut body = String::new();
-        let _ = std::io::Read::read_to_string(req.as_reader(), &mut body);
 
+        // Before the auth check, not after. The placeholder page is unguarded —
+        // it is a page, not a brain route — and asking `is_authenticated` about a
+        // request that is not going to be authorised anyway is not free: the
+        // check *spends* a propagation attempt while a rotation is in flight. A
+        // dashboard window loading this page mid-rotation would land the new
+        // password one refusal earlier than the demo was set up to require.
         if method == "GET" && (path == "/" || path == "/index.html") {
             let response = tiny_http::Response::from_string(PLACEHOLDER).with_header(
                 "Content-Type: text/html; charset=utf-8"
@@ -662,6 +689,10 @@ fn serve(server: &tiny_http::Server, demo: &Demo) {
             let _ = req.respond(response);
             continue;
         }
+
+        let authed = is_authenticated(demo, &req);
+        let mut body = String::new();
+        let _ = std::io::Read::read_to_string(req.as_reader(), &mut body);
 
         let (status, payload) = if authed {
             demo.handle(&method, &path, &body)
@@ -715,12 +746,101 @@ fn running() -> &'static Running {
     })
 }
 
+// A brain bound for the duration of one test, standing in for the process-wide
+// one — see `scoped_brain`.
+#[cfg(test)]
+thread_local! {
+    static SCOPED: std::cell::RefCell<Option<Arc<Running>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// The brain the functions below reach: the one bound for the current test if
+/// there is one, and otherwise the process-wide one.
+fn with_current<T>(f: impl FnOnce(&Running) -> T) -> T {
+    #[cfg(test)]
+    if let Some(scoped) = SCOPED.with(|slot| slot.borrow().clone()) {
+        return f(&scoped);
+    }
+    f(running())
+}
+
+/// Binds a demo brain for this test and points [`base_url`], [`auth_token`],
+/// [`rotate_to`] and [`deployed_with`] at it until the returned guard is
+/// dropped.
+///
+/// For any test that changes a demo brain's password. The process-wide brain is
+/// exactly that — process-wide — so rotating it changes what every other test in
+/// the process must send, and the suite runs in parallel: what reads as two
+/// adjacent statements is a race against whatever else is mid-request. At
+/// `RUST_TEST_THREADS=64` one such test failed 10 runs out of 15, and CI's thread
+/// count follows the runner's cores.
+///
+/// Thread-local rather than a second static, because that is the scope the
+/// property needs: `#[tokio::test]` drives its future to completion on the
+/// calling thread, so everything the test awaits sees the binding and nothing
+/// outside the test can.
+#[cfg(test)]
+pub fn scoped_brain() -> ScopedBrain {
+    scoped_brain_with(test_options())
+}
+
+/// [`scoped_brain`] with the demo knobs set by hand — for the tests that are
+/// *about* a knob.
+#[cfg(test)]
+pub fn scoped_brain_with(options: Options) -> ScopedBrain {
+    let (base_url, demo) = bind(options).expect("bind loopback");
+    let running = Arc::new(Running { base_url: base_url.clone(), demo: Some(demo) });
+    let previous = SCOPED.with(|slot| slot.borrow_mut().replace(running));
+    ScopedBrain { base_url, previous }
+}
+
+/// Holds a [`scoped_brain`] in place. Dropping it hands the free functions back
+/// to whatever they reached before — the process-wide brain, or an outer scoped
+/// one. Restored rather than cleared so a nested binding cannot silently promote
+/// the inner brain's successor to the global.
+#[cfg(test)]
+pub struct ScopedBrain {
+    base_url: String,
+    previous: Option<Arc<Running>>,
+}
+
+#[cfg(test)]
+impl ScopedBrain {
+    /// This brain's address — the same value [`base_url`] answers while the
+    /// guard is alive, for tests that would rather be explicit about it.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+#[cfg(test)]
+impl Drop for ScopedBrain {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        SCOPED.with(|slot| *slot.borrow_mut() = previous);
+    }
+}
+
+/// The options a test's brain runs with: the shipped numbers minus the delays,
+/// and with both environment gates pinned off. Both read the environment, and a
+/// variable left exported in a developer's shell must not change what the suite
+/// proves.
+#[cfg(test)]
+pub fn test_options() -> Options {
+    Options {
+        batch_pause: Duration::ZERO,
+        stall_after: None,
+        rotate_after: None,
+        ..Options::default()
+    }
+}
+
 /// The demo brain's address, starting it if it is not already up.
 ///
 /// Lazy as well as started at launch so no caller can be handed a dead address:
 /// the port is chosen by the OS, so it cannot be a constant.
 pub fn base_url() -> String {
-    running().base_url.clone()
+    with_current(|running| running.base_url.clone())
 }
 
 /// The password the demo brain accepts right now — [`DEFAULT_TOKEN`] until a
@@ -730,11 +850,13 @@ pub fn base_url() -> String {
 /// that hands a token to a window has to ask the brain what it currently
 /// answers to, or the window 401s for the rest of the run.
 pub fn auth_token() -> String {
-    running()
-        .demo
-        .as_ref()
-        .map(|demo| demo.auth_token())
-        .unwrap_or_else(|| DEFAULT_TOKEN.to_string())
+    with_current(|running| {
+        running
+            .demo
+            .as_ref()
+            .map(|demo| demo.auth_token())
+            .unwrap_or_else(|| DEFAULT_TOKEN.to_string())
+    })
 }
 
 /// Makes `token` the only password this demo brain accepts.
@@ -749,10 +871,22 @@ pub fn auth_token() -> String {
 /// Starts the brain if it is not up yet, so no ordering of a flow's calls can
 /// leave a rotation writing to a brain nobody is serving.
 pub fn rotate_to(token: &str) {
-    match &running().demo {
+    with_current(|running| match &running.demo {
         Some(demo) => demo.rotate_to(token),
         None => log::warn!("no demo brain is listening, so there is no password to rotate"),
-    }
+    })
+}
+
+/// Makes `token` the demo brain's password with no propagation delay, because a
+/// deploy carries the secret with it — see [`Demo::deployed_with`].
+///
+/// Called by `DryRunBackend::deploy_worker` when the upload metadata carries an
+/// `AUTH_TOKEN` binding, which is every fresh setup.
+pub fn deployed_with(token: &str) {
+    with_current(|running| match &running.demo {
+        Some(demo) => demo.deployed_with(token),
+        None => log::warn!("no demo brain is listening, so there is no password to set"),
+    })
 }
 
 /// Brings the demo brain up at launch, before any window can ask for it.
@@ -766,18 +900,11 @@ mod tests {
     use crate::i18n::Locale;
     use crate::settings::{self, CONTROLS, DEFAULT_LEVELS};
 
-    /// A demo brain with the delays removed. Everything else is what a real demo
-    /// run uses, so the tests exercise the shipped numbers. The two gates are
-    /// named rather than inherited: both read the environment, and a variable
-    /// left exported in a developer's shell must not change what the suite
-    /// proves.
+    /// A demo brain with the delays removed — [`test_options`] carries the
+    /// reasoning, and the shipped numbers otherwise, so the tests exercise what a
+    /// real demo run uses.
     fn brain() -> String {
-        brain_with(Options {
-            batch_pause: Duration::ZERO,
-            stall_after: None,
-            rotate_after: None,
-            ..Options::default()
-        })
+        brain_with(test_options())
     }
 
     fn brain_with(options: Options) -> String {
@@ -787,13 +914,7 @@ mod tests {
     /// A brain plus the handle a rotation goes through. Most tests need only an
     /// address; these have to reach the state behind it.
     fn brain_and_handle(rotate_after: Option<u64>) -> (String, Arc<Demo>) {
-        bind(Options {
-            batch_pause: Duration::ZERO,
-            stall_after: None,
-            rotate_after,
-            ..Options::default()
-        })
-        .expect("bind loopback")
+        bind(Options { rotate_after, ..test_options() }).expect("bind loopback")
     }
 
     async fn get(url: &str, path: &str) -> (u16, Value) {
@@ -846,7 +967,12 @@ mod tests {
         let (status, body) = post(&url, "/oauth/revoke-all").await;
         assert_eq!(status, 200);
         assert_eq!(body["ok"], true);
-        assert_eq!(body["revoked"], OAUTH_CONNECTIONS);
+        // A literal, not `OAUTH_CONNECTIONS`. Comparing the constant to itself
+        // would pass whatever the demo brain claimed to hold — set it to 0 and
+        // this stays green while the screen reports "0 connections closed" for a
+        // brain the app says has two connected tools. The number is the point:
+        // it is what the app can connect, Claude Code and Cursor.
+        assert_eq!(body["revoked"], 2);
         assert_eq!(body["failed"], 0);
 
         let (status, body) = post(&url, "/oauth/revoke-all").await;
@@ -1208,6 +1334,105 @@ mod tests {
         assert_eq!(demo.auth_token(), "new-password");
     }
 
+    /// The propagation delay belongs to a rotation and to nothing else.
+    ///
+    /// A fresh deploy carries `AUTH_TOKEN` in its upload metadata, so the Worker
+    /// comes up already holding it — there is nothing to propagate. Delaying it
+    /// anyway aims [`ROTATE_ENV`] at `provision`'s health poll, which treats a
+    /// 401 as terminal: with the variable exported, first-time demo setup died
+    /// with "Something went wrong" and the retry loop the variable exists to
+    /// exercise was never reached. A knob for demonstrating one screen must not
+    /// break the flow that leads to it.
+    #[tokio::test]
+    async fn a_password_that_arrives_with_a_deploy_is_live_at_once_even_with_the_delay_set() {
+        let (url, demo) = brain_and_handle(Some(3));
+
+        demo.deployed_with("deployed-password");
+        assert_eq!(
+            bearer_status(&url, "deployed-password").await,
+            200,
+            "a deployed password has nothing to propagate and must work at once"
+        );
+
+        // …and the knob still does its job on the path it is for.
+        demo.rotate_to("rotated-password");
+        assert_eq!(
+            bearer_status(&url, "rotated-password").await,
+            401,
+            "a rotation must still spend its refusals, or the retry loop the \
+             variable exists to exercise is never exercised"
+        );
+    }
+
+    /// Loading the demo dashboard page must not spend a propagation attempt.
+    ///
+    /// `is_authenticated` is a *write* while a rotation is in flight — it spends
+    /// one of the refusals the new password owes — and the placeholder page is
+    /// unguarded, so asking the question at all is pure cost. It used to be
+    /// asked before the page's early return, which made a window that happened to
+    /// load the page land the new password sooner than the demo was set up to
+    /// require.
+    #[tokio::test]
+    async fn loading_the_placeholder_page_does_not_spend_a_propagation_attempt() {
+        const REFUSALS: u64 = 2;
+        let (url, demo) = brain_and_handle(Some(REFUSALS));
+        demo.rotate_to("new-password");
+
+        let client = reqwest::Client::new();
+        for path in ["/", "/index.html", "/"] {
+            let resp = client
+                .get(format!("{url}{path}"))
+                .bearer_auth("new-password")
+                .send()
+                .await
+                .expect("request");
+            assert_eq!(resp.status().as_u16(), 200, "{path} is an unguarded page");
+        }
+
+        for attempt in 1..=REFUSALS {
+            assert_eq!(
+                bearer_status(&url, "new-password").await,
+                401,
+                "attempt {attempt} of {REFUSALS}: the page loads must not have \
+                 spent any of the refusals"
+            );
+        }
+        assert_eq!(bearer_status(&url, "new-password").await, 200);
+    }
+
+    /// The mechanism every password test outside this file relies on.
+    ///
+    /// A test that rotates the process-wide brain changes the password every
+    /// other test in the process is sending, and the harness runs them in
+    /// parallel — a race that only shows up on a machine with enough cores. A
+    /// scoped brain is how such a test stays local; if the binding silently
+    /// stopped taking effect, those tests would go back to rotating the global
+    /// one and the flake would return with nothing to point at.
+    #[tokio::test]
+    async fn a_scoped_brain_stands_in_for_the_process_wide_one() {
+        let process_wide = base_url();
+        {
+            let scoped = scoped_brain();
+            assert_ne!(scoped.base_url(), process_wide, "a brain of its own");
+            assert_eq!(base_url(), scoped.base_url(), "and the one handed out");
+
+            rotate_to("a-password-only-this-test-sets");
+            assert_eq!(auth_token(), "a-password-only-this-test-sets");
+            assert_eq!(
+                bearer_status(scoped.base_url(), "a-password-only-this-test-sets").await,
+                200,
+                "the rotation must have reached the scoped brain"
+            );
+        }
+
+        assert_eq!(base_url(), process_wide, "dropping the guard gives it back");
+        assert_ne!(
+            auth_token(),
+            "a-password-only-this-test-sets",
+            "the process-wide brain must not have been touched"
+        );
+    }
+
     #[test]
     fn the_rotation_delay_is_off_unless_the_env_var_names_an_attempt_count() {
         assert_eq!(parse_rotate_after(None), None);
@@ -1505,7 +1730,31 @@ mod tests {
         let url = base_url();
         assert!(url.starts_with("http://127.0.0.1:"), "got {url}");
         assert_eq!(url, base_url(), "the address must be stable across calls");
-        let (status, body) = get(&url, "/config").await;
+
+        // Polled rather than asserted once, and only past a 401.
+        //
+        // This is the *process-wide* brain, which one test has to rotate —
+        // `rotate_to_reaches_the_brain_the_app_is_handed`, whose whole subject is
+        // that `rotate_to` reaches the brain the app is handed. With
+        // `SECOND_BRAIN_DEMO_ROTATE_AFTER` exported that rotation opens a window
+        // several requests long in which the brain refuses exactly the token
+        // every other caller sends, and this test would then be reporting that
+        // test's timing rather than anything about `base_url`.
+        //
+        // Nothing is weakened: a 401 is itself proof that a brain answered, which
+        // is what this asserts, and an address with nothing behind it still fails
+        // — `get` panics on a connection that goes nowhere.
+        let mut status;
+        let mut body;
+        let mut attempts = 0;
+        loop {
+            (status, body) = get(&url, "/config").await;
+            if status != 401 {
+                break;
+            }
+            attempts += 1;
+            assert!(attempts < 20, "the address never authenticated anyone");
+        }
         assert_eq!(status, 200, "base_url returned an address nothing is serving");
         assert!(body["config"].is_object());
     }

--- a/installer/src-tauri/src/demo_brain.rs
+++ b/installer/src-tauri/src/demo_brain.rs
@@ -83,6 +83,10 @@ const UNREACHABLE: &str = "http://127.0.0.1:1";
 /// non-empty, so nothing breaks if a caller uses a different string.
 pub const DEFAULT_TOKEN: &str = "demo";
 
+/// AI tools a demo brain starts out believing are connected — the two the app
+/// can connect, Claude Code and Cursor.
+const OAUTH_CONNECTIONS: u32 = 2;
+
 const THREADS: usize = 3;
 
 // ── Options ─────────────────────────────────────────────────────────────────
@@ -99,6 +103,14 @@ pub struct Options {
     /// Refuse a newly rotated password this many times before honouring it, so
     /// the health gate's retry loop has something to retry through.
     pub rotate_after: Option<u64>,
+    /// How many AI tools this brain believes are connected through the browser
+    /// OAuth flow, before anything disconnects them.
+    ///
+    /// Two, because that is what the app can connect: Claude Code and Cursor.
+    /// A count rather than a fixed reply so the route can report what it
+    /// actually closed and then report nothing left, which is the sequence a
+    /// user sees when they press the button twice.
+    pub oauth_connections: u32,
 }
 
 impl Default for Options {
@@ -110,6 +122,7 @@ impl Default for Options {
             batch_pause: BATCH_PAUSE,
             stall_after: parse_stall_after(std::env::var(STALL_ENV).ok().as_deref()),
             rotate_after: parse_rotate_after(std::env::var(ROTATE_ENV).ok().as_deref()),
+            oauth_connections: OAUTH_CONNECTIONS,
         }
     }
 }
@@ -265,6 +278,10 @@ struct State {
     /// Sparse, exactly like `config:overrides` in KV.
     overrides: Map<String, Value>,
     ledger: Option<Ledger>,
+    /// `None` until something disconnects the AI tools, after which it is
+    /// whatever is left. Kept apart from [`Options::oauth_connections`] so the
+    /// seeded count stays readable while the live one changes.
+    oauth_connections: Option<u32>,
     /// `None` until something rotates this brain — see [`is_authenticated`] for
     /// why the default is permissive.
     password: Option<Password>,
@@ -297,8 +314,27 @@ impl Demo {
                 self.state.lock().unwrap().ledger = None;
                 (200, json!({ "ok": true }))
             }
+            ("POST", "/oauth/revoke-all") => (200, self.revoke_all()),
             _ => (404, json!({ "ok": false, "error": "Not found" })),
         }
+    }
+
+    /// `{ ok, revoked, failed }`, as `src/routes/oauth-revoke.ts` returns it.
+    ///
+    /// Rotation deliberately leaves OAuth-connected tools working, so the app
+    /// offers this as a separate action — and an action whose whole purpose is
+    /// to close a door has to be demonstrable, or the one screen that must not
+    /// lie is the one nobody ever sees.
+    ///
+    /// Counts down rather than replying with a fixed number: pressing the button
+    /// twice reports two connections closed and then none left, which is the
+    /// real sequence. A constant `{ ok: true, revoked: 2 }` would report closing
+    /// connections that were already closed.
+    fn revoke_all(&self) -> Value {
+        let mut state = self.state.lock().unwrap();
+        let live = state.oauth_connections.unwrap_or(self.options.oauth_connections);
+        state.oauth_connections = Some(0);
+        json!({ "ok": true, "revoked": live, "failed": 0 })
     }
 
     /// `{ ok, version, vectorize }`, as `src/routes/admin.ts` returns it. The
@@ -795,6 +831,40 @@ mod tests {
             .expect("request");
         let status = resp.status().as_u16();
         (status, resp.json().await.unwrap_or(Value::Null))
+    }
+
+    /// Disconnecting reports what it closed, then reports nothing left.
+    ///
+    /// The second call is the point of the test. A demo route that always
+    /// answered `{ revoked: 2 }` would tell a user it had just closed two
+    /// connections that were already closed — and this is the one action whose
+    /// entire value is that its report can be believed.
+    #[tokio::test]
+    async fn disconnecting_reports_what_it_closed_and_then_that_none_are_left() {
+        let url = brain();
+
+        let (status, body) = post(&url, "/oauth/revoke-all").await;
+        assert_eq!(status, 200);
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["revoked"], OAUTH_CONNECTIONS);
+        assert_eq!(body["failed"], 0);
+
+        let (status, body) = post(&url, "/oauth/revoke-all").await;
+        assert_eq!(status, 200);
+        assert_eq!(body["ok"], true, "nothing to close is still a success");
+        assert_eq!(body["revoked"], 0);
+
+        // Guarded like every other route the real Worker guards.
+        let resp = reqwest::Client::new()
+            .post(format!("{url}/oauth/revoke-all"))
+            .send()
+            .await
+            .expect("request");
+        assert_eq!(resp.status().as_u16(), 401);
+
+        // A page load must never disconnect anything.
+        let (status, _) = get(&url, "/oauth/revoke-all").await;
+        assert_eq!(status, 404, "GET must not do the work");
     }
 
     // ── The config the window renders ───────────────────────────────────────

--- a/installer/src-tauri/src/i18n.rs
+++ b/installer/src-tauri/src/i18n.rs
@@ -131,6 +131,7 @@ pub enum Key {
     // the webview owns, never a screen of its own — every failure state in that
     // flow has to carry the new password, which a bare error string cannot do.
     ErrorRotateBlocked,
+    ErrorRotateNeedsHttps,
     ErrorRotateNotConfirmed,
     ErrorRotateSecureStore,
 }
@@ -292,6 +293,13 @@ Second Brain's address by hand instead."
         (Locale::En, Key::ErrorRotateBlocked) => {
             "Your Second Brain is rebuilding how it reads your memories, so its password \
 can't be changed just now."
+        }
+        // Deliberately not ErrorBadUrl: `http://my-brain.acme.workers.dev` is a
+        // perfectly good address, and telling someone it does not look like one
+        // sends them hunting for a typo that is not there.
+        (Locale::En, Key::ErrorRotateNeedsHttps) => {
+            "Your Second Brain's address has to start with https://. A plain http:// address \
+would send your new password unprotected."
         }
         (Locale::En, Key::ErrorRotateNotConfirmed) => {
             "Your Second Brain didn't confirm the new password in time."
@@ -467,6 +475,10 @@ Puoi inserire a mano l'indirizzo del tuo Second Brain."
             "Il tuo Second Brain sta ricostruendo il modo in cui legge i tuoi ricordi, \
 quindi la sua password non può essere cambiata adesso."
         }
+        (Locale::It, Key::ErrorRotateNeedsHttps) => {
+            "L'indirizzo del tuo Second Brain deve iniziare con https://. Un indirizzo http:// \
+invierebbe la tua nuova password senza protezione."
+        }
         (Locale::It, Key::ErrorRotateNotConfirmed) => {
             "Il tuo Second Brain non ha confermato la nuova password in tempo."
         }
@@ -614,6 +626,7 @@ mod tests {
             ErrorBrainUnexpected,
             ErrorNotionSyncFailed,
             ErrorRotateBlocked,
+            ErrorRotateNeedsHttps,
             ErrorRotateNotConfirmed,
             ErrorRotateSecureStore,
         ]

--- a/installer/src-tauri/src/i18n.rs
+++ b/installer/src-tauri/src/i18n.rs
@@ -127,6 +127,12 @@ pub enum Key {
     ErrorBrainHttpStatus,
     ErrorBrainUnexpected,
     ErrorNotionSyncFailed,
+    // Changing the password (#235). Each of these is a {detail} inside a screen
+    // the webview owns, never a screen of its own — every failure state in that
+    // flow has to carry the new password, which a bare error string cannot do.
+    ErrorRotateBlocked,
+    ErrorRotateNotConfirmed,
+    ErrorRotateSecureStore,
 }
 
 pub fn t(locale: Locale, key: Key) -> &'static str {
@@ -282,6 +288,18 @@ Second Brain's address by hand instead."
         (Locale::En, Key::ErrorBrainUnexpected) => "Unexpected response from your Second Brain.",
         (Locale::En, Key::ErrorNotionSyncFailed) => {
             "The sync didn't finish. Please try again from the dashboard."
+        }
+        (Locale::En, Key::ErrorRotateBlocked) => {
+            "Your Second Brain is rebuilding how it reads your memories, so its password \
+can't be changed just now."
+        }
+        (Locale::En, Key::ErrorRotateNotConfirmed) => {
+            "Your Second Brain didn't confirm the new password in time."
+        }
+        // Not ErrorSecureStoreConnect: that one says "Connected, but…", and
+        // nothing was connected here — a working password was replaced.
+        (Locale::En, Key::ErrorRotateSecureStore) => {
+            "Your password was changed, but we couldn't save it to this device's secure storage."
         }
 
         // Menu / tray — IT
@@ -445,6 +463,17 @@ Puoi inserire a mano l'indirizzo del tuo Second Brain."
         (Locale::It, Key::ErrorNotionSyncFailed) => {
             "La sincronizzazione non è terminata. Riprova dalla dashboard."
         }
+        (Locale::It, Key::ErrorRotateBlocked) => {
+            "Il tuo Second Brain sta ricostruendo il modo in cui legge i tuoi ricordi, \
+quindi la sua password non può essere cambiata adesso."
+        }
+        (Locale::It, Key::ErrorRotateNotConfirmed) => {
+            "Il tuo Second Brain non ha confermato la nuova password in tempo."
+        }
+        (Locale::It, Key::ErrorRotateSecureStore) => {
+            "La password è stata cambiata, ma non è stato possibile salvarla nell'archivio \
+sicuro del dispositivo."
+        }
     }
 }
 
@@ -584,6 +613,9 @@ mod tests {
             ErrorBrainHttpStatus,
             ErrorBrainUnexpected,
             ErrorNotionSyncFailed,
+            ErrorRotateBlocked,
+            ErrorRotateNotConfirmed,
+            ErrorRotateSecureStore,
         ]
     }
 

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -42,12 +42,7 @@ fn open_dashboard_from_menu(app: &AppHandle) {
                 .try_state::<AppLocale>()
                 .map(|l| l.get())
                 .unwrap_or(i18n::Locale::En);
-            // dry_run first: `&&` is short-circuiting, so testing it second
-            // still performs the keychain read, and every read can raise an OS
-            // password prompt on an unsigned dev build. This fired at startup,
-            // before any window opened, which is why demo mode has always asked
-            // for the login keychain.
-            if !session.dry_run && secure_store::load_setup().is_none() {
+            if not_connected_yet(session.dry_run, secure_store::load_setup) {
                 let _ = windows::open_setup_window(app);
             } else {
                 app.dialog()
@@ -58,6 +53,27 @@ fn open_dashboard_from_menu(app: &AppHandle) {
             }
         }
     }
+}
+
+/// Whether a failed "open my dashboard" means "this computer is not connected
+/// yet" — in which case the setup window is the answer rather than a warning.
+///
+/// The early return is the point, and it is `load_setup_unless_dry_run`'s point
+/// as well. Written inline as `!dry_run && load_setup().is_none()` this is one
+/// short-circuit away from #252: `&&` evaluates left to right, so swapping the
+/// terms — which compiles, reads the same to a reviewer, and survives every
+/// assertion about the value — makes a demo launch read the keychain and raise an
+/// OS password prompt on an unsigned dev build, before any window has opened.
+/// As a function with `dry_run` in a `return`, the ordering is structural and the
+/// loader is injectable, so a test can watch whether it was called at all.
+fn not_connected_yet(dry_run: bool, load: impl FnOnce() -> Option<SetupInfo>) -> bool {
+    if dry_run {
+        // Demo mode is never "not connected": the demo brain is always there, and
+        // asking secure storage about it would be asking the wrong question at
+        // the cost of a credential prompt.
+        return false;
+    }
+    load().is_none()
 }
 
 /// Menu-bar "Sync Notion now": runs the sync in the background and reports the
@@ -347,5 +363,67 @@ mod tests {
     fn normal_launch_without_stored_setup_falls_through_to_setup() {
         let got = load_setup_unless_dry_run(false, || None);
         assert!(got.is_none());
+    }
+
+    /// The other place #252's short-circuit lives: the menu-bar "Open dashboard"
+    /// that failed, deciding whether to show setup or a warning.
+    ///
+    /// Same bug, same shape, and until now nothing watched it. The prompt itself
+    /// is an OS dialog no test can see; whether the loader was called at all is
+    /// observable, and that is the thing that causes it.
+    #[test]
+    fn a_failed_menu_open_asks_the_keychain_nothing_in_dry_run() {
+        let called = Cell::new(false);
+        let answer = not_connected_yet(true, || {
+            called.set(true);
+            None
+        });
+        assert!(!called.get(), "dry-run must not touch the keychain");
+        assert!(
+            !answer,
+            "demo mode is never 'not connected' — the demo brain is always there"
+        );
+
+        // …and a real run does consult it, both ways round, so the guard above
+        // cannot be satisfied by never asking anyone.
+        assert!(not_connected_yet(false, || None), "no stored setup means setup");
+        assert!(
+            !not_connected_yet(false, || Some(info())),
+            "a connected computer gets the warning, not a fresh setup flow"
+        );
+    }
+
+    /// A command that is written, tested, and left unregistered is invisible to
+    /// the UI: `invoke` fails at runtime with "command not found", and nothing in
+    /// this crate notices, because every test here calls the Rust function
+    /// directly and never goes through the bridge.
+    ///
+    /// #235 added six, which is more than anyone keeps in their head. Scans only
+    /// the handler list, so the names written here cannot satisfy it.
+    #[test]
+    fn every_command_the_password_change_needs_is_reachable_from_the_webview() {
+        let src = include_str!("lib.rs");
+        let start = src
+            .find("tauri::generate_handler![")
+            .expect("the invoke handler");
+        let rest = &src[start..];
+        let handlers = &rest[..rest
+            .find("])")
+            .expect("the handler list closes with `])`")];
+
+        for command in [
+            "begin_password_change",
+            "rotation_blocked",
+            "rotate_password",
+            "recheck_password",
+            "validate_brain_address",
+            "disconnect_ai_tools",
+        ] {
+            assert!(
+                handlers.contains(&format!("commands::{command},")),
+                "`{command}` is not registered, so the screen that calls it gets \
+                 \"command not found\" and no test in this crate can tell"
+            );
+        }
     }
 }

--- a/installer/src-tauri/src/lib.rs
+++ b/installer/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod i18n;
 mod mcp_config;
 mod migration;
 mod password_check;
+mod rotate;
 mod secure_store;
 mod settings;
 mod version;
@@ -210,6 +211,14 @@ pub fn run() {
             commands::get_brain_settings,
             commands::save_brain_settings,
             commands::open_settings_window,
+            // Changing the brain's password (#235). A command that is written,
+            // tested, and left unregistered is invisible to the UI.
+            commands::begin_password_change,
+            commands::rotation_blocked,
+            commands::rotate_password,
+            commands::recheck_password,
+            commands::validate_brain_address,
+            commands::disconnect_ai_tools,
         ])
         .setup(move |app| {
             let handle = app.handle().clone();
@@ -280,9 +289,10 @@ pub fn run() {
             match load_setup_unless_dry_run(dry_run, secure_store::load_setup) {
                 Some(info) => {
                     windows::open_wrapper_window(&handle, &info.worker_url, &info.auth_token)?;
-                    // In wrapper mode, quietly check whether the deployed Worker
-                    // is behind what this app bundles and offer to update it.
-                    commands::maybe_offer_worker_update(&handle);
+                    // In wrapper mode, quietly ask the brain how it is: whether
+                    // the deployed Worker is behind what this app bundles, and
+                    // whether the password stored here still opens it at all.
+                    commands::check_brain_at_launch(&handle);
                 }
                 _ => windows::open_setup_window(&handle)?,
             }

--- a/installer/src-tauri/src/rotate.rs
+++ b/installer/src-tauri/src/rotate.rs
@@ -15,7 +15,7 @@
 //! moved, and writing the new password here first would lock this computer out
 //! of a brain that is still working perfectly on the old one.
 
-use crate::{cli_config, secure_store};
+use crate::cli_config;
 use std::path::Path;
 
 /// What happened at each of the places this computer keeps the password.
@@ -51,18 +51,38 @@ pub struct RotateOutcome {
 /// specifies — secure storage first, because it is the store the app itself
 /// depends on and the one whose failure the user must be told about.
 ///
-/// `refresh_dashboard` is injected rather than called directly so this stays
-/// testable: reaching an open webview needs a Tauri `AppHandle`, which cannot be
-/// constructed in a unit test, and the ordering above is exactly the sort of
-/// thing that quietly rots when it is only exercised by hand.
+/// Both `save_secure` and `refresh_dashboard` are injected rather than called
+/// directly, for two reasons that turned out to be the same reason.
+///
+/// Reaching an open webview needs a Tauri `AppHandle`, which cannot be
+/// constructed in a unit test — so without the seam the ordering here is only
+/// ever exercised by hand, and an ordering nothing asserts is exactly the sort of
+/// thing that quietly rots.
+///
+/// Secure storage has the mirror-image problem. Under `cfg(test)` its backing map
+/// is *process-global*, so calling it from here wrote state that `secure_store`'s
+/// own end-to-end test was mid-way through asserting on: this module's tests
+/// failed that neighbour roughly one run in fifteen at default parallelism, and
+/// never at `--test-threads=1`, so CI would have blamed `secure_store` for a fault
+/// introduced here. The seam removes the shared state entirely rather than
+/// serialising against it, and it buys the thing serialising could not: a
+/// `save_setup` that *fails*, which the real test backend cannot do, and which is
+/// the difference between the done screen's "this computer is using the new
+/// password already" being a fact and being a guess.
+///
+/// `save_secure` returns `Result<(), String>` rather than `secure_store`'s own
+/// error type because that type's inner field is private to its module — a test
+/// here could not construct one, which would leave the failure branch as
+/// unreachable as it was before.
 pub fn persist(
     home: &Path,
     worker_url: &str,
     new_token: &str,
+    save_secure: impl FnOnce(&str, &str) -> Result<(), String>,
     refresh_dashboard: impl FnOnce(&str) -> bool,
 ) -> RotateOutcome {
     // 1. Secure storage.
-    let keychain = match secure_store::save_setup(worker_url, new_token) {
+    let keychain = match save_secure(worker_url, new_token) {
         Ok(()) => true,
         Err(e) => {
             log::error!("could not save the new password to secure storage: {e}");
@@ -82,8 +102,17 @@ pub fn persist(
     // So `None` means "not installed", which is not a failure, and the existence
     // check is the whole point of this branch. Collapsing it to an unconditional
     // write is the mutation this module's tests exist to catch.
+    //
+    // The check is on the *file*, deliberately, and `is_file` rather than
+    // `exists`. Widening it to the parent directory — which `~/.config` users
+    // very often have, because anything else may have created
+    // `~/.config/second-brain/` — hands a plaintext credential file to exactly
+    // the person this branch exists to protect. That widening is a one-token edit
+    // and it survived every test in this module until
+    // `a_cli_directory_without_a_config_file_is_still_not_an_installed_cli` was
+    // written, so the guard against it is behavioural and not a source scan.
     let cli_config = cli_config::config_path(home)
-        .exists()
+        .is_file()
         .then(|| match cli_config::write_config(home, worker_url, new_token) {
             Ok(_) => true,
             Err(e) => {
@@ -123,56 +152,73 @@ mod tests {
     const URL: &str = "https://second-brain.demo.workers.dev";
     const NEW: &str = "k7hpq-3mrxd-9wfty-2njca";
 
+    /// A `save_secure` seam that succeeds and records what it was handed.
+    fn ok_store() -> impl FnOnce(&str, &str) -> Result<(), String> {
+        |_, _| Ok(())
+    }
+
     /// The store the app itself reads at launch. A rotation that changed the
     /// brain and not this one leaves the computer locked out of its own brain.
     ///
-    /// Reads back through `secure_store` rather than trusting the returned flag:
-    /// the flag is what `persist` claims, and the claim is what the done screen
-    /// repeats to the user.
-    ///
-    /// Reading the store back is deliberately not attempted, and the reason is
-    /// worth writing down rather than rediscovering. `secure_store`'s backing map
-    /// is process-global, and its own test clears and rewrites it from end to
-    /// end; a save-then-load here is measuring that test as much as this one, in
-    /// both directions. A guard that fails one run in thirty gets deleted rather
-    /// than fixed, so this asserts the two things that are actually stable: that
-    /// the write is reported, and — below — that it goes through `secure_store`
-    /// at all.
+    /// The address and the password are both asserted, because `save_setup` takes
+    /// two `&str` in that order and swapping them is a silent, compiling change
+    /// that would store the password as the address.
     #[test]
     fn writes_the_new_password_to_secure_storage() {
         let home = temp_home("keychain");
-        let outcome = persist(&home, URL, NEW, |_| true);
+        let seen = std::cell::RefCell::new(None);
+        let outcome = persist(
+            &home,
+            URL,
+            NEW,
+            |url, token| {
+                *seen.borrow_mut() = Some((url.to_string(), token.to_string()));
+                Ok(())
+            },
+            |_| true,
+        );
         assert!(
             outcome.keychain,
             "the store the app itself reads at launch. A rotation that changed the \
              brain and not this one leaves the computer locked out of its own brain"
         );
+        assert_eq!(
+            *seen.borrow(),
+            Some((URL.to_string(), NEW.to_string())),
+            "secure storage must be handed this brain's address and the NEW password"
+        );
     }
 
-    /// …and the write is a real one, not a reported one.
+    /// `keychain: true` is a claim, and the done screen opens by repeating it to
+    /// the user — "this computer is using the new password already". A store that
+    /// refused the write must not be reported as one that took it, or the one
+    /// screen whose job is to say what is safe now says the opposite of the truth.
     ///
-    /// The other half of the test above: `keychain: true` is a claim, and the done
-    /// screen repeats that claim to the user, so something has to hold the call
-    /// that makes it true in place.
+    /// Only reachable because the store is injected. The `cfg(test)` backend
+    /// behind `secure_store::save_setup` cannot fail, so before the seam existed
+    /// this branch was dead code that any mutation could delete unnoticed.
     #[test]
-    fn the_keychain_write_goes_through_secure_store() {
-        let src = include_str!("rotate.rs");
-        let code = &src[..src.find("#[cfg(test)]").expect("test module")];
-        let start = code.find("pub fn persist(").expect("persist");
-        let body = &code[start..];
-        let body = &body[..body.find("\n}").expect("end of fn")];
-
-        assert!(
-            body.contains("secure_store::save_setup"),
-            "persist no longer writes secure storage, so `keychain: true` would be \
-             telling the user their computer holds a password it does not have"
+    fn a_refused_keychain_write_is_reported_as_refused() {
+        let home = temp_home("keychain-fail");
+        let outcome = persist(
+            &home,
+            URL,
+            NEW,
+            |_, _| Err("the login keychain is locked".into()),
+            |_| true,
         );
         assert!(
-            body.contains("cli_config::config_path") && body.contains("exists()"),
-            "persist no longer checks whether the CLI config is there before \
-             writing it, so changing a password would create a plaintext \
-             credential file for someone who never installed the CLI"
+            !outcome.keychain,
+            "a store that refused the write must not be reported as holding the new \
+             password — the done screen tells the user this computer is already \
+             using it, and the next launch would then ask for a password nothing here has"
         );
+        assert_eq!(
+            outcome.cli_config, None,
+            "a failed keychain write does not abandon the rest: each store is \
+             independent and the user is told which one did not take"
+        );
+        assert!(outcome.dashboard, "…including the ones that did work");
     }
 
     /// The bug #235's own analysis missed. A user who never installed the CLI
@@ -183,7 +229,7 @@ mod tests {
         let path = cli_config::config_path(&home);
         assert!(!path.exists(), "precondition: the CLI was never set up here");
 
-        let outcome = persist(&home, URL, NEW, |_| true);
+        let outcome = persist(&home, URL, NEW, ok_store(), |_| true);
 
         assert_eq!(
             outcome.cli_config, None,
@@ -196,6 +242,37 @@ mod tests {
         assert!(
             !home.join(".config").join("second-brain").exists(),
             "nor the directory that would hold one"
+        );
+    }
+
+    /// The half-installed case, and the one the previous source-scanning guard
+    /// could not see.
+    ///
+    /// That guard asserted only that the words `config_path` and `exists()`
+    /// appeared in `persist`, so widening the test from the file to its parent
+    /// directory kept it green — while handing a plaintext copy of the user's new
+    /// password to anyone whose `~/.config/second-brain/` exists without a
+    /// `config.json` in it. That directory is created by an uninstall that left
+    /// the folder behind, by a `brain` command that failed before its first write,
+    /// or by hand; the file is the only thing that means "the CLI is set up here".
+    #[test]
+    fn a_cli_directory_without_a_config_file_is_still_not_an_installed_cli() {
+        let home = temp_home("cli-dir-only");
+        let path = cli_config::config_path(&home);
+        let dir = path.parent().expect("the config file has a parent");
+        fs::create_dir_all(dir).unwrap();
+        assert!(dir.exists() && !path.exists(), "precondition: directory, no file");
+
+        let outcome = persist(&home, URL, NEW, ok_store(), |_| true);
+
+        assert_eq!(
+            outcome.cli_config, None,
+            "an empty config directory is not an installed CLI"
+        );
+        assert!(
+            !path.exists(),
+            "changing a password created a plaintext credential file for someone \
+             who never installed the CLI — the exact harm this branch exists to prevent"
         );
     }
 
@@ -213,7 +290,7 @@ mod tests {
         )
         .unwrap();
 
-        let outcome = persist(&home, URL, NEW, |_| true);
+        let outcome = persist(&home, URL, NEW, ok_store(), |_| true);
 
         assert_eq!(outcome.cli_config, Some(true));
         let parsed: serde_json::Value =
@@ -233,7 +310,7 @@ mod tests {
     fn the_dashboard_result_is_passed_through_both_ways() {
         let home = temp_home("dash-ok");
         let seen = std::cell::RefCell::new(String::new());
-        let outcome = persist(&home, URL, NEW, |token| {
+        let outcome = persist(&home, URL, NEW, ok_store(), |token| {
             *seen.borrow_mut() = token.to_string();
             true
         });
@@ -245,8 +322,107 @@ mod tests {
         );
 
         let home = temp_home("dash-fail");
-        let outcome = persist(&home, URL, NEW, |_| false);
+        let outcome = persist(&home, URL, NEW, ok_store(), |_| false);
         assert!(!outcome.dashboard, "a refused refresh must not be reported as done");
+    }
+
+    /// The order of the three writes, asserted rather than described.
+    ///
+    /// The module doc calls this "exactly the sort of thing that quietly rots",
+    /// and it was right: moving the dashboard refresh above the keychain write
+    /// changed nothing any test could see. It matters because the stores are not
+    /// equal. Secure storage is the one the app itself reads at every launch, so
+    /// it goes first and its failure is the one the user must be told about; the
+    /// dashboard goes last because it is the only one the user can put right
+    /// themselves by closing the window and reopening it. Between them, the CLI
+    /// config — after the keychain, so a crash mid-run never leaves a plaintext
+    /// copy of a password that secure storage does not have.
+    ///
+    /// Each seam observes the *file* rather than a call log, so this pins all
+    /// three positions from two callbacks.
+    #[test]
+    fn the_stores_are_written_in_the_order_that_makes_a_half_finished_run_safe() {
+        let home = temp_home("order");
+        let path = cli_config::config_path(&home);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, r#"{"workerUrl":"x","authToken":"old"}"#).unwrap();
+
+        let calls = std::cell::RefCell::new(Vec::new());
+        let holds_new_password =
+            |p: &std::path::Path| fs::read_to_string(p).is_ok_and(|t| t.contains(NEW));
+
+        let outcome = persist(
+            &home,
+            URL,
+            NEW,
+            |_, _| {
+                calls.borrow_mut().push("keychain");
+                assert!(
+                    !holds_new_password(&path),
+                    "the CLI config was written before secure storage. A run that \
+                     stops in between then leaves a plaintext copy of a password \
+                     the app itself does not hold."
+                );
+                Ok(())
+            },
+            |_| {
+                calls.borrow_mut().push("dashboard");
+                assert!(
+                    holds_new_password(&path),
+                    "the dashboard was refreshed before the CLI config was written"
+                );
+                true
+            },
+        );
+
+        assert_eq!(
+            *calls.borrow(),
+            vec!["keychain", "dashboard"],
+            "secure storage is written first: it is the store the app reads at every \
+             launch, and the only one whose failure locks this computer out"
+        );
+        assert_eq!(outcome.cli_config, Some(true));
+    }
+
+    /// The wire shape the done screen reads, pinned by name.
+    ///
+    /// `#[serde(rename_all = "camelCase")]` is one line, deleting it compiles, and
+    /// every test above reads the Rust field rather than the JSON one — so the UI
+    /// would start seeing `cli_config` where it looks for `cliConfig`, silently
+    /// render "the CLI was not installed" for a user whose CLI was just rewritten,
+    /// and nothing would fail.
+    #[test]
+    fn the_outcome_reaches_the_screen_under_the_names_it_reads() {
+        let outcome = RotateOutcome {
+            keychain: true,
+            cli_config: Some(false),
+            dashboard: false,
+        };
+        assert_eq!(
+            serde_json::to_value(&outcome).expect("RotateOutcome serializes"),
+            serde_json::json!({
+                "keychain": true,
+                "cliConfig": false,
+                "dashboard": false,
+            })
+        );
+
+        // `None` has to arrive as an explicit null rather than a missing key: the
+        // screen distinguishes "the CLI was never installed" from "the CLI write
+        // failed", and an absent field reads as neither.
+        assert_eq!(
+            serde_json::to_value(RotateOutcome {
+                keychain: false,
+                cli_config: None,
+                dashboard: true,
+            })
+            .expect("RotateOutcome serializes"),
+            serde_json::json!({
+                "keychain": false,
+                "cliConfig": serde_json::Value::Null,
+                "dashboard": true,
+            })
+        );
     }
 
     /// The test that would have caught the CLI config.

--- a/installer/src-tauri/src/rotate.rs
+++ b/installer/src-tauri/src/rotate.rs
@@ -303,6 +303,53 @@ mod tests {
         );
     }
 
+    /// The CLI branch's other failure, and the one nothing could reach until
+    /// now: the file *is* there, so the write is attempted, and it does not take.
+    ///
+    /// `Some(true)` and `Some(false)` are different sentences on the done screen.
+    /// Reported as a success, the user is told the `brain` command is on the new
+    /// password; it then 401s from their next command onwards with nothing on
+    /// screen — and nothing in the outcome — to point at the cause. That is the
+    /// precise failure this module's own header says #235 would have shipped, so
+    /// the branch that reports it has to be pinned rather than merely written.
+    ///
+    /// The failure used here is a config file that is not JSON, for two reasons.
+    /// It is one `write_config` genuinely produces and refuses to clobber — its
+    /// own `malformed_config_is_not_clobbered` pins that — and it needs no
+    /// permissions: a read-only file or directory proves nothing under a CI
+    /// container running as root, where mode bits do not stop a write and this
+    /// test would silently invert into asserting that a *successful* write is
+    /// reported as a failure. It is also how a user really arrives here, by hand
+    /// editing the file or by a half-finished write.
+    #[test]
+    fn a_cli_config_that_could_not_be_rewritten_is_reported_as_not_rewritten() {
+        let home = temp_home("cli-unwritable");
+        let path = cli_config::config_path(&home);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "{ hand-edited, and no longer json").unwrap();
+
+        let outcome = persist(&home, URL, NEW, ok_store(), |_| true);
+
+        assert_eq!(
+            outcome.cli_config,
+            Some(false),
+            "the CLI is installed and the write did not take, which is a failed \
+             write and not an absent CLI. As `Some(true)` the done screen tells \
+             the user their `brain` command is on the new password, and the \
+             command then refuses them with no explanation available anywhere."
+        );
+        assert!(
+            !fs::read_to_string(&path).unwrap().contains(NEW),
+            "the report has to be true in the other direction too: the write \
+             failed, so the file must still hold what it held"
+        );
+        assert!(
+            outcome.keychain && outcome.dashboard,
+            "each store is independent — a CLI write that failed does not \
+             abandon the stores on either side of it"
+        );
+    }
+
     /// The dashboard result is reported, not assumed. An open window keeps the
     /// token it was created with, so "we told it" and "we could not" are
     /// different facts and the screen says different things about them.

--- a/installer/src-tauri/src/rotate.rs
+++ b/installer/src-tauri/src/rotate.rs
@@ -1,0 +1,291 @@
+//! The local half of a password change: every place on *this* computer that
+//! holds the brain's password, rewritten in one pass.
+//!
+//! Split out of `commands.rs` on the `migration.rs` precedent — `provision.rs`
+//! grows by one call (`rotate_secret`), not by a flow — and kept as one function
+//! for the reason #235 itself demonstrates. The issue named two stores. There are
+//! three, and the third is the one that would have shipped broken: the `brain`
+//! CLI reads a plaintext config file that nothing else touches, so a rotation
+//! that skipped it would leave the command silently 401ing with no clue why.
+//! [`RotateOutcome`] is the enumeration that was missing, and the guard test at
+//! the bottom of this file pins it.
+//!
+//! Called **only** after `provision::rotate_secret` reports success. Until the
+//! Worker has authenticated the new token there is no guarantee the brain has
+//! moved, and writing the new password here first would lock this computer out
+//! of a brain that is still working perfectly on the old one.
+
+use crate::{cli_config, secure_store};
+use std::path::Path;
+
+/// What happened at each of the places this computer keeps the password.
+///
+/// Returned to the webview on success as well as consulted on failure: the done
+/// screen opens by claiming "this computer is using the new password already",
+/// which it may only say if it knows the local writes landed.
+///
+/// One field per store, and the set of fields is the specification — see
+/// `the_places_a_rotation_writes_are_exactly_these_three`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RotateOutcome {
+    /// OS secure storage (Keychain / Credential Manager). The one the app itself
+    /// reads at every launch, so a `false` here means this computer will ask for
+    /// the password the next time it opens.
+    pub keychain: bool,
+    /// `~/.config/second-brain/config.json`, which the `brain` CLI reads.
+    ///
+    /// `None` means the file is not there, i.e. the CLI was never set up on this
+    /// computer. That is not a failure and gets no sentence on any screen.
+    pub cli_config: Option<bool>,
+    /// The dashboard window that is already open, if there is one. The token is
+    /// injected when that window is *created*, so an open one keeps serving the
+    /// old value until it is told otherwise.
+    pub dashboard: bool,
+}
+
+/// Writes `new_token` everywhere this computer keeps the brain's password.
+///
+/// Never fails as a whole: each store is independent, and a caller has to be
+/// able to tell the user precisely which one did not take. Ordered as the design
+/// specifies — secure storage first, because it is the store the app itself
+/// depends on and the one whose failure the user must be told about.
+///
+/// `refresh_dashboard` is injected rather than called directly so this stays
+/// testable: reaching an open webview needs a Tauri `AppHandle`, which cannot be
+/// constructed in a unit test, and the ordering above is exactly the sort of
+/// thing that quietly rots when it is only exercised by hand.
+pub fn persist(
+    home: &Path,
+    worker_url: &str,
+    new_token: &str,
+    refresh_dashboard: impl FnOnce(&str) -> bool,
+) -> RotateOutcome {
+    // 1. Secure storage.
+    let keychain = match secure_store::save_setup(worker_url, new_token) {
+        Ok(()) => true,
+        Err(e) => {
+            log::error!("could not save the new password to secure storage: {e}");
+            false
+        }
+    };
+
+    // 2. The CLI's config file — but only if it is already there.
+    //
+    // `cli_config::write_config` creates the file and its parent directory when
+    // they are missing. That is right at setup, where the user has just asked for
+    // the CLI, and wrong here: someone who never installed it would end up with a
+    // plaintext copy of their password sitting in their home directory as a side
+    // effect of *changing* that password. A change made for hygiene would leave
+    // them measurably worse off than before they made it.
+    //
+    // So `None` means "not installed", which is not a failure, and the existence
+    // check is the whole point of this branch. Collapsing it to an unconditional
+    // write is the mutation this module's tests exist to catch.
+    let cli_config = cli_config::config_path(home)
+        .exists()
+        .then(|| match cli_config::write_config(home, worker_url, new_token) {
+            Ok(_) => true,
+            Err(e) => {
+                log::warn!("could not update the CLI config with the new password: {e}");
+                false
+            }
+        });
+
+    // 3. The open dashboard window, last, because it is the only one the user
+    // can put right themselves by closing and reopening it.
+    let dashboard = refresh_dashboard(new_token);
+
+    RotateOutcome {
+        keychain,
+        cli_config,
+        dashboard,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn temp_home(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "sb-rotate-test-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    const URL: &str = "https://second-brain.demo.workers.dev";
+    const NEW: &str = "k7hpq-3mrxd-9wfty-2njca";
+
+    /// The store the app itself reads at launch. A rotation that changed the
+    /// brain and not this one leaves the computer locked out of its own brain.
+    ///
+    /// Reads back through `secure_store` rather than trusting the returned flag:
+    /// the flag is what `persist` claims, and the claim is what the done screen
+    /// repeats to the user.
+    ///
+    /// Reading the store back is deliberately not attempted, and the reason is
+    /// worth writing down rather than rediscovering. `secure_store`'s backing map
+    /// is process-global, and its own test clears and rewrites it from end to
+    /// end; a save-then-load here is measuring that test as much as this one, in
+    /// both directions. A guard that fails one run in thirty gets deleted rather
+    /// than fixed, so this asserts the two things that are actually stable: that
+    /// the write is reported, and — below — that it goes through `secure_store`
+    /// at all.
+    #[test]
+    fn writes_the_new_password_to_secure_storage() {
+        let home = temp_home("keychain");
+        let outcome = persist(&home, URL, NEW, |_| true);
+        assert!(
+            outcome.keychain,
+            "the store the app itself reads at launch. A rotation that changed the \
+             brain and not this one leaves the computer locked out of its own brain"
+        );
+    }
+
+    /// …and the write is a real one, not a reported one.
+    ///
+    /// The other half of the test above: `keychain: true` is a claim, and the done
+    /// screen repeats that claim to the user, so something has to hold the call
+    /// that makes it true in place.
+    #[test]
+    fn the_keychain_write_goes_through_secure_store() {
+        let src = include_str!("rotate.rs");
+        let code = &src[..src.find("#[cfg(test)]").expect("test module")];
+        let start = code.find("pub fn persist(").expect("persist");
+        let body = &code[start..];
+        let body = &body[..body.find("\n}").expect("end of fn")];
+
+        assert!(
+            body.contains("secure_store::save_setup"),
+            "persist no longer writes secure storage, so `keychain: true` would be \
+             telling the user their computer holds a password it does not have"
+        );
+        assert!(
+            body.contains("cli_config::config_path") && body.contains("exists()"),
+            "persist no longer checks whether the CLI config is there before \
+             writing it, so changing a password would create a plaintext \
+             credential file for someone who never installed the CLI"
+        );
+    }
+
+    /// The bug #235's own analysis missed. A user who never installed the CLI
+    /// must not acquire a plaintext credential file by changing their password.
+    #[test]
+    fn an_absent_cli_config_is_left_absent_rather_than_created() {
+        let home = temp_home("no-cli");
+        let path = cli_config::config_path(&home);
+        assert!(!path.exists(), "precondition: the CLI was never set up here");
+
+        let outcome = persist(&home, URL, NEW, |_| true);
+
+        assert_eq!(
+            outcome.cli_config, None,
+            "a CLI that was never installed is not a failed write"
+        );
+        assert!(
+            !path.exists(),
+            "changing a password must never create a plaintext credential file"
+        );
+        assert!(
+            !home.join(".config").join("second-brain").exists(),
+            "nor the directory that would hold one"
+        );
+    }
+
+    /// The other half: when the CLI *is* set up, leaving it on the old password
+    /// means `brain` 401s from the next command onwards with nothing on screen
+    /// to explain it.
+    #[test]
+    fn an_existing_cli_config_is_rewritten_and_its_other_keys_survive() {
+        let home = temp_home("with-cli");
+        let path = cli_config::config_path(&home);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            r#"{"workerUrl":"https://second-brain.demo.workers.dev","authToken":"old","defaultTags":["work"]}"#,
+        )
+        .unwrap();
+
+        let outcome = persist(&home, URL, NEW, |_| true);
+
+        assert_eq!(outcome.cli_config, Some(true));
+        let parsed: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(parsed["authToken"], NEW);
+        assert_eq!(parsed["workerUrl"], URL);
+        assert_eq!(
+            parsed["defaultTags"][0], "work",
+            "the CLI's own settings are not ours to discard"
+        );
+    }
+
+    /// The dashboard result is reported, not assumed. An open window keeps the
+    /// token it was created with, so "we told it" and "we could not" are
+    /// different facts and the screen says different things about them.
+    #[test]
+    fn the_dashboard_result_is_passed_through_both_ways() {
+        let home = temp_home("dash-ok");
+        let seen = std::cell::RefCell::new(String::new());
+        let outcome = persist(&home, URL, NEW, |token| {
+            *seen.borrow_mut() = token.to_string();
+            true
+        });
+        assert!(outcome.dashboard);
+        assert_eq!(
+            *seen.borrow(),
+            NEW,
+            "the window must be handed the new password, not the old one"
+        );
+
+        let home = temp_home("dash-fail");
+        let outcome = persist(&home, URL, NEW, |_| false);
+        assert!(!outcome.dashboard, "a refused refresh must not be reported as done");
+    }
+
+    /// The test that would have caught the CLI config.
+    ///
+    /// Pins the complete list of places a rotation writes, in the shape of
+    /// `secure_store`'s `the_stored_key_set_is_exactly_these_five`. #235 was
+    /// filed naming two stores; nothing in the codebase enumerated them, so the
+    /// third was found by reading `cli_config.rs` rather than by anything
+    /// failing. Adding a fourth is then a deliberate act that forces someone to
+    /// decide what a rotation owes it.
+    ///
+    /// Scans only the source *above* the test module, and only the struct's own
+    /// body. A source-scanning guard that reads the whole file matches its own
+    /// expectation string and passes no matter what the code says — that has
+    /// quietly disabled three guards in this repo already.
+    #[test]
+    fn the_places_a_rotation_writes_are_exactly_these_three() {
+        let src = include_str!("rotate.rs");
+        let code = &src[..src.find("#[cfg(test)]").expect("test module")];
+
+        let start = code
+            .find("pub struct RotateOutcome {")
+            .expect("RotateOutcome is declared above the tests");
+        let body = &code[start..];
+        let body = &body[..body.find("\n}").expect("end of the struct")];
+
+        let fields: Vec<&str> = body
+            .lines()
+            .skip(1) // the `pub struct …` line itself
+            .filter_map(|line| line.trim().strip_prefix("pub "))
+            .filter_map(|field| field.split(':').next())
+            .collect();
+
+        assert_eq!(
+            fields,
+            vec!["keychain", "cli_config", "dashboard"],
+            "a rotation gained or lost somewhere it writes. Every store here has \
+             to be rewritten together, because the ones that are missed do not \
+             announce themselves — they just start refusing the user's password."
+        );
+    }
+}

--- a/installer/src-tauri/src/windows.rs
+++ b/installer/src-tauri/src/windows.rs
@@ -242,6 +242,54 @@ fn open_wrapper_window_impl(
     Ok(())
 }
 
+/// Re-points an already-open dashboard window at a new password, then reloads it.
+///
+/// The origin check is not ceremony, and it is the reason this is a separate
+/// script rather than a re-run of the creation-time one. The `brain` window
+/// navigates to third-party sites during an integration's OAuth handshake
+/// (Notion, Google, Microsoft), and `eval` runs against whatever document is
+/// loaded at the time — so an unguarded write would hand the user's brain
+/// password to someone else's origin. The reload sits inside the same guard for
+/// a milder version of the same reason: reloading a half-finished sign-in throws
+/// it away.
+const REFRESH_TOKEN_JS: &str = r#"(function () {
+  try {
+    if (location.origin !== __ORIGIN__) { return; }
+    localStorage.setItem('sb_url', __ORIGIN__);
+    localStorage.setItem('sb_token', __TOKEN__);
+    location.reload();
+  } catch (_) {}
+})();"#;
+
+/// Hands the open dashboard window the new password and reloads it.
+///
+/// The token reaches that window through an `initialization_script`, which runs
+/// once per page load. A window that was already open when the password changed
+/// therefore goes on presenting the old one indefinitely: nothing about it looks
+/// broken, it simply starts 401ing, and the only route back is Disconnect.
+///
+/// Returns whether the dashboard is now on the new password. `true` when there is
+/// no wrapper window at all — the caller is asking whether a stale copy is left
+/// anywhere, and with no window there is none.
+pub fn refresh_wrapper_token(app: &AppHandle, worker_url: &str, auth_token: &str) -> bool {
+    let Some(window) = app.get_webview_window("brain") else {
+        return true;
+    };
+    let origin = worker_url.trim_end_matches('/');
+    // serde_json turns both values into safely-escaped JS string literals, the
+    // same way the creation-time injection does.
+    let script = REFRESH_TOKEN_JS
+        .replace("__ORIGIN__", &serde_json::to_string(origin).expect("string serializes"))
+        .replace("__TOKEN__", &serde_json::to_string(auth_token).expect("string serializes"));
+    match window.eval(&script) {
+        Ok(()) => true,
+        Err(e) => {
+            log::warn!("could not refresh the dashboard window's password: {e}");
+            false
+        }
+    }
+}
+
 pub fn open_details_window(app: &AppHandle) {
     let locale = app
         .try_state::<crate::i18n::AppLocale>()
@@ -330,5 +378,41 @@ mod tests {
         let body = &src[start..end];
         assert!(body.contains("CONNECTIONS_PATH"));
         assert!(body.contains("SETTINGS_PATH"));
+    }
+
+    /// A rotation re-injects the password into an already-open dashboard window.
+    /// That window is not always on the user's own origin: an integration's
+    /// OAuth handshake navigates it to Notion or Google, and `eval` targets
+    /// whatever document is loaded. Writing the password there would hand the key
+    /// to the user's whole brain to a third party.
+    ///
+    /// Asserted on the source because the failure needs a live webview sitting on
+    /// a foreign origin, which this suite has no way to produce — but the guard
+    /// that prevents it is a single line, and its absence is checkable.
+    ///
+    /// Reads only the literal's own body, so the strings in this test cannot
+    /// satisfy it.
+    #[test]
+    fn the_token_refresh_writes_nothing_outside_the_brains_own_origin() {
+        let src = include_str!("windows.rs");
+        let start = src.find("const REFRESH_TOKEN_JS").expect("REFRESH_TOKEN_JS");
+        let body = &src[start..];
+        let body = &body[..body.find("\"#;").expect("end of the literal")];
+
+        let guard = body
+            .find("location.origin !== __ORIGIN__")
+            .expect("the refresh script must compare origins before writing");
+        let write = body.find("sb_token").expect("the token write");
+        let reload = body.find("location.reload").expect("the reload");
+
+        assert!(
+            guard < write,
+            "the password is written before the origin is checked, which leaks it \
+             to whatever site the dashboard window happens to be showing"
+        );
+        assert!(
+            guard < reload,
+            "an unguarded reload discards a third-party sign-in that is mid-flight"
+        );
     }
 }

--- a/installer/src-tauri/src/windows.rs
+++ b/installer/src-tauri/src/windows.rs
@@ -171,9 +171,13 @@ fn open_wrapper_window_impl(
         let _ = w.set_focus();
         return Ok(());
     }
-    let origin = worker_url.trim_end_matches('/');
+    // Through `brain_origin`, the same definition the refresh below uses. Two
+    // spellings of "origin" in one file is how they drift, and the guard in both
+    // injected scripts compares against `location.origin`, which carries no path
+    // and no trailing slash.
+    let origin = brain_origin(worker_url).ok_or(tauri::Error::WindowNotFound)?;
     // serde_json turns the values into safely-escaped JS string literals.
-    let origin_js = serde_json::to_string(origin).expect("string serializes");
+    let origin_js = serde_json::to_string(&origin).expect("string serializes");
     let token_js = serde_json::to_string(auth_token).expect("string serializes");
     let mut init = format!(
         r#"(function () {{
@@ -261,6 +265,40 @@ const REFRESH_TOKEN_JS: &str = r#"(function () {
   } catch (_) {}
 })();"#;
 
+/// A stored brain address as a browser origin: scheme, host, and port only.
+///
+/// `location.origin` never carries a path or a trailing slash, and a stored
+/// address very often does — `connect_existing` accepts one, and
+/// `details_from_anywhere` trims it back off for exactly this reason. Compared
+/// raw, `https://brain.workers.dev/` never equals `https://brain.workers.dev`, so
+/// the injected guard below would decline to write on every rotation for those
+/// users while this function went on reporting success. Parsing rather than
+/// trimming means that difference cannot be reintroduced by deleting one call.
+///
+/// `None` for anything that is not a real `scheme://host` — an opaque origin can
+/// never legitimately equal a brain's, and treating "unparseable" as "matches"
+/// is how a password reaches a page it does not belong on.
+fn brain_origin(worker_url: &str) -> Option<String> {
+    let origin = url::Url::parse(worker_url.trim()).ok()?.origin();
+    origin.is_tuple().then(|| origin.ascii_serialization())
+}
+
+/// Whether the page a window is currently showing is the user's own brain.
+///
+/// The `brain` window is not always on the brain: an integration's OAuth
+/// handshake navigates it to Notion, Google or Microsoft, and it stays there
+/// until the user finishes. Asked in Rust as well as in the injected script
+/// because the two answer different questions — the script decides whether to
+/// *write*, and this decides what the caller may be *told*, and until now the
+/// caller was told "done" whenever the script had been handed over successfully,
+/// whether or not it had written anything.
+fn showing_the_brain(window_url: &str, worker_url: &str) -> bool {
+    match (brain_origin(window_url), brain_origin(worker_url)) {
+        (Some(showing), Some(brain)) => showing == brain,
+        _ => false,
+    }
+}
+
 /// Hands the open dashboard window the new password and reloads it.
 ///
 /// The token reaches that window through an `initialization_script`, which runs
@@ -268,18 +306,51 @@ const REFRESH_TOKEN_JS: &str = r#"(function () {
 /// therefore goes on presenting the old one indefinitely: nothing about it looks
 /// broken, it simply starts 401ing, and the only route back is Disconnect.
 ///
-/// Returns whether the dashboard is now on the new password. `true` when there is
-/// no wrapper window at all — the caller is asking whether a stale copy is left
-/// anywhere, and with no window there is none.
+/// Returns whether the dashboard is now on the new password — not whether a
+/// script was handed over. Those came apart in the two cases that matter: a
+/// window sitting on a third-party OAuth page, where the injected guard correctly
+/// declines to write, and a stored address with a trailing slash, where the
+/// comparison could never succeed. `eval` is fire-and-forget and cannot report
+/// either back, so the origin is settled here, from what the window says it is
+/// showing, before the script is sent at all.
+///
+/// The guard inside the script stays regardless. This check and that one race —
+/// the window can navigate in between — and the one that runs in the same tick as
+/// the write is the one that keeps the password off someone else's origin.
+///
+/// `true` when there is no wrapper window at all: the caller is asking whether a
+/// stale copy is left anywhere, and with no window there is none.
 pub fn refresh_wrapper_token(app: &AppHandle, worker_url: &str, auth_token: &str) -> bool {
     let Some(window) = app.get_webview_window("brain") else {
         return true;
     };
-    let origin = worker_url.trim_end_matches('/');
+    let Some(origin) = brain_origin(worker_url) else {
+        log::warn!("cannot refresh the dashboard window: {worker_url} has no origin");
+        return false;
+    };
+    match window.url() {
+        Ok(showing) if showing_the_brain(showing.as_str(), &origin) => {}
+        Ok(showing) => {
+            // Not an error and not worth a scary message: the user is part-way
+            // through connecting an integration. The window will pick the new
+            // password up from the creation-time script on its next load, and the
+            // done screen says so rather than claiming it is already there.
+            log::info!(
+                "the dashboard window is on {} rather than the brain, so it keeps the \
+                 old password until it navigates back",
+                showing.origin().ascii_serialization()
+            );
+            return false;
+        }
+        Err(e) => {
+            log::warn!("could not read the dashboard window's address: {e}");
+            return false;
+        }
+    }
     // serde_json turns both values into safely-escaped JS string literals, the
     // same way the creation-time injection does.
     let script = REFRESH_TOKEN_JS
-        .replace("__ORIGIN__", &serde_json::to_string(origin).expect("string serializes"))
+        .replace("__ORIGIN__", &serde_json::to_string(&origin).expect("string serializes"))
         .replace("__TOKEN__", &serde_json::to_string(auth_token).expect("string serializes"));
     match window.eval(&script) {
         Ok(()) => true,
@@ -334,6 +405,52 @@ pub fn open_settings_window(app: &AppHandle) {
 
 #[cfg(test)]
 mod tests {
+    use super::{brain_origin, showing_the_brain};
+
+    /// This file's source, stopping at the test module.
+    ///
+    /// Every guard below reads the code and nothing but the code. A scan that
+    /// runs on past the last item finds the assertion strings written to describe
+    /// it and passes with the thing it guards deleted — which is not a
+    /// hypothetical here. `both_sentinel_paths_are_deferred` passed with
+    /// `SETTINGS_PATH` removed from the handler outright, because its end anchor
+    /// (`"\n        .build()"`) was neither unique nor tied to this window and its
+    /// `unwrap_or(rest.len())` fallback sent `end` to the end of the file, where
+    /// the literal `"SETTINGS_PATH"` in its own assertion satisfied it. That
+    /// pattern has now misfired four times in this repository, so: bounded source,
+    /// unique anchors, and `expect` everywhere. A guard that cannot find what it
+    /// is anchored to must fail, never widen.
+    fn code() -> &'static str {
+        let src = include_str!("windows.rs");
+        &src[..src
+            .find("\n#[cfg(test)]\nmod tests {")
+            .expect("the test module is the boundary of the scannable source")]
+    }
+
+    /// The `brain` window's navigation handler, and only that.
+    ///
+    /// Anchored inside `open_wrapper_window_impl` first, so it is tied to the
+    /// window whose handler this is rather than to whichever `.on_navigation(`
+    /// happens to come first in the file.
+    fn navigation_handler() -> &'static str {
+        let code = code();
+        let builder = code
+            .find("fn open_wrapper_window_impl(")
+            .expect("the brain window's builder");
+        let scope = &code[builder..];
+        let scope = &scope[..scope
+            .find("\n}\n")
+            .expect("open_wrapper_window_impl ends at a closing brace in column zero")];
+        let start = scope
+            .find(".on_navigation(")
+            .expect("the brain window still installs a navigation handler");
+        let rest = &scope[start..];
+        let end = rest
+            .find("\n        })\n")
+            .expect("the navigation closure closes at eight spaces, before .build()");
+        &rest[..end]
+    }
+
     /// Windows 11 report: the Connections button in the injected sidebar hung the
     /// app ("Not Responding", unpainted window) while the same window opened fine
     /// from the menu bar.
@@ -349,11 +466,7 @@ mod tests {
     /// rather than doing it inline.
     #[test]
     fn navigation_handler_never_builds_a_window_inline() {
-        let src = include_str!("windows.rs");
-        let start = src.find(".on_navigation(").expect("on_navigation");
-        let rest = &src[start..];
-        let end = rest.find("\n        .build()").unwrap_or(rest.len()) + start;
-        let body = &src[start..end];
+        let body = navigation_handler();
 
         assert!(
             body.contains("run_on_main_thread"),
@@ -371,13 +484,101 @@ mod tests {
     /// covering only Connections would leave Advanced Settings hanging.
     #[test]
     fn both_sentinel_paths_are_deferred() {
-        let src = include_str!("windows.rs");
-        let start = src.find(".on_navigation(").expect("on_navigation");
-        let rest = &src[start..];
-        let end = rest.find("\n        .build()").unwrap_or(rest.len()) + start;
-        let body = &src[start..end];
-        assert!(body.contains("CONNECTIONS_PATH"));
-        assert!(body.contains("SETTINGS_PATH"));
+        let body = navigation_handler();
+        for path in ["CONNECTIONS_PATH", "SETTINGS_PATH"] {
+            assert!(
+                body.contains(path),
+                "{path} is no longer intercepted, so clicking that button navigates \
+                 the dashboard to a route it does not serve — and on Windows the \
+                 window it was meant to open never appears at all"
+            );
+        }
+    }
+
+    /// A stored address becomes the origin a browser would report, by parsing
+    /// rather than by trimming.
+    ///
+    /// The trailing slash is the whole point. `location.origin` never has one, and
+    /// stored addresses sometimes do, so `https://brain.workers.dev/` compared raw
+    /// against `location.origin` is never equal: the injected guard declines to
+    /// write on every rotation, the dashboard keeps the old password, and — before
+    /// this — the function reported `true` anyway. Deleting a `trim_end_matches`
+    /// used to be that bug and left every test green; there is now nothing to
+    /// delete, because the comparison is between parsed origins.
+    #[test]
+    fn a_stored_address_becomes_the_origin_the_page_will_report() {
+        for input in [
+            "https://second-brain.acme.workers.dev",
+            "https://second-brain.acme.workers.dev/",
+            "https://second-brain.acme.workers.dev/graph?tab=all",
+            "  https://second-brain.acme.workers.dev/  ",
+        ] {
+            assert_eq!(
+                brain_origin(input).as_deref(),
+                Some("https://second-brain.acme.workers.dev"),
+                "input: {input:?}"
+            );
+        }
+
+        // The port is part of the origin, and the demo brain lives on one.
+        assert_eq!(
+            brain_origin("http://127.0.0.1:8787/").as_deref(),
+            Some("http://127.0.0.1:8787")
+        );
+
+        // Nothing that is not a real scheme://host may produce an origin. An
+        // opaque one can never legitimately equal a brain's, and answering
+        // "matches" for an address nobody could parse is how a password reaches a
+        // page it does not belong on.
+        for input in ["", "not a url", "data:text/html,x", "https://"] {
+            assert_eq!(brain_origin(input), None, "input: {input:?}");
+        }
+    }
+
+    /// `dashboard: true` means "that window now has the new password", not "a
+    /// script was handed over".
+    ///
+    /// The two came apart wherever it mattered. `eval` is fire-and-forget: it
+    /// returns `Ok` as soon as the script has been posted to the webview, and
+    /// says nothing about whether the origin guard inside it decided to write. So
+    /// a `brain` window part-way through an integration's OAuth handshake — on
+    /// Notion, Google or Microsoft, which is where that window spends real time —
+    /// correctly refused the write and was reported to the user as done, leaving a
+    /// dashboard that 401s under a screen saying it had been updated.
+    #[test]
+    fn only_the_brains_own_page_counts_as_holding_the_new_password() {
+        let brain = "https://second-brain.acme.workers.dev";
+
+        for showing in [
+            brain,
+            "https://second-brain.acme.workers.dev/",
+            "https://second-brain.acme.workers.dev/graph?tab=all",
+        ] {
+            assert!(showing_the_brain(showing, brain), "showing: {showing:?}");
+        }
+
+        for showing in [
+            // Where the window actually goes during an integration handshake.
+            "https://api.notion.com/v1/oauth/authorize?client_id=x",
+            "https://accounts.google.com/o/oauth2/v2/auth",
+            "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+            // A different brain, and a look-alike host.
+            "https://second-brain.other.workers.dev/",
+            "https://second-brain.acme.workers.dev.evil.example/",
+            // Same host, different scheme and different port: neither is the same
+            // origin, and `localStorage` is partitioned by all three.
+            "http://second-brain.acme.workers.dev/",
+            "https://second-brain.acme.workers.dev:8443/",
+            "about:blank",
+            "",
+        ] {
+            assert!(
+                !showing_the_brain(showing, brain),
+                "a window on {showing:?} was treated as the user's own dashboard — \
+                 which is both a false 'done' on the screen and, if the script's own \
+                 guard ever went, the user's brain password written to that origin"
+            );
+        }
     }
 
     /// A rotation re-injects the password into an already-open dashboard window.
@@ -394,9 +595,9 @@ mod tests {
     /// satisfy it.
     #[test]
     fn the_token_refresh_writes_nothing_outside_the_brains_own_origin() {
-        let src = include_str!("windows.rs");
-        let start = src.find("const REFRESH_TOKEN_JS").expect("REFRESH_TOKEN_JS");
-        let body = &src[start..];
+        let code = code();
+        let start = code.find("const REFRESH_TOKEN_JS").expect("REFRESH_TOKEN_JS");
+        let body = &code[start..];
         let body = &body[..body.find("\"#;").expect("end of the literal")];
 
         let guard = body
@@ -413,6 +614,53 @@ mod tests {
         assert!(
             guard < reload,
             "an unguarded reload discards a third-party sign-in that is mid-flight"
+        );
+
+        // The Rust half of the same rule. The script's guard decides whether to
+        // write; this one decides what the user is told, and it has to be settled
+        // before `eval` because `eval` cannot answer. Both stay: they race, and
+        // the one that runs in the same tick as the write is the one that keeps
+        // the password off someone else's origin.
+        let refresh = {
+            let start = code
+                .find("pub fn refresh_wrapper_token(")
+                .expect("the refresh function");
+            let rest = &code[start..];
+            &rest[..rest
+                .find("\n}\n")
+                .expect("refresh_wrapper_token ends at a closing brace in column zero")]
+        };
+        let asked = refresh
+            .find("window.url()")
+            .expect("the window is no longer asked where it is, so a refresh that \
+                     wrote nothing is reported as done");
+        let evaluated = refresh.find("window.eval").expect("the script is still sent");
+        assert!(
+            asked < evaluated,
+            "the origin has to be settled before the script is handed over — after \
+             it there is nothing left to decide, because `eval` returns `Ok` as soon \
+             as the script is posted and never says what it did"
+        );
+
+        // …and the answer has to be acted on. The comparison is unit-tested
+        // above; what only the source can show is that a window on someone else's
+        // page leaves this function as a `false`. Turning that into a `true` is a
+        // one-word edit that restores the original bug exactly: a screen telling
+        // the user their dashboard is on the new password when nothing wrote it.
+        let decision = &refresh[asked..evaluated];
+        assert!(
+            decision.contains("showing_the_brain"),
+            "the window's address is read and then ignored"
+        );
+        assert!(
+            decision.contains("return false"),
+            "a window that is not showing the brain must leave this function as a \
+             `false`: nothing was written, and the done screen repeats this flag to \
+             the user as \"your dashboard is already using the new password\""
+        );
+        assert!(
+            !decision.contains("return true"),
+            "something short-circuits to success before the script has been sent"
         );
     }
 }

--- a/installer/src/details.ts
+++ b/installer/src/details.ts
@@ -43,6 +43,11 @@ async function boot() {
   const update = await invoke<{ availableVersion: string } | null>(
     "worker_update_available",
   ).catch(() => null);
+  // A rebuild in flight blocks a password change (#235 §4). If the check itself
+  // can't run — offline, brain unreachable — the button stays enabled: a
+  // network blip must not present as "you may not change your password", and
+  // the command re-checks before it does anything anyway.
+  const rotationBlocked = await invoke<boolean>("rotation_blocked").catch(() => false);
 
   // One pane at a time, chosen from a rail. Everything used to be stacked in a
   // single column, so most of it was below the fold and the only way to find
@@ -60,7 +65,12 @@ async function boot() {
         h("h2", { class: "pane-title" }, [t("details.navConnection")]),
         h("p", { class: "pane-desc" }, [t("details.lede")]),
         ...detailCards(details),
+        // After both URL cards, never between them: "Copy both" copies exactly
+        // those two values, so anything inserted between them makes its label
+        // wrong.
+        passwordCard(rotationBlocked),
         h("div", { class: "actions-spread" }, [copyBothButton(details), emailButton(details)]),
+        disconnectSection(),
       ];
     }
     if (id === "tools") {
@@ -125,6 +135,104 @@ function updateCard(availableVersion: string): HTMLElement {
     h("div", { class: "url-desc" }, [t("details.updateDesc")]),
     button,
   ]);
+}
+
+/// The one card here with no value and no Copy button. That absence is the
+/// first thing a reader notices, so the description explains it rather than
+/// leaving it to be inferred: nothing can read the password back, so there is
+/// nothing to show.
+function passwordCard(blocked: boolean): HTMLElement {
+  const card = h("div", { class: "card url-card" }, [
+    h("div", { class: "url-label" }, [t("details.passwordLabel")]),
+    h("div", { class: "url-desc" }, [t("details.passwordDesc")]),
+  ]);
+
+  if (!blocked) {
+    const change = h("button", { class: "btn-secondary" }, [t("details.passwordButton")]);
+    change.addEventListener("click", () => void invoke("begin_password_change"));
+    card.append(h("div", { class: "row-actions", style: "justify-content:flex-end" }, [change]));
+    return card;
+  }
+
+  // In place of the button, inside the same card. Opening a window that
+  // immediately dead-ends is worse than never enabling the door, and the escape
+  // route has to be visible next to the thing it unblocks — an abandoned
+  // rebuild would otherwise block this forever with no on-screen reason.
+  const settings = h("button", { class: "btn-secondary" }, [t("changePassword.blockedButton")]);
+  settings.addEventListener("click", () => void invoke("open_settings_window"));
+  card.append(
+    h("div", { class: "notice" }, [
+      "⚠️",
+      h("div", {}, [
+        h("div", { class: "url-label" }, [t("changePassword.blockedTitle")]),
+        h("div", {}, [t("changePassword.blockedBody")]),
+        h("div", { style: "margin-top:8px" }, [t("changePassword.blockedEscape")]),
+      ]),
+    ]),
+    h("div", { class: "row-actions", style: "justify-content:flex-end" }, [settings]),
+  );
+  return card;
+}
+
+/// Deliberately not part of changing the password (#235 §6). Tools connected
+/// with the connection link hold their own access and never used the password,
+/// so a change does not reach them — and a change made after a leak would
+/// otherwise leave them open. Confirmation names what will need reconnecting.
+function disconnectSection(): HTMLElement {
+  const container = h("div", { class: "logout-section" });
+
+  // `note` replaces the description with what just happened, so a partial
+  // failure keeps the button it needs to be retried with.
+  const render = (confirming: boolean, note?: string) => {
+    const label = h("div", { class: "url-label" }, [t("details.disconnectLabel")]);
+    if (!confirming) {
+      const start = h("button", { class: "btn-danger" }, [t("details.disconnectButton")]);
+      start.addEventListener("click", () => render(true));
+      container.replaceChildren(
+        label,
+        h("div", { class: "url-desc" }, [note ?? t("details.disconnectDesc")]),
+        h("div", { class: "row-actions" }, [start]),
+      );
+      return;
+    }
+
+    const confirm = h("button", { class: "btn-danger" }, [t("details.disconnectConfirm")]);
+    const keep = h("button", { class: "btn-ghost" }, [t("details.disconnectKeep")]);
+    const status = h("div", { class: "url-desc" }, [t("details.disconnectConfirmDesc")]);
+    keep.addEventListener("click", () => render(false));
+    confirm.addEventListener("click", async () => {
+      confirm.disabled = true;
+      keep.disabled = true;
+      confirm.textContent = t("details.disconnectWorking");
+      try {
+        const result = await invoke<{ ok: boolean; revoked: number; failed: number }>(
+          "disconnect_ai_tools",
+        );
+        // `failed` is reported rather than swallowed: a tool that kept its
+        // access is the whole thing this control exists to close, so that case
+        // goes back to a state the user can run again.
+        if (!result.ok) {
+          render(false, t("details.disconnectFailed"));
+          return;
+        }
+        container.replaceChildren(
+          label,
+          h("div", { class: "url-desc" }, [
+            result.revoked === 0 ? t("details.disconnectDoneNone") : t("details.disconnectDone"),
+          ]),
+        );
+      } catch (e) {
+        status.textContent = String(e);
+        confirm.disabled = false;
+        keep.disabled = false;
+        confirm.textContent = t("details.disconnectConfirm");
+      }
+    });
+    container.replaceChildren(label, status, h("div", { class: "row-actions" }, [confirm, keep]));
+  };
+
+  render(false);
+  return container;
 }
 
 function logoutSection(): HTMLElement {

--- a/installer/src/details.ts
+++ b/installer/src/details.ts
@@ -47,7 +47,27 @@ async function boot() {
   // can't run — offline, brain unreachable — the button stays enabled: a
   // network blip must not present as "you may not change your password", and
   // the command re-checks before it does anything anyway.
-  const rotationBlocked = await invoke<boolean>("rotation_blocked").catch(() => false);
+  let rotationBlocked = await invoke<boolean>("rotation_blocked").catch(() => false);
+
+  // Re-asked rather than captured once. A rebuild is finished (or carried on)
+  // in the Advanced Settings window, and the user comes straight back here to
+  // do the thing they were blocked from — so a value read at boot would go on
+  // saying the password can't be changed until this window was closed and
+  // reopened. Only a change in the answer redraws, so this settles after one
+  // flip instead of looping.
+  const refreshRotationBlocked = () => {
+    void invoke<boolean>("rotation_blocked").then(
+      blocked => {
+        if (blocked === rotationBlocked) return;
+        rotationBlocked = blocked;
+        render();
+      },
+      () => {
+        /* offline: keep whatever the last successful answer was */
+      },
+    );
+  };
+  window.addEventListener("focus", refreshRotationBlocked);
 
   // One pane at a time, chosen from a rail. Everything used to be stacked in a
   // single column, so most of it was below the fold and the only way to find
@@ -57,6 +77,8 @@ async function boot() {
 
   const paneFor = (id: SectionId): HTMLElement[] => {
     if (id === "connection") {
+      // Every time this pane is drawn, not only the first.
+      refreshRotationBlocked();
       // No "open the dashboard" button here on purpose: this window is reached
       // from the dashboard, which stays open behind it, so the button only sent
       // this window to the back. The menu bar still has one for the case where

--- a/installer/src/i18n/en.ts
+++ b/installer/src/i18n/en.ts
@@ -348,6 +348,7 @@ export const en: Messages = {
     unlockLede:
       "This is the password you chose when you first set up your Second Brain. " +
       "Nothing will be changed or reset.",
+    lostPassword: "I don't have my password",
   },
   password: {
     title: "Create your password",
@@ -374,6 +375,160 @@ export const en: Messages = {
       "We check new passwords against known data breaches without ever " +
       "sending your password anywhere — only a fragment of a fingerprint " +
       "leaves this computer.",
+  },
+  changePassword: {
+    title: "Change your password",
+    lede:
+      "You'll pick a new one, save it, and it replaces the old one everywhere. " +
+      "Your memories, your address, and your connected AI tools are all kept.",
+    notice:
+      "The old password stops working as soon as this finishes. Your other " +
+      "computers will ask for the new one the next time you open them.",
+    signInButton: "Sign in and continue",
+    signInFootnote:
+      "Your Second Brain lives in your own space at Cloudflare, so we sign in " +
+      "there to change it. We never see your Cloudflare password.",
+    waitingLede:
+      "Finish signing in to Cloudflare in the browser window that just opened, " +
+      "then come back here.",
+    blockedTitle: "The password can't be changed right now",
+    blockedBody:
+      "Your Second Brain is rebuilding how it reads your memories. Changing your " +
+      "password in the middle of that can stop the rebuild partway and make a " +
+      "password problem look like a failed rebuild, so it waits until the " +
+      "rebuild is done.",
+    blockedEscape:
+      "If nothing is rebuilding, one was left unfinished. Open Advanced Settings " +
+      "to carry it on or start it over — either one clears this.",
+    blockedButton: "Open Advanced Settings",
+    lostTitle: "Your memories are safe",
+    lostLede:
+      "Nothing is lost. Your password can't be read back — not by this app, not " +
+      "by Cloudflare — but it can be replaced, and replacing it is how you get " +
+      "back in.",
+    lostBodySignedIn:
+      "You're already signed in to the Cloudflare space your Second Brain lives " +
+      "in, which is what decides who gets in. So you can set a new password " +
+      "right now. Everything you've stored stays exactly where it is.",
+    lostBodySignIn:
+      "Your Second Brain lives in your own Cloudflare space, and that's what " +
+      "decides who gets in. Sign in there and you can set a new password. " +
+      "Everything you've stored stays exactly where it is.",
+    lostNotice:
+      "Anything that already has the old password will ask for the new one — " +
+      "your other computers, the browser extension, the Obsidian plugin.",
+    lostContinueButton: "Choose a new password",
+    // Word for word the same as connectExisting.signInButton: it is the same
+    // act with the same consequence, and two labels would read as two things.
+    lostSignInButton: "Sign in with Cloudflare",
+    pickBrainLedeOne: "Set a new password on it, or go back and pick another.",
+    pickBrainLedeMany: "Pick the one you've lost the password for.",
+    addressTitle: "What's your Second Brain's address?",
+    addressLede:
+      "We couldn't find it in that space. Enter the address and we'll set a new " +
+      "password on it — no current password needed.",
+    addressLedeManual:
+      "Enter the address of the Second Brain you want a new password for — no " +
+      "current password needed.",
+    pickTitle: "Choose a new password",
+    pickLede:
+      "This one replaces the old one. Nothing can read it back afterwards, so " +
+      "the copy you keep is the only copy.",
+    generatedNote: "We've made a strong one for you. Type over it if you'd rather choose your own.",
+    pickNotice: "The old password stops working the moment this takes effect.",
+    saveTitle: "Save this somewhere",
+    saveLede:
+      "Nothing can read this back once it's set — not this app, not Cloudflare, " +
+      "not us. It stays available in this window until you close it, and after " +
+      "that the only copy is the one you kept.",
+    passwordLabel: "Your new password",
+    saveAdvice:
+      "A password manager is the right place for it. If you keep it anywhere " +
+      "else, keep it somewhere you'd trust with the key to everything you've " +
+      "written down.",
+    saveConfirm: "I've saved it — change my password",
+    saveBack: "Choose a different one",
+    progressTitle: "Changing your password",
+    progressLede: "This takes up to a minute or two. Leave this window open.",
+    stepSend: "Setting the new password",
+    stepConfirm: "Waiting for your Second Brain to accept it",
+    stepLocal: "Saving it on this computer",
+    doneTitle: "Your password has been changed",
+    doneTitleLost: "You're back in",
+    doneLede:
+      "This computer is using the new password already. Your memories, your " +
+      "address, and everything you've connected are unchanged.",
+    doneNeedsHead: "What will ask for the new password",
+    doneNeeds1: "Your other computers, the next time you open Second Brain on them.",
+    doneNeeds2:
+      "The browser extension, the Obsidian plugin, and the brain command in a " +
+      "terminal on any other computer.",
+    doneNeeds3: "Any browser tab where you opened your dashboard directly.",
+    doneKeptHead: "What is still connected",
+    doneKept:
+      "The AI tools you connected with your connection link are still connected " +
+      "and still working. Each one was given its own access when you connected " +
+      "it, so none of them ever used your password — and changing it doesn't " +
+      "reach them.",
+    doneLeak:
+      "If you changed your password because someone else may have had it, those " +
+      "connections are the one thing this didn't close. Disconnecting them makes " +
+      "every tool ask to be connected again.",
+    doneDisconnectButton: "Disconnect AI tools…",
+    doneShow: "Show my new password",
+    doneHide: "Hide it",
+    failNotSentTitle: "Nothing was changed",
+    failNotSentBody:
+      "The new password never reached your Second Brain, so your old one still " +
+      "works and everything is exactly as it was. Trying again is safe.",
+    failNotSentLabel: "The password you chose — not in use",
+    failDetail: "What went wrong: {detail}",
+    failUnsureTitle: "Your new password may already be in use",
+    failUnsureBody:
+      "The change was sent to your Second Brain, but it didn't confirm in time, " +
+      "so we can't tell you which password is live. Save the one below before " +
+      "you do anything else — it may be the one that works now.",
+    failUnsureRetry:
+      "Try again. Setting the same password a second time changes nothing if it " +
+      "already went through, and finishes the job if it didn't — either way you " +
+      "end up knowing.",
+    failUnsureFootnote:
+      "This computer hasn't been updated yet, so it may ask for a password too. " +
+      "If it does, use the one above.",
+    failUnsureLeave: "Leave it for now",
+    recheckButton: "Check again",
+    recheckConfirmed:
+      "Your Second Brain answers to the new password, so that part is done. This " +
+      "computer hasn't saved it yet — try again to finish, and nothing on your " +
+      "Second Brain changes.",
+    recheckUnconfirmed:
+      "Your Second Brain still doesn't answer to the new password. It may need " +
+      "another moment, or the change may not have landed — trying again settles " +
+      "it either way.",
+    failLocalTitle: "Your password was changed, but not saved on this computer",
+    failLocalBody:
+      "Your Second Brain is using the new password. This computer couldn't store " +
+      "it, so it will ask you for it — save it now, if you haven't.",
+    failLocalCli:
+      "The brain command in your terminal is still set to the old password. Run " +
+      "brain setup to point it at the new one.",
+  },
+  passwordChangedElsewhere: {
+    title: "Your password was changed on another computer",
+    lede:
+      "Your Second Brain has a new password, so the one saved on this computer " +
+      "no longer opens it. Nothing was lost and nothing was deleted — this " +
+      "computer just needs the new one.",
+    body:
+      "You'll find it wherever you saved it when you changed it. It's the same " +
+      "Second Brain at the same address.",
+    findAgain: "Find my Second Brain again",
+    findAgainHint:
+      "Signs in to Cloudflare and looks for it, in case you're connecting to a " +
+      "different one now.",
+    footnote:
+      "Don't have the new one — or didn't change it yourself? Choosing a new " +
+      "password closes the old one for good.",
   },
   cloudflare: {
     title: "Connect your account",
@@ -433,6 +588,29 @@ export const en: Messages = {
     addressDesc: "Your private web dashboard, and where you connect new tools. Save it somewhere safe.",
     mcpLabel: "Your connection link (for AI tools)",
     mcpDesc: "Paste this into any AI tool that supports connectors.",
+    passwordLabel: "Your password",
+    passwordDesc:
+      "The key to your Second Brain. It can't be shown here — nothing can read " +
+      "it back, not even this app. If you want a different one, you can set one now.",
+    passwordButton: "Change my password",
+    disconnectLabel: "Disconnect your AI tools",
+    disconnectDesc:
+      "Every AI tool you connected with your connection link was given its own " +
+      "access, separate from your password. This closes all of it at once. Your " +
+      "memories and your password are untouched.",
+    disconnectButton: "Disconnect AI tools…",
+    disconnectConfirmDesc:
+      "Every AI tool you connected with your connection link — on this computer " +
+      "and on any other — will need connecting again, and each one will ask for " +
+      "your password when you do.",
+    disconnectConfirm: "Yes, disconnect them all",
+    disconnectKeep: "Keep them connected",
+    disconnectWorking: "Disconnecting…",
+    disconnectDone: "Disconnected. Each tool will ask to be connected again the next time you use it.",
+    disconnectDoneNone: "There was nothing connected to disconnect. Nothing was changed.",
+    disconnectFailed:
+      "Some connections couldn't be closed. The ones that were closed stay " +
+      "closed, so trying again only picks up what's left.",
     connectToolsTitle: "Connect your AI tools",
     connectToolsDesc:
       "Tools on this computer connect with one click. For anything else, " +

--- a/installer/src/i18n/en.ts
+++ b/installer/src/i18n/en.ts
@@ -397,14 +397,19 @@ export const en: Messages = {
       "password in the middle of that can stop the rebuild partway and make a " +
       "password problem look like a failed rebuild, so it waits until the " +
       "rebuild is done.",
+    // Carrying on and starting over are not equivalent here, and saying they
+    // were sent people to the one that doesn't work: a restarted rebuild writes
+    // a fresh unfinished record straight away, so it re-blocks within a second.
     blockedEscape:
       "If nothing is rebuilding, one was left unfinished. Open Advanced Settings " +
-      "to carry it on or start it over — either one clears this.",
+      "and carry it on — this clears when the rebuild finishes. Starting it over " +
+      "gets there too, but it reads every memory again from the first one, so it " +
+      "takes longer.",
     blockedButton: "Open Advanced Settings",
     lostTitle: "Your memories are safe",
     lostLede:
-      "Nothing is lost. Your password can't be read back — not by this app, not " +
-      "by Cloudflare — but it can be replaced, and replacing it is how you get " +
+      "Nothing is lost. Nobody can look your password up for you — not this app, " +
+      "not Cloudflare — but it can be replaced, and replacing it is how you get " +
       "back in.",
     lostBodySignedIn:
       "You're already signed in to the Cloudflare space your Second Brain lives " +
@@ -431,16 +436,21 @@ export const en: Messages = {
       "Enter the address of the Second Brain you want a new password for — no " +
       "current password needed.",
     pickTitle: "Choose a new password",
+    // Not "the copy you keep is the only copy". This computer keeps one too —
+    // in secure storage, and in the CLI's plaintext config file when that
+    // exists — and someone reasoning about where their secret lives has to be
+    // told the truth about that. What is true is that nobody will show it to
+    // them again.
     pickLede:
-      "This one replaces the old one. Nothing can read it back afterwards, so " +
-      "the copy you keep is the only copy.",
+      "This one replaces the old one. Cloudflare can't show it to you again, and " +
+      "neither can we, so keep your own copy of it.",
     generatedNote: "We've made a strong one for you. Type over it if you'd rather choose your own.",
     pickNotice: "The old password stops working the moment this takes effect.",
     saveTitle: "Save this somewhere",
     saveLede:
-      "Nothing can read this back once it's set — not this app, not Cloudflare, " +
-      "not us. It stays available in this window until you close it, and after " +
-      "that the only copy is the one you kept.",
+      "Once it's set, nothing in this app or at Cloudflare will show it to you " +
+      "again. It stays on screen in this window until you close it, and after " +
+      "that you'll need the copy you kept.",
     passwordLabel: "Your new password",
     saveAdvice:
       "A password manager is the right place for it. If you keep it anywhere " +
@@ -460,16 +470,24 @@ export const en: Messages = {
       "address, and everything you've connected are unchanged.",
     doneNeedsHead: "What will ask for the new password",
     doneNeeds1: "Your other computers, the next time you open Second Brain on them.",
+    // On this computer as well: a password change writes to secure storage, the
+    // brain command's config and the open dashboard window, and nothing else.
     doneNeeds2:
-      "The browser extension, the Obsidian plugin, and the brain command in a " +
-      "terminal on any other computer.",
-    doneNeeds3: "Any browser tab where you opened your dashboard directly.",
+      "The browser extension and the Obsidian plugin, on this computer as well " +
+      "as any other. Each keeps its own copy, and this change doesn't reach them.",
+    doneNeeds3: "The brain command in a terminal on any other computer.",
+    doneNeeds4: "Any browser tab where you opened your dashboard directly.",
     doneKeptHead: "What is still connected",
+    // Not "none of them ever used your password". A tool set up by pasting the
+    // password straight in — which is the documented route for anything that
+    // can't open a browser — did use it, does break, and cannot be reached by
+    // Disconnect either, because it has nothing stored to disconnect.
     doneKept:
-      "The AI tools you connected with your connection link are still connected " +
-      "and still working. Each one was given its own access when you connected " +
-      "it, so none of them ever used your password — and changing it doesn't " +
-      "reach them.",
+      "AI tools you connected by signing in through your connection link are " +
+      "still connected and still working. Each one was given its own access at " +
+      "the time, separate from your password, so changing it doesn't reach them. " +
+      "Anything you connected by pasting the password itself is in the list " +
+      "above — it will ask for the new one.",
     doneLeak:
       "If you changed your password because someone else may have had it, those " +
       "connections are the one thing this didn't close. Disconnecting them makes " +
@@ -505,13 +523,32 @@ export const en: Messages = {
       "Your Second Brain still doesn't answer to the new password. It may need " +
       "another moment, or the change may not have landed — trying again settles " +
       "it either way.",
+    // The third answer, and not the same as "no". Collapsing a failed probe
+    // into "still doesn't answer" reports a question that was never asked as an
+    // answer of no.
+    recheckUnreachable:
+      "We couldn't reach your Second Brain to ask, so this settles nothing " +
+      "either way — the change may still have gone through. Check again in a " +
+      "moment, or go straight to trying the change again.",
     failLocalTitle: "Your password was changed, but not saved on this computer",
+    failLocalTitlePartial:
+      "Your password was changed, but something on this computer still has the old one",
     failLocalBody:
       "Your Second Brain is using the new password. This computer couldn't store " +
-      "it, so it will ask you for it — save it now, if you haven't.",
+      "it, so it can't open your Second Brain until you connect again with the " +
+      "new one — save it now, if you haven't.",
     failLocalCli:
       "The brain command in your terminal is still set to the old password. Run " +
       "brain setup to point it at the new one.",
+    failLocalDashboard:
+      "The Second Brain window that's already open is still using the old " +
+      "password. Close it and open it again.",
+    failLocalReconnect: "Connect this computer again",
+    leaveWarn:
+      "This is the last screen that shows this password. If you haven't put it " +
+      "somewhere safe, do it now.",
+    leaveConfirm: "I've saved it — leave",
+    leaveKeep: "Stay here",
   },
   passwordChangedElsewhere: {
     title: "Your password was changed on another computer",
@@ -589,25 +626,39 @@ export const en: Messages = {
     mcpLabel: "Your connection link (for AI tools)",
     mcpDesc: "Paste this into any AI tool that supports connectors.",
     passwordLabel: "Your password",
+    // "Nothing can read it back, not even this app" was true of Cloudflare and
+    // false of the app: it is in this computer's secure storage, and this very
+    // feature writes it as plain text to the brain command's config file. A
+    // card whose whole job is to explain where a secret lives has to say so.
     passwordDesc:
-      "The key to your Second Brain. It can't be shown here — nothing can read " +
-      "it back, not even this app. If you want a different one, you can set one now.",
+      "The key to your Second Brain. It isn't shown here, but this computer " +
+      "keeps a copy: in its secure storage, and in the brain command's settings " +
+      "file if you set that up. Cloudflare can't read it back at all. If you " +
+      "want a different one, you can set one now.",
     passwordButton: "Change my password",
     disconnectLabel: "Disconnect your AI tools",
+    // Not "this closes all of it at once". Tools set up by pasting the password
+    // have no keys here to delete, so this route cannot reach them at all —
+    // changing the password is what closes those.
     disconnectDesc:
-      "Every AI tool you connected with your connection link was given its own " +
-      "access, separate from your password. This closes all of it at once. Your " +
-      "memories and your password are untouched.",
+      "AI tools that signed in through your connection link were each given " +
+      "their own access, separate from your password. This closes all of those " +
+      "at once. Anything you connected by pasting your password instead isn't " +
+      "affected — changing your password is what closes those. Your memories " +
+      "and your password stay as they are.",
     disconnectButton: "Disconnect AI tools…",
     disconnectConfirmDesc:
-      "Every AI tool you connected with your connection link — on this computer " +
-      "and on any other — will need connecting again, and each one will ask for " +
-      "your password when you do.",
+      "Every AI tool that signed in through your connection link — on this " +
+      "computer and on any other — will need connecting again, and each one " +
+      "will ask for your password when you do.",
     disconnectConfirm: "Yes, disconnect them all",
     disconnectKeep: "Keep them connected",
     disconnectWorking: "Disconnecting…",
     disconnectDone: "Disconnected. Each tool will ask to be connected again the next time you use it.",
-    disconnectDoneNone: "There was nothing connected to disconnect. Nothing was changed.",
+    disconnectDoneNone:
+      "No tool had signed in through your connection link, so there was nothing " +
+      "to close here. Tools that use your password are unaffected — changing " +
+      "your password is what closes those.",
     disconnectFailed:
       "Some connections couldn't be closed. The ones that were closed stay " +
       "closed, so trying again only picks up what's left.",

--- a/installer/src/i18n/en.ts
+++ b/installer/src/i18n/en.ts
@@ -406,6 +406,15 @@ export const en: Messages = {
       "gets there too, but it reads every memory again from the first one, so it " +
       "takes longer.",
     blockedButton: "Open Advanced Settings",
+    // Only on the blocked screen, and only after an attempt that may have
+    // landed. The rebuild takes away the one thing that would settle it —
+    // trying again — so the sentence that says so has to come with the reason
+    // the password below is still worth keeping.
+    blockedMayBeLive:
+      "An earlier attempt was sent to your Second Brain and never confirmed, so " +
+      "the password below may already be the one that works. Save it before you " +
+      "close this window. Trying again is what would settle that, and it has to " +
+      "wait until the rebuild is finished.",
     lostTitle: "Your memories are safe",
     lostLede:
       "Nothing is lost. Nobody can look your password up for you — not this app, " +

--- a/installer/src/i18n/it.ts
+++ b/installer/src/i18n/it.ts
@@ -398,6 +398,15 @@ export const it: Messages = {
       "quando la ricostruzione finisce. Anche ricominciarla da capo ci arriva, " +
       "ma rilegge tutti i ricordi dal primo, quindi ci vuole più tempo.",
     blockedButton: "Apri le Impostazioni avanzate",
+    // "non è mai arrivata conferma" riprende alla lettera failUnsureBody: è lo
+    // stesso fatto, e due formulazioni diverse leggerebbero come due situazioni
+    // diverse.
+    blockedMayBeLive:
+      "Un tentativo precedente è stato inviato al tuo Second Brain e non è mai " +
+      "arrivata conferma, quindi la password qui sotto potrebbe già essere " +
+      "quella che funziona. Salvala prima di chiudere questa finestra. " +
+      "Riprovare chiarirebbe la situazione, ma è possibile solo quando la " +
+      "ricostruzione è finita.",
     lostTitle: "I tuoi ricordi sono al sicuro",
     lostLede:
       "Non hai perso nulla. Nessuno può recuperare la tua password al posto tuo " +

--- a/installer/src/i18n/it.ts
+++ b/installer/src/i18n/it.ts
@@ -344,6 +344,7 @@ export const it: Messages = {
     unlockLede:
       "È la password che hai scelto quando hai configurato il tuo Second Brain " +
       "la prima volta. Nulla verrà modificato o resettato.",
+    lostPassword: "Non ho la mia password",
   },
   password: {
     title: "Crea la tua password",
@@ -369,6 +370,165 @@ export const it: Messages = {
     footnote:
       "Verifichiamo le password contro violazioni note senza inviare la password: " +
       "solo un frammento di impronta lascia questo computer.",
+  },
+  changePassword: {
+    title: "Cambia la tua password",
+    lede:
+      "Ne scegli una nuova, la salvi, e sostituisce la vecchia ovunque. " +
+      "I tuoi ricordi, il tuo indirizzo e gli strumenti AI collegati restano.",
+    notice:
+      "La vecchia password smette di funzionare appena questa operazione " +
+      "finisce. Gli altri tuoi computer chiederanno quella nuova alla prossima " +
+      "apertura.",
+    signInButton: "Accedi e continua",
+    signInFootnote:
+      "Il tuo Second Brain si trova nel tuo spazio su Cloudflare, quindi " +
+      "accediamo lì per cambiarla. Non vediamo mai la tua password Cloudflare.",
+    waitingLede:
+      "Completa l'accesso a Cloudflare nel browser aperto, poi torna qui.",
+    blockedTitle: "La password non può essere cambiata adesso",
+    blockedBody:
+      "Il tuo Second Brain sta ricostruendo il modo in cui legge i tuoi ricordi. " +
+      "Cambiare la password nel mezzo può fermare la ricostruzione a metà e far " +
+      "sembrare un problema di password una ricostruzione fallita, quindi si " +
+      "aspetta che finisca.",
+    blockedEscape:
+      "Se non c'è nessuna ricostruzione in corso, significa che ne è rimasta una " +
+      "a metà. Apri le Impostazioni avanzate per continuarla o ricominciarla da " +
+      "capo: in entrambi i casi questo blocco sparisce.",
+    blockedButton: "Apri le Impostazioni avanzate",
+    lostTitle: "I tuoi ricordi sono al sicuro",
+    lostLede:
+      "Non hai perso nulla. La tua password non può essere riletta — né da " +
+      "questa app né da Cloudflare — ma può essere sostituita, ed è così che " +
+      "rientri.",
+    lostBodySignedIn:
+      "Hai già effettuato l'accesso allo spazio Cloudflare in cui si trova il tuo " +
+      "Second Brain, ed è quello a decidere chi può entrare. Puoi quindi " +
+      "impostare subito una nuova password. Tutto ciò che hai salvato resta " +
+      "esattamente dov'è.",
+    lostBodySignIn:
+      "Il tuo Second Brain si trova nel tuo spazio su Cloudflare, ed è quello a " +
+      "decidere chi può entrare. Accedi lì e potrai impostare una nuova password. " +
+      "Tutto ciò che hai salvato resta esattamente dov'è.",
+    lostNotice:
+      "Tutto ciò che ha già la vecchia password chiederà quella nuova: gli altri " +
+      "tuoi computer, l'estensione del browser, il plugin di Obsidian.",
+    lostContinueButton: "Scegli una nuova password",
+    lostSignInButton: "Accedi con Cloudflare",
+    pickBrainLedeOne:
+      "Imposta una nuova password su questo, oppure torna indietro e scegline un altro.",
+    pickBrainLedeMany: "Scegli quello di cui hai perso la password.",
+    addressTitle: "Qual è l'indirizzo del tuo Second Brain?",
+    addressLede:
+      "Non l'abbiamo trovato in quello spazio. Inserisci l'indirizzo e " +
+      "imposteremo una nuova password: non serve quella attuale.",
+    addressLedeManual:
+      "Inserisci l'indirizzo del Second Brain a cui vuoi dare una nuova " +
+      "password: non serve quella attuale.",
+    pickTitle: "Scegli una nuova password",
+    pickLede:
+      "Questa sostituisce la vecchia. Dopo non potrà più essere riletta da " +
+      "nessuno, quindi la copia che conservi è l'unica.",
+    generatedNote:
+      "Ne abbiamo generata una robusta per te. Scrivici sopra se preferisci " +
+      "sceglierne una tua.",
+    pickNotice:
+      "La vecchia password smette di funzionare nel momento in cui questa entra in vigore.",
+    saveTitle: "Salvala da qualche parte",
+    saveLede:
+      "Una volta impostata, nessuno può più rileggerla: né questa app, né " +
+      "Cloudflare, né noi. Resta disponibile in questa finestra finché non la " +
+      "chiudi; dopo, l'unica copia è quella che hai conservato.",
+    passwordLabel: "La tua nuova password",
+    saveAdvice:
+      "Un gestore password è il posto giusto. Se la tieni altrove, tienila dove " +
+      "terresti la chiave di tutto ciò che hai scritto.",
+    saveConfirm: "L'ho salvata — cambia la password",
+    saveBack: "Scegline un'altra",
+    progressTitle: "Cambio della password",
+    progressLede: "Ci vogliono fino a un paio di minuti. Lascia aperta questa finestra.",
+    stepSend: "Impostazione della nuova password",
+    stepConfirm: "Attesa che il tuo Second Brain la accetti",
+    stepLocal: "Salvataggio su questo computer",
+    doneTitle: "La tua password è stata cambiata",
+    doneTitleLost: "Sei di nuovo dentro",
+    doneLede:
+      "Questo computer sta già usando la nuova password. I tuoi ricordi, il tuo " +
+      "indirizzo e tutto ciò che hai collegato non sono cambiati.",
+    doneNeedsHead: "Che cosa chiederà la nuova password",
+    doneNeeds1: "Gli altri tuoi computer, la prossima volta che ci apri Second Brain.",
+    doneNeeds2:
+      "L'estensione del browser, il plugin di Obsidian e il comando brain nel " +
+      "terminale di qualsiasi altro computer.",
+    doneNeeds3: "Le schede del browser in cui hai aperto la dashboard direttamente.",
+    doneKeptHead: "Che cosa resta collegato",
+    doneKept:
+      "Gli strumenti AI che hai collegato con il tuo link di connessione restano " +
+      "collegati e continuano a funzionare. Quando li hai collegati, ognuno ha " +
+      "ricevuto un accesso proprio: non hanno mai usato la tua password, quindi " +
+      "cambiarla non li tocca.",
+    doneLeak:
+      "Se hai cambiato la password perché qualcun altro potrebbe averla vista, " +
+      "quelle connessioni sono l'unica cosa che questa operazione non ha chiuso. " +
+      "Scollegarle fa sì che ogni strumento chieda di essere collegato di nuovo.",
+    doneDisconnectButton: "Scollega gli strumenti AI…",
+    doneShow: "Mostra la mia nuova password",
+    doneHide: "Nascondila",
+    failNotSentTitle: "Non è cambiato nulla",
+    failNotSentBody:
+      "La nuova password non è mai arrivata al tuo Second Brain, quindi la " +
+      "vecchia funziona ancora e tutto è rimasto com'era. Riprovare è sicuro.",
+    failNotSentLabel: "La password che hai scelto — non in uso",
+    failDetail: "Cosa è andato storto: {detail}",
+    failUnsureTitle: "La tua nuova password potrebbe essere già attiva",
+    failUnsureBody:
+      "La modifica è stata inviata al tuo Second Brain, ma non è arrivata " +
+      "conferma in tempo, quindi non possiamo dirti quale password sia in uso. " +
+      "Salva quella qui sotto prima di fare qualsiasi altra cosa: potrebbe essere " +
+      "quella che funziona adesso.",
+    failUnsureRetry:
+      "Riprova. Impostare la stessa password una seconda volta non cambia nulla " +
+      "se era già passata, e completa l'operazione se non lo era: in entrambi i " +
+      "casi saprai come stanno le cose.",
+    failUnsureFootnote:
+      "Questo computer non è ancora stato aggiornato, quindi potrebbe chiederti " +
+      "una password. Se succede, usa quella qui sopra.",
+    failUnsureLeave: "Lascia perdere per ora",
+    recheckButton: "Controlla di nuovo",
+    recheckConfirmed:
+      "Il tuo Second Brain risponde alla nuova password, quindi quella parte è " +
+      "fatta. Questo computer non l'ha ancora salvata: riprova per completare " +
+      "l'operazione, sul tuo Second Brain non cambierà nulla.",
+    recheckUnconfirmed:
+      "Il tuo Second Brain non risponde ancora alla nuova password. Forse serve " +
+      "ancora un momento, oppure la modifica non è arrivata: riprovare chiarisce " +
+      "la situazione in entrambi i casi.",
+    failLocalTitle: "La password è stata cambiata, ma non salvata su questo computer",
+    failLocalBody:
+      "Il tuo Second Brain sta usando la nuova password. Questo computer non è " +
+      "riuscito a memorizzarla, quindi te la chiederà: salvala ora, se non l'hai " +
+      "già fatto.",
+    failLocalCli:
+      "Il comando brain nel terminale usa ancora la vecchia password. Esegui " +
+      "brain setup per puntarlo a quella nuova.",
+  },
+  passwordChangedElsewhere: {
+    title: "La tua password è stata cambiata su un altro computer",
+    lede:
+      "Il tuo Second Brain ha una nuova password, quindi quella salvata su questo " +
+      "computer non lo apre più. Non è andato perso nulla e non è stato " +
+      "cancellato nulla: a questo computer serve solo quella nuova.",
+    body:
+      "La trovi dove l'hai salvata quando l'hai cambiata. È lo stesso Second " +
+      "Brain, allo stesso indirizzo.",
+    findAgain: "Ritrova il mio Second Brain",
+    findAgainHint:
+      "Accede a Cloudflare e lo cerca, nel caso tu stia collegando un Second " +
+      "Brain diverso.",
+    footnote:
+      "Non hai quella nuova — o non sei stato tu a cambiarla? Scegliendo una " +
+      "nuova password, la vecchia viene chiusa definitivamente.",
   },
   cloudflare: {
     title: "Collega il tuo account",
@@ -427,6 +587,32 @@ export const it: Messages = {
     addressDesc: "La dashboard web privata e dove collegi nuovi strumenti. Salvalo.",
     mcpLabel: "Link di connessione (per strumenti AI)",
     mcpDesc: "Incollalo in qualsiasi strumento AI che supporta i connettori.",
+    passwordLabel: "La tua password",
+    passwordDesc:
+      "È la chiave del tuo Second Brain. Qui non può essere mostrata: nessuno " +
+      "può rileggerla, nemmeno questa app. Se ne vuoi una diversa, puoi " +
+      "impostarla ora.",
+    passwordButton: "Cambia la password",
+    disconnectLabel: "Scollega i tuoi strumenti AI",
+    disconnectDesc:
+      "Ogni strumento AI che hai collegato con il tuo link di connessione ha " +
+      "ricevuto un accesso proprio, separato dalla tua password. Questa azione " +
+      "li chiude tutti insieme. I tuoi ricordi e la tua password non vengono " +
+      "toccati.",
+    disconnectButton: "Scollega gli strumenti AI…",
+    disconnectConfirmDesc:
+      "Ogni strumento AI che hai collegato con il tuo link di connessione — su " +
+      "questo computer e su qualsiasi altro — andrà collegato di nuovo, e ognuno " +
+      "ti chiederà la password quando lo farai.",
+    disconnectConfirm: "Sì, scollegali tutti",
+    disconnectKeep: "Lasciali collegati",
+    disconnectWorking: "Scollegamento…",
+    disconnectDone:
+      "Scollegati. Ogni strumento chiederà di essere collegato di nuovo alla prossima occasione.",
+    disconnectDoneNone: "Non c'era nulla di collegato da scollegare. Nulla è stato modificato.",
+    disconnectFailed:
+      "Non è stato possibile chiudere alcune connessioni. Quelle già chiuse " +
+      "restano chiuse, quindi riprovando si riprende solo da ciò che manca.",
     connectToolsTitle: "Collega i tuoi strumenti AI",
     connectToolsDesc:
       "Gli strumenti su questo computer si collegano con un clic. Per gli altri, " +

--- a/installer/src/i18n/it.ts
+++ b/installer/src/i18n/it.ts
@@ -394,13 +394,14 @@ export const it: Messages = {
       "aspetta che finisca.",
     blockedEscape:
       "Se non c'è nessuna ricostruzione in corso, significa che ne è rimasta una " +
-      "a metà. Apri le Impostazioni avanzate per continuarla o ricominciarla da " +
-      "capo: in entrambi i casi questo blocco sparisce.",
+      "a metà. Apri le Impostazioni avanzate e continuala: il blocco sparisce " +
+      "quando la ricostruzione finisce. Anche ricominciarla da capo ci arriva, " +
+      "ma rilegge tutti i ricordi dal primo, quindi ci vuole più tempo.",
     blockedButton: "Apri le Impostazioni avanzate",
     lostTitle: "I tuoi ricordi sono al sicuro",
     lostLede:
-      "Non hai perso nulla. La tua password non può essere riletta — né da " +
-      "questa app né da Cloudflare — ma può essere sostituita, ed è così che " +
+      "Non hai perso nulla. Nessuno può recuperare la tua password al posto tuo " +
+      "— né questa app né Cloudflare — ma può essere sostituita, ed è così che " +
       "rientri.",
     lostBodySignedIn:
       "Hai già effettuato l'accesso allo spazio Cloudflare in cui si trova il tuo " +
@@ -428,8 +429,8 @@ export const it: Messages = {
       "password: non serve quella attuale.",
     pickTitle: "Scegli una nuova password",
     pickLede:
-      "Questa sostituisce la vecchia. Dopo non potrà più essere riletta da " +
-      "nessuno, quindi la copia che conservi è l'unica.",
+      "Questa sostituisce la vecchia. Cloudflare non potrà più mostrartela, e " +
+      "nemmeno noi: conservane una copia tua.",
     generatedNote:
       "Ne abbiamo generata una robusta per te. Scrivici sopra se preferisci " +
       "sceglierne una tua.",
@@ -437,9 +438,9 @@ export const it: Messages = {
       "La vecchia password smette di funzionare nel momento in cui questa entra in vigore.",
     saveTitle: "Salvala da qualche parte",
     saveLede:
-      "Una volta impostata, nessuno può più rileggerla: né questa app, né " +
-      "Cloudflare, né noi. Resta disponibile in questa finestra finché non la " +
-      "chiudi; dopo, l'unica copia è quella che hai conservato.",
+      "Una volta impostata, niente in questa app né su Cloudflare te la mostrerà " +
+      "di nuovo. Resta visibile in questa finestra finché non la chiudi; dopo, " +
+      "ti servirà la copia che hai conservato.",
     passwordLabel: "La tua nuova password",
     saveAdvice:
       "Un gestore password è il posto giusto. Se la tieni altrove, tienila dove " +
@@ -459,17 +460,24 @@ export const it: Messages = {
     doneNeedsHead: "Che cosa chiederà la nuova password",
     doneNeeds1: "Gli altri tuoi computer, la prossima volta che ci apri Second Brain.",
     doneNeeds2:
-      "L'estensione del browser, il plugin di Obsidian e il comando brain nel " +
-      "terminale di qualsiasi altro computer.",
-    doneNeeds3: "Le schede del browser in cui hai aperto la dashboard direttamente.",
+      "L'estensione del browser e il plugin di Obsidian, su questo computer come " +
+      "su qualsiasi altro. Ognuno conserva la propria copia e questa modifica " +
+      "non li raggiunge.",
+    doneNeeds3: "Il comando brain nel terminale di qualsiasi altro computer.",
+    doneNeeds4: "Le schede del browser in cui hai aperto la dashboard direttamente.",
     doneKeptHead: "Che cosa resta collegato",
     doneKept:
-      "Gli strumenti AI che hai collegato con il tuo link di connessione restano " +
-      "collegati e continuano a funzionare. Quando li hai collegati, ognuno ha " +
-      "ricevuto un accesso proprio: non hanno mai usato la tua password, quindi " +
-      "cambiarla non li tocca.",
+      "Gli strumenti AI che hai collegato accedendo tramite il tuo link di " +
+      "connessione restano collegati e continuano a funzionare. Al momento del " +
+      "collegamento ognuno ha ricevuto un accesso proprio, separato dalla tua " +
+      "password, quindi cambiarla non li tocca. Ciò che invece hai collegato " +
+      "incollando la password si trova nell'elenco qui sopra: chiederà quella " +
+      "nuova.",
+    // "averla vista" softened EN's "may have had it": vedere una password legge
+    // come un'occhiata alle spalle, averla è ciò che la rende pericolosa — e
+    // questa è l'unica riga rivolta a chi ha subito una fuga di dati.
     doneLeak:
-      "Se hai cambiato la password perché qualcun altro potrebbe averla vista, " +
+      "Se hai cambiato la password perché qualcun altro potrebbe averla avuta, " +
       "quelle connessioni sono l'unica cosa che questa operazione non ha chiuso. " +
       "Scollegarle fa sì che ogni strumento chieda di essere collegato di nuovo.",
     doneDisconnectButton: "Scollega gli strumenti AI…",
@@ -499,19 +507,36 @@ export const it: Messages = {
     recheckConfirmed:
       "Il tuo Second Brain risponde alla nuova password, quindi quella parte è " +
       "fatta. Questo computer non l'ha ancora salvata: riprova per completare " +
-      "l'operazione, sul tuo Second Brain non cambierà nulla.",
+      "l'operazione, e sul tuo Second Brain non cambierà nulla.",
     recheckUnconfirmed:
       "Il tuo Second Brain non risponde ancora alla nuova password. Forse serve " +
       "ancora un momento, oppure la modifica non è arrivata: riprovare chiarisce " +
       "la situazione in entrambi i casi.",
+    recheckUnreachable:
+      "Non siamo riusciti a raggiungere il tuo Second Brain per chiederglielo, " +
+      "quindi questo non chiarisce nulla in un senso o nell'altro: la modifica " +
+      "potrebbe essere comunque passata. Controlla di nuovo tra un momento, " +
+      "oppure passa direttamente a riprovare il cambio.",
     failLocalTitle: "La password è stata cambiata, ma non salvata su questo computer",
+    failLocalTitlePartial:
+      "La password è stata cambiata, ma su questo computer qualcosa ha ancora la vecchia",
     failLocalBody:
       "Il tuo Second Brain sta usando la nuova password. Questo computer non è " +
-      "riuscito a memorizzarla, quindi te la chiederà: salvala ora, se non l'hai " +
-      "già fatto.",
+      "riuscito a memorizzarla, quindi non potrà aprire il tuo Second Brain " +
+      "finché non ti ricolleghi con quella nuova: salvala ora, se non l'hai già " +
+      "fatto.",
     failLocalCli:
       "Il comando brain nel terminale usa ancora la vecchia password. Esegui " +
       "brain setup per puntarlo a quella nuova.",
+    failLocalDashboard:
+      "La finestra di Second Brain già aperta usa ancora la vecchia password. " +
+      "Chiudila e riaprila.",
+    failLocalReconnect: "Ricollega questo computer",
+    leaveWarn:
+      "Questa è l'ultima schermata che mostra questa password. Se non l'hai " +
+      "ancora messa al sicuro, fallo adesso.",
+    leaveConfirm: "L'ho salvata — esci",
+    leaveKeep: "Resta qui",
   },
   passwordChangedElsewhere: {
     title: "La tua password è stata cambiata su un altro computer",
@@ -526,9 +551,12 @@ export const it: Messages = {
     findAgainHint:
       "Accede a Cloudflare e lo cerca, nel caso tu stia collegando un Second " +
       "Brain diverso.",
+    // "non sei stato tu" era l'unico partecipio al maschile singolare rivolto
+    // all'utente in tutto il catalogo: ovunque altrove l'accordo è con un
+    // oggetto, mai con chi legge.
     footnote:
-      "Non hai quella nuova — o non sei stato tu a cambiarla? Scegliendo una " +
-      "nuova password, la vecchia viene chiusa definitivamente.",
+      "Non hai quella nuova — o non l'hai cambiata tu? Scegliendo una nuova " +
+      "password, la vecchia viene chiusa definitivamente.",
   },
   cloudflare: {
     title: "Collega il tuo account",
@@ -589,27 +617,38 @@ export const it: Messages = {
     mcpDesc: "Incollalo in qualsiasi strumento AI che supporta i connettori.",
     passwordLabel: "La tua password",
     passwordDesc:
-      "È la chiave del tuo Second Brain. Qui non può essere mostrata: nessuno " +
-      "può rileggerla, nemmeno questa app. Se ne vuoi una diversa, puoi " +
-      "impostarla ora.",
+      "È la chiave del tuo Second Brain. Qui non viene mostrata, ma questo " +
+      "computer ne conserva una copia: nel suo archivio sicuro e, se hai " +
+      "configurato il comando brain, nel file di impostazioni di quel comando. " +
+      "Cloudflare invece non può rileggerla in alcun modo. Se ne vuoi una " +
+      "diversa, puoi impostarla ora.",
     passwordButton: "Cambia la password",
     disconnectLabel: "Scollega i tuoi strumenti AI",
     disconnectDesc:
-      "Ogni strumento AI che hai collegato con il tuo link di connessione ha " +
-      "ricevuto un accesso proprio, separato dalla tua password. Questa azione " +
-      "li chiude tutti insieme. I tuoi ricordi e la tua password non vengono " +
-      "toccati.",
+      "Gli strumenti AI che hanno effettuato l'accesso tramite il tuo link di " +
+      "connessione hanno ricevuto ognuno un accesso proprio, separato dalla tua " +
+      "password. Questa azione li chiude tutti insieme. Ciò che invece hai " +
+      "collegato incollando la password non viene toccato: quelle connessioni si " +
+      "chiudono cambiando la password. I tuoi ricordi e la tua password restano " +
+      "come sono.",
     disconnectButton: "Scollega gli strumenti AI…",
     disconnectConfirmDesc:
-      "Ogni strumento AI che hai collegato con il tuo link di connessione — su " +
-      "questo computer e su qualsiasi altro — andrà collegato di nuovo, e ognuno " +
-      "ti chiederà la password quando lo farai.",
+      "Ogni strumento AI che ha effettuato l'accesso tramite il tuo link di " +
+      "connessione — su questo computer e su qualsiasi altro — andrà collegato " +
+      "di nuovo, e ognuno ti chiederà la password quando lo farai.",
     disconnectConfirm: "Sì, scollegali tutti",
     disconnectKeep: "Lasciali collegati",
     disconnectWorking: "Scollegamento…",
+    // Non "Scollegati.": in apertura di frase si legge prima come imperativo
+    // riflessivo — "scollegati tu" — invece che come participio.
     disconnectDone:
-      "Scollegati. Ogni strumento chiederà di essere collegato di nuovo alla prossima occasione.",
-    disconnectDoneNone: "Non c'era nulla di collegato da scollegare. Nulla è stato modificato.",
+      "Connessioni chiuse. Ogni strumento chiederà di essere collegato di nuovo " +
+      "la prossima volta che lo usi.",
+    disconnectDoneNone:
+      "Nessuno strumento aveva effettuato l'accesso tramite il tuo link di " +
+      "connessione, quindi qui non c'era nulla da chiudere. Gli strumenti che " +
+      "usano la tua password non sono interessati: quelle connessioni si " +
+      "chiudono cambiando la password.",
     disconnectFailed:
       "Non è stato possibile chiudere alcune connessioni. Quelle già chiuse " +
       "restano chiuse, quindi riprovando si riprende solo da ciò che manca.",

--- a/installer/src/i18n/types.ts
+++ b/installer/src/i18n/types.ts
@@ -222,6 +222,14 @@ export type Messages = {
     /** An abandoned rebuild blocks this forever without a way out on screen. */
     blockedEscape: string;
     blockedButton: string;
+    /**
+     * Added to the blocked *screen* — never the Connection pane's card — when an
+     * earlier attempt in the same window reached the brain and never confirmed.
+     * Being blocked and having a password that may already be live are both
+     * true at once, and the screen that drops either one is lying about the
+     * other.
+     */
+    blockedMayBeLive: string;
     // Door B intro — one screen, two variants
     lostTitle: string;
     lostLede: string;

--- a/installer/src/i18n/types.ts
+++ b/installer/src/i18n/types.ts
@@ -178,6 +178,8 @@ export type Messages = {
     noneFound: string;
     unlockTitle: string;
     unlockLede: string;
+    /** Door B into the password change (#235) — a ghost link on both screens. */
+    lostPassword: string;
   };
   password: {
     title: string;
@@ -194,6 +196,108 @@ export type Messages = {
     breachHint: string;
     mismatch: string;
     notice: string;
+    footnote: string;
+  };
+  /**
+   * Changing the password on an existing Second Brain (#235). Two doors reach
+   * the same sequence: a voluntary change from the Connection pane, and "I
+   * don't have my password" from the connect screens.
+   *
+   * Every failure state in here shows the new password, because once the
+   * change lands nothing can read it back — not the app, not Cloudflare. A
+   * screen that reports a failure without the password on it is how someone
+   * loses a brain.
+   */
+  changePassword: {
+    // Door A intro
+    title: string;
+    lede: string;
+    notice: string;
+    signInButton: string;
+    signInFootnote: string;
+    waitingLede: string;
+    // Blocked by a rebuild, rendered inside the Connection pane's card
+    blockedTitle: string;
+    blockedBody: string;
+    /** An abandoned rebuild blocks this forever without a way out on screen. */
+    blockedEscape: string;
+    blockedButton: string;
+    // Door B intro — one screen, two variants
+    lostTitle: string;
+    lostLede: string;
+    lostBodySignedIn: string;
+    lostBodySignIn: string;
+    lostNotice: string;
+    lostContinueButton: string;
+    lostSignInButton: string;
+    // Finding the brain again in lost mode
+    pickBrainLedeOne: string;
+    pickBrainLedeMany: string;
+    addressTitle: string;
+    addressLede: string;
+    /** Same screen, reached deliberately rather than because nothing was found. */
+    addressLedeManual: string;
+    // Choosing the new one
+    pickTitle: string;
+    pickLede: string;
+    generatedNote: string;
+    pickNotice: string;
+    // The save gate
+    saveTitle: string;
+    saveLede: string;
+    /** The label on the password card, shared with every failure screen. */
+    passwordLabel: string;
+    saveAdvice: string;
+    saveConfirm: string;
+    saveBack: string;
+    // Progress
+    progressTitle: string;
+    progressLede: string;
+    stepSend: string;
+    stepConfirm: string;
+    stepLocal: string;
+    // Done
+    doneTitle: string;
+    doneTitleLost: string;
+    doneLede: string;
+    doneNeedsHead: string;
+    doneNeeds1: string;
+    doneNeeds2: string;
+    doneNeeds3: string;
+    doneKeptHead: string;
+    doneKept: string;
+    /** Conditional, not a warning: most changes are hygiene, not a leak. */
+    doneLeak: string;
+    doneDisconnectButton: string;
+    doneShow: string;
+    doneHide: string;
+    // Nothing was changed
+    failNotSentTitle: string;
+    failNotSentBody: string;
+    /** Labelled by what it actually is here: a password that is not in use. */
+    failNotSentLabel: string;
+    failDetail: string;
+    // It may already be live — never says "failed"
+    failUnsureTitle: string;
+    failUnsureBody: string;
+    failUnsureRetry: string;
+    failUnsureFootnote: string;
+    failUnsureLeave: string;
+    recheckButton: string;
+    recheckConfirmed: string;
+    recheckUnconfirmed: string;
+    // Changed, but not saved on this computer
+    failLocalTitle: string;
+    failLocalBody: string;
+    failLocalCli: string;
+  };
+  /** The other machines, holding a password that was replaced elsewhere (#235 §5). */
+  passwordChangedElsewhere: {
+    title: string;
+    lede: string;
+    body: string;
+    findAgain: string;
+    findAgainHint: string;
     footnote: string;
   };
   cloudflare: {
@@ -247,6 +351,29 @@ export type Messages = {
     addressDesc: string;
     mcpLabel: string;
     mcpDesc: string;
+    /**
+     * The password card in the Connection pane. It has no value and no Copy
+     * button, unlike the two cards above it, so the description explains the
+     * absence rather than leaving it to be inferred.
+     */
+    passwordLabel: string;
+    passwordDesc: string;
+    passwordButton: string;
+    /**
+     * Disconnecting every AI tool (#235 §6). Deliberately not part of changing
+     * the password: tools that went through the connection link hold their own
+     * access and never used the password, so a rotation does not reach them.
+     */
+    disconnectLabel: string;
+    disconnectDesc: string;
+    disconnectButton: string;
+    disconnectConfirmDesc: string;
+    disconnectConfirm: string;
+    disconnectKeep: string;
+    disconnectWorking: string;
+    disconnectDone: string;
+    disconnectDoneNone: string;
+    disconnectFailed: string;
     connectToolsTitle: string;
     connectToolsDesc: string;
     integrationsTitle: string;

--- a/installer/src/i18n/types.ts
+++ b/installer/src/i18n/types.ts
@@ -262,8 +262,15 @@ export type Messages = {
     doneLede: string;
     doneNeedsHead: string;
     doneNeeds1: string;
+    /**
+     * The extension and the Obsidian plugin hold the old password on *this*
+     * computer too — `persist` writes secure storage, the CLI config and the
+     * open dashboard window, and nothing else — so this list is not scoped to
+     * "any other computer". Door B's `lostNotice` has always said so.
+     */
     doneNeeds2: string;
     doneNeeds3: string;
+    doneNeeds4: string;
     doneKeptHead: string;
     doneKept: string;
     /** Conditional, not a warning: most changes are hygiene, not a leak. */
@@ -286,10 +293,25 @@ export type Messages = {
     recheckButton: string;
     recheckConfirmed: string;
     recheckUnconfirmed: string;
+    /** The third answer: we could not ask, which settles nothing either way. */
+    recheckUnreachable: string;
     // Changed, but not saved on this computer
     failLocalTitle: string;
+    /** When secure storage took it and something else here did not, so the
+     *  unconditional heading above would be untrue. */
+    failLocalTitlePartial: string;
     failLocalBody: string;
     failLocalCli: string;
+    failLocalDashboard: string;
+    failLocalReconnect: string;
+    /**
+     * The save gate confirms a password that is merely proposed. By the time a
+     * failure screen renders, the same password may already be the only key to
+     * the brain — so the exits from those screens get the same acknowledgement.
+     */
+    leaveWarn: string;
+    leaveConfirm: string;
+    leaveKeep: string;
   };
   /** The other machines, holding a password that was replaced elsewhere (#235 §5). */
   passwordChangedElsewhere: {

--- a/installer/src/main.ts
+++ b/installer/src/main.ts
@@ -10,6 +10,7 @@ import {
   detailCards,
   emailButton,
   h,
+  secretCard,
   toolRows,
 } from "./shared";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -21,7 +22,10 @@ interface Account {
   name: string;
 }
 
-type StepId = "space" | "memory" | "recall" | "finish";
+// The last three are the password change's steps (#235). They are none of the
+// four provisioning steps, and labelling "waiting for your Second Brain to
+// accept it" as `recall` would mislead the next person to read this.
+type StepId = "space" | "memory" | "recall" | "finish" | "secret" | "confirm" | "local";
 interface StepEvent {
   step: StepId;
   status: "running" | "done" | "error";
@@ -218,6 +222,18 @@ function unlockBrainScreen(
   // discard the scan and cost another Cloudflare sign-in to get here again.
   back.addEventListener("click", () => brainPickerScreen(found));
 
+  // Last element, below Back, and a ghost: it is the rarer path, and above the
+  // password field it would invite people to take it before trying the password
+  // they have. The brain is chosen and Cloudflare is signed in from discovery,
+  // so this goes straight to the password step.
+  const lost = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("connectExisting.lostPassword"),
+  ]);
+  lost.addEventListener("click", () => {
+    rotationExit = () => unlockBrainScreen(brain, undefined, found);
+    lostPasswordIntroScreen(brain.url);
+  });
+
   connect.addEventListener("click", async () => {
     connect.disabled = true;
     connect.textContent = t("common.checking");
@@ -240,6 +256,7 @@ function unlockBrainScreen(
     h("div", { class: "field-stack" }, [password]),
     connect,
     back,
+    lost,
   );
   password.focus();
 }
@@ -265,6 +282,18 @@ function manualEntryScreen(
   const back = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [t("common.back")]);
   back.addEventListener("click", () => connectExistingScreen());
 
+  // No Cloudflare session here, so this door routes through sign-in and
+  // discovery first. Anything already typed is carried over as the fallback
+  // address, for the brain a scan can't see — a custom domain, another account.
+  const lost = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("connectExisting.lostPassword"),
+  ]);
+  lost.addEventListener("click", () => {
+    rotationExit = () => manualEntryScreen(errorMsg, address.value, tone);
+    rotationTypedAddress = address.value.trim();
+    lostPasswordIntroScreen(null);
+  });
+
   connect.addEventListener("click", async () => {
     connect.disabled = true;
     connect.textContent = t("common.checking");
@@ -288,6 +317,7 @@ function manualEntryScreen(
     connect,
     back,
     h("p", { class: "footnote" }, [t("connectExisting.footnote")]),
+    lost,
   );
   address.focus();
 }
@@ -706,6 +736,786 @@ function workerUpdateDoneScreen() {
   );
 }
 
+// ── Changing your password (#235) ────────────────────────────────────────────
+//
+// Two doors, one sequence. Door A is a voluntary change from the Connection
+// pane; Door B is "I don't have my password" on the connect screens. Neither
+// needs the current password — Cloudflare account access is the authority
+// either way — so they differ only in where they start and what they say.
+//
+// The rule this whole section is written around: after the change lands, the
+// new password cannot be read back by anything, so it stays on screen in every
+// state that follows the save gate, including all three failures, and behind a
+// reveal on the done screen.
+
+/** Which door this run came through. Selects the intro and the done heading. */
+let rotationDoor: "change" | "lost" = "change";
+
+/**
+ * The brain being changed. Door A leaves it null — the address is whatever this
+ * computer already has stored. Door B has no stored setup, so the address the
+ * user picked or typed has to travel with the call.
+ */
+let rotationAddress: string | null = null;
+
+/** An address typed on the connect screen before taking Door B, kept as the
+ *  prefill for lost-mode address entry when a scan turns up nothing. */
+let rotationTypedAddress = "";
+
+/**
+ * The chosen password, held here rather than read out of the field, so a
+ * locale change re-renders a screen without discarding a password the user may
+ * already have written down.
+ */
+let rotationPassword = "";
+/** True while the field still holds what `generate_password` produced. */
+let rotationGenerated = false;
+
+/** Where the password step's Back leads. Usually the intro; the discovery paths
+ *  set it to the picker they came from, because the intro would mean signing in
+ *  to Cloudflare a second time to get back here. */
+let rotationBack: () => void = () => changePasswordIntroScreen();
+
+/** Where Door B leads out — the screen the ghost link was clicked on. */
+let rotationExit: () => void = () => connectExistingScreen();
+
+/** What `rotate_password` reports when the remote change succeeded. */
+interface RotateOutcome {
+  keychain: boolean;
+  /** null when the CLI was never installed — that is not a failure. */
+  cliConfig: boolean | null;
+}
+
+/** Which failure happened, and with it what may honestly be claimed. */
+interface RotateError {
+  /** "notSent" — the old password still works. "unconfirmed" — it may not.
+   *  "local" — the brain has the new one, a local write did not. */
+  stage: "notSent" | "unconfirmed" | "local";
+  /** Already localised by Rust; fills the failure screen's detail slot. */
+  detail: string;
+}
+
+function rotateErrorOf(e: unknown): RotateError {
+  if (typeof e === "object" && e !== null) {
+    const { stage, detail } = e as { stage?: unknown; detail?: unknown };
+    if (stage === "notSent" || stage === "unconfirmed" || stage === "local") {
+      return { stage, detail: typeof detail === "string" ? detail : "" };
+    }
+  }
+  // Anything we cannot read is treated as "may already be live", deliberately.
+  // Telling someone their old password still works when it may not is the one
+  // mistake in this flow that ends with a brain nobody can open.
+  return { stage: "unconfirmed", detail: String(e) };
+}
+
+/**
+ * True once `connect_cloudflare` has succeeded in this window. The account list
+ * is only ever set from its result, and that result is never empty — a login
+ * with no usable account is an error, not a success.
+ */
+function signedInToCloudflare(): boolean {
+  return accounts.length > 0;
+}
+
+/** Leaves the flow without changing anything. Door A has a dashboard to go back
+ *  to; Door B does not, so it returns to the screen the link was taken from. */
+function leaveRotation() {
+  if (rotationDoor === "lost") rotationExit();
+  else void invoke("open_dashboard");
+}
+
+function cloudflareWaitingScreen(lede: string) {
+  show(
+    brand(),
+    h("h1", {}, [t("cloudflare.waitingTitle")]),
+    h("p", { class: "lede" }, [lede]),
+    h("div", { class: "checklist" }, [
+      h("li", { class: "running" }, [
+        h("span", { class: "check-icon" }, [h("span", { class: "spinner" })]),
+        t("cloudflare.watchingSignIn"),
+      ]),
+    ]),
+  );
+}
+
+async function rotationSignIn(onError: (msg: string) => void, next: () => void) {
+  currentScreen = () => cloudflareWaitingScreen(t("changePassword.waitingLede"));
+  cloudflareWaitingScreen(t("changePassword.waitingLede"));
+  try {
+    accounts = await invoke<Account[]>("connect_cloudflare");
+    next();
+  } catch (e) {
+    onError(String(e));
+  }
+}
+
+/// Door A. Sign-in comes before the password because it is the step most likely
+/// to fail, and failing before the user has committed to anything is cleaner.
+/// There is no account picker: the account is derived from the address, so a
+/// login that does not hold it is a wrong answer rather than a choice.
+function changePasswordIntroScreen(errorMsg?: string) {
+  currentScreen = () => changePasswordIntroScreen(errorMsg);
+  rotationDoor = "change";
+  rotationAddress = null;
+  rotationBack = () => changePasswordIntroScreen();
+
+  const signIn = h("button", { class: "btn-primary" }, [t("changePassword.signInButton")]);
+  signIn.addEventListener("click", () =>
+    void rotationSignIn(
+      (msg) => changePasswordIntroScreen(msg),
+      () => choosePasswordScreen(),
+    ),
+  );
+  const notNow = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("common.notNow"),
+  ]);
+  notNow.addEventListener("click", () => void invoke("open_dashboard"));
+
+  show(
+    brand(),
+    h("h1", {}, [t("changePassword.title")]),
+    h("p", { class: "lede" }, [t("changePassword.lede")]),
+    h("div", { class: "notice" }, ["🔑", h("span", {}, [t("changePassword.notice")])]),
+    errorMsg ? notice(errorMsg) : "",
+    signIn,
+    notNow,
+    h("p", { class: "footnote" }, [t("changePassword.signInFootnote")]),
+  );
+}
+
+/// Door B. One screen, two variants — the heading does the reassurance on its
+/// own, because the heading is what a frightened person reads before anything
+/// else. `address` is null when the brain still has to be found.
+function lostPasswordIntroScreen(address: string | null, errorMsg?: string) {
+  currentScreen = () => lostPasswordIntroScreen(address, errorMsg);
+  rotationDoor = "lost";
+  rotationAddress = address;
+  rotationBack = () => lostPasswordIntroScreen(address);
+
+  const signedIn = signedInToCloudflare();
+  // With the brain already known there is nothing left to look for; otherwise
+  // the scan runs first and the picker chooses.
+  const proceed = () => (address ? choosePasswordScreen() : void lostDiscovery());
+
+  const primary = h("button", { class: "btn-primary" }, [
+    t(signedIn ? "changePassword.lostContinueButton" : "changePassword.lostSignInButton"),
+  ]);
+  primary.addEventListener("click", () => {
+    if (signedIn) return proceed();
+    void rotationSignIn((msg) => lostPasswordIntroScreen(address, msg), proceed);
+  });
+
+  const back = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("common.back"),
+  ]);
+  back.addEventListener("click", () => rotationExit());
+
+  show(
+    brand(),
+    h("h1", {}, [t("changePassword.lostTitle")]),
+    h("p", { class: "lede" }, [t("changePassword.lostLede")]),
+    h("p", { class: "lede" }, [
+      t(signedIn ? "changePassword.lostBodySignedIn" : "changePassword.lostBodySignIn"),
+    ]),
+    h("div", { class: "notice" }, ["🔑", h("span", {}, [t("changePassword.lostNotice")])]),
+    errorMsg ? notice(errorMsg) : "",
+    primary,
+    back,
+    // What granting Cloudflare access means, unchanged: nothing about changing
+    // a password alters that bargain.
+    signedIn ? "" : h("p", { class: "footnote" }, [t("connectExisting.signInFootnote")]),
+  );
+}
+
+async function lostDiscovery() {
+  if (accounts.length === 1) {
+    chosenAccount = accounts[0];
+    await runLostDiscovery();
+    return;
+  }
+  accountPickerScreen(
+    () => void runLostDiscovery(),
+    t("connectExisting.accountPickerTitle"),
+    t("connectExisting.accountPickerLede"),
+    () => lostPasswordIntroScreen(null),
+  );
+}
+
+async function runLostDiscovery() {
+  currentScreen = searchingScreen;
+  searchingScreen();
+  try {
+    const found = await invoke<DiscoveredBrain[]>("discover_brains", {
+      accountId: chosenAccount?.id ?? "",
+    });
+    if (found.length === 0) {
+      lostAddressScreen([]);
+      return;
+    }
+    lostBrainPickerScreen(found);
+  } catch (e) {
+    // A scan that fails is not a dead end for someone already locked out: the
+    // address can be typed, and the change works the same way from there.
+    lostAddressScreen([], String(e));
+  }
+}
+
+/// The existing picker's headings still read correctly; its ledes do not —
+/// "Connect to it" is wrong when there is nothing to connect with yet.
+function lostBrainPickerScreen(found: DiscoveredBrain[]) {
+  currentScreen = () => lostBrainPickerScreen(found);
+  const list = h("ul", { class: "account-list" });
+  for (const brain of found) {
+    const btn = h("button", {}, [brain.url.replace(/^https:\/\//, "")]);
+    btn.addEventListener("click", () => {
+      rotationAddress = brain.url;
+      rotationBack = () => lostBrainPickerScreen(found);
+      choosePasswordScreen();
+    });
+    list.append(h("li", {}, [btn]));
+  }
+  // Same slot as on the connect picker, different destination: the screen it
+  // used to open has a password field, which is the one thing this user hasn't
+  // got.
+  const manual = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("connectExisting.manualButton"),
+  ]);
+  manual.addEventListener("click", () => lostAddressScreen(found, undefined, true));
+
+  const back = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("common.back"),
+  ]);
+  back.addEventListener("click", () => lostPasswordIntroScreen(null));
+
+  const one = found.length === 1;
+  show(
+    brand(),
+    h("h1", {}, [t(one ? "connectExisting.pickTitleOne" : "connectExisting.pickTitleMany")]),
+    h("p", { class: "lede" }, [
+      t(one ? "changePassword.pickBrainLedeOne" : "changePassword.pickBrainLedeMany"),
+    ]),
+    list,
+    manual,
+    back,
+  );
+}
+
+/// Discovery finding nothing is not a failure — custom domains and second
+/// accounts exist — and without this the only fallback is a screen asking for
+/// the password the user came here without.
+function lostAddressScreen(
+  found: DiscoveredBrain[],
+  errorMsg?: string,
+  fromPicker = false,
+  prefill = rotationTypedAddress,
+) {
+  currentScreen = () => lostAddressScreen(found, errorMsg, fromPicker, prefill);
+  const address = h("input", {
+    type: "text",
+    placeholder: t("connectExisting.addressPlaceholder"),
+    autocapitalize: "off",
+    autocorrect: "off",
+    spellcheck: "false",
+  });
+  address.value = prefill;
+
+  const next = h("button", { class: "btn-primary" }, [t("common.continue")]);
+  const sync = () => {
+    if (address.value.trim()) next.removeAttribute("disabled");
+    else next.setAttribute("disabled", "");
+  };
+  address.addEventListener("input", sync);
+  next.addEventListener("click", () => {
+    rotationAddress = address.value.trim();
+    rotationTypedAddress = rotationAddress;
+    rotationBack = () => lostAddressScreen(found, undefined, fromPicker, rotationTypedAddress);
+    choosePasswordScreen();
+  });
+
+  const back = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("common.back"),
+  ]);
+  // Back to the picker when there was one. With no picker there is nothing
+  // behind this screen but the sign-in that reached it, so Back leaves.
+  back.addEventListener("click", () =>
+    found.length ? lostBrainPickerScreen(found) : rotationExit(),
+  );
+
+  show(
+    brand(),
+    h("h1", {}, [t("changePassword.addressTitle")]),
+    h("p", { class: "lede" }, [
+      t(fromPicker ? "changePassword.addressLedeManual" : "changePassword.addressLede"),
+    ]),
+    errorMsg ? notice(errorMsg) : "",
+    h("div", { class: "field-stack" }, [address]),
+    next,
+    back,
+  );
+  sync();
+  address.focus();
+}
+
+/// Setup's password mechanics exactly — same meter, same debounced
+/// `check_password`, same generate button — with two differences: the field
+/// arrives pre-filled from `generate_password`, and it stays readable. Rotation
+/// replaces a string that lives in a password manager and gets pasted into a
+/// handful of devices once each, so memorability buys nothing and the fastest
+/// way through is also the strongest. Typing over it brings the meter and the
+/// breach check back exactly as at setup.
+function choosePasswordScreen() {
+  currentScreen = choosePasswordScreen;
+  const pw = h("input", { type: "text", placeholder: t("password.placeholder") });
+  const confirm = h("input", { type: "text", placeholder: t("password.confirmPlaceholder") });
+  pw.value = rotationPassword;
+  confirm.value = rotationPassword;
+  const fill = h("div", { class: "strength-fill" });
+  const label = h("span", { class: "strength-label" });
+  const hint = h("p", { class: "hint" }, [""]);
+  const generatedNote = h("p", { class: "hint" }, [""]);
+  const generate = h("button", {
+    class: "input-action",
+    title: t("password.generateTitle"),
+    "aria-label": t("password.generateTitle"),
+  });
+  generate.innerHTML =
+    '<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">' +
+    '<path d="M11 2 C11.7 6.8 13.2 8.3 18 9 C13.2 9.7 11.7 11.2 11 16 C10.3 11.2 8.8 9.7 4 9 C8.8 8.3 10.3 6.8 11 2 Z"/>' +
+    '<path d="M18 13 C18.35 15.4 19.1 16.15 21.5 16.5 C19.1 16.85 18.35 17.6 18 20 C17.65 17.6 16.9 16.85 14.5 16.5 C16.9 16.15 17.65 15.4 18 13 Z"/>' +
+    "</svg>";
+  const next = h("button", { class: "btn-primary", disabled: "" }, [t("common.continue")]);
+
+  let check: PasswordCheck | null = null;
+  let debounce: number | undefined;
+
+  const render = () => {
+    const s = meterFor(pw.value, check);
+    fill.style.width = `${s.pct}%`;
+    fill.style.background = s.color;
+    label.textContent = s.label;
+    generatedNote.textContent = rotationGenerated ? t("changePassword.generatedNote") : "";
+    const longEnough = pw.value.trim().length >= 12;
+    const match = pw.value === confirm.value;
+    const breached = check?.breached ?? false;
+    if (breached) {
+      hint.textContent = t("password.breachHint");
+      hint.className = "hint error";
+    } else if (pw.value && confirm.value && !match) {
+      hint.textContent = t("password.mismatch");
+      hint.className = "hint error";
+    } else {
+      hint.textContent = "";
+      hint.className = "hint";
+    }
+    if (longEnough && match && check !== null && !breached) {
+      next.removeAttribute("disabled");
+    } else {
+      next.setAttribute("disabled", "");
+    }
+  };
+
+  const runCheck = () => {
+    const value = pw.value.trim();
+    if (value.length < 12) return;
+    invoke<PasswordCheck>("check_password", { password: pw.value })
+      .then((result) => {
+        if (pw.value.trim() !== value) return;
+        check = result;
+        render();
+      })
+      .catch(() => {
+        // Fails open, exactly as at setup: a change must not be blocked by an
+        // offline third party, least of all on the door for someone locked out.
+        check = { breached: false, count: 0, score: 3, online: false };
+        render();
+      });
+  };
+
+  const useGenerated = (generated: string) => {
+    pw.value = generated;
+    confirm.value = generated;
+    rotationPassword = generated;
+    rotationGenerated = true;
+    check = null;
+    render();
+    runCheck();
+  };
+
+  pw.addEventListener("input", () => {
+    rotationPassword = pw.value;
+    rotationGenerated = false;
+    check = null;
+    render();
+    window.clearTimeout(debounce);
+    debounce = window.setTimeout(runCheck, 450);
+  });
+  confirm.addEventListener("input", render);
+
+  generate.addEventListener("click", () => {
+    void invoke<string>("generate_password").then(useGenerated);
+  });
+
+  next.addEventListener("click", () => {
+    rotationPassword = pw.value;
+    savePasswordScreen();
+  });
+
+  const back = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("common.back"),
+  ]);
+  back.addEventListener("click", () => rotationBack());
+
+  show(
+    brand(),
+    h("h1", {}, [t("changePassword.pickTitle")]),
+    h("p", { class: "lede" }, [t("changePassword.pickLede")]),
+    h("div", { class: "field-stack" }, [
+      h("div", { class: "input-wrap" }, [pw, generate]),
+      h("div", { class: "strength" }, [h("div", { class: "strength-track" }, [fill]), label]),
+      confirm,
+      hint,
+      generatedNote,
+    ]),
+    h("div", { class: "notice" }, ["🔑", h("span", {}, [t("changePassword.pickNotice")])]),
+    next,
+    back,
+    h("p", { class: "footnote" }, [t("password.footnote")]),
+  );
+
+  if (rotationPassword) {
+    render();
+    runCheck();
+  } else {
+    // Pre-filled on arrival, not on a click. If that ever fails the screen is
+    // still usable: an empty field the user types into, exactly as at setup.
+    void invoke<string>("generate_password").then(useGenerated, render);
+  }
+}
+
+/// The gate. One screen, one job. No email button: the address and the
+/// connection link are not secrets and this is, and a button is advice.
+function savePasswordScreen() {
+  currentScreen = savePasswordScreen;
+  // btn-danger is a small pill everywhere else in the app; here it is the
+  // screen's primary, so it borrows the setup buttons' metrics. Its label is
+  // itself the acknowledgement, matching the one other place in the app where
+  // that is true (freeing the old search index).
+  const confirm = h(
+    "button",
+    { class: "btn-primary btn-danger", style: "padding:15px;font-size:15px" },
+    [t("changePassword.saveConfirm")],
+  );
+  confirm.addEventListener("click", () => void runRotation());
+  const back = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("changePassword.saveBack"),
+  ]);
+  back.addEventListener("click", () => choosePasswordScreen());
+
+  show(
+    brand(),
+    h("h1", {}, [t("changePassword.saveTitle")]),
+    h("p", { class: "lede" }, [t("changePassword.saveLede")]),
+    secretCard(t("changePassword.passwordLabel"), rotationPassword),
+    h("p", { class: "footnote" }, [t("changePassword.saveAdvice")]),
+    confirm,
+    back,
+  );
+}
+
+function rotationSteps(): { id: StepId; label: string }[] {
+  return [
+    { id: "secret", label: t("changePassword.stepSend") },
+    { id: "confirm", label: t("changePassword.stepConfirm") },
+    { id: "local", label: t("changePassword.stepLocal") },
+  ];
+}
+
+/** Step state lives outside the render so a locale change redraws the checklist
+ *  instead of starting a second change. */
+const rotationStepStatus = new Map<StepId, StepEvent["status"]>();
+
+/// No Cancel: between the change going out and the brain confirming it there is
+/// no state to return to, and a button that abandons the flow at that exact
+/// moment would manufacture the "may already be live" case on purpose.
+function rotationProgressScreen() {
+  currentScreen = rotationProgressScreen;
+  const list = h("ul", { class: "checklist" });
+  for (const step of rotationSteps()) {
+    const status = rotationStepStatus.get(step.id);
+    const icon =
+      status === "running"
+        ? h("span", { class: "spinner" })
+        : status === "done"
+          ? "✓"
+          : status === "error"
+            ? "!"
+            : "•";
+    list.append(
+      h("li", status ? { class: status } : {}, [
+        h("span", { class: "check-icon" }, [icon]),
+        step.label,
+      ]),
+    );
+  }
+  show(
+    brand(),
+    h("h1", {}, [t("changePassword.progressTitle")]),
+    h("p", { class: "lede" }, [t("changePassword.progressLede")]),
+    h("div", { class: "card" }, [list]),
+  );
+}
+
+async function runRotation() {
+  rotationStepStatus.clear();
+  rotationProgressScreen();
+  const unlisten = await listen<StepEvent>("setup-progress", (e) => {
+    rotationStepStatus.set(e.payload.step, e.payload.status);
+    rotationProgressScreen();
+  });
+  try {
+    // Door B has no stored setup, so the brain it picked travels with the call.
+    // Door A omits it and the command uses the address this computer holds.
+    const args: Record<string, unknown> = { newPassword: rotationPassword };
+    if (rotationAddress) args.address = rotationAddress;
+    const outcome = await invoke<RotateOutcome>("rotate_password", args);
+    unlisten();
+    // The done screen opens by claiming this computer already uses the new
+    // password, so it only gets shown when the local writes say so.
+    if (!outcome.keychain || outcome.cliConfig === false) rotateFailLocalScreen(outcome);
+    else rotateDoneScreen();
+  } catch (e) {
+    unlisten();
+    const failure = rotateErrorOf(e);
+    if (failure.stage === "notSent") rotateFailNotSentScreen(failure.detail);
+    else if (failure.stage === "local") rotateFailLocalScreen(null, failure.detail);
+    else rotateFailUnsureScreen(failure.detail);
+  }
+}
+
+function failDetailLine(detail: string): HTMLElement | string {
+  return detail ? h("p", { class: "footnote" }, [t("changePassword.failDetail", { detail })]) : "";
+}
+
+/// Nothing reached the brain, so the old password still works. This is the one
+/// screen in the feature where the word "failed" belongs, and the password is
+/// labelled by what it actually is here: chosen, and not in use.
+function rotateFailNotSentScreen(detail: string) {
+  currentScreen = () => rotateFailNotSentScreen(detail);
+  const retry = h("button", { class: "btn-primary" }, [t("common.tryAgain")]);
+  retry.addEventListener("click", () => void runRotation());
+  const leave = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("common.notNow"),
+  ]);
+  leave.addEventListener("click", leaveRotation);
+
+  show(
+    brand(),
+    h("h1", {}, [t("changePassword.failNotSentTitle")]),
+    notice(t("changePassword.failNotSentBody")),
+    failDetailLine(detail),
+    secretCard(t("changePassword.failNotSentLabel"), rotationPassword),
+    retry,
+    leave,
+  );
+}
+
+/// The change went out and never confirmed. Never says "failed": the heading is
+/// a statement about the password, which is the only fact the app has. Retry is
+/// the escape and the copy says why — setting the same password twice confirms
+/// what landed or completes what did not.
+function rotateFailUnsureScreen(detail: string, recheck?: "confirmed" | "unconfirmed") {
+  currentScreen = () => rotateFailUnsureScreen(detail, recheck);
+  const retry = h("button", { class: "btn-primary" }, [t("common.tryAgain")]);
+  retry.addEventListener("click", () => void runRotation());
+
+  // Read-only: a /health probe with the new password, no write. It is safe to
+  // offer on the one screen where the user does not know what happened.
+  const check = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("changePassword.recheckButton"),
+  ]);
+  check.addEventListener("click", async () => {
+    check.disabled = true;
+    check.textContent = t("common.checking");
+    const live = await invoke<boolean>("recheck_password", {
+      password: rotationPassword,
+    }).catch(() => false);
+    rotateFailUnsureScreen(detail, live ? "confirmed" : "unconfirmed");
+  });
+
+  const leave = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("changePassword.failUnsureLeave"),
+  ]);
+  leave.addEventListener("click", leaveRotation);
+
+  show(
+    brand(),
+    h("h1", {}, [t("changePassword.failUnsureTitle")]),
+    notice(t("changePassword.failUnsureBody")),
+    secretCard(t("changePassword.passwordLabel"), rotationPassword),
+    recheck
+      ? notice(
+          t(
+            recheck === "confirmed"
+              ? "changePassword.recheckConfirmed"
+              : "changePassword.recheckUnconfirmed",
+          ),
+          "info",
+        )
+      : "",
+    h("p", { class: "lede" }, [t("changePassword.failUnsureRetry")]),
+    failDetailLine(detail),
+    retry,
+    check,
+    leave,
+    // Not decoration: nothing local was written, so this machine still holds a
+    // password that may now be dead, and the window with the live one is about
+    // to be closed.
+    h("p", { class: "footnote" }, [t("changePassword.failUnsureFootnote")]),
+  );
+}
+
+/// The brain has the new password; something local did not get it. No "try
+/// again" — the change is done, and re-running the flow to fix a keychain write
+/// would change the password a second time.
+function rotateFailLocalScreen(outcome: RotateOutcome | null, detail = "") {
+  currentScreen = () => rotateFailLocalScreen(outcome, detail);
+  // When only the CLI config is stale the keychain succeeded, so the body
+  // saying this computer will ask for the password would be untrue.
+  const keychainFailed = outcome === null || !outcome.keychain;
+  const cliFailed = outcome !== null && outcome.cliConfig === false;
+  const done = h("button", { class: "btn-primary" }, [t("details.openDashboard")]);
+  done.addEventListener("click", () => void invoke("open_dashboard"));
+
+  show(
+    brand(),
+    h("h1", {}, [t("changePassword.failLocalTitle")]),
+    notice(t(keychainFailed ? "changePassword.failLocalBody" : "changePassword.failLocalCli")),
+    keychainFailed && cliFailed
+      ? h("p", { class: "lede" }, [t("changePassword.failLocalCli")])
+      : "",
+    secretCard(t("changePassword.passwordLabel"), rotationPassword),
+    failDetailLine(detail),
+    done,
+  );
+}
+
+/// Read correctly by two people: someone doing routine hygiene, who is
+/// finished, and someone who has just had a leak, who is not. What will ask for
+/// the new password comes first because it is true for everyone; the OAuth
+/// explanation is context, and the leak sentence is a condition rather than a
+/// warning, so a hygiene user dismisses it in one beat.
+function rotateDoneScreen(revealed = false) {
+  currentScreen = () => rotateDoneScreen(revealed);
+  const needs = h("ul", { class: "url-desc", style: "padding-left:18px" }, [
+    h("li", {}, [t("changePassword.doneNeeds1")]),
+    h("li", {}, [t("changePassword.doneNeeds2")]),
+    h("li", {}, [t("changePassword.doneNeeds3")]),
+  ]);
+  const disconnect = h("button", { class: "btn-secondary" }, [
+    t("changePassword.doneDisconnectButton"),
+  ]);
+  // Opens the pane the control lives in; it disconnects nothing on click.
+  disconnect.addEventListener("click", () => void invoke("open_details_window"));
+
+  const reveal = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t(revealed ? "changePassword.doneHide" : "changePassword.doneShow"),
+  ]);
+  reveal.addEventListener("click", () => rotateDoneScreen(!revealed));
+
+  const open = h("button", { class: "btn-primary" }, [t("details.openDashboard")]);
+  open.addEventListener("click", () => void invoke("open_dashboard"));
+
+  show(
+    brand(),
+    h("h1", {}, [
+      t(rotationDoor === "lost" ? "changePassword.doneTitleLost" : "changePassword.doneTitle"),
+    ]),
+    h("p", { class: "lede" }, [t("changePassword.doneLede")]),
+    h("div", { class: "card" }, [
+      h("div", { class: "url-label" }, [t("changePassword.doneNeedsHead")]),
+      needs,
+    ]),
+    h("div", { class: "card" }, [
+      h("div", { class: "url-label" }, [t("changePassword.doneKeptHead")]),
+      h("div", { class: "url-desc" }, [t("changePassword.doneKept")]),
+      // A notice, not a notice error. Most changes are hygiene, and a red block
+      // on every one of them trains people to skip the block — including the
+      // person it was written for.
+      h("div", { class: "notice" }, ["🔑", h("span", {}, [t("changePassword.doneLeak")])]),
+      h("div", { class: "row-actions" }, [disconnect]),
+    ]),
+    // Collapsed by default, so it is not sitting in a window someone walked
+    // away from — but still reachable, which is what the save gate promised.
+    revealed ? secretCard(t("changePassword.passwordLabel"), rotationPassword) : "",
+    reveal,
+    open,
+  );
+}
+
+/// Shown at launch when this computer's stored password no longer opens the
+/// brain. Three ways forward: enter the new one, find the brain again, or set a
+/// new one — the last is for the two people most likely to be here, someone
+/// without the new password and someone who did not make the change.
+async function passwordChangedElsewhereScreen(errorMsg?: string) {
+  currentScreen = () => void passwordChangedElsewhereScreen(errorMsg);
+  const stored = await invoke<ConnectionDetails>("get_connection_details").catch(() => null);
+  if (!stored) {
+    // Nothing stored to be stale about; the ordinary connect path applies.
+    connectExistingScreen();
+    return;
+  }
+
+  const password = h("input", {
+    type: "password",
+    placeholder: t("connectExisting.passwordPlaceholder"),
+  });
+  const connect = h("button", { class: "btn-primary" }, [t("common.connect")]);
+  connect.addEventListener("click", async () => {
+    connect.disabled = true;
+    connect.textContent = t("common.checking");
+    try {
+      details = await invoke<ConnectionDetails>("connect_existing", {
+        address: stored.workerUrl,
+        password: password.value,
+      });
+      // Straight on to the wrapper window with no comment: if the brain answers
+      // normally now, this screen was a transient 401 and an apology for it
+      // would be noise.
+      await invoke("open_dashboard");
+    } catch (e) {
+      void passwordChangedElsewhereScreen(String(e));
+    }
+  });
+
+  const findAgain = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("passwordChangedElsewhere.findAgain"),
+  ]);
+  findAgain.addEventListener("click", () => void discoverScreen());
+
+  const lost = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("connectExisting.lostPassword"),
+  ]);
+  lost.addEventListener("click", () => {
+    rotationExit = () => void passwordChangedElsewhereScreen();
+    lostPasswordIntroScreen(stored.workerUrl);
+  });
+
+  show(
+    brand(),
+    h("h1", {}, [t("passwordChangedElsewhere.title")]),
+    h("p", { class: "lede" }, [t("passwordChangedElsewhere.lede")]),
+    h("p", { class: "lede" }, [t("passwordChangedElsewhere.body")]),
+    errorMsg ? notice(errorMsg) : "",
+    h("div", { class: "field-stack" }, [password]),
+    connect,
+    findAgain,
+    h("p", { class: "footnote" }, [t("passwordChangedElsewhere.findAgainHint")]),
+    h("p", { class: "footnote" }, [t("passwordChangedElsewhere.footnote")]),
+    lost,
+  );
+  password.focus();
+}
+
 function applyWindowTitle() {
   document.title = t("common.appTitle");
   void getCurrentWindow().setTitle(t("common.appTitle"));
@@ -726,6 +1536,14 @@ async function boot() {
     }
     if (state.mode === "worker-update") {
       void workerUpdateScreen();
+      return;
+    }
+    if (state.mode === "change-password") {
+      changePasswordIntroScreen();
+      return;
+    }
+    if (state.mode === "stale-password") {
+      void passwordChangedElsewhereScreen();
       return;
     }
   } catch {

--- a/installer/src/main.ts
+++ b/installer/src/main.ts
@@ -16,14 +16,18 @@ import {
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { initI18n, LOCALE_CHANGE_EVENT, t } from "./i18n";
 import {
+  blockedCopy,
   localFailureCopy,
+  recheckArgs,
+  rotateArgs,
   rotateErrorOf,
   screenForFailure,
   screenForOutcome,
-  withAddress,
+  ROTATION_STEP_IDS,
   type ChangePasswordKey,
   type RecheckResult,
   type RotateOutcome,
+  type RotationStepId,
 } from "./rotation-state";
 import "./style.css";
 
@@ -32,10 +36,12 @@ interface Account {
   name: string;
 }
 
-// The last three are the password change's steps (#235). They are none of the
-// four provisioning steps, and labelling "waiting for your Second Brain to
-// accept it" as `recall` would mislead the next person to read this.
-type StepId = "space" | "memory" | "recall" | "finish" | "secret" | "confirm" | "local";
+// The password change's three steps (#235) come from `ROTATION_STEP_IDS`, not
+// from a second list written out here. They are none of the four provisioning
+// steps — labelling "waiting for your Second Brain to accept it" as `recall`
+// would mislead the next person to read this — and spelling them twice is how
+// one copy gets renamed and the other does not.
+type StepId = "space" | "memory" | "recall" | "finish" | RotationStepId;
 interface StepEvent {
   step: StepId;
   status: "running" | "done" | "error";
@@ -1284,12 +1290,18 @@ function savePasswordScreen() {
   );
 }
 
+/// The ids are `ROTATION_STEP_IDS`, which is where the wire contract with the
+/// Rust `Step` enum is stated and tested; this only decides what each one is
+/// called on screen. Keyed by id rather than listed alongside them so a label
+/// cannot be attached to a step that does not exist, or a step left unlabelled.
+const ROTATION_STEP_LABELS: Record<RotationStepId, ChangePasswordKey> = {
+  secret: "changePassword.stepSend",
+  confirm: "changePassword.stepConfirm",
+  local: "changePassword.stepLocal",
+};
+
 function rotationSteps(): { id: StepId; label: string }[] {
-  return [
-    { id: "secret", label: t("changePassword.stepSend") },
-    { id: "confirm", label: t("changePassword.stepConfirm") },
-    { id: "local", label: t("changePassword.stepLocal") },
-  ];
+  return ROTATION_STEP_IDS.map((id) => ({ id, label: t(ROTATION_STEP_LABELS[id]) }));
 }
 
 /** Step state lives outside the render so a locale change redraws the checklist
@@ -1339,7 +1351,7 @@ async function runRotation() {
     // Door A omits it and the command uses the address this computer holds.
     const outcome = await invoke<RotateOutcome>(
       "rotate_password",
-      withAddress({ newPassword: rotationPassword }, rotationAddress),
+      rotateArgs(rotationPassword, rotationAddress),
     );
     unlisten();
     // The brain confirmed the new password, so there is no ambiguity left for a
@@ -1373,25 +1385,44 @@ async function runRotation() {
 /// same three strings the Connection pane shows in place of the door, including
 /// the escape — an abandoned rebuild would otherwise leave this screen as a dead
 /// end with the reason relegated to a footnote under "Try again".
+///
+/// This screen renders whenever the stage is `blocked`, including after an
+/// earlier attempt that may already have changed the password. It is the only
+/// place the escape route is named, and a run that is blocked stays blocked, so
+/// routing that case to "may already be live" would leave a "Try again" button
+/// on a run that cannot succeed and no way to reach the thing that unsticks it.
+/// The other truth is not dropped: `blockedCopy` puts it on this screen.
 function rotateBlockedScreen(detail: string) {
   currentScreen = () => rotateBlockedScreen(detail);
+  const copy = blockedCopy(rotationMayBeLive);
   const settings = h("button", { class: "btn-primary" }, [t("changePassword.blockedButton")]);
   settings.addEventListener("click", () => void invoke("open_settings_window"));
-  const leave = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
-    t("common.notNow"),
-  ]);
-  leave.addEventListener("click", leaveRotation);
+  // Leaving is a click when nothing was sent and the old password still works,
+  // and a decision when this window holds the only copy of one that may already
+  // be live — the same acknowledgement the other may-be-live screen asks for.
+  const leave = copy.guardLeaving
+    ? guardedExit(t("changePassword.failUnsureLeave"), leaveRotation)
+    : (() => {
+        const go = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+          t("common.notNow"),
+        ]);
+        go.addEventListener("click", leaveRotation);
+        return go;
+      })();
 
   show(
     brand(),
     h("h1", {}, [t("changePassword.blockedTitle")]),
     notice(t("changePassword.blockedBody")),
     h("p", { class: "lede" }, [t("changePassword.blockedEscape")]),
+    // Above the password card, because it is the reason to keep what is in it.
+    copy.liveNotice ? notice(t(copy.liveNotice)) : "",
     failDetailLine(detail),
-    // Labelled as chosen and not in use, exactly as on the "nothing was
-    // changed" screen: nothing was sent, so calling it "your new password" here
-    // would tell someone who saved it that they now hold the working key.
-    secretCard(t("changePassword.failNotSentLabel"), rotationPassword),
+    // "The password you chose — not in use" while nothing has been sent, and
+    // "Your new password" once an attempt may have landed. Calling it not in
+    // use on that second path would tell someone deciding whether to keep it
+    // that they can safely throw away the only key to their brain.
+    secretCard(t(copy.passwordLabel), rotationPassword),
     settings,
     leave,
   );
@@ -1453,7 +1484,7 @@ function rotateFailUnsureScreen(detail: string, recheck?: RecheckResult) {
     try {
       const live = await invoke<boolean>(
         "recheck_password",
-        withAddress({ password: rotationPassword }, rotationAddress),
+        recheckArgs(rotationPassword, rotationAddress),
       );
       result = live ? "confirmed" : "notLive";
     } catch {

--- a/installer/src/main.ts
+++ b/installer/src/main.ts
@@ -15,6 +15,16 @@ import {
 } from "./shared";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { initI18n, LOCALE_CHANGE_EVENT, t } from "./i18n";
+import {
+  localFailureCopy,
+  rotateErrorOf,
+  screenForFailure,
+  screenForOutcome,
+  withAddress,
+  type ChangePasswordKey,
+  type RecheckResult,
+  type RotateOutcome,
+} from "./rotation-state";
 import "./style.css";
 
 interface Account {
@@ -230,6 +240,7 @@ function unlockBrainScreen(
     t("connectExisting.lostPassword"),
   ]);
   lost.addEventListener("click", () => {
+    beginRotation();
     rotationExit = () => unlockBrainScreen(brain, undefined, found);
     lostPasswordIntroScreen(brain.url);
   });
@@ -289,6 +300,7 @@ function manualEntryScreen(
     t("connectExisting.lostPassword"),
   ]);
   lost.addEventListener("click", () => {
+    beginRotation();
     rotationExit = () => manualEntryScreen(errorMsg, address.value, tone);
     rotationTypedAddress = address.value.trim();
     lostPasswordIntroScreen(null);
@@ -771,6 +783,34 @@ let rotationPassword = "";
 /** True while the field still holds what `generate_password` produced. */
 let rotationGenerated = false;
 
+/**
+ * True once *any* attempt in this window has reached the "may already be live"
+ * state, and never cleared until a change is confirmed.
+ *
+ * The reason it is sticky rather than per-attempt: attempt one can PUT the
+ * secret and then time out waiting for the brain to confirm it, and attempt two
+ * can fail before the PUT — an expired sign-in, a transient account lookup —
+ * which on its own is honestly "nothing was changed". Rendering that screen
+ * would tell someone whose old password is already dead that everything is
+ * exactly as it was, which is the one message in this flow that ends with a
+ * brain nobody can open.
+ */
+let rotationMayBeLive = false;
+
+/**
+ * Entering the flow from outside — Door A at launch, or the ghost link on any
+ * of the three connect screens. Deliberately not called by the Back paths,
+ * which are inside a flow that is still choosing its password.
+ *
+ * `rotationMayBeLive` is *not* reset here: a second run with a second password
+ * does not undo a first run that may already have taken effect, so the doubt
+ * outlives the flow that created it and only a confirmed change clears it.
+ */
+function beginRotation() {
+  rotationPassword = "";
+  rotationGenerated = false;
+}
+
 /** Where the password step's Back leads. Usually the intro; the discovery paths
  *  set it to the picker they came from, because the intro would mean signing in
  *  to Cloudflare a second time to get back here. */
@@ -778,35 +818,6 @@ let rotationBack: () => void = () => changePasswordIntroScreen();
 
 /** Where Door B leads out — the screen the ghost link was clicked on. */
 let rotationExit: () => void = () => connectExistingScreen();
-
-/** What `rotate_password` reports when the remote change succeeded. */
-interface RotateOutcome {
-  keychain: boolean;
-  /** null when the CLI was never installed — that is not a failure. */
-  cliConfig: boolean | null;
-}
-
-/** Which failure happened, and with it what may honestly be claimed. */
-interface RotateError {
-  /** "notSent" — the old password still works. "unconfirmed" — it may not.
-   *  "local" — the brain has the new one, a local write did not. */
-  stage: "notSent" | "unconfirmed" | "local";
-  /** Already localised by Rust; fills the failure screen's detail slot. */
-  detail: string;
-}
-
-function rotateErrorOf(e: unknown): RotateError {
-  if (typeof e === "object" && e !== null) {
-    const { stage, detail } = e as { stage?: unknown; detail?: unknown };
-    if (stage === "notSent" || stage === "unconfirmed" || stage === "local") {
-      return { stage, detail: typeof detail === "string" ? detail : "" };
-    }
-  }
-  // Anything we cannot read is treated as "may already be live", deliberately.
-  // Telling someone their old password still works when it may not is the one
-  // mistake in this flow that ends with a brain nobody can open.
-  return { stage: "unconfirmed", detail: String(e) };
-}
 
 /**
  * True once `connect_cloudflare` has succeeded in this window. The account list
@@ -822,6 +833,44 @@ function signedInToCloudflare(): boolean {
 function leaveRotation() {
   if (rotationDoor === "lost") rotationExit();
   else void invoke("open_dashboard");
+}
+
+/**
+ * An exit from a screen that may be holding the only password that opens the
+ * brain.
+ *
+ * The save gate has a deliberate "I've saved it" confirmation for a password
+ * that is merely *proposed*. Past that point the same password may already be
+ * the live one and this window the only place it exists, so walking away from
+ * it gets the same acknowledgement rather than a single click on a ghost.
+ *
+ * Not used on the "nothing was changed" screen: that screen renders only when
+ * no attempt in this window has ever reached the brain, so the password on it
+ * is by the app's own account not in use, and its copy says so.
+ *
+ * The two-step shape matches the Disconnect and Log out controls in the
+ * Connections window, so the pattern is already familiar where it matters most.
+ */
+function guardedExit(label: string, leave: () => void): HTMLElement {
+  const host = h("div", {});
+  const render = (confirming: boolean) => {
+    if (!confirming) {
+      const go = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [label]);
+      go.addEventListener("click", () => render(true));
+      host.replaceChildren(go);
+      return;
+    }
+    const confirm = h("button", { class: "btn-danger" }, [t("changePassword.leaveConfirm")]);
+    confirm.addEventListener("click", leave);
+    const stay = h("button", { class: "btn-ghost" }, [t("changePassword.leaveKeep")]);
+    stay.addEventListener("click", () => render(false));
+    host.replaceChildren(
+      h("div", { class: "notice" }, ["🔑", h("span", {}, [t("changePassword.leaveWarn")])]),
+      h("div", { class: "row-actions" }, [confirm, stay]),
+    );
+  };
+  render(false);
+  return host;
 }
 
 function cloudflareWaitingScreen(lede: string) {
@@ -1025,9 +1074,22 @@ function lostAddressScreen(
     else next.setAttribute("disabled", "");
   };
   address.addEventListener("input", sync);
-  next.addEventListener("click", () => {
-    rotationAddress = address.value.trim();
-    rotationTypedAddress = rotationAddress;
+  // Checked here rather than at the far end of the flow. `validate_brain_address`
+  // runs exactly the checks `rotate_password` runs on an explicit address, so a
+  // typo is reported in the field it was typed in — not after the save gate, a
+  // progress screen and a failure screen that has to hedge about what happened.
+  next.addEventListener("click", async () => {
+    const typed = address.value.trim();
+    next.disabled = true;
+    next.textContent = t("common.checking");
+    try {
+      await invoke("validate_brain_address", { address: typed });
+    } catch (e) {
+      lostAddressScreen(found, String(e), fromPicker, typed);
+      return;
+    }
+    rotationAddress = typed;
+    rotationTypedAddress = typed;
     rotationBack = () => lostAddressScreen(found, undefined, fromPicker, rotationTypedAddress);
     choosePasswordScreen();
   });
@@ -1275,21 +1337,64 @@ async function runRotation() {
   try {
     // Door B has no stored setup, so the brain it picked travels with the call.
     // Door A omits it and the command uses the address this computer holds.
-    const args: Record<string, unknown> = { newPassword: rotationPassword };
-    if (rotationAddress) args.address = rotationAddress;
-    const outcome = await invoke<RotateOutcome>("rotate_password", args);
+    const outcome = await invoke<RotateOutcome>(
+      "rotate_password",
+      withAddress({ newPassword: rotationPassword }, rotationAddress),
+    );
     unlisten();
+    // The brain confirmed the new password, so there is no ambiguity left for a
+    // later attempt to inherit.
+    rotationMayBeLive = false;
     // The done screen opens by claiming this computer already uses the new
-    // password, so it only gets shown when the local writes say so.
-    if (!outcome.keychain || outcome.cliConfig === false) rotateFailLocalScreen(outcome);
+    // password, so it only gets shown when every local write says so.
+    if (screenForOutcome(outcome) === "failLocal") rotateFailLocalScreen(outcome);
     else rotateDoneScreen();
   } catch (e) {
     unlisten();
     const failure = rotateErrorOf(e);
-    if (failure.stage === "notSent") rotateFailNotSentScreen(failure.detail);
-    else if (failure.stage === "local") rotateFailLocalScreen(null, failure.detail);
-    else rotateFailUnsureScreen(failure.detail);
+    if (failure.stage === "unconfirmed") rotationMayBeLive = true;
+    switch (screenForFailure(failure.stage, rotationMayBeLive)) {
+      case "failLocal":
+        rotateFailLocalScreen(null, failure.detail);
+        break;
+      case "failUnsure":
+        rotateFailUnsureScreen(failure.detail);
+        break;
+      case "blocked":
+        rotateBlockedScreen(failure.detail);
+        break;
+      default:
+        rotateFailNotSentScreen(failure.detail);
+    }
   }
+}
+
+/// A rebuild started while this flow was open, so nothing was attempted. The
+/// same three strings the Connection pane shows in place of the door, including
+/// the escape — an abandoned rebuild would otherwise leave this screen as a dead
+/// end with the reason relegated to a footnote under "Try again".
+function rotateBlockedScreen(detail: string) {
+  currentScreen = () => rotateBlockedScreen(detail);
+  const settings = h("button", { class: "btn-primary" }, [t("changePassword.blockedButton")]);
+  settings.addEventListener("click", () => void invoke("open_settings_window"));
+  const leave = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
+    t("common.notNow"),
+  ]);
+  leave.addEventListener("click", leaveRotation);
+
+  show(
+    brand(),
+    h("h1", {}, [t("changePassword.blockedTitle")]),
+    notice(t("changePassword.blockedBody")),
+    h("p", { class: "lede" }, [t("changePassword.blockedEscape")]),
+    failDetailLine(detail),
+    // Labelled as chosen and not in use, exactly as on the "nothing was
+    // changed" screen: nothing was sent, so calling it "your new password" here
+    // would tell someone who saved it that they now hold the working key.
+    secretCard(t("changePassword.failNotSentLabel"), rotationPassword),
+    settings,
+    leave,
+  );
 }
 
 function failDetailLine(detail: string): HTMLElement | string {
@@ -1323,7 +1428,7 @@ function rotateFailNotSentScreen(detail: string) {
 /// a statement about the password, which is the only fact the app has. Retry is
 /// the escape and the copy says why — setting the same password twice confirms
 /// what landed or completes what did not.
-function rotateFailUnsureScreen(detail: string, recheck?: "confirmed" | "unconfirmed") {
+function rotateFailUnsureScreen(detail: string, recheck?: RecheckResult) {
   currentScreen = () => rotateFailUnsureScreen(detail, recheck);
   const retry = h("button", { class: "btn-primary" }, [t("common.tryAgain")]);
   retry.addEventListener("click", () => void runRotation());
@@ -1336,37 +1441,46 @@ function rotateFailUnsureScreen(detail: string, recheck?: "confirmed" | "unconfi
   check.addEventListener("click", async () => {
     check.disabled = true;
     check.textContent = t("common.checking");
-    const live = await invoke<boolean>("recheck_password", {
-      password: rotationPassword,
-    }).catch(() => false);
-    rotateFailUnsureScreen(detail, live ? "confirmed" : "unconfirmed");
+    // Three answers, not two. The command deliberately separates "the brain
+    // answered, and not to this password" from "we could not ask it": reporting
+    // the second as the first turns a question that was never put into an answer
+    // of no, on the one screen where the user is deciding what to believe.
+    //
+    // The address travels with the call for the same reason it does with the
+    // change itself — Door B is a computer with no stored setup, so a missing
+    // address resolves to nothing rather than to the brain being asked about.
+    let result: RecheckResult;
+    try {
+      const live = await invoke<boolean>(
+        "recheck_password",
+        withAddress({ password: rotationPassword }, rotationAddress),
+      );
+      result = live ? "confirmed" : "notLive";
+    } catch {
+      result = "unreachable";
+    }
+    rotateFailUnsureScreen(detail, result);
   });
 
-  const leave = h("button", { class: "btn-ghost", style: "width:100%;margin-top:8px" }, [
-    t("changePassword.failUnsureLeave"),
-  ]);
-  leave.addEventListener("click", leaveRotation);
+  const recheckKey: Record<RecheckResult, ChangePasswordKey> = {
+    confirmed: "changePassword.recheckConfirmed",
+    notLive: "changePassword.recheckUnconfirmed",
+    unreachable: "changePassword.recheckUnreachable",
+  };
 
   show(
     brand(),
     h("h1", {}, [t("changePassword.failUnsureTitle")]),
     notice(t("changePassword.failUnsureBody")),
     secretCard(t("changePassword.passwordLabel"), rotationPassword),
-    recheck
-      ? notice(
-          t(
-            recheck === "confirmed"
-              ? "changePassword.recheckConfirmed"
-              : "changePassword.recheckUnconfirmed",
-          ),
-          "info",
-        )
-      : "",
+    recheck ? notice(t(recheckKey[recheck]), "info") : "",
     h("p", { class: "lede" }, [t("changePassword.failUnsureRetry")]),
     failDetailLine(detail),
     retry,
     check,
-    leave,
+    // This window may hold the only password that opens the brain, so leaving
+    // it is a decision rather than a click.
+    guardedExit(t("changePassword.failUnsureLeave"), leaveRotation),
     // Not decoration: nothing local was written, so this machine still holds a
     // password that may now be dead, and the window with the live one is about
     // to be closed.
@@ -1379,23 +1493,34 @@ function rotateFailUnsureScreen(detail: string, recheck?: "confirmed" | "unconfi
 /// would change the password a second time.
 function rotateFailLocalScreen(outcome: RotateOutcome | null, detail = "") {
   currentScreen = () => rotateFailLocalScreen(outcome, detail);
-  // When only the CLI config is stale the keychain succeeded, so the body
-  // saying this computer will ask for the password would be untrue.
-  const keychainFailed = outcome === null || !outcome.keychain;
-  const cliFailed = outcome !== null && outcome.cliConfig === false;
-  const done = h("button", { class: "btn-primary" }, [t("details.openDashboard")]);
-  done.addEventListener("click", () => void invoke("open_dashboard"));
+  // Heading and body are chosen together. They used to disagree: the body
+  // switched to the CLI-specific message when secure storage had in fact
+  // succeeded, while the heading went on saying the password was "not saved on
+  // this computer" — and the heading was the false one.
+  const copy = localFailureCopy(outcome);
+
+  // When secure storage took the new password this computer can open its own
+  // brain, so the dashboard button is the right exit. When it did not, that
+  // button opens a window that silently 401s — on Door B it rejects outright,
+  // leaving the screen's only control visibly doing nothing, forever. The
+  // honest offer there is to connect this computer again with the password on
+  // screen, and it is guarded, because taking it means leaving this screen.
+  const exit = copy.reconnect
+    ? guardedExit(t("changePassword.failLocalReconnect"), () => connectExistingScreen())
+    : (() => {
+        const open = h("button", { class: "btn-primary" }, [t("details.openDashboard")]);
+        open.addEventListener("click", () => void invoke("open_dashboard"));
+        return open;
+      })();
 
   show(
     brand(),
-    h("h1", {}, [t("changePassword.failLocalTitle")]),
-    notice(t(keychainFailed ? "changePassword.failLocalBody" : "changePassword.failLocalCli")),
-    keychainFailed && cliFailed
-      ? h("p", { class: "lede" }, [t("changePassword.failLocalCli")])
-      : "",
+    h("h1", {}, [t(copy.title)]),
+    notice(t(copy.notice)),
+    ...copy.extra.map((key) => h("p", { class: "lede" }, [t(key)])),
     secretCard(t("changePassword.passwordLabel"), rotationPassword),
     failDetailLine(detail),
-    done,
+    exit,
   );
 }
 
@@ -1406,10 +1531,15 @@ function rotateFailLocalScreen(outcome: RotateOutcome | null, detail = "") {
 /// warning, so a hygiene user dismisses it in one beat.
 function rotateDoneScreen(revealed = false) {
   currentScreen = () => rotateDoneScreen(revealed);
+  // Four items, not three. A change writes to secure storage, the brain
+  // command's config and the open dashboard window — so the extension and the
+  // Obsidian plugin hold the old password on *this* computer too, which is what
+  // Door B's notice has always told people and this list used to deny.
   const needs = h("ul", { class: "url-desc", style: "padding-left:18px" }, [
     h("li", {}, [t("changePassword.doneNeeds1")]),
     h("li", {}, [t("changePassword.doneNeeds2")]),
     h("li", {}, [t("changePassword.doneNeeds3")]),
+    h("li", {}, [t("changePassword.doneNeeds4")]),
   ]);
   const disconnect = h("button", { class: "btn-secondary" }, [
     t("changePassword.doneDisconnectButton"),
@@ -1496,6 +1626,7 @@ async function passwordChangedElsewhereScreen(errorMsg?: string) {
     t("connectExisting.lostPassword"),
   ]);
   lost.addEventListener("click", () => {
+    beginRotation();
     rotationExit = () => void passwordChangedElsewhereScreen();
     lostPasswordIntroScreen(stored.workerUrl);
   });
@@ -1539,6 +1670,7 @@ async function boot() {
       return;
     }
     if (state.mode === "change-password") {
+      beginRotation();
       changePasswordIntroScreen();
       return;
     }

--- a/installer/src/rotation-state.ts
+++ b/installer/src/rotation-state.ts
@@ -1,0 +1,188 @@
+/**
+ * The decisions the password-change flow makes about *which* screen to show and
+ * *what may honestly be claimed on it* (#235 §4).
+ *
+ * Deliberately free of DOM, of `@tauri-apps/api`, and of every import: the rest
+ * of `main.ts` cannot be loaded outside a webview, and these are the rules whose
+ * being wrong costs a user their brain — "nothing was changed" on a run where
+ * something was, a heading that contradicts its own body, a local write that
+ * failed and was never mentioned. They belong somewhere a test can reach them.
+ *
+ * `main.ts` holds the rendering; this holds the reasoning.
+ */
+
+/** Which failure happened, and with it what may honestly be claimed. */
+export type RotateStage =
+  /** Nothing reached Cloudflare; the old password still works. */
+  | "notSent"
+  /** The secret was accepted; health never went green. It may already be live. */
+  | "unconfirmed"
+  /** The brain has the new password; a local write did not. */
+  | "local"
+  /** A rebuild started while the flow was open, so nothing was attempted. */
+  | "blocked";
+
+export interface RotateError {
+  stage: RotateStage;
+  /** Already localised by Rust; fills the failure screen's detail slot. */
+  detail: string;
+}
+
+/** What `rotate_password` reports when the remote change succeeded. */
+export interface RotateOutcome {
+  /** OS secure storage. False here means this computer can no longer open the brain. */
+  keychain: boolean;
+  /** null when the CLI was never installed — that is not a failure. */
+  cliConfig: boolean | null;
+  /**
+   * The already-open dashboard window. The password is injected when that window
+   * is *created*, so an open one keeps serving the old value until it is told
+   * otherwise. True when there was no window to tell.
+   */
+  dashboard: boolean;
+}
+
+export type RotationScreen = "done" | "failLocal" | "failNotSent" | "failUnsure" | "blocked";
+
+const STAGES: RotateStage[] = ["notSent", "unconfirmed", "local", "blocked"];
+
+/**
+ * Reads whatever `rotate_password` rejected with.
+ *
+ * Anything unreadable is treated as "may already be live", deliberately.
+ * Telling someone their old password still works when it may not is the one
+ * mistake in this flow that ends with a brain nobody can open.
+ */
+export function rotateErrorOf(e: unknown): RotateError {
+  if (typeof e === "object" && e !== null) {
+    const { stage, detail } = e as { stage?: unknown; detail?: unknown };
+    if (typeof stage === "string" && (STAGES as string[]).includes(stage)) {
+      return { stage: stage as RotateStage, detail: typeof detail === "string" ? detail : "" };
+    }
+  }
+  return { stage: "unconfirmed", detail: String(e) };
+}
+
+/**
+ * A run that succeeded remotely still has three places on this computer that
+ * can have missed the new password, and the done screen opens by claiming none
+ * of them did.
+ */
+export function screenForOutcome(outcome: RotateOutcome): "done" | "failLocal" {
+  if (!outcome.keychain) return "failLocal";
+  if (outcome.cliConfig === false) return "failLocal";
+  if (!outcome.dashboard) return "failLocal";
+  return "done";
+}
+
+/**
+ * Which failure screen a run lands on.
+ *
+ * `mayBeLive` is sticky across every attempt in this window, and that is the
+ * whole point of it. One attempt can PUT the secret and time out waiting for
+ * confirmation — correctly reported as "may already be live" — and the *next*
+ * attempt can then fail before the PUT, on an expired sign-in or a transient
+ * lookup, which taken on its own is honestly `notSent`. Rendering the `notSent`
+ * screen there would tell someone whose old password is already dead that
+ * "everything is exactly as it was".
+ *
+ * So once any attempt has reached `unconfirmed`, the only stage allowed to
+ * overrule it is `local` — which is the brain confirming the new password, i.e.
+ * the ambiguity resolving in the direction that ends the doubt.
+ */
+export function screenForFailure(stage: RotateStage, mayBeLive: boolean): RotationScreen {
+  if (stage === "local") return "failLocal";
+  if (mayBeLive) return "failUnsure";
+  if (stage === "unconfirmed") return "failUnsure";
+  if (stage === "blocked") return "blocked";
+  return "failNotSent";
+}
+
+/** What the three-way "Check again" probe found. */
+export type RecheckResult =
+  /** The brain answers to the new password. */
+  | "confirmed"
+  /** The brain answered, and not to the new password. */
+  | "notLive"
+  /** We could not ask, so nothing is settled either way. */
+  | "unreachable";
+
+/**
+ * The copy the "changed, but not saved here" screen is built from.
+ *
+ * Returned as i18n keys rather than strings so the choice can be asserted
+ * without a locale: the bug this replaces was a heading that stayed
+ * unconditional while its body switched, so title and body contradicted each
+ * other and the title was the false one.
+ */
+/**
+ * A dotted key in the `changePassword` namespace. Spelled as a template type
+ * rather than imported from the catalogue so this module keeps its one useful
+ * property — no imports at all, and therefore loadable outside a webview.
+ */
+export type ChangePasswordKey = `changePassword.${string}`;
+
+export interface LocalFailureCopy {
+  title: ChangePasswordKey;
+  /** The warning notice at the top. */
+  notice: ChangePasswordKey;
+  /** Further lines below it, in order, for the stores the notice did not name. */
+  extra: ChangePasswordKey[];
+  /**
+   * True when secure storage is the store that failed, which is the only case
+   * where this computer can no longer open the brain on its own — and so the
+   * only case where "Open my Second Brain" would 401 instead of working.
+   */
+  reconnect: boolean;
+}
+
+export function localFailureCopy(outcome: RotateOutcome | null): LocalFailureCopy {
+  // A null outcome is the `"local"` stage: `persist` could not run at all, so
+  // nothing on this computer was written and secure storage is among the misses.
+  const keychainFailed = outcome === null || !outcome.keychain;
+  const cliFailed = outcome !== null && outcome.cliConfig === false;
+  const dashboardFailed = outcome !== null && !outcome.dashboard;
+
+  if (keychainFailed) {
+    const extra: ChangePasswordKey[] = [];
+    if (cliFailed) extra.push("changePassword.failLocalCli");
+    if (dashboardFailed) extra.push("changePassword.failLocalDashboard");
+    return {
+      title: "changePassword.failLocalTitle",
+      notice: "changePassword.failLocalBody",
+      extra,
+      reconnect: true,
+    };
+  }
+
+  // Secure storage took it, so this computer is fine and the unconditional
+  // heading would be untrue. Something else here still holds the old one.
+  const notice = cliFailed
+    ? "changePassword.failLocalCli"
+    : "changePassword.failLocalDashboard";
+  const extra: ChangePasswordKey[] =
+    cliFailed && dashboardFailed ? ["changePassword.failLocalDashboard"] : [];
+  return {
+    title: "changePassword.failLocalTitlePartial",
+    notice,
+    extra,
+    reconnect: false,
+  };
+}
+
+/**
+ * Adds Door B's address to a command's arguments.
+ *
+ * Both `rotate_password` and `recheck_password` take `address: Option<String>`,
+ * and a missing key deserialises to `None` — which resolves the setup *stored on
+ * this computer*. Door B is by definition a computer with no stored setup, so an
+ * omitted address there does not mean "use the default", it means "probe the
+ * wrong brain, or none at all". One helper, both callers, so the two cannot
+ * drift apart again.
+ */
+export function withAddress(
+  args: Record<string, unknown>,
+  address: string | null,
+): Record<string, unknown> {
+  return address ? { ...args, address } : { ...args };
+}

--- a/installer/src/rotation-state.ts
+++ b/installer/src/rotation-state.ts
@@ -86,16 +86,65 @@ export function screenForOutcome(outcome: RotateOutcome): "done" | "failLocal" {
  * screen there would tell someone whose old password is already dead that
  * "everything is exactly as it was".
  *
- * So once any attempt has reached `unconfirmed`, the only stage allowed to
- * overrule it is `local` — which is the brain confirming the new password, i.e.
- * the ambiguity resolving in the direction that ends the doubt.
+ * So once any attempt has reached `unconfirmed`, the stages allowed to overrule
+ * it are exactly two:
+ *
+ * - `local`, which is the brain confirming the new password — the ambiguity
+ *   resolving in the direction that ends the doubt.
+ * - `blocked`, which is not a resolution but an *instruction*, and the only
+ *   screen that carries it. `blocked` was split out of `notSent` because an
+ *   abandoned rebuild ledger blocks every attempt forever, and the way out is
+ *   in Advanced Settings — somewhere no user would think to look. Letting the
+ *   sticky flag route this to `failUnsure` puts a "Try again" button on a run
+ *   that can never succeed and hides the one paragraph that says why.
+ *
+ * The two facts are not in competition: the run is blocked *and* an earlier
+ * attempt may already have landed. `blockedCopy` carries the second onto the
+ * blocked screen rather than trading one truth for the other.
  */
 export function screenForFailure(stage: RotateStage, mayBeLive: boolean): RotationScreen {
   if (stage === "local") return "failLocal";
+  if (stage === "blocked") return "blocked";
   if (mayBeLive) return "failUnsure";
   if (stage === "unconfirmed") return "failUnsure";
-  if (stage === "blocked") return "blocked";
   return "failNotSent";
+}
+
+/** What the blocked screen says, once an earlier attempt is in the picture. */
+export interface BlockedCopy {
+  /**
+   * The may-already-be-live warning, or null on a run where nothing was ever
+   * sent and the old password demonstrably still works.
+   */
+  liveNotice: ChangePasswordKey | null;
+  /**
+   * The password card's label. `failNotSentLabel` calls it "not in use", which
+   * is only true while nothing has been sent — after an `unconfirmed` attempt
+   * it may be the one key that opens the brain, and saying otherwise to someone
+   * deciding whether to keep it is the mistake that costs them the brain.
+   */
+  passwordLabel: ChangePasswordKey;
+  /**
+   * Whether leaving needs the acknowledgement the other may-be-live screen
+   * uses. This window holds the only copy of a password that may already be
+   * live, and the blocked screen offers no way to settle it.
+   */
+  guardLeaving: boolean;
+}
+
+export function blockedCopy(mayBeLive: boolean): BlockedCopy {
+  if (!mayBeLive) {
+    return {
+      liveNotice: null,
+      passwordLabel: "changePassword.failNotSentLabel",
+      guardLeaving: false,
+    };
+  }
+  return {
+    liveNotice: "changePassword.blockedMayBeLive",
+    passwordLabel: "changePassword.passwordLabel",
+    guardLeaving: true,
+  };
 }
 
 /** What the three-way "Check again" probe found. */
@@ -170,6 +219,35 @@ export function localFailureCopy(outcome: RotateOutcome | null): LocalFailureCop
   };
 }
 
+/* ------------------------------------------------------------------------- *
+ * What crosses the IPC boundary.
+ *
+ * Everything below is a string the Rust side also spells out, and every one of
+ * them type-checks perfectly when it is wrong: a step id is a legal `StepId`
+ * whichever of the seven it is, and an `invoke` argument bag is
+ * `Record<string, unknown>`. Both halves compile, the build passes, and the only
+ * symptom is at runtime. So they live here, where a test can read them without
+ * a webview, rather than inline at the call site where nothing can.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * The three rows of the password-change checklist, in the order they run.
+ *
+ * These are the `step` values `rotate_password` emits on `setup-progress`, and
+ * they must match the `Step` variants in
+ * `installer/src-tauri/src/cf/provision.rs` — `Step::Secret`, `Step::Confirm`,
+ * `Step::Local` — as serialised by that enum's `rename_all`. The Rust end of
+ * the same contract is pinned by
+ * `the_step_ids_on_the_wire_are_the_ones_the_screens_key_on` in that file; this
+ * is the other end. Both are needed, because either half can be renamed on its
+ * own and still compile, which is exactly how a rotation once shipped emitting
+ * `"finish"` at a checklist keyed on `"secret"` — three static bullets for the
+ * whole run, under copy reading "Leave this window open".
+ */
+export const ROTATION_STEP_IDS = ["secret", "confirm", "local"] as const;
+
+export type RotationStepId = (typeof ROTATION_STEP_IDS)[number];
+
 /**
  * Adds Door B's address to a command's arguments.
  *
@@ -185,4 +263,21 @@ export function withAddress(
   address: string | null,
 ): Record<string, unknown> {
   return address ? { ...args, address } : { ...args };
+}
+
+/**
+ * The argument bag for `invoke("rotate_password", …)`.
+ *
+ * Tauri matches these keys to the command's parameters by name, camelCase to
+ * snake_case, and an unmatched key is not a compile error at either end — it is
+ * a deserialisation failure at runtime. `newPassword` here is `new_password` in
+ * `commands::rotate_password`; renaming either alone breaks the call silently.
+ */
+export function rotateArgs(newPassword: string, address: string | null): Record<string, unknown> {
+  return withAddress({ newPassword }, address);
+}
+
+/** The same, for `commands::recheck_password(password, address)`. */
+export function recheckArgs(password: string, address: string | null): Record<string, unknown> {
+  return withAddress({ password }, address);
 }

--- a/installer/src/shared.ts
+++ b/installer/src/shared.ts
@@ -60,6 +60,23 @@ export function urlCard(label: string, desc: string, value: string): HTMLElement
   ]);
 }
 
+/// A password on screen, with a Copy button and no description — the label
+/// carries the whole meaning, and it changes with the state (see #235 §4.1,
+/// where the same value is "not in use").
+///
+/// Deliberately separate from `urlCard`: once a password change lands, nothing
+/// can read that password back — not this app, not Cloudflare, not Wrangler —
+/// so every screen that reports what happened has to carry it. This is the card
+/// that does that, and there is no Email button anywhere near it.
+export function secretCard(label: string, value: string): HTMLElement {
+  const copyBtn = h("button", { class: "btn-secondary" }, [t("common.copy")]);
+  copyBtn.addEventListener("click", () => void copyText(value, copyBtn));
+  return h("div", { class: "card url-card" }, [
+    h("div", { class: "url-label" }, [label]),
+    h("div", { class: "url-line" }, [h("div", { class: "url-value" }, [value]), copyBtn]),
+  ]);
+}
+
 /// The two URL cards used on the final setup screen AND in Connection details.
 export function detailCards(details: ConnectionDetails): HTMLElement[] {
   return [

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -10,6 +10,7 @@ import { handleIntegrationsRoutes } from "./integrations";
 import { handleAdminRoutes } from "./admin";
 import { handleConfigRoutes } from "./config";
 import { handleMigrationRoutes } from "./migration";
+import { handleOAuthRevokeRoutes } from "./oauth-revoke";
 
 type RouteHandler = (
   request: Request,
@@ -27,6 +28,7 @@ const routeHandlers: RouteHandler[] = [
   handleAdminRoutes,
   handleConfigRoutes,
   handleMigrationRoutes,
+  handleOAuthRevokeRoutes,
 ];
 
 export function createDefaultHandler() {

--- a/src/routes/oauth-revoke.ts
+++ b/src/routes/oauth-revoke.ts
@@ -91,9 +91,17 @@ export async function handleOAuthRevokeRoutes(
       do {
         const page = await env.OAUTH_KV.list({ prefix, limit: LIST_PAGE_LIMIT, cursor });
         for (const key of page.keys) {
-          // KV already filtered by prefix; this re-check is the guard that a
-          // widened scan can never reach `config:overrides`,
+          // The delete is driven by the key's own name, never by the fact that
+          // `list()` handed it over. `prefix` is the only thing that decides,
+          // so a scan that came back wider than it was asked for — a widened
+          // query, a `prefix` dropped in a refactor, a namespace that answers
+          // loosely — still cannot reach `config:overrides`,
           // `migration:embedding` or `integrations:*`.
+          //
+          // `a_kv_that_over_returns_...` in the route's test drives exactly
+          // that: a namespace double that ignores the prefix and returns
+          // everything. Without this line it destroys the user's settings and
+          // every integration's credentials.
           if (!key.name.startsWith(prefix)) continue;
           try {
             await env.OAUTH_KV.delete(key.name);

--- a/src/routes/oauth-revoke.ts
+++ b/src/routes/oauth-revoke.ts
@@ -1,0 +1,121 @@
+/**
+ * Disconnecting every AI tool (#235 §6).
+ *
+ * `AUTH_TOKEN` is the brain's password, but it is not the only credential that
+ * opens a brain. Clients that came in through `/oauth/authorize` — Claude Code,
+ * Cursor — hold tokens issued by `@cloudflare/workers-oauth-provider` and stored
+ * in `OAUTH_KV`. Those are validated against KV, never against `AUTH_TOKEN`, so
+ * changing the password leaves them connected and working.
+ *
+ * That is the right behaviour for a routine password change and the wrong one
+ * after a leak: whoever used the leaked password to complete an authorization
+ * keeps access permanently. This route is the explicit way to close that door,
+ * kept separate from rotation so neither action silently does the other's work.
+ *
+ * ## What actually has to be deleted
+ *
+ * Verified against `@cloudflare/workers-oauth-provider@0.8.2`
+ * (`dist/oauth-provider.js`), which writes four families of key:
+ *
+ * - `grant:<userId>:<grantId>` — the authorization itself. Refresh tokens are
+ *   *not* a separate key family: `refreshTokenId` / `previousRefreshTokenId`
+ *   live inside this record, so deleting the grant kills the refresh tokens
+ *   with it.
+ * - `token:<userId>:<grantId>:<tokenId>` — access tokens. These must go too,
+ *   and this is the part a grant-only implementation gets wrong: token
+ *   validation (`handleApiRequest`) looks up the `token:` key and reads the
+ *   client's props straight out of it. It never checks that the grant still
+ *   exists. Delete only the grants and every live access token keeps working
+ *   until it expires on its own.
+ * - `client:<clientId>` — dynamic client registrations. Deliberately kept. A
+ *   registration is an app's identity, not a credential for this brain: with no
+ *   grant behind it, the client can do nothing but start a fresh authorization,
+ *   which needs the password. Deleting it would instead make clients that
+ *   cached their `client_id` fail with `invalid_client` rather than simply
+ *   asking to reconnect — a worse experience for no security gain.
+ * - `enterprise-jti:<hash>` — EMA replay markers, TTL'd. Not credentials.
+ *   Deleting them would weaken replay protection, not strengthen anything.
+ *
+ * There is no separate user→grant index to clean up; the provider enumerates
+ * grants with a prefix list, exactly as this route does.
+ *
+ * `OAUTH_KV` is shared with the rest of the Worker — `config:overrides`,
+ * `migration:embedding`, `integrations:<provider>`. Wiping those would be a
+ * data-loss bug far worse than the problem this solves, so the scan is
+ * prefix-scoped and every key is re-checked before it is deleted.
+ */
+import type { Env } from "../env";
+import { json, requireAuth } from "../lib/http";
+
+/**
+ * The key families that constitute a live OAuth connection. Everything else in
+ * `OAUTH_KV` is either the Worker's own state or an inert client registration —
+ * see the module comment for why each of those is left alone.
+ */
+const REVOCABLE_PREFIXES = ["grant:", "token:"] as const;
+
+/**
+ * Cloudflare's maximum `list()` page size. Asking for it explicitly keeps the
+ * number of round trips low; it does not remove the need to page, because KV
+ * decides how much it returns regardless of what was requested.
+ */
+const LIST_PAGE_LIMIT = 1000;
+
+export async function handleOAuthRevokeRoutes(
+  request: Request,
+  url: URL,
+  env: Env,
+  _ctx: ExecutionContext,
+): Promise<Response | null> {
+  // POST /oauth/revoke-all — sign out every client that authorized through the
+  // browser flow. POST only: a GET that fell through to this would revoke every
+  // connection on a page load or a link preview.
+  if (url.pathname === "/oauth/revoke-all" && request.method === "POST") {
+    const authErr = requireAuth(request, env);
+    if (authErr) return authErr;
+
+    let revoked = 0;
+    let failed = 0;
+
+    for (const prefix of REVOCABLE_PREFIXES) {
+      // KV `list()` is paginated. A single call returns one page plus a cursor,
+      // and a brain with more grants than fit in a page would be *partially*
+      // revoked by a one-shot implementation — which is the worst outcome a
+      // security action can have, because it reports success while leaving
+      // access open. Page until KV says it is done.
+      //
+      // Deleting keys that earlier pages already returned is safe: the cursor
+      // resumes after the last key name it handed out, so removing keys behind
+      // it cannot make the scan skip anything ahead of it.
+      let cursor: string | undefined;
+      do {
+        const page = await env.OAUTH_KV.list({ prefix, limit: LIST_PAGE_LIMIT, cursor });
+        for (const key of page.keys) {
+          // KV already filtered by prefix; this re-check is the guard that a
+          // widened scan can never reach `config:overrides`,
+          // `migration:embedding` or `integrations:*`.
+          if (!key.name.startsWith(prefix)) continue;
+          try {
+            await env.OAUTH_KV.delete(key.name);
+            revoked++;
+          } catch (e) {
+            // Deleting a page is not atomic and there is nothing to roll back
+            // to. The honest response is the count that actually went away,
+            // not a success claim covering keys that are still there.
+            console.error("Revoke failed for OAuth key", key.name, e);
+            failed++;
+          }
+        }
+        cursor = page.list_complete ? undefined : page.cursor;
+      } while (cursor);
+    }
+
+    // `ok` reports whether every connection found was actually closed, so a
+    // partial revocation cannot read as a clean one. It stays a 200 either way:
+    // `revoked` is the number the app tells the user, and a non-2xx invites a
+    // caller to throw the body away along with the count.
+    return json({ ok: failed === 0, revoked, failed });
+  }
+
+  return null;
+}

--- a/test/integration/oauth-revoke-routes.test.ts
+++ b/test/integration/oauth-revoke-routes.test.ts
@@ -1,0 +1,218 @@
+/**
+ * #235 §6 — `POST /oauth/revoke-all`, the control that disconnects every AI tool.
+ *
+ * These go through the real default handler, the same path a request from the
+ * Tauri app takes, rather than calling the route function directly. That is what
+ * catches a handler that was never registered in `routeHandlers` — the feature
+ * would be complete, tested, and unreachable.
+ *
+ * Two of these tests exist because the naive implementation of a bulk delete is
+ * wrong in ways that look fine: it stops after one `list()` page, and it decides
+ * what to delete by walking the whole namespace. The first silently leaves half
+ * the connections open while reporting success; the second destroys the config,
+ * the migration ledger and every integration's credentials.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createDefaultHandler } from "../../src/routes/index";
+import { makeTestDb, makeTestEnv } from "../helpers/make-env";
+import { CONFIG_KEY } from "../../src/config";
+import { MIGRATION_KEY } from "../../src/migration/embedding";
+import type { Env } from "../../src/env";
+
+const ctx = { waitUntil: () => {} } as unknown as ExecutionContext;
+const TOKEN = "test-token";
+
+function req(path: string, init: RequestInit = {}, auth = true) {
+  return new Request(`http://localhost${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(auth ? { Authorization: `Bearer ${TOKEN}` } : {}),
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+/**
+ * A KV stub that pages the way the real namespace does: `list()` returns at most
+ * `pageSize` keys and, when more match, `list_complete: false` plus a cursor to
+ * resume after the last key it handed out.
+ *
+ * The shared `makeMemoryKV` helper always answers `list_complete: true`, so a
+ * route that only ever reads the first page passes against it. Deliberately kept
+ * local to this file: raising the fidelity of the shared helper would change
+ * what every other suite is testing.
+ */
+function makePagingKV(pageSize: number) {
+  const store = new Map<string, string>();
+  const kv = {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    list: async (opts: { prefix?: string; limit?: number; cursor?: string } = {}) => {
+      const prefix = opts.prefix ?? "";
+      // Real cursors are opaque; all that matters is that they resume after a
+      // point in the (lexicographically ordered) key space.
+      const after = opts.cursor ? atob(opts.cursor) : null;
+      const matching = [...store.keys()]
+        .filter(k => k.startsWith(prefix))
+        .sort()
+        .filter(k => after === null || k > after);
+      const limit = Math.min(opts.limit ?? pageSize, pageSize);
+      const page = matching.slice(0, limit);
+      const keys = page.map(name => ({ name }));
+      if (page.length < matching.length) {
+        return { keys, list_complete: false, cursor: btoa(page[page.length - 1]), cacheStatus: null };
+      }
+      return { keys, list_complete: true, cacheStatus: null };
+    },
+  };
+  return { kv: kv as unknown as KVNamespace, store };
+}
+
+describe("oauth revoke-all route", () => {
+  let env: Env;
+  let store: Map<string, string>;
+  let handler: ReturnType<typeof createDefaultHandler>;
+
+  beforeEach(() => {
+    // A page size of 2 with more than two keys per family means every test in
+    // this file exercises the pagination loop, not only the one that names it.
+    const paging = makePagingKV(2);
+    store = paging.store;
+    env = makeTestEnv(makeTestDb(), { OAUTH_KV: paging.kv, AUTH_TOKEN: TOKEN });
+    handler = createDefaultHandler();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  /** One grant plus one access token, the shape the provider writes per client. */
+  function seedConnection(userId: string, grantId: string) {
+    store.set(`grant:${userId}:${grantId}`, JSON.stringify({ clientId: "c" }));
+    store.set(`token:${userId}:${grantId}:tok-${grantId}`, JSON.stringify({ grantId, userId }));
+  }
+
+  it("refuses without a token", async () => {
+    seedConnection("owner", "g1");
+
+    const res = await handler.fetch(req("/oauth/revoke-all", { method: "POST" }, false), env, ctx);
+
+    expect(res.status).toBe(401);
+    // An unauthenticated caller must not be able to knock every client off a
+    // stranger's brain, so the refusal has to happen before anything is deleted.
+    expect(store.has("grant:owner:g1")).toBe(true);
+    expect(store.has("token:owner:g1:tok-g1")).toBe(true);
+  });
+
+  it("is reachable through the real handler, not just registered in a module", async () => {
+    // A handler missing from routeHandlers falls through to the 404 at the end
+    // of createDefaultHandler, which is exactly the failure this catches.
+    const res = await handler.fetch(req("/oauth/revoke-all", { method: "POST" }), env, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it("clears both key families", async () => {
+    seedConnection("owner", "g1");
+
+    const res = await handler.fetch(req("/oauth/revoke-all", { method: "POST" }), env, ctx);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(body.ok).toBe(true);
+    // Grants alone are not enough: token validation reads the props out of the
+    // `token:` record and never checks that the grant still exists, so a live
+    // access token outlives its grant.
+    expect([...store.keys()].filter(k => k.startsWith("grant:"))).toEqual([]);
+    expect([...store.keys()].filter(k => k.startsWith("token:"))).toEqual([]);
+  });
+
+  it("leaves the config, the migration ledger and the integrations untouched", async () => {
+    // The data-loss guard. OAUTH_KV is shared with the rest of the Worker; an
+    // implementation that walked the namespace instead of the two prefixes would
+    // pass every other test here while destroying the user's settings and every
+    // connected integration's credentials.
+    store.set(CONFIG_KEY, JSON.stringify({ EMBEDDING_MODEL: "@cf/baai/bge-base-en-v1.5" }));
+    store.set(MIGRATION_KEY, JSON.stringify({ model: "x", startedAt: 1 }));
+    store.set("integrations:notion", JSON.stringify({ credentials: { token: "secret" } }));
+    store.set("integrations:linear", JSON.stringify({ credentials: { token: "secret" } }));
+    // Client registrations are an app's identity, not a credential for this
+    // brain, and are deliberately kept — see the route's module comment.
+    store.set("client:abc", JSON.stringify({ clientId: "abc" }));
+    seedConnection("owner", "g1");
+
+    const res = await handler.fetch(req("/oauth/revoke-all", { method: "POST" }), env, ctx);
+    expect(res.status).toBe(200);
+
+    expect(store.get(CONFIG_KEY)).toContain("bge-base-en-v1.5");
+    expect(store.get(MIGRATION_KEY)).toContain("startedAt");
+    expect(store.get("integrations:notion")).toContain("secret");
+    expect(store.get("integrations:linear")).toContain("secret");
+    expect(store.get("client:abc")).toContain("abc");
+    // ...and the connection really was revoked, so this cannot pass by doing
+    // nothing at all.
+    expect(store.has("grant:owner:g1")).toBe(false);
+  });
+
+  it("pages past a single list() page", async () => {
+    // Five connections against a page size of two: an implementation that reads
+    // one page revokes two of them, reports success, and leaves three clients
+    // with working access — the worst outcome a security action can have.
+    for (let i = 0; i < 5; i++) seedConnection("owner", `g${i}`);
+    expect(store.size).toBe(10);
+
+    const res = await handler.fetch(req("/oauth/revoke-all", { method: "POST" }), env, ctx);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(body.ok).toBe(true);
+    expect(body.revoked).toBe(10);
+    expect(store.size).toBe(0);
+  });
+
+  it("returns an accurate count", async () => {
+    // The count is what the app tells the user, so it has to be the number of
+    // keys that actually went away — not the number found, and not a total.
+    seedConnection("owner", "g1");
+    seedConnection("owner", "g2");
+    seedConnection("owner", "g3");
+    store.set(CONFIG_KEY, "{}");
+
+    const res = await handler.fetch(req("/oauth/revoke-all", { method: "POST" }), env, ctx);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(body.revoked).toBe(6);
+    expect(body.failed).toBe(0);
+  });
+
+  it("reports what it actually deleted when a delete fails", async () => {
+    // Deleting a page is not atomic and there is nothing to roll back to, so a
+    // partial revocation must not read as a clean one.
+    seedConnection("owner", "g1");
+    seedConnection("owner", "g2");
+    const realDelete = env.OAUTH_KV.delete.bind(env.OAUTH_KV);
+    vi.spyOn(env.OAUTH_KV, "delete").mockImplementation(async (key: string) => {
+      if (key === "token:owner:g2:tok-g2") throw new Error("KV unavailable");
+      return realDelete(key);
+    });
+
+    const res = await handler.fetch(req("/oauth/revoke-all", { method: "POST" }), env, ctx);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(false);
+    expect(body.revoked).toBe(3);
+    expect(body.failed).toBe(1);
+  });
+
+  it("does not revoke on a GET", async () => {
+    // A page load, a link preview or a prefetch must never disconnect anything.
+    seedConnection("owner", "g1");
+
+    const res = await handler.fetch(req("/oauth/revoke-all"), env, ctx);
+
+    expect(res.status).toBe(404);
+    expect(store.has("grant:owner:g1")).toBe(true);
+    expect(store.has("token:owner:g1:tok-g1")).toBe(true);
+  });
+});

--- a/test/integration/oauth-revoke-routes.test.ts
+++ b/test/integration/oauth-revoke-routes.test.ts
@@ -74,6 +74,38 @@ function makePagingKV(pageSize: number) {
   return { kv: kv as unknown as KVNamespace, store };
 }
 
+/**
+ * A namespace that answers `list()` with *everything*, whatever prefix it was
+ * asked for.
+ *
+ * Both the real KV and `makePagingKV` filter by prefix, which makes the route's
+ * own `startsWith` re-check unreachable — and a guard nothing can reach is a
+ * comment claiming protection rather than protection. This double is the thing
+ * the guard is written against: a scan that comes back wider than it was asked
+ * for, whether because the query was widened in a refactor or because the
+ * namespace answered loosely. Without the re-check the route deletes the config,
+ * the migration ledger and every integration's credentials.
+ */
+function makeOverReturningKV() {
+  const store = new Map<string, string>();
+  const kv = {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    // `prefix` is accepted and deliberately ignored.
+    list: async () => ({
+      keys: [...store.keys()].sort().map(name => ({ name })),
+      list_complete: true,
+      cacheStatus: null,
+    }),
+  };
+  return { kv: kv as unknown as KVNamespace, store };
+}
+
 describe("oauth revoke-all route", () => {
   let env: Env;
   let store: Map<string, string>;
@@ -203,6 +235,36 @@ describe("oauth revoke-all route", () => {
     expect(body.ok).toBe(false);
     expect(body.revoked).toBe(3);
     expect(body.failed).toBe(1);
+  });
+
+  it("deletes by key name even when the scan comes back wider than it asked", async () => {
+    // The `startsWith` re-check inside the route is unreachable against KV and
+    // against the paging double above, both of which filter by prefix. This is
+    // the namespace that makes it fire: it returns the whole store for every
+    // list(), so the route's own decision about each key is the only thing
+    // standing between a revoke and a wipe.
+    const over = makeOverReturningKV();
+    const overEnv = makeTestEnv(makeTestDb(), { OAUTH_KV: over.kv, AUTH_TOKEN: TOKEN });
+    over.store.set(CONFIG_KEY, JSON.stringify({ EMBEDDING_MODEL: "@cf/baai/bge-base-en-v1.5" }));
+    over.store.set(MIGRATION_KEY, JSON.stringify({ model: "x", startedAt: 1 }));
+    over.store.set("integrations:notion", JSON.stringify({ credentials: { token: "secret" } }));
+    over.store.set("client:abc", JSON.stringify({ clientId: "abc" }));
+    over.store.set("grant:owner:g1", JSON.stringify({ clientId: "c" }));
+    over.store.set("token:owner:g1:tok-g1", JSON.stringify({ grantId: "g1" }));
+
+    const res = await handler.fetch(req("/oauth/revoke-all", { method: "POST" }), overEnv, ctx);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    // Exactly the two connection keys, and each counted once even though every
+    // list() offered the whole namespace twice over.
+    expect(body.revoked).toBe(2);
+    expect(over.store.has("grant:owner:g1")).toBe(false);
+    expect(over.store.has("token:owner:g1:tok-g1")).toBe(false);
+    expect(over.store.get(CONFIG_KEY)).toContain("bge-base-en-v1.5");
+    expect(over.store.get(MIGRATION_KEY)).toContain("startedAt");
+    expect(over.store.get("integrations:notion")).toContain("secret");
+    expect(over.store.get("client:abc")).toContain("abc");
   });
 
   it("does not revoke on a GET", async () => {

--- a/test/unit/rotation-screens.test.ts
+++ b/test/unit/rotation-screens.test.ts
@@ -15,11 +15,15 @@
  */
 import { describe, it, expect } from "vitest";
 import {
+  blockedCopy,
   localFailureCopy,
+  recheckArgs,
+  rotateArgs,
   rotateErrorOf,
   screenForFailure,
   screenForOutcome,
   withAddress,
+  ROTATION_STEP_IDS,
   type RotateOutcome,
 } from "../../installer/src/rotation-state";
 
@@ -83,13 +87,67 @@ describe("which failure screen", () => {
     // Showing that screen would read: "your old one still works and everything
     // is exactly as it was". The old one is dead.
     expect(screenForFailure("notSent", true)).toBe("failUnsure");
-    expect(screenForFailure("blocked", true)).toBe("failUnsure");
+  });
+
+  it("still shows the blocked screen after an attempt that may have landed", () => {
+    // This assertion used to read `.toBe("failUnsure")`, and that was the bug.
+    //
+    // "blocked" is the one stage that is not a report on what happened — it is
+    // an instruction, and this is the only screen that carries it. The escape
+    // paragraph and the Advanced Settings button are the sole route out of an
+    // abandoned rebuild ledger, which is exactly why the stage was split out of
+    // "notSent" in the first place.
+    //
+    // The sticky flag was undoing the split for one sequence: once any attempt
+    // reached "unconfirmed", every later attempt — all of them blocked, none of
+    // them capable of succeeding — rendered "may already be live" with a "Try
+    // again" button and no mention of the rebuild. The user retries forever
+    // against a gate whose key is in another window they have no reason to
+    // open.
+    //
+    // Both facts are true and neither is optional, so the screen carries both:
+    // it is blocked, *and* the password may already be live.
+    expect(screenForFailure("blocked", true)).toBe("blocked");
   });
 
   it("lets the local stage overrule the doubt, because it resolves it", () => {
     // "local" means the brain confirmed the new password. That is the ambiguity
     // ending in the direction that leaves nothing to be unsure about.
     expect(screenForFailure("local", true)).toBe("failLocal");
+  });
+});
+
+describe("the blocked screen, when an earlier attempt may already have landed", () => {
+  it("says nothing about a live password on a run where nothing was sent", () => {
+    const copy = blockedCopy(false);
+    expect(copy.liveNotice).toBe(null);
+    // Nothing reached the brain, so the old password still works and this one
+    // demonstrably does not. Calling it "your new password" here would tell
+    // someone who saved it that they now hold the working key.
+    expect(copy.passwordLabel).toBe("changePassword.failNotSentLabel");
+    expect(copy.guardLeaving).toBe(false);
+  });
+
+  it("carries the warning the failUnsure screen would have carried", () => {
+    const copy = blockedCopy(true);
+    // Without this, rendering the blocked screen after an unconfirmed attempt
+    // would drop the may-already-be-live warning entirely — which is what made
+    // routing to failUnsure look like the lesser evil.
+    expect(copy.liveNotice).toBe("changePassword.blockedMayBeLive");
+  });
+
+  it("does not call a password that may be live 'not in use'", () => {
+    // The label failNotSentLabel spells out "not in use". After an attempt that
+    // reached the brain and never confirmed, that may be the only key the brain
+    // still answers to — and this screen offers no Try again to settle it, so
+    // the user's next move is deciding whether to keep what is on screen.
+    expect(blockedCopy(true).passwordLabel).toBe("changePassword.passwordLabel");
+  });
+
+  it("asks before letting the only copy of it be closed", () => {
+    // The same acknowledgement failUnsure guards its exit with, for the same
+    // reason: this window may hold the only password that opens the brain.
+    expect(blockedCopy(true).guardLeaving).toBe(true);
   });
 });
 
@@ -137,6 +195,45 @@ describe("the 'changed, but not saved here' screen", () => {
     const bothLesser = localFailureCopy({ keychain: true, cliConfig: false, dashboard: false });
     expect(bothLesser.notice).toBe("changePassword.failLocalCli");
     expect(bothLesser.extra).toEqual(["changePassword.failLocalDashboard"]);
+  });
+});
+
+describe("what crosses the IPC boundary", () => {
+  it("keys the checklist on the step ids the Rust side emits", () => {
+    // These must match the `Step` variants in
+    // `installer/src-tauri/src/cf/provision.rs` — Step::Secret, Step::Confirm,
+    // Step::Local — as that enum's `rename_all` serialises them. The Rust half
+    // is pinned by `the_step_ids_on_the_wire_are_the_ones_the_screens_key_on`
+    // in the same file; this is the other half, and both are needed.
+    //
+    // Nothing else catches a drift. Every one of the seven ids in `StepId` is a
+    // legal value for a rotation row, so writing `finish` where `secret`
+    // belongs type-checks, builds, and passes the whole suite — while the
+    // checklist sits at three static bullets for the entire run under copy
+    // reading "Leave this window open". That is the exact defect this branch
+    // was opened to fix, and until this assertion existed it could be
+    // reintroduced by a one-word edit.
+    expect([...ROTATION_STEP_IDS]).toEqual(["secret", "confirm", "local"]);
+  });
+
+  it("names the rotate arguments the way the command declares them", () => {
+    // `commands::rotate_password(new_password: String, address: Option<String>)`
+    // and `commands::recheck_password(password: String, address: Option<String>)`.
+    // Tauri matches an argument bag to those parameters by name, camelCase to
+    // snake_case, and a key that matches nothing is not a type error at either
+    // end — the call compiles, ships, and fails only when a user runs it.
+    expect(rotateArgs("pw", null)).toEqual({ newPassword: "pw" });
+    expect(recheckArgs("pw", null)).toEqual({ password: "pw" });
+    // …and the address, when Door B supplies one, keeps the name the commands
+    // declare too.
+    expect(rotateArgs("pw", "https://brain.example.workers.dev")).toEqual({
+      newPassword: "pw",
+      address: "https://brain.example.workers.dev",
+    });
+    expect(recheckArgs("pw", "https://brain.example.workers.dev")).toEqual({
+      password: "pw",
+      address: "https://brain.example.workers.dev",
+    });
   });
 });
 

--- a/test/unit/rotation-screens.test.ts
+++ b/test/unit/rotation-screens.test.ts
@@ -1,0 +1,160 @@
+/**
+ * #235 — which screen a password change lands on, and what it is allowed to say.
+ *
+ * The desktop app has no test setup of its own: `installer/` ships a Vite build
+ * and nothing else, and `main.ts` cannot even be imported outside a webview (it
+ * resolves `#app` at module scope). So the rules that decide between "nothing
+ * was changed", "it may already be live" and "changed, but not saved here" live
+ * in `installer/src/rotation-state.ts`, which imports nothing at all and is
+ * therefore reachable from here.
+ *
+ * They are worth reaching. Each of these three screens exists because the other
+ * two would be a lie, and the cost of picking the wrong one is a user who
+ * believes their old password still works when it does not — after which the
+ * brain has no key at all.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  localFailureCopy,
+  rotateErrorOf,
+  screenForFailure,
+  screenForOutcome,
+  withAddress,
+  type RotateOutcome,
+} from "../../installer/src/rotation-state";
+
+const ok: RotateOutcome = { keychain: true, cliConfig: true, dashboard: true };
+
+describe("reading what rotate_password rejected with", () => {
+  it("keeps a stage it recognises", () => {
+    expect(rotateErrorOf({ stage: "notSent", detail: "expired" })).toEqual({
+      stage: "notSent",
+      detail: "expired",
+    });
+  });
+
+  it("treats anything it cannot read as 'may already be live'", () => {
+    // The asymmetry is deliberate and this is the test that pins it. Guessing
+    // "notSent" on an unreadable rejection tells a user whose password may have
+    // already changed that nothing happened; guessing "unconfirmed" only ever
+    // costs them a retry that is idempotent either way.
+    for (const junk of ["a string", null, undefined, 42, { stage: "elsewhere" }, {}]) {
+      expect(rotateErrorOf(junk).stage).toBe("unconfirmed");
+    }
+  });
+
+  it("recognises the stage a rebuild-in-flight refusal carries", () => {
+    expect(rotateErrorOf({ stage: "blocked", detail: "rebuilding" }).stage).toBe("blocked");
+  });
+});
+
+describe("a run that succeeded remotely", () => {
+  it("lands on the done screen only when every local store took it", () => {
+    expect(screenForOutcome(ok)).toBe("done");
+    // A CLI that was never installed is not a failure and gets no screen.
+    expect(screenForOutcome({ ...ok, cliConfig: null })).toBe("done");
+  });
+
+  it("does not claim this computer is using the new password when it isn't", () => {
+    expect(screenForOutcome({ ...ok, keychain: false })).toBe("failLocal");
+    expect(screenForOutcome({ ...ok, cliConfig: false })).toBe("failLocal");
+    // The one that used to be dropped: the dashboard window is told its new
+    // password at creation, so an open one sits on a dead value until someone
+    // says otherwise. Reporting that run as a clean success left a window
+    // 401ing with nothing on screen to explain it.
+    expect(screenForOutcome({ ...ok, dashboard: false })).toBe("failLocal");
+  });
+});
+
+describe("which failure screen", () => {
+  it("maps each stage to its own screen on a first attempt", () => {
+    expect(screenForFailure("notSent", false)).toBe("failNotSent");
+    expect(screenForFailure("unconfirmed", false)).toBe("failUnsure");
+    expect(screenForFailure("local", false)).toBe("failLocal");
+    expect(screenForFailure("blocked", false)).toBe("blocked");
+  });
+
+  it("never says 'nothing was changed' after an attempt that may have changed something", () => {
+    // The sequence: attempt one PUTs the secret and the health poll times out,
+    // so the app correctly says the new password may already be live. The user
+    // clicks Try again. Attempt two dies *before* the PUT — an expired sign-in,
+    // a transient account lookup — which taken alone is honestly "notSent".
+    //
+    // Showing that screen would read: "your old one still works and everything
+    // is exactly as it was". The old one is dead.
+    expect(screenForFailure("notSent", true)).toBe("failUnsure");
+    expect(screenForFailure("blocked", true)).toBe("failUnsure");
+  });
+
+  it("lets the local stage overrule the doubt, because it resolves it", () => {
+    // "local" means the brain confirmed the new password. That is the ambiguity
+    // ending in the direction that leaves nothing to be unsure about.
+    expect(screenForFailure("local", true)).toBe("failLocal");
+  });
+});
+
+describe("the 'changed, but not saved here' screen", () => {
+  it("names secure storage, and offers a way back in, when that is what failed", () => {
+    const copy = localFailureCopy({ keychain: false, cliConfig: null, dashboard: true });
+    expect(copy.title).toBe("changePassword.failLocalTitle");
+    expect(copy.notice).toBe("changePassword.failLocalBody");
+    expect(copy.reconnect).toBe(true);
+  });
+
+  it("treats a stage-'local' failure, which has no outcome at all, as the same case", () => {
+    const copy = localFailureCopy(null);
+    expect(copy.title).toBe("changePassword.failLocalTitle");
+    expect(copy.reconnect).toBe(true);
+  });
+
+  it("does not keep the unconditional heading when secure storage succeeded", () => {
+    // The defect this pins: the body switched to the CLI-specific message while
+    // the heading went on saying "not saved on this computer". It was saved on
+    // this computer. Title and body contradicted each other and the title was
+    // the false one.
+    const cliOnly = localFailureCopy({ keychain: true, cliConfig: false, dashboard: true });
+    expect(cliOnly.title).toBe("changePassword.failLocalTitlePartial");
+    expect(cliOnly.notice).toBe("changePassword.failLocalCli");
+    expect(cliOnly.extra).toEqual([]);
+    // ...and the dashboard button still works, because this computer can open
+    // its own brain.
+    expect(cliOnly.reconnect).toBe(false);
+
+    const dashboardOnly = localFailureCopy({ keychain: true, cliConfig: true, dashboard: false });
+    expect(dashboardOnly.title).toBe("changePassword.failLocalTitlePartial");
+    expect(dashboardOnly.notice).toBe("changePassword.failLocalDashboard");
+    expect(dashboardOnly.reconnect).toBe(false);
+  });
+
+  it("mentions every store that missed it, not only the first", () => {
+    const all = localFailureCopy({ keychain: false, cliConfig: false, dashboard: false });
+    expect(all.notice).toBe("changePassword.failLocalBody");
+    expect(all.extra).toEqual([
+      "changePassword.failLocalCli",
+      "changePassword.failLocalDashboard",
+    ]);
+
+    const bothLesser = localFailureCopy({ keychain: true, cliConfig: false, dashboard: false });
+    expect(bothLesser.notice).toBe("changePassword.failLocalCli");
+    expect(bothLesser.extra).toEqual(["changePassword.failLocalDashboard"]);
+  });
+});
+
+describe("Door B's address travelling with the call", () => {
+  it("is sent when there is one", () => {
+    // Both `rotate_password` and `recheck_password` take `address:
+    // Option<String>`, and a missing key deserialises to None — which resolves
+    // the setup stored on *this* computer. Door B is by definition a computer
+    // with no stored setup, so omitting it does not fall back to the right
+    // brain; it probes a different one or none at all.
+    expect(withAddress({ password: "pw" }, "https://brain.example.workers.dev")).toEqual({
+      password: "pw",
+      address: "https://brain.example.workers.dev",
+    });
+  });
+
+  it("is omitted on Door A, where the command resolves the stored address", () => {
+    expect(withAddress({ newPassword: "pw" }, null)).toEqual({ newPassword: "pw" });
+    expect(withAddress({ newPassword: "pw" }, "")).toEqual({ newPassword: "pw" });
+  });
+});


### PR DESCRIPTION
Closes #235.

Lets someone change their Second Brain's password, or set a new one when they have lost the old one.

## One operation, two doors

Changing a password and recovering a lost one are the same act. Neither needs the current password: a Cloudflare Worker secret is write-only, so there is nothing to check against, and account access is the authority either way. They differ only in where you come in from.

- **Connections → Connection pane**, under the address: change it deliberately.
- **The unlock and manual-entry screens**: *"I don't have my password"*. This is the one that matters — today that screen is a dead end, and #247 only helps someone who lost their *address*.

Sign-in comes first, then the password: it is the step most likely to fail, and failing before the user has committed to anything is cleaner. On the lost-password door they are already signed in from discovery, so it is skipped.

## How it changes the secret

`PUT /workers/scripts/{script}/secrets` — one call, one secret. Not the full redeploy the issue proposed: that re-uploads assets and rewrites every binding for a one-field change, and forces an unresolved question about whether an explicit `secret_text` binding beats `keep_bindings`. The wrong answer there silently keeps the old password and is invisible until lockout.

The script name comes from the address, never the manifest (#257). A rotation writing to the wrong script is worse than an update doing so, and on the lost-password door the address comes from the user — so the target is confirmed to be a brain from its **Cloudflare bindings** rather than an HTTP probe. A Worker authors its own responses but cannot forge account state.

Nothing local is written until the Worker authenticates the **new** password. That gate asks only whether the brain lets the password in — not whether it is healthy. `/health` reports `ok` as the vector index's health, so gating on it meant a brain with a degraded index could never confirm a rotation that had already succeeded, leaving the keychain on the old password with no way out.

## Where the password actually lives

The issue named two places. There are six, and the third would have shipped broken:

| Where | On rotation |
|---|---|
| The Cloudflare secret | the thing we change |
| Keychain / Credential Manager | rewritten |
| `~/.config/second-brain/config.json` — **plaintext** | rewritten, but only if it already exists |
| The dashboard window's `localStorage` | re-injected, origin-checked |
| A browser where the dashboard was opened directly | user re-enters |
| Other computers | see below |

The CLI config is silent when wrong — `brain` just starts 401ing. A guard now pins the complete list, so a future place the password lands is a deliberate addition rather than an omission. And it is only ever rewritten, never created: someone who never installed the CLI should not acquire a plaintext credential file as a side effect of changing their password.

## Your other computers

Rotating leaves every other machine holding a dead password, and the app previously gave no sign — it opened a dashboard that silently 401d, with no route back but disconnecting.

This costs no new request. The launch-time update check already makes an authenticated `/health` call and already distinguishes a 401; it was discarding that. It now routes to a screen offering the new password or a fresh look for the brain. Only a literal 401 reaches it — an outage, a timeout or a brain that is simply down all stay quiet, because telling someone their password changed when their wifi dropped is worse than saying nothing.

## Blocked during a rebuild

An embedding migration in flight blocks a change. The ledger is not deleted on completion, it gains `finishedAt`, so an unfinished ledger is the block and an outstanding old index is not. A part-way rotation would stall the next batch on a 401 and present a recoverable password problem as a failed migration — the more frightening of the two, and the one that invites a destructive fix.

The lost-password door is never blocked: checking needs a working password, which that door by definition lacks.

## Disconnecting AI tools — separate, deliberately

Changing the password does **not** disconnect Claude Code or Cursor. They hold tokens issued by the OAuth provider and validated against KV, never against `AUTH_TOKEN`. Correct for routine hygiene; wrong after a leak.

`POST /oauth/revoke-all` closes those explicitly. It deletes `grant:` **and** `token:` — both are load-bearing, because token validation reads the client's props out of an embedded copy inside the token record and never checks the grant still exists. Revoking grants alone would leave every live access token working until it expired, while reporting success.

It pages through `list()`, leaves `client:` registrations and `integrations:*` alone, and reports what it actually deleted. A partially revoked brain that claims success is the worst outcome a security action can have.

## Reviews

Four independent reviews — security, correctness, interface honesty, test quality — each prompted to refute rather than confirm. Between them they found 35 defects that 208 passing tests had not, including:

- a rotation that could succeed and then be permanently unrecoverable, silently
- "Nothing was changed" shown after the password *had* changed
- the progress checklist never moving on any rotation, because two halves of a contract drifted and no compiler could see it
- a ~6% CI flake this branch introduced, which would have been blamed on an unrelated module
- `http://` accepted, putting a brand-new password on the wire in the clear

All are fixed. The reviews also confirmed what held: auth on the revoke route, the prefix-scoped KV scan, the #257 script derivation, the non-forgeable bindings check, the write-then-confirm ordering, the origin guard, and dry-run performing zero keychain reads.

## Testing

Everything runs locally — no live brain, no live Cloudflare account.

The demo brain starts permissive and becomes strict once a rotation names a password, so the retry loop, the flip and the stale-password screen are all exercisable in dry-run. `SECOND_BRAIN_DEMO_ROTATE_AFTER` makes a rotation take N refusals before it lands, counted in attempts rather than seconds so it maps onto the health poll and needs no sleeping.

The flow's decisions live in an import-free module, which is what made the screen-selection logic testable without a webview — the gap the three worst interface defects were hiding in. The step ids and the `invoke` argument names are now pinned from both ends; renaming either type-checks cleanly and fails only when a real person presses the button.

Not covered by any of this: whether Cloudflare accepts the call against a real account. That is the same acceptance gap #248 left open.
