### PR TITLE
feat(staleness): nightly pass, volatility tags, and recall warnings (#228)

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS entries (
   importance_score     INTEGER DEFAULT 0,
   contradiction_wins   INTEGER DEFAULT 0,
   contradiction_losses INTEGER DEFAULT 0
+  -- Runtime ALTER columns (see src/db/init.ts): updated_at, staleness_checked_at
 );
 
 CREATE INDEX IF NOT EXISTS idx_entries_created_at ON entries(created_at DESC);

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -43,6 +43,7 @@
         --accent-soft: rgba(253, 84, 10, 0.09);
         --accent-ink: #c43d00;
         --good: #18794e;
+        --warn: #b45309;
         --danger: #b42318;
         --danger-soft: rgba(180, 35, 24, 0.08);
         --on-accent: #161616;
@@ -96,6 +97,7 @@
         --accent-soft: rgba(253, 111, 18, 0.16);
         --accent-ink: #ffab6e;
         --good: #7bae8a;
+        --warn: #d9a15c;
         --danger: #d9806b;
         --danger-soft: rgba(217, 128, 107, 0.14);
         --on-accent: #161616;
@@ -968,9 +970,14 @@
         opacity: 0.65;
       }
 
+      /* Dashed rather than tinted, so it reads as provisional next to card--synthesized
+         without touching the card background. --text-tertiary is already below WCAG AA
+         on --bg-card — 4.4987 in dark, 3.0457 in light — so there is no headroom to
+         spend: a lightening tint pushes dark further down, and a darkening tint (which
+         would raise dark to ~4.58) pushes light further down instead. A border changes
+         neither, and matches how the other card modifiers signal state. */
       .memory-card.card--stale {
-        border-left: 3px solid #f59e0b;
-        background: #fffbeb;
+        border-left: 3px dashed var(--warn);
       }
 
       .memory-card.card--synthesized {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -968,6 +968,11 @@
         opacity: 0.65;
       }
 
+      .memory-card.card--stale {
+        border-left: 3px solid #f59e0b;
+        background: #fffbeb;
+      }
+
       .memory-card.card--synthesized {
         border-left: 3px solid var(--accent);
       }

--- a/public/js/recall.js
+++ b/public/js/recall.js
@@ -119,7 +119,8 @@ function makeRecallCard(entry) {
   const card = document.createElement('div')
   const isSynthesized = entry.tags.includes('synthesized')
   const isRolledUp = entry.tags.includes('rolled-up')
-  card.className = 'memory-card' + (isSynthesized ? ' card--synthesized' : '') + (isRolledUp ? ' card--rolled-up' : '')
+  const isStale = entry.stale_as_of || entry.tags.includes('stale:as-of')
+  card.className = 'memory-card' + (isSynthesized ? ' card--synthesized' : '') + (isRolledUp ? ' card--rolled-up' : '') + (isStale ? ' card--stale' : '')
   card.innerHTML = `
     <div class="match-line">
 <span class="match-pct">${entry.score}%</span>

--- a/public/js/recent.js
+++ b/public/js/recent.js
@@ -90,6 +90,7 @@ function makeRecentCard(entry) {
   } catch {}
   const isSynthesized = tags.includes('synthesized')
   const isRolledUp = tags.includes('rolled-up')
+  const isStale = tags.includes('stale:as-of')
 
   let vectorIds = []
   try {
@@ -108,7 +109,7 @@ function makeRecentCard(entry) {
         : `<span class="tag-chip vec-chip vec-chip--off" title="Not vectorized — won't appear in recall">Not indexed</span>`
 
   const card = document.createElement('div')
-  card.className = 'memory-card' + (isSynthesized ? ' card--synthesized' : '') + (isRolledUp ? ' card--rolled-up' : '')
+  card.className = 'memory-card' + (isSynthesized ? ' card--synthesized' : '') + (isRolledUp ? ' card--rolled-up' : '') + (isStale ? ' card--stale' : '')
   card.dataset.id = entry.id
   card.innerHTML = `
 <div class="card-content" style="cursor: pointer;">${escHtml(entry.content)}</div>

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -33,6 +33,7 @@ Incremental split of the former monolithic `index.ts`. Entry point remains `src/
 | recall search pipeline | `recall/*` |
 | capture write path | `capture/*` |
 | compression nightly/digest | `compression/*` |
+| staleness pass + classifier | `staleness/*` |
 | integration mirror | `integrations/mirror.ts` |
 | OAuth pages/register/authorize | `oauth/*` |
 | MCP server + sanitize | `mcp/*` |

--- a/src/capture/entry.ts
+++ b/src/capture/entry.ts
@@ -7,6 +7,7 @@ import { scheduleClassifyAndTag } from "./classify";
 import { checkDuplicateAndContradiction } from "./duplicate";
 import { deprecateEntry } from "./lifecycle";
 import { deleteStaleVectors, reembedOrThrow, storeEntry } from "./store";
+import { tagsAfterWrite } from "../memory/stale";
 
 export function buildEntryFilterQuery(params: {
   n: number;
@@ -86,7 +87,10 @@ export async function captureEntry(
       }
 
       if (newVectorIds) {
-        await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`).bind(newContent, targetId).run();
+        const refreshedTags = tagsAfterWrite(existingTags);
+        const now = Date.now();
+        await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
+          .bind(newContent, JSON.stringify(refreshedTags), now, targetId).run();
         try {
           await deleteStaleVectors(env, oldVectorIds, newVectorIds);
         } catch (e) { console.error("Old vector cleanup failed (non-fatal):", e); }
@@ -106,8 +110,8 @@ export async function captureEntry(
   const finalTags = dup.status === "flagged" ? [...baseTags, "duplicate-candidate"] : baseTags;
 
   await env.DB.prepare(
-    `INSERT INTO entries (id, content, tags, source, created_at, vector_ids) VALUES (?, ?, ?, ?, ?, ?)`
-  ).bind(id, c, JSON.stringify(finalTags), source, now, "[]").run();
+    `INSERT INTO entries (id, content, tags, source, created_at, updated_at, vector_ids) VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).bind(id, c, JSON.stringify(finalTags), source, now, now, "[]").run();
 
   ctx.waitUntil(
     storeEntry(env, id, c, finalTags, source, now, cfg)

--- a/src/capture/store.ts
+++ b/src/capture/store.ts
@@ -6,6 +6,7 @@ import { inferEdgesOnWrite } from "../graph/edges";
 import { neighborsFromVectorQuery } from "../graph/traverse";
 import { chunkText } from "../text/chunk";
 import { isVectorizeUnavailable } from "../vectorize/health";
+import { tagsAfterWrite } from "../memory/stale";
 
 export async function storeEntry(
   env: Env,
@@ -105,9 +106,11 @@ export async function appendToEntry(
 
   if (newContent.length > CHUNK_MAX_CHARS) {
     const newVectorIds = await reembedOrDegrade(env, id, newContent, tags, source, config);
+    const refreshedTags = tagsAfterWrite(tags);
+    const now = Date.now();
 
-    await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`)
-      .bind(newContent, id).run();
+    await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
+      .bind(newContent, JSON.stringify(refreshedTags), now, id).run();
 
     // Skipped when Vectorize is unavailable: the old vectors are the entry's only
     // remaining semantic index, and retiring them would leave it unsearchable.
@@ -161,9 +164,12 @@ export async function appendToEntry(
     indexed = false;
   }
 
+  const refreshedTags = tagsAfterWrite(tags);
+  const now = Date.now();
+
   await env.DB.prepare(
-    `UPDATE entries SET content = ?, vector_ids = ? WHERE id = ?`
-  ).bind(newContent, JSON.stringify(indexed ? [...existingVectorIds, newChunkId] : existingVectorIds), id).run();
+    `UPDATE entries SET content = ?, vector_ids = ?, tags = ?, updated_at = ? WHERE id = ?`
+  ).bind(newContent, JSON.stringify(indexed ? [...existingVectorIds, newChunkId] : existingVectorIds), JSON.stringify(refreshedTags), now, id).run();
 
   try {
     await inferEdgesOnWrite(id, await neighborsFromVectorQuery(values, env), env);

--- a/src/compression/digest.ts
+++ b/src/compression/digest.ts
@@ -5,6 +5,8 @@ import { DIGEST_MAX_TOKENS, LLM_MODEL } from "../constants";
 import { readStreamText } from "../lib/ai";
 import { KIND_PREFIX } from "../memory/kind";
 import { STATUS_PREFIX } from "../memory/status";
+import { VOLATILITY_PREFIX } from "../memory/volatility";
+import { STALE_AS_OF } from "../memory/stale";
 import {
   compressionEligibilitySql,
 } from "./eligibility";
@@ -49,7 +51,7 @@ export async function compressTag(
   ctx: ExecutionContext
 ): Promise<{ synthesizedId: string | null; entriesUsed: number; text: string }> {
   const cfg = await resolveConfig(env);
-  if (tag.startsWith(STATUS_PREFIX) || tag.startsWith(KIND_PREFIX)) {
+  if (tag.startsWith(STATUS_PREFIX) || tag.startsWith(KIND_PREFIX) || tag.startsWith(VOLATILITY_PREFIX) || tag === STALE_AS_OF) {
     return { synthesizedId: null, entriesUsed: 0, text: "" };
   }
 

--- a/src/compression/digest.ts
+++ b/src/compression/digest.ts
@@ -50,10 +50,12 @@ export async function compressTag(
   env: Env,
   ctx: ExecutionContext
 ): Promise<{ synthesizedId: string | null; entriesUsed: number; text: string }> {
-  const cfg = await resolveConfig(env);
+  // Guard before resolveConfig: that is a KV read, and a system tag never compresses, so
+  // paying for it first is a wasted subrequest per skipped tag per night.
   if (tag.startsWith(STATUS_PREFIX) || tag.startsWith(KIND_PREFIX) || tag.startsWith(VOLATILITY_PREFIX) || tag === STALE_AS_OF) {
     return { synthesizedId: null, entriesUsed: 0, text: "" };
   }
+  const cfg = await resolveConfig(env);
 
   const recentSynth = await env.DB.prepare(`
     SELECT id FROM entries

--- a/src/db/init.ts
+++ b/src/db/init.ts
@@ -1,36 +1,84 @@
 import type { Env } from "../env";
 
+// The schema work below is idempotent but not free — roughly a dozen D1 statements per
+// call. All four nightly jobs run inside a single scheduled() invocation and therefore
+// share one subrequest budget, and each of them awaits initializeDatabase, so without
+// memoisation the same CREATE/ALTER sequence is paid for three or four times per cron.
+// Memoise per isolate: the first caller does the work, everyone else awaits that promise.
+//
+// Deliberately not routed through ensureDbReady (src/runtime/state.ts) — that fires under
+// ctx.waitUntil *without* awaiting, and the nightly jobs must not begin querying before
+// the schema exists. They await this directly and must keep doing so.
+let initPromise: Promise<void> | null = null;
+
 export async function initializeDatabase(env: Env): Promise<void> {
-  try {
-    await env.DB.exec(`CREATE TABLE IF NOT EXISTS entries (id TEXT PRIMARY KEY, content TEXT NOT NULL, tags TEXT NOT NULL DEFAULT '[]', source TEXT NOT NULL DEFAULT 'api', created_at INTEGER NOT NULL, vector_ids TEXT NOT NULL DEFAULT '[]')`);
-    await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_entries_created_at ON entries(created_at DESC)`);
-    await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_entries_source ON entries(source)`);
-    // Relationship graph (issue #16). One additive table — never touches existing
-    // rows/queries, so old code ignores it and rollback is a no-op. Designed to never
-    // need an ALTER: type/provenance are free TEXT validated in code, and metadata is
-    // a JSON escape-hatch for any future per-edge attribute.
-    await env.DB.exec(`CREATE TABLE IF NOT EXISTS edges (id TEXT PRIMARY KEY, source_id TEXT NOT NULL, target_id TEXT NOT NULL, type TEXT NOT NULL DEFAULT 'relates_to', weight REAL NOT NULL DEFAULT 0.5, provenance TEXT NOT NULL DEFAULT 'inferred', metadata TEXT NOT NULL DEFAULT '{}', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, UNIQUE(source_id, target_id, type))`);
-    await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id)`);
-    await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_id)`);
-  } catch (e) {
-    console.error("Database initialization error (non-fatal):", e);
+  if (!initPromise) {
+    initPromise = applySchema(env).catch((e) => {
+      // The memo keys on SUCCESS, not on completion. Clearing it here is what makes a
+      // failed or half-applied schema retryable: latching a resolved promise would leave
+      // every later caller in this isolate doing nothing against a database that was
+      // never migrated. Before memoisation each nightly job re-ran the DDL and repaired
+      // the previous one's transient failure; this preserves that.
+      initPromise = null;
+      throw e;
+    });
   }
+  return initPromise;
+}
+
+/**
+ * Test seam. The memo is module-scoped, so within a single test file the second call
+ * would otherwise be a no-op and assertions about issued statements would go blind.
+ */
+export function resetDatabaseInit(): void {
+  initPromise = null;
+}
+
+/**
+ * The one ALTER failure that is routine rather than a fault: the column was added by an
+ * earlier run. Every other error means the schema is not in the shape the code expects.
+ */
+function isDuplicateColumn(e: unknown): boolean {
+  return /duplicate column name/i.test(String((e as { message?: string })?.message ?? e));
+}
+
+// Rejects on any genuine failure. Nothing here may swallow errors: a resolved promise is
+// the signal initializeDatabase memoises, so swallowing would cache a schema that was
+// never applied. The installer creates the D1 database moments before the first request
+// reaches the Worker, so the very first run is exactly when a transient error is most
+// likely — and most damaging, since that run is the one that creates every table.
+async function applySchema(env: Env): Promise<void> {
+  await env.DB.exec(`CREATE TABLE IF NOT EXISTS entries (id TEXT PRIMARY KEY, content TEXT NOT NULL, tags TEXT NOT NULL DEFAULT '[]', source TEXT NOT NULL DEFAULT 'api', created_at INTEGER NOT NULL, vector_ids TEXT NOT NULL DEFAULT '[]')`);
+  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_entries_created_at ON entries(created_at DESC)`);
+  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_entries_source ON entries(source)`);
+  // Relationship graph (issue #16). One additive table — never touches existing
+  // rows/queries, so old code ignores it and rollback is a no-op. Designed to never
+  // need an ALTER: type/provenance are free TEXT validated in code, and metadata is
+  // a JSON escape-hatch for any future per-edge attribute.
+  await env.DB.exec(`CREATE TABLE IF NOT EXISTS edges (id TEXT PRIMARY KEY, source_id TEXT NOT NULL, target_id TEXT NOT NULL, type TEXT NOT NULL DEFAULT 'relates_to', weight REAL NOT NULL DEFAULT 0.5, provenance TEXT NOT NULL DEFAULT 'inferred', metadata TEXT NOT NULL DEFAULT '{}', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, UNIQUE(source_id, target_id, type))`);
+  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id)`);
+  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_id)`);
   for (const alter of [
     `ALTER TABLE entries ADD COLUMN recall_count INTEGER DEFAULT 0`,
     `ALTER TABLE entries ADD COLUMN importance_score INTEGER DEFAULT 0`,
     `ALTER TABLE entries ADD COLUMN contradiction_wins INTEGER DEFAULT 0`,
     `ALTER TABLE entries ADD COLUMN contradiction_losses INTEGER DEFAULT 0`,
+    // updated_at and staleness_checked_at are deliberately nullable and deliberately NOT
+    // backfilled. Every reader coalesces them to a sensible default — updated_at to
+    // created_at (COALESCE in SQL, ?? in TS), staleness_checked_at to 0 — so on an
+    // existing row a NULL and a written value are indistinguishable downstream, and a
+    // backfill would be a pure no-op that still costs one row written per entry. That is
+    // not free: D1's plan limits row writes per day, and exceeding the cap fails every
+    // query account-wide until 00:00 UTC, so backfilling a large brain on the ordinary
+    // upgrade path is an availability risk that buys nothing. Please do not add one.
+    // test/unit/updated-at-coalesced.test.ts fails if any reader stops coalescing.
     `ALTER TABLE entries ADD COLUMN updated_at INTEGER`,
     `ALTER TABLE entries ADD COLUMN staleness_checked_at INTEGER`,
   ]) {
-    try { await env.DB.exec(alter); } catch { /* column already exists — no-op */ }
-  }
-  try {
-    const row = await env.DB.prepare(`SELECT 1 AS n FROM entries WHERE updated_at IS NULL LIMIT 1`).first() as { n: number } | null;
-    if (row) {
-      await env.DB.exec(`UPDATE entries SET updated_at = created_at WHERE updated_at IS NULL`);
+    try {
+      await env.DB.exec(alter);
+    } catch (e) {
+      if (!isDuplicateColumn(e)) throw e; // column already exists — anything else is real
     }
-  } catch (e) {
-    console.error("updated_at backfill failed (non-fatal):", e);
   }
 }

--- a/src/db/init.ts
+++ b/src/db/init.ts
@@ -20,7 +20,17 @@ export async function initializeDatabase(env: Env): Promise<void> {
     `ALTER TABLE entries ADD COLUMN importance_score INTEGER DEFAULT 0`,
     `ALTER TABLE entries ADD COLUMN contradiction_wins INTEGER DEFAULT 0`,
     `ALTER TABLE entries ADD COLUMN contradiction_losses INTEGER DEFAULT 0`,
+    `ALTER TABLE entries ADD COLUMN updated_at INTEGER`,
+    `ALTER TABLE entries ADD COLUMN staleness_checked_at INTEGER`,
   ]) {
     try { await env.DB.exec(alter); } catch { /* column already exists — no-op */ }
+  }
+  try {
+    const row = await env.DB.prepare(`SELECT 1 AS n FROM entries WHERE updated_at IS NULL LIMIT 1`).first() as { n: number } | null;
+    if (row) {
+      await env.DB.exec(`UPDATE entries SET updated_at = created_at WHERE updated_at IS NULL`);
+    }
+  } catch (e) {
+    console.error("updated_at backfill failed (non-fatal):", e);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,9 +41,14 @@ export default {
     return oauthProvider.fetch(req, env as any, ctx);
   },
   scheduled: async (_event: ScheduledEvent, env: Env, ctx: ExecutionContext) => {
-    ctx.waitUntil(runNightlyCompression(env, ctx));
-    ctx.waitUntil(runGraphPass(env, ctx));
-    ctx.waitUntil(runScheduledIntegrationSync(env));
-    ctx.waitUntil(runStalenessPass(env, ctx));
+    // The jobs are independent, and each begins by awaiting the shared schema init. One
+    // of them failing — including on that init — must not take the others down or surface
+    // as an unhandled rejection inside waitUntil.
+    const job = (name: string, run: Promise<void>) =>
+      ctx.waitUntil(run.catch((e) => console.error(`${name} failed (non-fatal):`, e)));
+    job("nightly compression", runNightlyCompression(env, ctx));
+    job("graph pass", runGraphPass(env, ctx));
+    job("integration sync", runScheduledIntegrationSync(env));
+    job("staleness pass", runStalenessPass(env, ctx));
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import type { Env } from "./env";
 import { runNightlyCompression } from "./compression/nightly";
 import { runGraphPass } from "./graph/pass";
 import { runScheduledIntegrationSync } from "./integrations/mirror";
+import { runStalenessPass } from "./staleness/pass";
 import { apiHandler } from "./mcp/handler";
 import { augmentOAuthRegistrationRequest } from "./oauth/register";
 import { defaultHandler } from "./routes";
@@ -43,5 +44,6 @@ export default {
     ctx.waitUntil(runNightlyCompression(env, ctx));
     ctx.waitUntil(runGraphPass(env, ctx));
     ctx.waitUntil(runScheduledIntegrationSync(env));
+    ctx.waitUntil(runStalenessPass(env, ctx));
   },
 };

--- a/src/integrations/mirror.ts
+++ b/src/integrations/mirror.ts
@@ -13,6 +13,7 @@ import { deleteStaleVectors, storeEntry } from "../capture/store";
 import { classifyEntry } from "../capture/classify";
 import { withKind } from "../memory/kind";
 import { withStatus } from "../memory/status";
+import { tagsAfterWrite } from "../memory/stale";
 
 export function makeMirrorStore(env: Env): MirrorStore {
   return {
@@ -37,8 +38,8 @@ export function makeMirrorStore(env: Env): MirrorStore {
         console.error("Mirror classify failed (non-fatal):", e);
       }
       await env.DB.prepare(
-        `INSERT INTO entries (id, content, tags, source, created_at, vector_ids, importance_score) VALUES (?, ?, ?, ?, ?, ?, ?)`
-      ).bind(id, content, JSON.stringify(finalTags), source, now, "[]", importance).run();
+        `INSERT INTO entries (id, content, tags, source, created_at, updated_at, vector_ids, importance_score) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      ).bind(id, content, JSON.stringify(finalTags), source, now, now, "[]", importance).run();
       try {
         await storeEntry(env, id, content, finalTags, source, now, cfg);
       } catch (e) {
@@ -55,10 +56,14 @@ export function makeMirrorStore(env: Env): MirrorStore {
       const tags: string[] = JSON.parse(row.tags ?? "[]");
       const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
 
-      await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`).bind(content, id).run();
+      const refreshedTags = tagsAfterWrite(tags);
+      const now = Date.now();
+
+      await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
+        .bind(content, JSON.stringify(refreshedTags), now, id).run();
       let newVectorIds: string[] = [];
       try {
-        newVectorIds = await storeEntry(env, id, content, tags, row.source as string, Date.now(), await resolveConfig(env));
+        newVectorIds = await storeEntry(env, id, content, refreshedTags, row.source as string, now, await resolveConfig(env));
       } catch (e) {
         console.error("Vectorize re-embed failed (non-fatal):", e);
       }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -203,7 +203,7 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
     },
     async ({ query, topK, tag, after, before, kind, hops }) => {
       const cfg = await resolveConfig(env);
-      const { matches, insight, semanticUnavailable, queryTokens } = await recallEntries({ query, topK, tag, after, before, kind: kind as MemoryKind | undefined, hops, synthesize: false }, env, ctx, cfg);
+      const { matches, insight, semanticUnavailable, queryTokens, compoundStale } = await recallEntries({ query, topK, tag, after, before, kind: kind as MemoryKind | undefined, hops, synthesize: false }, env, ctx, cfg);
 
       const notice = semanticUnavailable
         ? `Note: semantic search is unavailable because the Vectorize index is missing, so these are keyword matches only. Fix: ${VECTORIZE_FIX_HINT}.\n\n`
@@ -213,7 +213,7 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         return { content: [{ type: "text", text: notice + "Nothing found matching that query." }] };
       }
 
-      return { content: [{ type: "text", text: notice + renderRecallText(matches, insight, { queryTokens, config: cfg }) }] };
+      return { content: [{ type: "text", text: notice + renderRecallText(matches, insight, { queryTokens, config: cfg, compoundStale }) }] };
     }
   );
 

--- a/src/memory/stale.ts
+++ b/src/memory/stale.ts
@@ -1,0 +1,26 @@
+import { withoutVolatility } from "./volatility";
+
+export const STALE_AS_OF = "stale:as-of";
+
+export function hasStaleAsOf(tags: string[]): boolean {
+  return tags.includes(STALE_AS_OF);
+}
+
+export function withStaleAsOf(tags: string[]): string[] {
+  if (tags.includes(STALE_AS_OF)) return tags;
+  return [...tags, STALE_AS_OF];
+}
+
+export function withoutStaleAsOf(tags: string[]): string[] {
+  return tags.filter(t => t !== STALE_AS_OF);
+}
+
+/** Strip staleness/volatility system tags after a content-changing write. */
+export function tagsAfterWrite(tags: string[]): string[] {
+  return withoutVolatility(withoutStaleAsOf(tags));
+}
+
+export function formatAsOfQualifier(updatedAt: number): string {
+  const date = new Date(updatedAt).toLocaleDateString();
+  return `true as of ${date}, verify before asserting`;
+}

--- a/src/memory/volatility.ts
+++ b/src/memory/volatility.ts
@@ -1,0 +1,19 @@
+export const VOLATILITY_VALUES = ["durable", "state", "volatile"] as const;
+export type Volatility = (typeof VOLATILITY_VALUES)[number];
+export const VOLATILITY_PREFIX = "volatility:";
+
+export function getVolatility(tags: string[]): Volatility | null {
+  const tag = tags.find(t => t.startsWith(VOLATILITY_PREFIX));
+  if (!tag) return null;
+  const value = tag.slice(VOLATILITY_PREFIX.length) as Volatility;
+  return (VOLATILITY_VALUES as readonly string[]).includes(value) ? value : null;
+}
+
+export function withVolatility(tags: string[], volatility: Volatility): string[] {
+  const cleaned = tags.filter(t => !t.startsWith(VOLATILITY_PREFIX));
+  return [...cleaned, `${VOLATILITY_PREFIX}${volatility}`];
+}
+
+export function withoutVolatility(tags: string[]): string[] {
+  return tags.filter(t => !t.startsWith(VOLATILITY_PREFIX));
+}

--- a/src/recall/compound-stale.ts
+++ b/src/recall/compound-stale.ts
@@ -1,0 +1,13 @@
+import type { RecallMatch, CompoundStaleSignal } from "./types";
+
+export const COMPOUND_STALE_AGE_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Warn when multiple recalled sources have not been touched in 90+ days. */
+export function computeCompoundStale(matches: RecallMatch[], now = Date.now()): CompoundStaleSignal | undefined {
+  const aged = matches.filter(m => m.staleAsOf && now - m.updatedAt >= COMPOUND_STALE_AGE_MS);
+  if (aged.length < 2) return undefined;
+  return {
+    count: aged.length,
+    oldestUpdatedAt: Math.min(...aged.map(m => m.updatedAt)),
+  };
+}

--- a/src/recall/math.ts
+++ b/src/recall/math.ts
@@ -1,5 +1,6 @@
 import { CHUNK_OVERLAP_CHARS } from "../constants";
 import { getStatus } from "../memory/status";
+import { getVolatility } from "../memory/volatility";
 import { DEFAULTS, type Config } from "../config";
 
 export interface VectorizeMatch {
@@ -13,9 +14,9 @@ export interface VectorizeMatch {
 // keeps regardless of age (applied in rerankWithTimeDecay). Because decay now
 // bottoms out at a floor instead of exp()-ing toward zero, recency becomes a
 // tie-breaker rather than a gate — a strong old match can no longer be buried
-// under a fresh weak one. Durability sets the floor: settled/important memories
-// barely fade, volatile tasks still do. Staleness is handled by status +
-// contradiction, not by making old memories invisible.
+// under a fresh weak one. Durability sets the floor via volatility: (preferred)
+// or legacy proxies (canonical / importance / task). Time-triggered staleness
+// warnings use stale:as-of tags set by the nightly pass.
 export const RECENCY_FLOOR = 0.6;
 export const RECENCY_FLOOR_DURABLE = 0.9;
 export const RECENCY_FLOOR_VOLATILE = 0.15;
@@ -24,6 +25,16 @@ export const RECENCY_FLOOR_VOLATILE = 0.15;
 // more relevance-focused, lower = more diverse. 0.7 keeps the top hit intact while
 // stopping near-duplicate (usually recent) memories from taking every slot.
 export const MMR_LAMBDA = 0.7;
+
+export function getRecencyFloor(tags: string[], imp: number, config: Readonly<Config> = DEFAULTS): number {
+  if (getStatus(tags) === "canonical" || imp >= 4) return config.RECENCY_FLOOR_DURABLE;
+  const vol = getVolatility(tags);
+  if (vol === "durable") return config.RECENCY_FLOOR_DURABLE;
+  if (vol === "volatile") return config.RECENCY_FLOOR_VOLATILE;
+  if (vol === "state") return config.RECENCY_FLOOR;
+  if (tags.includes("task")) return config.RECENCY_FLOOR_VOLATILE;
+  return config.RECENCY_FLOOR;
+}
 
 export function getHalfLifeMs(tags: string[]): number {
   if (tags.includes("task")) return 7 * 24 * 60 * 60 * 1000;
@@ -49,6 +60,7 @@ export function rerankWithTimeDecay(
   queryTags: string[] = [],
   contradictionWins: Map<string, number> = new Map(),
   contradictionLosses: Map<string, number> = new Map(),
+  d1Tags: Map<string, string[]> = new Map(),
   // Ranking seam: config in, ordering out. Threaded rather than read from
   // module scope so this stays pure and directly assertable without an env.
   config: Readonly<Config> = DEFAULTS
@@ -59,18 +71,16 @@ export function rerankWithTimeDecay(
     .map(match => {
       const meta = match.metadata as any;
       const createdAt = meta?.created_at ?? now;
-      const tags: string[] = Array.isArray(meta?.tags) ? meta.tags : [];
-      const ageMs = now - createdAt;
       const parentId = (meta?.parentId ?? match.id) as string;
+      const metaTags: string[] = Array.isArray(meta?.tags) ? meta.tags : [];
+      const tags: string[] = d1Tags.get(parentId) ?? metaTags;
+      const ageMs = now - createdAt;
       const rc = recallCounts.get(parentId) ?? 0;
 
       const halfLifeMs = getHalfLifeMs(tags);
       const imp = importanceScores.get(parentId) ?? 0;
 
-      const recencyFloor =
-        getStatus(tags) === "canonical" || imp >= 4 ? config.RECENCY_FLOOR_DURABLE
-        : tags.includes("task") ? config.RECENCY_FLOOR_VOLATILE
-        : config.RECENCY_FLOOR;
+      const recencyFloor = getRecencyFloor(tags, imp, config);
       const recencyMultiplier = recencyFloor + (1 - recencyFloor) * Math.exp(-ageMs / halfLifeMs);
       const frequencyMultiplier = 1 + Math.log1p(rc);
       const combinedMultiplier = Math.min(1.0, recencyMultiplier * frequencyMultiplier);

--- a/src/recall/render.ts
+++ b/src/recall/render.ts
@@ -1,16 +1,21 @@
 import type { RecallMatch } from "./types";
+import { formatAsOfQualifier } from "../memory/stale";
 import { DEFAULTS, type Config } from "../config";
-import { allowanceFor, RECALL_OUTPUT_BUDGET, snippetOf, truncationNote, type Snippet } from "./snippet";
+import { allowanceFor, snippetOf, truncationNote, type Snippet } from "./snippet";
+import { computeCompoundStale } from "./compound-stale";
+import type { CompoundStaleSignal } from "./types";
 
 export function renderRecallText(
   matches: RecallMatch[],
   insight: string,
-  opts: { full?: boolean; queryTokens?: string[]; config?: Readonly<Config> } = {},
+  opts: { full?: boolean; queryTokens?: string[]; config?: Readonly<Config>; compoundStale?: CompoundStaleSignal } = {},
 ): string {
   const contentById = new Map(matches.map(m => [m.id, m.content]));
   const blocks: string[] = [];
+  const renderedMatches: RecallMatch[] = [];
   let used = 0;
   let omitted = 0;
+  const cfg = opts.config ?? DEFAULTS;
 
   for (let i = 0; i < matches.length; i++) {
     const m = matches[i];
@@ -20,27 +25,37 @@ export function renderRecallText(
     const score = (m.score * 100).toFixed(0);
     const updateLabel = m.isUpdate ? " [updated]" : "";
     const hopLabel = m.hop > 0 ? ` [related · ${hopProvenance(m, contentById)}]` : "";
+    const staleLabel = m.staleAsOf ? ` · ${formatAsOfQualifier(m.updatedAt)}` : "";
 
     const s: Snippet = opts.full
       ? { text: (m.content ?? "").trim(), truncated: false, fullLength: (m.content ?? "").length }
-      : snippetOf(m.content, allowanceFor(i, m.score, opts.config), { queryTokens: opts.queryTokens });
+      : snippetOf(m.content, allowanceFor(i, m.score, cfg), { queryTokens: opts.queryTokens });
     const body = s.truncated ? `${s.text}${truncationNote(m.id, s)}` : s.text;
-    const block = `${i + 1}. [${date}${src}${tagList}] (${score}% match)${updateLabel}${hopLabel}\nID: ${m.id}\n${body}`;
+    const block = `${i + 1}. [${date}${src}${tagList}] (${score}% match)${updateLabel}${hopLabel}${staleLabel}\nID: ${m.id}\n${body}`;
 
     // Stop once the budget is spent, but always return at least one match.
-    if (!opts.full && blocks.length && used + block.length > (opts.config ?? DEFAULTS).RECALL_OUTPUT_BUDGET) {
+    if (!opts.full && blocks.length && used + block.length > cfg.RECALL_OUTPUT_BUDGET) {
       omitted = matches.length - i;
       break;
     }
     used += block.length;
+    renderedMatches.push(m);
     blocks.push(block);
+  }
+
+  const compoundStale = opts.compoundStale ?? computeCompoundStale(renderedMatches);
+  let prefix = "";
+  if (compoundStale) {
+    const oldest = new Date(compoundStale.oldestUpdatedAt).toLocaleDateString();
+    prefix = `**Staleness warning:** ${compoundStale.count} sources are marked stale as-of (oldest touch: ${oldest}). Verify before combining them into a single claim.\n\n---\n\n`;
   }
 
   let text = blocks.join("\n\n");
   if (omitted > 0) {
     text += `\n\n${omitted} more match${omitted > 1 ? "es" : ""} omitted to bound the response size. Narrow the query, or call get("<id>") for a specific memory.`;
   }
-  return insight ? `**Insight:** ${insight}\n\n---\n\n${text}` : text;
+  const body = insight ? `**Insight:** ${insight}\n\n---\n\n${text}` : text;
+  return prefix ? prefix + body : body;
 }
 
 // For a graph-expanded match, describe why it surfaced: who formed the edge

--- a/src/recall/search.ts
+++ b/src/recall/search.ts
@@ -14,8 +14,10 @@ import { parseTimePhrase } from "../text/temporal";
 import { tokenizeQuery } from "../text/tokenize";
 import { distillToRareTerms, inferQueryTags, type DistilledQuery } from "./distill";
 import { synthesizeInsight } from "./insight";
+import { hasStaleAsOf } from "../memory/stale";
 import { cosineSim, mmrRerank, rerankWithTimeDecay, type VectorizeMatch } from "./math";
 import { rrfFuse } from "./rrf";
+import { computeCompoundStale } from "./compound-stale";
 import type { KeywordRow, RecallMatch, RecallSearchResult } from "./types";
 
 async function keywordSearch(tokens: string[], env: Env, limit: number): Promise<KeywordRow[]> {
@@ -189,21 +191,22 @@ export async function recallEntries(
   if (!fusedMatches.length) return { matches: [], insight: "", semanticUnavailable };
 
   const candidateIds = [...new Set(fusedMatches.map(m => (m.metadata as any)?.parentId ?? m.id))] as string[];
-  const rcRows: { id: string; recall_count: number; importance_score: number; contradiction_wins: number; contradiction_losses: number }[] = [];
+  const rcRows: { id: string; recall_count: number; importance_score: number; contradiction_wins: number; contradiction_losses: number; tags: string }[] = [];
   for (let i = 0; i < candidateIds.length; i += D1_MAX_BOUND_PARAMS) {
     const batch = candidateIds.slice(i, i + D1_MAX_BOUND_PARAMS);
     const rcPlaceholders = batch.map(() => "?").join(", ");
     const { results: rows } = await env.DB.prepare(
-      `SELECT id, recall_count, importance_score, contradiction_wins, contradiction_losses FROM entries WHERE id IN (${rcPlaceholders})`
-    ).bind(...batch).all() as { results: { id: string; recall_count: number; importance_score: number; contradiction_wins: number; contradiction_losses: number }[] };
+      `SELECT id, recall_count, importance_score, contradiction_wins, contradiction_losses, tags FROM entries WHERE id IN (${rcPlaceholders})`
+    ).bind(...batch).all() as { results: { id: string; recall_count: number; importance_score: number; contradiction_wins: number; contradiction_losses: number; tags: string }[] };
     rcRows.push(...rows);
   }
   const recallCounts = new Map(rcRows.map(r => [r.id, r.recall_count ?? 0]));
   const importanceScores = new Map(rcRows.map(r => [r.id, r.importance_score ?? 0]));
   const contradictionWins = new Map(rcRows.map(r => [r.id, r.contradiction_wins ?? 0]));
   const contradictionLosses = new Map(rcRows.map(r => [r.id, r.contradiction_losses ?? 0]));
+  const d1Tags = new Map(rcRows.map(r => [r.id, JSON.parse(r.tags ?? "[]") as string[]]));
 
-  const reranked = rerankWithTimeDecay(fusedMatches, recallCounts, importanceScores, queryTags, contradictionWins, contradictionLosses, cfg);
+  const reranked = rerankWithTimeDecay(fusedMatches, recallCounts, importanceScores, queryTags, contradictionWins, contradictionLosses, d1Tags, cfg);
 
   const seen = new Set<string>();
   const dedupedAll = reranked.filter((m) => {
@@ -236,7 +239,7 @@ export async function recallEntries(
   const allParentIds = [...seedParentIds, ...expandedScored.map(e => e.parentId)];
   const placeholders = allParentIds.map(() => "?").join(", ");
   const d1Bindings: (string | number)[] = [...allParentIds];
-  let d1Sql = `SELECT id, content, tags, source, created_at FROM entries WHERE id IN (${placeholders}) AND tags NOT LIKE '%"auto-pattern"%' AND tags NOT LIKE '%"status:deprecated"%'`;
+  let d1Sql = `SELECT id, content, tags, source, created_at, updated_at FROM entries WHERE id IN (${placeholders}) AND tags NOT LIKE '%"auto-pattern"%' AND tags NOT LIKE '%"status:deprecated"%'`;
   if (kind && (KIND_VALUES as readonly string[]).includes(kind)) {
     d1Sql += ` AND tags LIKE '%"kind:${kind}"%'`;
   }
@@ -265,10 +268,12 @@ export async function recallEntries(
       content: row.content as string,
       score: m.score,
       createdAt: row.created_at as number,
+      updatedAt: (row.updated_at as number | null) ?? (row.created_at as number),
       tags: JSON.parse(row.tags ?? "[]"),
       source: row.source as string,
       isUpdate: !!meta?.isUpdate,
       hop: 0,
+      staleAsOf: hasStaleAsOf(JSON.parse(row.tags ?? "[]")),
     }];
   });
 
@@ -280,10 +285,12 @@ export async function recallEntries(
       content: row.content as string,
       score: e.score,
       createdAt: row.created_at as number,
+      updatedAt: (row.updated_at as number | null) ?? (row.created_at as number),
       tags: JSON.parse(row.tags ?? "[]"),
       source: row.source as string,
       isUpdate: false,
       hop: e.hop,
+      staleAsOf: hasStaleAsOf(JSON.parse(row.tags ?? "[]")),
       viaProvenance: e.viaProvenance,
       viaType: e.viaType,
       viaLinkedAt: e.viaLinkedAt,
@@ -298,6 +305,8 @@ export async function recallEntries(
   const maxScore = matches.reduce((mx, m) => Math.max(mx, m.score), 0);
   if (maxScore > 0) for (const m of matches) m.score = m.score / maxScore;
 
+  const compoundStale = computeCompoundStale(matches);
+
   const insight = synthesize && matches.length > 1
     ? await synthesizeInsight(embedQuery, matches.map(m => ({ id: m.id, content: m.content })), env, cfg)
     : "";
@@ -309,5 +318,5 @@ export async function recallEntries(
     );
   }
 
-  return { matches, insight, semanticUnavailable, queryUsed: embedQuery, queryTokens: tokens };
+  return { matches, insight, semanticUnavailable, queryUsed: embedQuery, queryTokens: tokens, compoundStale };
 }

--- a/src/recall/types.ts
+++ b/src/recall/types.ts
@@ -1,14 +1,21 @@
 import type { EdgeProvenance, EdgeType } from "../graph/types";
 
+export interface CompoundStaleSignal {
+  count: number;
+  oldestUpdatedAt: number;
+}
+
 export interface RecallMatch {
   id: string;
   content: string;
   score: number;
   createdAt: number;
+  updatedAt: number;
   tags: string[];
   source: string;
   isUpdate: boolean;
   hop: number;
+  staleAsOf?: boolean;
   // Set only on graph-expanded matches (hop > 0): why / when / whence the edge that surfaced this memory.
   viaProvenance?: EdgeProvenance; // "explicit" (you linked) / "inferred" (auto) / "system"
   viaType?: EdgeType;
@@ -24,6 +31,7 @@ export interface RecallSearchResult {
   // Distilled query terms, reused to pick a query-relevant excerpt when a long
   // memory has to be shortened for the response.
   queryTokens?: string[];
+  compoundStale?: CompoundStaleSignal;
 }
 
 export interface KeywordRow {

--- a/src/routes/capture.ts
+++ b/src/routes/capture.ts
@@ -6,6 +6,7 @@ import { captureEntry } from "../capture/entry";
 import { appendToEntry, deleteStaleVectors, reembedOrDegrade } from "../capture/store";
 import { isManagedMirror, mirrorEditError } from "../integrations/mirror";
 import { extractHashtags } from "../text/hashtags";
+import { tagsAfterWrite } from "../memory/stale";
 
 export async function handleCaptureRoutes(
   request: Request,
@@ -129,7 +130,7 @@ export async function handleCaptureRoutes(
 
     const tags: string[] = JSON.parse(row.tags ?? "[]");
     const { cleanContent, hashtags: newHashtags } = extractHashtags(newContent);
-    const mergedTags = [...new Set([...tags, ...newHashtags])];
+    const mergedTags = tagsAfterWrite([...new Set([...tags, ...newHashtags])]);
     const source = row.source as string;
     const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
     const finalContent = cleanContent || newContent;
@@ -148,8 +149,8 @@ export async function handleCaptureRoutes(
 
     // Safe to commit: either the embed succeeded, or Vectorize is unavailable and
     // the old vectors are kept below rather than retired.
-    await env.DB.prepare(`UPDATE entries SET content = ?, tags = ? WHERE id = ?`)
-      .bind(finalContent, JSON.stringify(mergedTags), id).run();
+    await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
+      .bind(finalContent, JSON.stringify(mergedTags), Date.now(), id).run();
 
     if (newVectorIds) {
       try {

--- a/src/routes/recall.ts
+++ b/src/routes/recall.ts
@@ -48,7 +48,7 @@ export async function handleRecallRoutes(
     const full = ["1", "true", "yes"].includes((url.searchParams.get("full") ?? "").toLowerCase());
 
     const cfg = await resolveConfig(env);
-    const { matches, insight, semanticUnavailable, queryUsed, queryTokens } = await recallEntries({ query, topK, tag, after, before, kind, hops }, env, ctx, cfg);
+    const { matches, insight, semanticUnavailable, queryUsed, queryTokens, compoundStale } = await recallEntries({ query, topK, tag, after, before, kind, hops }, env, ctx, cfg);
 
     if (!matches.length) {
       return json({
@@ -65,6 +65,7 @@ export async function handleRecallRoutes(
     return json({
       ok: true,
       query_used: queryUsed,
+      compound_stale: compoundStale ?? null,
       results: matches.map((m, i) => {
         const s = full
           ? { text: m.content, truncated: false, fullLength: (m.content ?? "").length }
@@ -78,6 +79,8 @@ export async function handleRecallRoutes(
           tags: m.tags,
           source: m.source,
           created_at: m.createdAt,
+          updated_at: m.updatedAt,
+          stale_as_of: m.staleAsOf,
           updated: m.isUpdate,
           hop: m.hop,
           via_provenance: m.viaProvenance ?? null,

--- a/src/runtime/state.ts
+++ b/src/runtime/state.ts
@@ -13,6 +13,12 @@ export function setDbReady(ready: boolean): void {
 
 export function ensureDbReady(ctx: ExecutionContext, env: Env): void {
   if (!dbReady) {
-    ctx.waitUntil(initializeDatabase(env).then(() => { dbReady = true; }));
+    ctx.waitUntil(
+      initializeDatabase(env)
+        .then(() => { dbReady = true; })
+        // Leave dbReady false so the next request tries again. Latching it after a failed
+        // init would leave this isolate serving a database whose schema never got applied.
+        .catch((e) => { console.error("Database initialization failed; will retry:", e); }),
+    );
   }
 }

--- a/src/staleness/heuristic.ts
+++ b/src/staleness/heuristic.ts
@@ -1,0 +1,62 @@
+import type { Volatility } from "../memory/volatility";
+
+const DURABLE_PATTERNS: RegExp[] = [
+  /\bbirthday\b/i,
+  /\bborn\b/i,
+  /\bbirth\s*date\b/i,
+  /\bdate of birth\b/i,
+  /\bgrew up in\b/i,
+  /\bname is\b/i,
+  /\bis called\b/i,
+  /\bnationality\b/i,
+  /\bmaiden name\b/i,
+];
+
+const STATE_PATTERNS: RegExp[] = [
+  /\bworks?\s+at\b/i,
+  /\bwork(s|ing)?\s+for\b/i,
+  /\bemployed\b/i,
+  /\bjob\s+(at|with)\b/i,
+  /\blives?\s+in\b/i,
+  /\bplan(s|ning)?\s+to\b/i,
+  /\brole\s+at\b/i,
+  /\bposition\s+at\b/i,
+];
+
+const VOLATILE_PATTERNS: RegExp[] = [
+  /\bmeeting\b/i,
+  /\bappointment\b/i,
+  /\bdeadline\b/i,
+];
+
+/**
+ * Cheap state-vs-fact classifier. Returns null when uncertain — caller should
+ * leave volatility unset and rely on ranking proxies until a clearer signal.
+ */
+export function classifyVolatility(content: string, tags: string[] = []): Volatility | null {
+  if (tags.includes("task")) return "volatile";
+
+  let durableHits = 0;
+  let stateHits = 0;
+  let volatileHits = 0;
+
+  for (const p of DURABLE_PATTERNS) {
+    if (p.test(content)) durableHits++;
+  }
+  for (const p of STATE_PATTERNS) {
+    if (p.test(content)) stateHits++;
+  }
+  for (const p of VOLATILE_PATTERNS) {
+    if (p.test(content)) volatileHits++;
+  }
+
+  if (volatileHits > 0 && durableHits === 0) return "volatile";
+  if (durableHits > 0 && stateHits === 0 && volatileHits === 0) return "durable";
+  if (stateHits > 0) return "state";
+
+  return null;
+}
+
+export function shouldFlagStale(volatility: Volatility | null): boolean {
+  return volatility === "state" || volatility === "volatile";
+}

--- a/src/staleness/pass.ts
+++ b/src/staleness/pass.ts
@@ -1,0 +1,95 @@
+import type { Env } from "../env";
+import { initializeDatabase } from "../db/init";
+import { getStatus } from "../memory/status";
+import { getVolatility, withVolatility } from "../memory/volatility";
+import { hasStaleAsOf, withStaleAsOf, withoutStaleAsOf } from "../memory/stale";
+import { classifyVolatility, shouldFlagStale } from "./heuristic";
+
+export const STALENESS_AGE_MS = 90 * 24 * 60 * 60 * 1000;
+export const STALENESS_PASS_LIMIT = 25;
+
+const SYSTEM_TAG_EXCLUSIONS = [
+  `tags NOT LIKE '%"status:deprecated"%'`,
+  `tags NOT LIKE '%"auto-pattern"%'`,
+  `tags NOT LIKE '%"synthesized"%'`,
+  `tags NOT LIKE '%"rolled-up"%'`,
+].join(" AND ");
+
+async function casUpdateEntry(
+  env: Env,
+  id: string,
+  mutate: (row: { tags: string[] }) => { tags: string[] },
+  extraSets: Record<string, unknown> = {},
+): Promise<boolean> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const row = await env.DB.prepare(`SELECT tags FROM entries WHERE id = ?`).bind(id).first() as { tags: string } | null;
+    if (!row) return false;
+    const currentTagsJson = row.tags ?? "[]";
+    const next = mutate({ tags: JSON.parse(currentTagsJson) });
+    const nextTagsJson = JSON.stringify(next.tags);
+    const setClauses = ["tags = ?"];
+    const bindings: unknown[] = [nextTagsJson];
+    for (const [col, val] of Object.entries(extraSets)) {
+      setClauses.push(`${col} = ?`);
+      bindings.push(val);
+    }
+    bindings.push(id, currentTagsJson);
+    const result = await env.DB.prepare(
+      `UPDATE entries SET ${setClauses.join(", ")} WHERE id = ? AND tags = ?`,
+    ).bind(...bindings).run();
+    if ((result.meta.changes ?? 0) > 0) return true;
+  }
+  return false;
+}
+
+export async function runStalenessPass(env: Env, _ctx: ExecutionContext): Promise<void> {
+  await initializeDatabase(env);
+
+  const cutoff = Date.now() - STALENESS_AGE_MS;
+  const now = Date.now();
+  let candidates: { id: string; content: string; tags: string }[] = [];
+
+  try {
+    const { results } = await env.DB.prepare(
+      `SELECT id, content, tags FROM entries
+       WHERE COALESCE(updated_at, created_at) < ?
+         AND ${SYSTEM_TAG_EXCLUSIONS}
+       ORDER BY COALESCE(staleness_checked_at, 0) ASC
+       LIMIT ${STALENESS_PASS_LIMIT}`,
+    ).bind(cutoff).all() as { results: { id: string; content: string; tags: string }[] };
+    candidates = results;
+  } catch (e) {
+    console.error("Staleness pass query failed (non-fatal):", e);
+    return;
+  }
+
+  for (const row of candidates) {
+    try {
+      if (getStatus(JSON.parse(row.tags ?? "[]")) === "deprecated") {
+        await env.DB.prepare(`UPDATE entries SET staleness_checked_at = ? WHERE id = ?`).bind(now, row.id).run();
+        continue;
+      }
+
+      await casUpdateEntry(env, row.id, ({ tags }) => {
+        const classified = classifyVolatility(row.content, tags);
+        const existing = getVolatility(tags);
+
+        if (classified && !existing) {
+          tags = withVolatility(tags, classified);
+        }
+
+        const volatility = getVolatility(tags);
+
+        if (shouldFlagStale(volatility)) {
+          if (!hasStaleAsOf(tags)) tags = withStaleAsOf(tags);
+        } else if (volatility === "durable") {
+          tags = withoutStaleAsOf(tags);
+        }
+
+        return { tags };
+      }, { staleness_checked_at: now });
+    } catch (e) {
+      console.error(`Staleness pass failed for ${row.id} (non-fatal):`, e);
+    }
+  }
+}

--- a/src/staleness/pass.ts
+++ b/src/staleness/pass.ts
@@ -15,17 +15,30 @@ const SYSTEM_TAG_EXCLUSIONS = [
   `tags NOT LIKE '%"rolled-up"%'`,
 ].join(" AND ");
 
+// `known` lets the caller spend the row it already selected on the first attempt instead
+// of re-reading it; a lost CAS drops back to a fresh read for the retry.
+//
+// The guard covers content as well as tags because the classification is derived from
+// content. Guarding tags alone is not enough: for an entry carrying neither a volatility:
+// nor a stale:as-of tag — the common case — the mutation is a no-op on tags, so a
+// concurrent rewrite would leave the guard satisfied and the CAS would commit a verdict
+// about content that no longer exists. That misfire does not self-correct either, since
+// the concurrent write also bumps updated_at past the staleness cutoff.
 async function casUpdateEntry(
   env: Env,
   id: string,
-  mutate: (row: { tags: string[] }) => { tags: string[] },
+  mutate: (row: { tags: string[]; content: string }) => { tags: string[] },
   extraSets: Record<string, unknown> = {},
+  known?: { tags: string; content: string },
 ): Promise<boolean> {
+  let current = known;
   for (let attempt = 0; attempt < 3; attempt++) {
-    const row = await env.DB.prepare(`SELECT tags FROM entries WHERE id = ?`).bind(id).first() as { tags: string } | null;
-    if (!row) return false;
-    const currentTagsJson = row.tags ?? "[]";
-    const next = mutate({ tags: JSON.parse(currentTagsJson) });
+    if (current === undefined) {
+      const row = await env.DB.prepare(`SELECT tags, content FROM entries WHERE id = ?`).bind(id).first() as { tags: string; content: string } | null;
+      if (!row) return false;
+      current = { tags: row.tags ?? "[]", content: row.content };
+    }
+    const next = mutate({ tags: JSON.parse(current.tags), content: current.content });
     const nextTagsJson = JSON.stringify(next.tags);
     const setClauses = ["tags = ?"];
     const bindings: unknown[] = [nextTagsJson];
@@ -33,11 +46,12 @@ async function casUpdateEntry(
       setClauses.push(`${col} = ?`);
       bindings.push(val);
     }
-    bindings.push(id, currentTagsJson);
+    bindings.push(id, current.tags, current.content);
     const result = await env.DB.prepare(
-      `UPDATE entries SET ${setClauses.join(", ")} WHERE id = ? AND tags = ?`,
+      `UPDATE entries SET ${setClauses.join(", ")} WHERE id = ? AND tags = ? AND content = ?`,
     ).bind(...bindings).run();
     if ((result.meta.changes ?? 0) > 0) return true;
+    current = undefined; // CAS lost (or the row is gone) — retry against a fresh read
   }
   return false;
 }
@@ -70,8 +84,8 @@ export async function runStalenessPass(env: Env, _ctx: ExecutionContext): Promis
         continue;
       }
 
-      await casUpdateEntry(env, row.id, ({ tags }) => {
-        const classified = classifyVolatility(row.content, tags);
+      const settled = await casUpdateEntry(env, row.id, ({ tags, content }) => {
+        const classified = classifyVolatility(content, tags);
         const existing = getVolatility(tags);
 
         if (classified && !existing) {
@@ -87,7 +101,15 @@ export async function runStalenessPass(env: Env, _ctx: ExecutionContext): Promis
         }
 
         return { tags };
-      }, { staleness_checked_at: now });
+      }, { staleness_checked_at: now }, { tags: row.tags ?? "[]", content: row.content });
+
+      if (!settled) {
+        // Every CAS attempt lost, or the row is gone. Advance the cursor anyway: the
+        // candidate query orders by COALESCE(staleness_checked_at, 0) ASC, so leaving it
+        // NULL would put this row first on every future pass, camping one of the 25 slots
+        // indefinitely. The next pass will pick it up again on its merits.
+        await env.DB.prepare(`UPDATE entries SET staleness_checked_at = ? WHERE id = ?`).bind(now, row.id).run();
+      }
     } catch (e) {
       console.error(`Staleness pass failed for ${row.id} (non-fatal):`, e);
     }

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -56,10 +56,12 @@ export class D1Mock {
           }
           return { meta: { changes: 0 } };
         }
-        if (s.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ? WHERE id = ? AND tags = ?")) {
-          const [tags, staleness_checked_at, id, expectedTags] = args;
+        if (s.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ? WHERE id = ? AND tags = ? AND content = ?")) {
+          // Staleness CAS: guards content as well as tags, because the verdict being
+          // written is derived from content and the tag mutation is often a no-op.
+          const [tags, staleness_checked_at, id, expectedTags, expectedContent] = args;
           const row = db.entries.find((e: any) => e.id === id);
-          if (row && row.tags === expectedTags) {
+          if (row && row.tags === expectedTags && row.content === expectedContent) {
             row.tags = tags;
             row.staleness_checked_at = staleness_checked_at;
             return { meta: { changes: 1 } };

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -11,11 +11,25 @@ export class D1Mock {
     const makeStmt = (args: any[]) => ({
       async run() {
         if (s.startsWith("INSERT INTO entries")) {
-          const [id, content, tags, source, created_at, vector_ids] = args;
-          db.entries.push({ id, content, tags, source, created_at, vector_ids, recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0 });
+          if (args.length >= 8) {
+            const [id, content, tags, source, created_at, updated_at, vector_ids, importance_score] = args;
+            db.entries.push({ id, content, tags, source, created_at, updated_at, vector_ids, recall_count: 0, importance_score: importance_score ?? 0, contradiction_wins: 0, contradiction_losses: 0 });
+          } else if (args.length === 7) {
+            const [id, content, tags, source, created_at, updated_at, vector_ids] = args;
+            db.entries.push({ id, content, tags, source, created_at, updated_at, vector_ids, recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0 });
+          } else {
+            const [id, content, tags, source, created_at, vector_ids] = args;
+            db.entries.push({ id, content, tags, source, created_at, updated_at: created_at, vector_ids, recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0 });
+          }
           return { meta: { changes: 1 } };
         }
-        if (s.startsWith("UPDATE entries SET content = ?, vector_ids")) {
+        if (s.startsWith("UPDATE entries SET content = ?, vector_ids = ?, tags = ?, updated_at = ? WHERE id")) {
+          const [content, vector_ids, tags, updated_at, id] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row) { row.content = content; row.vector_ids = vector_ids; row.tags = tags; row.updated_at = updated_at; }
+          return { meta: { changes: row ? 1 : 0 } };
+        }
+        if (s.startsWith("UPDATE entries SET content = ?, vector_ids = ? WHERE id")) {
           const [content, vector_ids, id] = args;
           const row = db.entries.find((e: any) => e.id === id);
           if (row) { row.content = content; row.vector_ids = vector_ids; }
@@ -33,10 +47,47 @@ export class D1Mock {
           if (row) row.vector_ids = vector_ids;
           return { meta: { changes: row ? 1 : 0 } };
         }
+        if (s.startsWith("UPDATE entries SET tags = ? WHERE id = ? AND tags = ?")) {
+          const [tags, id, expectedTags] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row && row.tags === expectedTags) {
+            row.tags = tags;
+            return { meta: { changes: 1 } };
+          }
+          return { meta: { changes: 0 } };
+        }
+        if (s.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ? WHERE id = ? AND tags = ?")) {
+          const [tags, staleness_checked_at, id, expectedTags] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row && row.tags === expectedTags) {
+            row.tags = tags;
+            row.staleness_checked_at = staleness_checked_at;
+            return { meta: { changes: 1 } };
+          }
+          return { meta: { changes: 0 } };
+        }
+        if (s.startsWith("UPDATE entries SET staleness_checked_at = ? WHERE id = ?")) {
+          const [staleness_checked_at, id] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row) row.staleness_checked_at = staleness_checked_at;
+          return { meta: { changes: row ? 1 : 0 } };
+        }
         if (s.startsWith("UPDATE entries SET tags = ? WHERE id")) {
           const [tags, id] = args;
           const row = db.entries.find((e: any) => e.id === id);
           if (row) row.tags = tags;
+          return { meta: { changes: row ? 1 : 0 } };
+        }
+        if (s.startsWith("UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id")) {
+          const [content, tags, updated_at, id] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row) { row.content = content; row.tags = tags; row.updated_at = updated_at; }
+          return { meta: { changes: row ? 1 : 0 } };
+        }
+        if (s.startsWith("UPDATE entries SET content = ?, updated_at = ? WHERE id")) {
+          const [content, updated_at, id] = args;
+          const row = db.entries.find((e: any) => e.id === id);
+          if (row) { row.content = content; row.updated_at = updated_at; }
           return { meta: { changes: row ? 1 : 0 } };
         }
         if (s.startsWith("UPDATE entries SET content = ?, tags")) {
@@ -45,7 +96,7 @@ export class D1Mock {
           if (row) { row.content = content; row.tags = tags; }
           return { meta: { changes: row ? 1 : 0 } };
         }
-        if (s.startsWith("UPDATE entries SET content")) {
+        if (s.startsWith("UPDATE entries SET content = ? WHERE id")) {
           const [content, id] = args;
           const row = db.entries.find((e: any) => e.id === id);
           if (row) row.content = content;
@@ -279,7 +330,70 @@ export class D1Mock {
         if (s.includes("SELECT id, recall_count, importance_score") && s.includes("WHERE id IN")) {
           const results = db.entries
             .filter((e: any) => args.includes(e.id))
-            .map((e: any) => ({ id: e.id, recall_count: e.recall_count ?? 0, importance_score: e.importance_score ?? 0, contradiction_wins: e.contradiction_wins ?? 0, contradiction_losses: e.contradiction_losses ?? 0 }));
+            .map((e: any) => ({
+              id: e.id,
+              recall_count: e.recall_count ?? 0,
+              importance_score: e.importance_score ?? 0,
+              contradiction_wins: e.contradiction_wins ?? 0,
+              contradiction_losses: e.contradiction_losses ?? 0,
+              tags: e.tags ?? "[]",
+            }));
+          return { results };
+        }
+        if (s.includes("SELECT tags FROM entries WHERE id = ?")) {
+          const row = db.entries.find((e: any) => e.id === args[0]);
+          return { results: row ? [{ tags: row.tags }] : [] };
+        }
+        if (s.includes("COALESCE(updated_at, created_at) < ?") && s.includes("SELECT id, content, tags FROM entries")) {
+          const cutoff = Number(args[0]);
+          const limitMatch = s.match(/LIMIT (\d+)/);
+          const limit = limitMatch ? parseInt(limitMatch[1], 10) : 25;
+          const results = [...db.entries]
+            .filter((e: any) => {
+              const tags: string[] = JSON.parse(e.tags ?? "[]");
+              if (tags.includes("status:deprecated")) return false;
+              if (tags.includes("auto-pattern")) return false;
+              if (tags.includes("synthesized")) return false;
+              if (tags.includes("rolled-up")) return false;
+              const touched = e.updated_at ?? e.created_at;
+              return touched < cutoff;
+            })
+            .sort((a: any, b: any) => (a.staleness_checked_at ?? 0) - (b.staleness_checked_at ?? 0))
+            .slice(0, limit)
+            .map((e: any) => ({ id: e.id, content: e.content, tags: e.tags }));
+          return { results };
+        }
+        if (s.includes("SELECT id, content, tags, source, created_at, updated_at FROM entries WHERE id IN")) {
+          const inMatch = s.match(/WHERE id IN \(([^)]*)\)/);
+          const idCount = inMatch ? inMatch[1].split(",").length : 0;
+          const ids = args.slice(0, idCount);
+          const rest = args.slice(idCount);
+          let argIdx = 0;
+          const kindMatch = s.match(/tags LIKE '%"(kind:(?:episodic|semantic))"%'/);
+          let rows = db.entries.filter((e: any) => {
+            const tags: string[] = JSON.parse(e.tags ?? "[]");
+            if (!ids.includes(e.id)) return false;
+            if (tags.includes("auto-pattern")) return false;
+            if (s.includes('"status:deprecated"') && tags.includes("status:deprecated")) return false;
+            if (kindMatch && !tags.includes(kindMatch[1])) return false;
+            return true;
+          });
+          if (s.includes("created_at >= ?")) {
+            const after = Number(rest[argIdx++]);
+            rows = rows.filter((e: any) => e.created_at >= after);
+          }
+          if (s.includes("created_at <= ?")) {
+            const before = Number(rest[argIdx++]);
+            rows = rows.filter((e: any) => e.created_at <= before);
+          }
+          const results = rows.map((e: any) => ({
+            id: e.id,
+            content: e.content,
+            tags: e.tags,
+            source: e.source,
+            created_at: e.created_at,
+            updated_at: e.updated_at ?? e.created_at,
+          }));
           return { results };
         }
         if (s.includes("FROM entries WHERE id IN") && s.includes("tags NOT LIKE")) {

--- a/test/ui/card-stale-contrast.test.ts
+++ b/test/ui/card-stale-contrast.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The stale-card modifier must not reduce text contrast on the card.
+ *
+ * --text-tertiary is already below WCAG AA on --bg-card in BOTH themes — 4.4987 dark,
+ * 3.0457 light. That is pre-existing and app-wide, not something this modifier caused,
+ * but it means there is no headroom to spend: any lightening tint pushes dark further
+ * down (alpha 0.02 already gives 4.35), and a darkening tint — which would actually
+ * raise dark to ~4.58 — pushes light down to ~2.73 instead. No single tint helps both.
+ *
+ * So card--stale signals with a dashed border, matching how the other card modifiers
+ * work: card--synthesized varies border colour, card--rolled-up varies opacity, neither
+ * touches the background.
+ *
+ * This encodes the rule rather than the current declaration, so a re-added tint is
+ * caught by the number that matters — including via background-color, background-image,
+ * or a theme-scoped override, which a check keyed on the literal `background:` missed.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Comments stripped up front: they contain no braces, so a comment sitting above a rule
+// would otherwise be captured as part of that rule's selector, and a comment mentioning
+// card--stale would register as a phantom rule.
+const CSS = readFileSync(resolve(import.meta.dirname, "../../public/css/main.css"), "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, "");
+
+const srgb = (c: number) => { const s = c / 255; return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4; };
+const luminance = ([r, g, b]: number[]) => 0.2126 * srgb(r) + 0.7152 * srgb(g) + 0.0722 * srgb(b);
+const contrast = (a: number[], b: number[]) => {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+};
+const parseHex = (h: string) => [1, 3, 5].map(i => parseInt(h.slice(i, i + 2), 16));
+const composite = (fg: number[], alpha: number, bg: number[]) => fg.map((c, i) => alpha * c + (1 - alpha) * bg[i]);
+
+function themeBlock(theme: "light" | "dark"): string {
+  const start = theme === "dark" ? CSS.indexOf("html[data-theme='dark'] {") : CSS.indexOf(":root {");
+  expect(start).toBeGreaterThan(-1);
+  return CSS.slice(start, CSS.indexOf("}", start));
+}
+
+function variable(theme: "light" | "dark", name: string): number[] {
+  const m = themeBlock(theme).match(new RegExp(`${name}:\\s*(#[0-9a-f]{6})`, "i"));
+  expect(m, `${name} not found in ${theme} theme`).toBeTruthy();
+  return parseHex(m![1]);
+}
+
+/**
+ * EVERY rule whose selector mentions card--stale — matchAll, not match, so a later or
+ * theme-scoped override (`html[data-theme='dark'] .memory-card.card--stale { … }`) is
+ * seen rather than shadowed by the first hit.
+ */
+function staleRules(): { selector: string; body: string }[] {
+  return [...CSS.matchAll(/([^{}]*\.card--stale[^{}]*)\{([^}]*)\}/g)]
+    .map(m => ({ selector: m[1].trim(), body: m[2] }));
+}
+
+/** Any background declaration — shorthand, -color, or -image. */
+function backgroundDeclarations(): { selector: string; value: string }[] {
+  const out: { selector: string; value: string }[] = [];
+  for (const rule of staleRules()) {
+    for (const m of rule.body.matchAll(/\bbackground(?:-color|-image)?\s*:\s*([^;]+);?/g)) {
+      out.push({ selector: rule.selector, value: m[1].trim() });
+    }
+  }
+  return out;
+}
+
+/** Resolves a colour value to RGB composited over the card, or null if not a flat colour. */
+function resolveOver(value: string, card: number[]): number[] | null {
+  const rgba = value.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)/);
+  if (rgba) return composite([+rgba[1], +rgba[2], +rgba[3]], rgba[4] === undefined ? 1 : +rgba[4], card);
+  const hex = value.match(/#[0-9a-f]{6}\b/i);
+  if (hex) return parseHex(hex[0]);
+  return null;
+}
+
+describe("card--stale does not reduce text contrast", () => {
+  it.each(["light", "dark"] as const)("%s theme: the modifier declares no background at all", (theme) => {
+    // Stated as an absolute because neither direction of tint is safe in both themes.
+    const declared = backgroundDeclarations();
+    expect(declared, `card--stale must not set a background (found: ${JSON.stringify(declared)})`).toEqual([]);
+    // Belt and braces: if one is ever added, it must at minimum not degrade the baseline.
+    const card = variable(theme, "--bg-card");
+    const tertiary = variable(theme, "--text-tertiary");
+    for (const d of declared) {
+      const tinted = resolveOver(d.value, card);
+      expect(tinted, `unparseable background: ${d.value}`).toBeTruthy();
+      expect(contrast(tertiary, tinted!)).toBeGreaterThanOrEqual(contrast(tertiary, card));
+    }
+  });
+
+  it("records the baseline contrast the modifier must not worsen", () => {
+    // Asserted precisely: a ±0.05 tolerance cannot tell 4.4987 from 4.54, which is the
+    // difference between "already failing AA" and "passing".
+    expect(contrast(variable("dark", "--text-tertiary"), variable("dark", "--bg-card"))).toBeCloseTo(4.4987, 3);
+    expect(contrast(variable("light", "--text-tertiary"), variable("light", "--bg-card"))).toBeCloseTo(3.0457, 3);
+  });
+
+  it("documents that both baselines are below AA, so there is no headroom for a tint", () => {
+    // Pre-existing and app-wide, not caused by card--stale. Pinned so that if a theme
+    // change ever buys headroom, this test fails and the tint ban can be reconsidered.
+    for (const theme of ["light", "dark"] as const) {
+      expect(contrast(variable(theme, "--text-tertiary"), variable(theme, "--bg-card"))).toBeLessThan(4.5);
+    }
+  });
+
+  it("signals staleness with a border, like the other card modifiers", () => {
+    expect(staleRules()).toHaveLength(1);
+    expect(staleRules()[0].body).toMatch(/border-left:\s*3px\s+dashed\s+var\(--warn\)/);
+  });
+
+  it("the warn border clears the 3:1 floor for non-text elements in both themes", () => {
+    for (const theme of ["light", "dark"] as const) {
+      expect(contrast(variable(theme, "--warn"), variable(theme, "--bg-card"))).toBeGreaterThanOrEqual(3);
+    }
+  });
+});

--- a/test/unit/cron-subrequest-budget.test.ts
+++ b/test/unit/cron-subrequest-budget.test.ts
@@ -1,0 +1,90 @@
+/**
+ * All four nightly jobs are fired from a single scheduled() invocation (src/index.ts),
+ * so they share ONE subrequest budget — 50 on the free plan. Each of them awaits
+ * initializeDatabase, so before it was memoised the same dozen DDL statements were paid
+ * for once per job, and the pass that runs last could find the budget already spent.
+ *
+ * This measures the whole invocation rather than any one job, because per-job budget
+ * assertions are not true in situ.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { resetDatabaseInit } from "../../src/db/init";
+import { STALENESS_AGE_MS } from "../../src/staleness/pass";
+import { makeTestDb, makeTestEnv, makeVectorizeMock } from "../helpers/make-env";
+import { D1Mock } from "../helpers/d1-mock";
+
+const FREE_PLAN_SUBREQUESTS = 50;
+
+function countingEnv(db: D1Mock) {
+  const statements: string[] = [];
+  const DB = {
+    prepare(sql: string) { statements.push(sql.replace(/\s+/g, " ").trim()); return db.prepare(sql); },
+    exec(sql: string) { statements.push(sql.replace(/\s+/g, " ").trim()); return db.exec(sql); },
+    batch: (stmts: any[]) => db.batch(stmts),
+  } as unknown as D1Database;
+  return { env: makeTestEnv(db, { DB, VECTORIZE: makeVectorizeMock() }), statements };
+}
+
+async function runCron(env: any) {
+  const pending: Promise<any>[] = [];
+  const ctx = { waitUntil: (p: Promise<any>) => pending.push(p) } as any;
+  await (worker as any).scheduled({} as any, env, ctx);
+  await Promise.allSettled(pending);
+}
+
+describe("nightly cron D1 subrequest cost", () => {
+  beforeEach(() => {
+    resetDatabaseInit();
+    vi.restoreAllMocks();
+  });
+
+  it("pays for the schema DDL once per invocation, not once per job", async () => {
+    const db = makeTestDb();
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    for (let i = 0; i < 25; i++) {
+      db.entries.push({
+        id: `job-${i}`, content: `Person ${i} works at Company ${i}`, tags: "[]",
+        source: "api", created_at: old + i, updated_at: old + i, vector_ids: "[]",
+      });
+    }
+    const { env, statements } = countingEnv(db);
+
+    await runCron(env);
+
+    // The signature statement of initializeDatabase, once for the whole cron.
+    const ddl = statements.filter(s => s.startsWith("CREATE TABLE IF NOT EXISTS entries"));
+    expect(ddl).toHaveLength(1);
+  });
+
+  it("keeps a whole nightly run inside the free-plan subrequest budget", async () => {
+    const db = makeTestDb();
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    for (let i = 0; i < 25; i++) {
+      db.entries.push({
+        id: `job-${i}`, content: `Person ${i} works at Company ${i}`, tags: "[]",
+        source: "api", created_at: old + i, updated_at: old + i, vector_ids: "[]",
+      });
+    }
+    const { env, statements } = countingEnv(db);
+
+    await runCron(env);
+
+    expect(statements.length).toBeLessThanOrEqual(FREE_PLAN_SUBREQUESTS);
+  });
+
+  it("still leaves the staleness pass room to run after the other jobs", async () => {
+    const db = makeTestDb();
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "job", content: "Bob works at Example Inc", tags: "[]",
+      source: "api", created_at: old, updated_at: old, vector_ids: "[]",
+    });
+    const { env } = countingEnv(db);
+
+    await runCron(env);
+
+    const tags: string[] = JSON.parse(db.entries.find(e => e.id === "job")!.tags);
+    expect(tags).toContain("stale:as-of");
+  });
+});

--- a/test/unit/db-init.test.ts
+++ b/test/unit/db-init.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { initializeDatabase, resetDatabaseInit } from "../../src/db/init";
+import { makeTestEnv } from "../helpers/make-env";
+
+const MIGRATION: [column: string, alter: string][] = [
+  ["recall_count", `ALTER TABLE entries ADD COLUMN recall_count INTEGER DEFAULT 0`],
+  ["importance_score", `ALTER TABLE entries ADD COLUMN importance_score INTEGER DEFAULT 0`],
+  ["contradiction_wins", `ALTER TABLE entries ADD COLUMN contradiction_wins INTEGER DEFAULT 0`],
+  ["contradiction_losses", `ALTER TABLE entries ADD COLUMN contradiction_losses INTEGER DEFAULT 0`],
+  ["updated_at", `ALTER TABLE entries ADD COLUMN updated_at INTEGER`],
+  ["staleness_checked_at", `ALTER TABLE entries ADD COLUMN staleness_checked_at INTEGER`],
+];
+const ALL_COLUMNS = MIGRATION.map(([column]) => column);
+
+type Row = { created_at: number; updated_at?: number | null };
+
+// D1Mock's exec() never throws, so it cannot express "this column already exists".
+// This stand-in models what the migration path turns on, verified against real workerd
+// D1 via Miniflare: D1 rejects an ALTER for a column the table already has, and a column
+// added to a populated table reads NULL on every pre-existing row. Every statement is
+// recorded so a test can assert what a cold start costs — ALTERs are recorded even when
+// they go on to throw.
+function makeMigrationDb(existingColumns: string[] = [], rows: Row[] = []) {
+  const columns = new Set(existingColumns);
+  const execd: string[] = [];
+  const prepared: string[] = [];
+
+  const DB = {
+    async exec(sql: string) {
+      execd.push(sql);
+      const added = sql.match(/ALTER TABLE entries ADD COLUMN (\w+)/);
+      if (added) {
+        if (columns.has(added[1])) throw new Error(`D1_EXEC_ERROR: duplicate column name: ${added[1]}`);
+        columns.add(added[1]);
+        if (added[1] === "updated_at") rows.forEach(r => { r.updated_at = null; });
+      }
+    },
+    prepare(sql: string) {
+      prepared.push(sql);
+      const make = (args: unknown[]) => ({
+        bind: (...next: unknown[]) => make(next),
+        first: async () => null,
+        all: async () => ({ results: [] }),
+        run: async () => ({ meta: { changes: 0 } }),
+      });
+      return make([]);
+    },
+  } as unknown as D1Database;
+
+  return { env: makeTestEnv(undefined, { DB }), execd, prepared, rows };
+}
+
+const rowsAged = (n: number): Row[] => Array.from({ length: n }, (_, i) => ({ created_at: 1000 + i }));
+const touchesEntries = (statements: string[]) =>
+  statements.filter(s => /\bentries\b/.test(s) && !/^(CREATE|ALTER)\b/.test(s));
+
+describe("initializeDatabase updated_at migration", () => {
+  // initializeDatabase memoises per isolate, so each case needs a clean slate.
+  beforeEach(resetDatabaseInit);
+
+  // updated_at is added by ALTER and never backfilled. initializeDatabase runs on every
+  // cold isolate, so the target property is absolute: it issues no read and no write
+  // against entries on any path, on any brain. A probe would be a full table scan on an
+  // unindexed column (D1 bills rows_read); a backfill would be one row written per entry
+  // (D1 caps rows written per day) for a value no reader can distinguish from NULL.
+
+  it("issues no query at all on a fresh, unmigrated brain", async () => {
+    const { env, execd, prepared, rows } = makeMigrationDb([], rowsAged(3));
+
+    await initializeDatabase(env);
+
+    expect(prepared).toEqual([]);
+    expect(touchesEntries(execd)).toEqual([]);
+    // The rows are left NULL on purpose — readers coalesce updated_at to created_at.
+    expect(rows.every(r => r.updated_at === null)).toBe(true);
+  });
+
+  it("issues no query at all on an already-migrated brain", async () => {
+    const { env, execd, prepared } = makeMigrationDb(ALL_COLUMNS, [{ created_at: 1000, updated_at: 1000 }]);
+
+    await initializeDatabase(env);
+
+    expect(prepared).toEqual([]);
+    expect(touchesEntries(execd)).toEqual([]);
+  });
+
+  it("adds nothing on later cold starts", async () => {
+    const { env, execd, prepared } = makeMigrationDb([], rowsAged(1));
+
+    // Each reset stands in for a fresh isolate, which is what a cold start actually is.
+    await initializeDatabase(env);
+    const afterFirst = execd.length;
+    resetDatabaseInit();
+    await initializeDatabase(env);
+    resetDatabaseInit();
+    await initializeDatabase(env);
+
+    expect(prepared).toEqual([]);
+    expect(execd).toHaveLength(afterFirst * 3); // same DDL each time, nothing extra
+    expect(touchesEntries(execd)).toEqual([]);
+  });
+
+  // All four nightly jobs await initializeDatabase inside one scheduled() invocation,
+  // sharing a single subrequest budget. Without memoisation the DDL is paid for once per
+  // job. Callers must still await real completion — ensureDbReady's waitUntil does not.
+  describe("memoisation", () => {
+    it("runs the schema work once per isolate no matter how many callers await it", async () => {
+      const { env, execd } = makeMigrationDb([], rowsAged(1));
+
+      await initializeDatabase(env);
+      const once = execd.length;
+      await Promise.all([initializeDatabase(env), initializeDatabase(env), initializeDatabase(env)]);
+
+      expect(execd).toHaveLength(once);
+    });
+
+    it("shares one in-flight promise across concurrent callers", async () => {
+      const { env, execd } = makeMigrationDb([], rowsAged(1));
+
+      await Promise.all(Array.from({ length: 4 }, () => initializeDatabase(env)));
+
+      expect(execd.filter(s => s.startsWith("CREATE TABLE IF NOT EXISTS entries"))).toHaveLength(1);
+    });
+
+    it("resetDatabaseInit clears the memo so a later call redoes the work", async () => {
+      // Named for what it actually exercises — the test seam, not the failure path. The
+      // rejection tests below are the ones that cover failure.
+      const { env, execd } = makeMigrationDb([], rowsAged(1));
+
+      await initializeDatabase(env);
+      const once = execd.length;
+      resetDatabaseInit();
+      await initializeDatabase(env);
+
+      expect(execd).toHaveLength(once * 2);
+    });
+  });
+
+  // Regression: memoising on *completion* rather than on *success* latched a failed or
+  // half-applied schema for the isolate's lifetime. Before memoisation each nightly job
+  // re-ran the DDL and repaired the previous one's transient failure; these pin that a
+  // failure is still retryable. Most likely trigger is a brand-new brain, where the very
+  // first request must create every table against a D1 database made seconds earlier.
+  describe("failure is not latched", () => {
+    /** DB whose exec fails until `failing` is cleared. */
+    function flakyDb() {
+      const state = { failing: true, execd: [] as string[] };
+      const DB = {
+        async exec(sql: string) {
+          if (state.failing) throw new Error("D1_ERROR: Network connection lost.");
+          state.execd.push(sql);
+        },
+        prepare: () => { throw new Error("unexpected prepare"); },
+      } as unknown as D1Database;
+      return { state, env: makeTestEnv(undefined, { DB }) };
+    }
+
+    it("rejects rather than resolving when the schema could not be applied", async () => {
+      const { env } = flakyDb();
+      await expect(initializeDatabase(env)).rejects.toThrow(/Network connection lost/);
+    });
+
+    it("retries on the next call once D1 recovers", async () => {
+      const { state, env } = flakyDb();
+
+      await expect(initializeDatabase(env)).rejects.toThrow();
+      state.failing = false;
+      await initializeDatabase(env); // no resetDatabaseInit — the memo must have cleared itself
+
+      expect(state.execd.filter(s => s.startsWith("CREATE TABLE IF NOT EXISTS entries"))).toHaveLength(1);
+    });
+
+    it("rejects when a later statement fails, rather than latching a partial schema", async () => {
+      // The edges CREATE fails; entries already exists. Resolving here would leave the
+      // isolate believing a schema with no edges table is complete.
+      const execd: string[] = [];
+      let failEdges = true;
+      const DB = {
+        async exec(sql: string) {
+          if (failEdges && sql.includes("CREATE TABLE IF NOT EXISTS edges")) throw new Error("D1_ERROR: Network connection lost.");
+          execd.push(sql);
+        },
+        prepare: () => { throw new Error("unexpected prepare"); },
+      } as unknown as D1Database;
+      const env = makeTestEnv(undefined, { DB });
+
+      await expect(initializeDatabase(env)).rejects.toThrow();
+      expect(execd.some(s => s.includes("CREATE TABLE IF NOT EXISTS edges"))).toBe(false);
+
+      failEdges = false;
+      await initializeDatabase(env);
+      expect(execd.some(s => s.includes("CREATE TABLE IF NOT EXISTS edges"))).toBe(true);
+    });
+
+    it("still swallows the routine duplicate-column ALTER error", async () => {
+      // The one expected failure: every run after the first. It must NOT reject.
+      const { env } = makeMigrationDb(ALL_COLUMNS, []);
+      await expect(initializeDatabase(env)).resolves.toBeUndefined();
+    });
+
+    it("rejects on an ALTER failure that is not duplicate-column", async () => {
+      const DB = {
+        async exec(sql: string) {
+          if (sql.startsWith("ALTER TABLE entries ADD COLUMN importance_score")) {
+            throw new Error("D1_ERROR: database is locked");
+          }
+        },
+        prepare: () => { throw new Error("unexpected prepare"); },
+      } as unknown as D1Database;
+
+      await expect(initializeDatabase(makeTestEnv(undefined, { DB }))).rejects.toThrow(/database is locked/);
+    });
+  });
+
+  it("applies every missing ALTER on a partially-migrated brain", async () => {
+    const { env, execd, prepared } = makeMigrationDb(["recall_count", "importance_score"], rowsAged(1));
+
+    await initializeDatabase(env);
+
+    for (const [, alter] of MIGRATION) expect(execd).toContain(alter);
+    expect(prepared).toEqual([]);
+  });
+
+  // The backfill this replaced wrote one row per entry. On a 50,000-entry brain that was
+  // half of D1's daily row-write budget in a single statement, and exceeding the cap
+  // fails every query account-wide until 00:00 UTC.
+  it("never backfills, at any brain size", async () => {
+    const { env, execd, prepared, rows } = makeMigrationDb([], rowsAged(50_000));
+
+    await initializeDatabase(env);
+
+    const all = [...execd, ...prepared];
+    expect(all.filter(s => /UPDATE\s+entries/i.test(s))).toEqual([]);
+    expect(all.filter(s => /updated_at IS NULL/i.test(s))).toEqual([]);
+    expect(rows.filter(r => r.updated_at == null)).toHaveLength(50_000);
+  });
+});

--- a/test/unit/render-recall.test.ts
+++ b/test/unit/render-recall.test.ts
@@ -3,7 +3,7 @@ import { renderRecallText } from "../../src/recall/render";
 import type { RecallMatch } from "../../src/recall/types";
 
 function m(over: Partial<RecallMatch> = {}): RecallMatch {
-  return { id: "entry-123", content: "A memory", score: 1, createdAt: 1700000000000, tags: ["work"], source: "claude", isUpdate: false, hop: 0, ...over };
+  return { id: "entry-123", content: "A memory", score: 1, createdAt: 1700000000000, updatedAt: 1700000000000, tags: ["work"], source: "claude", isUpdate: false, hop: 0, ...over };
 }
 
 describe("renderRecallText", () => {

--- a/test/unit/render-stale.test.ts
+++ b/test/unit/render-stale.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { renderRecallText } from "../../src/recall/render";
+import { computeCompoundStale } from "../../src/recall/compound-stale";
+import type { RecallMatch } from "../../src/recall/types";
+
+const AGED_MS = 91 * 86400000;
+
+function match(partial: Partial<RecallMatch> & Pick<RecallMatch, "id">): RecallMatch {
+  const agedAt = Date.now() - AGED_MS;
+  return {
+    content: partial.content ?? "content",
+    score: partial.score ?? 0.8,
+    createdAt: partial.createdAt ?? agedAt,
+    updatedAt: partial.updatedAt ?? agedAt,
+    tags: partial.tags ?? [],
+    source: partial.source ?? "api",
+    isUpdate: partial.isUpdate ?? false,
+    hop: partial.hop ?? 0,
+    staleAsOf: partial.staleAsOf ?? false,
+    ...partial,
+  };
+}
+
+describe("renderRecallText staleness", () => {
+  it("includes as-of qualifier for stale entries", () => {
+    const text = renderRecallText([
+      match({ id: "a", staleAsOf: true, tags: ["stale:as-of"], updatedAt: new Date("2024-01-15").getTime() }),
+    ], "");
+    expect(text).toContain("verify before asserting");
+    expect(text).toContain("true as of");
+  });
+
+  it("prefixes compound stale warning from stale-as-of matches after budget", () => {
+    const text = renderRecallText([
+      match({ id: "a", staleAsOf: true, tags: ["stale:as-of"] }),
+      match({ id: "b", staleAsOf: true, tags: ["stale:as-of"], updatedAt: Date.now() - AGED_MS - 1000 }),
+    ], "");
+    expect(text).toContain("Staleness warning");
+    expect(text).toContain("stale as-of");
+  });
+});
+
+describe("computeCompoundStale", () => {
+  it("returns signal when two or more stale-as-of matches are 90+ days old", () => {
+    const aged = Date.now() - AGED_MS;
+    const signal = computeCompoundStale([
+      match({ id: "a", staleAsOf: true, updatedAt: aged }),
+      match({ id: "b", staleAsOf: true, updatedAt: aged - 1000 }),
+    ]);
+    expect(signal).toEqual({ count: 2, oldestUpdatedAt: aged - 1000 });
+  });
+
+  it("returns undefined for aged matches without stale-as-of flag", () => {
+    const aged = Date.now() - AGED_MS;
+    expect(computeCompoundStale([
+      match({ id: "a", updatedAt: aged }),
+      match({ id: "b", updatedAt: aged - 1000 }),
+    ])).toBeUndefined();
+  });
+
+  it("returns undefined for a single aged match", () => {
+    expect(computeCompoundStale([match({ id: "a" })])).toBeUndefined();
+  });
+
+  it("ignores fresh matches", () => {
+    expect(computeCompoundStale([
+      match({ id: "a", updatedAt: Date.now() - 10 * 86400000 }),
+      match({ id: "b", updatedAt: Date.now() - 20 * 86400000 }),
+    ])).toBeUndefined();
+  });
+});

--- a/test/unit/rerank-config.test.ts
+++ b/test/unit/rerank-config.test.ts
@@ -21,9 +21,9 @@ describe("rerankWithTimeDecay() config threading", () => {
   it("applies the volatile floor from the passed config to an aged task", async () => {
     const matches = [match("t", 1.0, ["task"])];
 
-    const withDefaults = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), DEFAULTS);
+    const withDefaults = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), new Map(), DEFAULTS);
     const withHighFloor = rerankWithTimeDecay(
-      matches, new Map(), new Map(), [], new Map(), new Map(),
+      matches, new Map(), new Map(), [], new Map(), new Map(), new Map(),
       { ...DEFAULTS, RECENCY_FLOOR_VOLATILE: 1.0 },
     );
 
@@ -37,11 +37,11 @@ describe("rerankWithTimeDecay() config threading", () => {
     const queryTags = ["work", "second-brain", "recall"];
 
     const capped = rerankWithTimeDecay(
-      matches, new Map(), new Map(), queryTags, new Map(), new Map(),
+      matches, new Map(), new Map(), queryTags, new Map(), new Map(), new Map(),
       { ...DEFAULTS, TAG_BOOST_MAX: 1.0 },
     );
     const uncapped = rerankWithTimeDecay(
-      matches, new Map(), new Map(), queryTags, new Map(), new Map(),
+      matches, new Map(), new Map(), queryTags, new Map(), new Map(), new Map(),
       { ...DEFAULTS, TAG_BOOST_MAX: 5.0, TAG_BOOST_STEP: 0.5 },
     );
 
@@ -52,7 +52,7 @@ describe("rerankWithTimeDecay() config threading", () => {
     const matches = [match("t", 1.0, ["task"])];
 
     const implicit = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map());
-    const explicit = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), DEFAULTS);
+    const explicit = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), new Map(), DEFAULTS);
 
     expect(implicit[0].score).toBe(explicit[0].score);
   });
@@ -73,8 +73,8 @@ describe("rerankWithTimeDecay() config threading", () => {
       const matches = [match("a", 0.9, ["work"]), match("b", 0.8, ["task"])];
       const snapshot = JSON.parse(JSON.stringify(matches));
 
-      const first = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), DEFAULTS);
-      const second = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), DEFAULTS);
+      const first = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), new Map(), DEFAULTS);
+      const second = rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), new Map(), DEFAULTS);
 
       expect(first.map(m => [m.id, m.score])).toEqual(second.map(m => [m.id, m.score]));
       expect(JSON.parse(JSON.stringify(matches))).toEqual(snapshot);
@@ -88,7 +88,7 @@ describe("rerankWithTimeDecay() config threading", () => {
   it("keeps ordering stable across calls even as the clock advances", async () => {
     const matches = [match("a", 0.9, ["work"]), match("b", 0.8, ["task"])];
     const ids = () =>
-      rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), DEFAULTS)
+      rerankWithTimeDecay(matches, new Map(), new Map(), [], new Map(), new Map(), new Map(), DEFAULTS)
         .map(m => m.id);
     expect(ids()).toEqual(ids());
   });

--- a/test/unit/rerank.test.ts
+++ b/test/unit/rerank.test.ts
@@ -224,4 +224,43 @@ describe("rerankWithTimeDecay", () => {
     ], new Map());
     expect(result[0].id).toBe("canonical");
   });
+
+  it("volatility:volatile floor beats ordinary old memory", () => {
+    const age = NOW - 365 * MS_DAY;
+    const [volatile] = rerankWithTimeDecay([match("v", 1.0, age, ["volatility:volatile"])], new Map());
+    const [state] = rerankWithTimeDecay([match("s", 1.0, age, ["volatility:state"])], new Map());
+    expect(state.score).toBeGreaterThan(volatile.score);
+  });
+
+  it("status:canonical durable floor overrides volatility:volatile", () => {
+    const age = NOW - 365 * MS_DAY;
+    const [canonicalVolatile] = rerankWithTimeDecay(
+      [match("cv", 0.8, age, ["status:canonical", "volatility:volatile"])],
+      new Map(),
+    );
+    const [ordinary] = rerankWithTimeDecay(
+      [match("plain", 0.8, age)],
+      new Map(),
+    );
+    expect(canonicalVolatile.score).toBeGreaterThan(ordinary.score);
+  });
+
+  it("prefers D1 tags over Vectorize metadata for recency floor", () => {
+    const age = NOW - 365 * MS_DAY;
+    const d1Tags = new Map<string, string[]>([["cv", ["volatility:volatile"]]]);
+    const [withD1Volatile] = rerankWithTimeDecay(
+      [match("cv", 0.8, age, ["status:canonical"])],
+      new Map(),
+      new Map(),
+      [],
+      new Map(),
+      new Map(),
+      d1Tags,
+    );
+    const [canonicalMeta] = rerankWithTimeDecay(
+      [match("cv2", 0.8, age, ["status:canonical"])],
+      new Map(),
+    );
+    expect(withD1Volatile.score).toBeLessThan(canonicalMeta.score);
+  });
 });

--- a/test/unit/runtime-state.test.ts
+++ b/test/unit/runtime-state.test.ts
@@ -1,0 +1,103 @@
+/**
+ * ensureDbReady must not latch the ready flag on a failed init.
+ *
+ * This is the same shape as the defect in db/init.ts: rejection handling that nothing
+ * exercises. If the .catch here set dbReady = true, the isolate would spend the rest of
+ * its life believing a schema it never applied is in place — and, exactly as before, no
+ * behavioural test elsewhere would notice, because every assertion about a *successful*
+ * init passes either way.
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { ensureDbReady, isDbReady, setDbReady } from "../../src/runtime/state";
+import { resetDatabaseInit } from "../../src/db/init";
+import { makeTestDb, makeTestEnv } from "../helpers/make-env";
+
+/** Captures what ensureDbReady hands to waitUntil, so the test can await and inspect it. */
+function capturingCtx() {
+  const pending: Promise<unknown>[] = [];
+  return {
+    ctx: { waitUntil: (p: Promise<unknown>) => pending.push(p) } as unknown as ExecutionContext,
+    pending,
+  };
+}
+
+function failingEnv() {
+  const DB = {
+    async exec() { throw new Error("D1_ERROR: Network connection lost."); },
+    prepare: () => { throw new Error("unexpected prepare"); },
+  } as unknown as D1Database;
+  return makeTestEnv(undefined, { DB });
+}
+
+describe("ensureDbReady", () => {
+  beforeEach(() => {
+    setDbReady(false);
+    resetDatabaseInit();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("marks the database ready once the schema is applied", async () => {
+    const { ctx, pending } = capturingCtx();
+
+    ensureDbReady(ctx, makeTestEnv(makeTestDb()));
+    await Promise.all(pending);
+
+    expect(isDbReady()).toBe(true);
+  });
+
+  it("leaves the database not-ready when init fails, so the next request retries", async () => {
+    const { ctx, pending } = capturingCtx();
+
+    ensureDbReady(ctx, failingEnv());
+    await Promise.all(pending);
+
+    expect(isDbReady()).toBe(false);
+  });
+
+  it("swallows the failure rather than leaking an unhandled rejection into waitUntil", async () => {
+    const { ctx, pending } = capturingCtx();
+
+    ensureDbReady(ctx, failingEnv());
+
+    expect(pending).toHaveLength(1);
+    await expect(pending[0]).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("recovers: a later successful init flips it ready", async () => {
+    const first = capturingCtx();
+    ensureDbReady(first.ctx, failingEnv());
+    await Promise.all(first.pending);
+    expect(isDbReady()).toBe(false);
+
+    // No resetDatabaseInit here on purpose — this also pins that the memo in db/init.ts
+    // cleared itself on rejection, which is what makes the retry reach the database.
+    const second = capturingCtx();
+    ensureDbReady(second.ctx, makeTestEnv(makeTestDb()));
+    await Promise.all(second.pending);
+
+    expect(isDbReady()).toBe(true);
+  });
+
+  it("does no work once the database is already ready", async () => {
+    setDbReady(true);
+    const { ctx, pending } = capturingCtx();
+
+    ensureDbReady(ctx, failingEnv()); // would throw if it touched the database
+
+    expect(pending).toEqual([]);
+    expect(isDbReady()).toBe(true);
+  });
+});
+
+describe("dbReady flag", () => {
+  afterEach(() => { setDbReady(false); });
+
+  it("round-trips through setDbReady/isDbReady", () => {
+    setDbReady(true);
+    expect(isDbReady()).toBe(true);
+    setDbReady(false);
+    expect(isDbReady()).toBe(false);
+  });
+});

--- a/test/unit/staleness-heuristic.test.ts
+++ b/test/unit/staleness-heuristic.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { classifyVolatility, shouldFlagStale } from "../../src/staleness/heuristic";
+
+describe("classifyVolatility", () => {
+  it("marks birthdays as durable", () => {
+    expect(classifyVolatility("Alice's birthday is March 12")).toBe("durable");
+  });
+
+  it("marks employment as state", () => {
+    expect(classifyVolatility("Bob works at Acme Corp as a PM")).toBe("state");
+  });
+
+  it("marks task tag as volatile", () => {
+    expect(classifyVolatility("Finish the report", ["task"])).toBe("volatile");
+  });
+
+  it("returns null when uncertain", () => {
+    expect(classifyVolatility("Some random note without clear signals")).toBeNull();
+  });
+
+  it("does not false-positive on email addresses", () => {
+    expect(classifyVolatility("Send the report to alice@example.com by Friday")).toBeNull();
+  });
+
+  it("does not false-positive on scheduled handler mentions", () => {
+    expect(classifyVolatility("The scheduled handler runs compression nightly")).toBeNull();
+  });
+
+  it("does not false-positive on API paths", () => {
+    expect(classifyVolatility("GET /api/v1/recall?query=test")).toBeNull();
+  });
+});
+
+describe("shouldFlagStale", () => {
+  it("flags state and volatile only", () => {
+    expect(shouldFlagStale("state")).toBe(true);
+    expect(shouldFlagStale("volatile")).toBe(true);
+    expect(shouldFlagStale("durable")).toBe(false);
+    expect(shouldFlagStale(null)).toBe(false);
+  });
+});

--- a/test/unit/staleness-pass.test.ts
+++ b/test/unit/staleness-pass.test.ts
@@ -150,9 +150,15 @@ describe("runStalenessPass", () => {
 
     await runStalenessPass(env, {} as ExecutionContext);
 
-    const tags: string[] = JSON.parse(db.entries.find(e => e.id === "user-vol")!.tags);
+    const row = db.entries.find(e => e.id === "user-vol")!;
+    const tags: string[] = JSON.parse(row.tags);
     expect(tags).toContain("volatility:volatile");
     expect(tags).not.toContain("volatility:durable");
+    // The seeded tag surviving proves nothing on its own — a pass that did nothing at all
+    // would satisfy that. Pin evidence that the row was actually processed and written:
+    // volatile entries get flagged, and the cursor advanced.
+    expect(tags).toContain("stale:as-of");
+    expect(row.staleness_checked_at).toBeGreaterThan(0);
   });
 
   it("advances staleness_checked_at even when classification is null", async () => {
@@ -218,6 +224,200 @@ describe("runStalenessPass", () => {
 
     const tags: string[] = JSON.parse(db.entries.find(e => e.id === "task-entry")!.tags);
     expect(tags).toContain("volatility:volatile");
+    expect(tags).toContain("stale:as-of");
+  });
+});
+
+// A free-plan Worker invocation gets 50 subrequests, and every D1 statement spends one.
+// The nightly cron already runs several jobs against that budget, so the staleness pass
+// has to be cheap or it never gets to run at all on a free deployment.
+describe("runStalenessPass D1 round-trip cost", () => {
+  const SUBREQUEST_BUDGET = 50;
+
+  function countingEnv(db: D1Mock) {
+    const prepared: string[] = [];
+    const execd: string[] = [];
+    const DB = {
+      prepare(sql: string) { prepared.push(sql); return db.prepare(sql); },
+      exec(sql: string) { execd.push(sql); return db.exec(sql); },
+      batch: (stmts: any[]) => db.batch(stmts),
+    } as unknown as D1Database;
+    return { env: makeTestEnv(db, { DB }), prepared, execd };
+  }
+
+  function seedAged(db: D1Mock, n: number) {
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    for (let i = 0; i < n; i++) {
+      db.entries.push({
+        id: `job-${i}`,
+        content: `Person ${i} works at Company ${i}`,
+        tags: "[]",
+        source: "api",
+        created_at: old + i,
+        updated_at: old + i,
+        vector_ids: "[]",
+      });
+    }
+  }
+
+  it("re-reads no tags it already selected", async () => {
+    const db = makeTestDb();
+    seedAged(db, STALENESS_PASS_LIMIT);
+    const { env, prepared } = countingEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    // The candidate query already returned tags for all 25 rows; a per-row SELECT is
+    // pure duplication. Optimistic concurrency is preserved by the CAS guard instead.
+    expect(prepared.filter(s => s.startsWith("SELECT tags, content FROM entries WHERE id = ?"))).toEqual([]);
+    expect(db.entries.filter(e => e.staleness_checked_at != null)).toHaveLength(STALENESS_PASS_LIMIT);
+  });
+
+  it("spends nothing per row beyond the write it has to make", async () => {
+    const db = makeTestDb();
+    seedAged(db, STALENESS_PASS_LIMIT);
+    const { env, prepared, execd } = countingEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    // One candidate query plus one CAS write per entry — nothing per-row on the read side.
+    expect(prepared.filter(s => s.includes("COALESCE(updated_at, created_at) <"))).toHaveLength(1);
+    expect(prepared.filter(s => s.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")))
+      .toHaveLength(STALENESS_PASS_LIMIT);
+    // The pass's own cost: 1 candidate query + 25 CAS writes. The DDL is not counted
+    // here because it is memoised across the whole invocation — see the cron budget test
+    // in test/unit/cron-subrequest-budget.test.ts, which is where the 50 actually binds.
+    expect(prepared).toHaveLength(STALENESS_PASS_LIMIT + 1);
+    expect(execd.length).toBeLessThanOrEqual(SUBREQUEST_BUDGET);
+  });
+
+  // The classification is derived from content, but the tag mutation is a no-op for an
+  // entry carrying neither a volatility: nor a stale:as-of tag — the common case. Without
+  // content in the CAS guard, a concurrent rewrite would leave tags identical, the CAS
+  // would succeed, and the pass would commit a verdict about content that no longer
+  // exists. It does not self-correct: the concurrent write bumps updated_at past the
+  // 90-day cutoff, so the row drops out of future passes still wrongly flagged.
+  it("does not flag an entry whose content was rewritten mid-pass", async () => {
+    const db = makeTestDb();
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "rewritten",
+      content: "Alice works at Acme Corp", // volatility:state — would be flagged stale
+      tags: "[]",
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    const { env } = countingEnv(db);
+    const original = db.prepare.bind(db);
+    let rewritten = false;
+    (db as any).prepare = (sql: string) => {
+      // Land the concurrent rewrite between the candidate query and the CAS write.
+      if (!rewritten && sql.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")) {
+        rewritten = true;
+        db.entries[0].content = "Birthday is March 12"; // now durable
+        db.entries[0].updated_at = Date.now();
+      }
+      return original(sql);
+    };
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const tags: string[] = JSON.parse(db.entries[0].tags);
+    expect(tags).not.toContain("stale:as-of");
+    expect(tags).not.toContain("volatility:state");
+    // The retry re-read the fresh content and classified that instead.
+    expect(tags).toContain("volatility:durable");
+  });
+
+  it("re-reads both fields when content and tags change together mid-pass", async () => {
+    const db = makeTestDb();
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "both",
+      content: "Alice works at Acme Corp",
+      tags: '["work"]',
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    const { env } = countingEnv(db);
+    const original = db.prepare.bind(db);
+    let raced = false;
+    (db as any).prepare = (sql: string) => {
+      if (!raced && sql.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")) {
+        raced = true;
+        db.entries[0].content = "Birthday is March 12";
+        db.entries[0].tags = '["personal"]';
+        db.entries[0].updated_at = Date.now();
+      }
+      return original(sql);
+    };
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const tags: string[] = JSON.parse(db.entries[0].tags);
+    expect(tags).toContain("personal");       // the concurrent tag write survived
+    expect(tags).not.toContain("work");       // and was not clobbered by the stale snapshot
+    expect(tags).toContain("volatility:durable");
+    expect(tags).not.toContain("stale:as-of");
+  });
+
+  // The candidate query orders by COALESCE(staleness_checked_at, 0) ASC, so a row left
+  // with a NULL cursor sorts first on every subsequent pass — permanently occupying one
+  // of the 25 slots. A row that loses every CAS attempt must still have its cursor moved.
+  it("advances the cursor even when every CAS attempt is lost", async () => {
+    const db = makeTestDb();
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "hot",
+      content: "Alice works at Acme Corp",
+      tags: "[]",
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    const { env } = countingEnv(db);
+    const original = db.prepare.bind(db);
+    let rewrites = 0;
+    (db as any).prepare = (sql: string) => {
+      // Rewrite before every attempt, so no CAS can ever land.
+      if (sql.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")) {
+        db.entries[0].content = `rewritten ${++rewrites}`;
+      }
+      return original(sql);
+    };
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    expect(rewrites).toBeGreaterThanOrEqual(3); // all attempts consumed
+    expect(db.entries[0].staleness_checked_at).toBeGreaterThan(0);
+  });
+
+  it("still re-reads tags when a concurrent write makes the CAS lose", async () => {
+    const db = makeTestDb();
+    seedAged(db, 1);
+    const { env, prepared } = countingEnv(db);
+    // Flip the row's tags out from under the pass on the first CAS attempt, exactly as a
+    // concurrent writer would. The retry must go back to the database for fresh tags.
+    const original = db.prepare.bind(db);
+    let flipped = false;
+    (db as any).prepare = (sql: string) => {
+      if (!flipped && sql.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")) {
+        flipped = true;
+        db.entries[0].tags = '["touched-by-someone-else"]';
+      }
+      return original(sql);
+    };
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    expect(prepared.filter(s => s.startsWith("SELECT tags, content FROM entries WHERE id = ?"))).toHaveLength(1);
+    const tags: string[] = JSON.parse(db.entries[0].tags);
+    expect(tags).toContain("touched-by-someone-else"); // retry built on the fresh tags
     expect(tags).toContain("stale:as-of");
   });
 });

--- a/test/unit/staleness-pass.test.ts
+++ b/test/unit/staleness-pass.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { runStalenessPass, STALENESS_AGE_MS, STALENESS_PASS_LIMIT } from "../../src/staleness/pass";
+import { makeTestDb, makeTestEnv } from "../helpers/make-env";
+import { D1Mock } from "../helpers/d1-mock";
+
+describe("runStalenessPass", () => {
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+  });
+
+  it("flags state entries older than threshold with stale:as-of", async () => {
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "job",
+      content: "Alice works at Acme Corp",
+      tags: "[]",
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    const env = makeTestEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const row = db.entries.find(e => e.id === "job")!;
+    const tags: string[] = JSON.parse(row.tags);
+    expect(tags).toContain("volatility:state");
+    expect(tags).toContain("stale:as-of");
+  });
+
+  it("does not flag durable entries", async () => {
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "bday",
+      content: "Birthday is March 12",
+      tags: "[]",
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    const env = makeTestEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const tags: string[] = JSON.parse(db.entries.find(e => e.id === "bday")!.tags);
+    expect(tags).toContain("volatility:durable");
+    expect(tags).not.toContain("stale:as-of");
+  });
+
+  it("skips entries newer than STALENESS_AGE_MS", async () => {
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    const recent = Date.now() - 7 * 86400000;
+    db.entries.push(
+      {
+        id: "old-job",
+        content: "Alice works at Acme Corp",
+        tags: "[]",
+        source: "api",
+        created_at: old,
+        updated_at: old,
+        vector_ids: "[]",
+      },
+      {
+        id: "recent-job",
+        content: "Bob works at Beta Inc",
+        tags: "[]",
+        source: "api",
+        created_at: recent,
+        updated_at: recent,
+        vector_ids: "[]",
+      },
+    );
+    const env = makeTestEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const oldTags: string[] = JSON.parse(db.entries.find(e => e.id === "old-job")!.tags);
+    const recentTags: string[] = JSON.parse(db.entries.find(e => e.id === "recent-job")!.tags);
+    expect(oldTags).toContain("stale:as-of");
+    expect(recentTags).not.toContain("stale:as-of");
+    expect(recentTags).not.toContain("volatility:state");
+  });
+
+  it(`processes at most STALENESS_PASS_LIMIT (${STALENESS_PASS_LIMIT}) entries per run`, async () => {
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    for (let i = 0; i < 30; i++) {
+      db.entries.push({
+        id: `job-${i}`,
+        content: `Person ${i} works at Company ${i}`,
+        tags: "[]",
+        source: "api",
+        created_at: old + i,
+        updated_at: old + i,
+        vector_ids: "[]",
+      });
+    }
+    const env = makeTestEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const flagged = db.entries.filter(e => {
+      const tags: string[] = JSON.parse(e.tags);
+      return tags.includes("stale:as-of");
+    });
+    expect(flagged).toHaveLength(STALENESS_PASS_LIMIT);
+    const unprocessed = db.entries.filter(e => {
+      const tags: string[] = JSON.parse(e.tags);
+      return !tags.includes("stale:as-of");
+    });
+    expect(unprocessed).toHaveLength(30 - STALENESS_PASS_LIMIT);
+  });
+
+  it("clears stale:as-of when reclassified as durable", async () => {
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "bday-stale",
+      content: "Birthday is March 12",
+      tags: '["stale:as-of"]',
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    const env = makeTestEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const tags: string[] = JSON.parse(db.entries.find(e => e.id === "bday-stale")!.tags);
+    expect(tags).toContain("volatility:durable");
+    expect(tags).not.toContain("stale:as-of");
+  });
+
+  it("does not overwrite existing volatility tag", async () => {
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "user-vol",
+      content: "Birthday is March 12",
+      tags: '["volatility:volatile"]',
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    const env = makeTestEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const tags: string[] = JSON.parse(db.entries.find(e => e.id === "user-vol")!.tags);
+    expect(tags).toContain("volatility:volatile");
+    expect(tags).not.toContain("volatility:durable");
+  });
+
+  it("advances staleness_checked_at even when classification is null", async () => {
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "uncertain",
+      content: "Some random note without clear signals",
+      tags: "[]",
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    const env = makeTestEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const row = db.entries.find(e => e.id === "uncertain")!;
+    expect(row.staleness_checked_at).toBeGreaterThan(0);
+    const tags: string[] = JSON.parse(row.tags);
+    expect(tags).not.toContain("volatility:state");
+    expect(tags).not.toContain("stale:as-of");
+  });
+
+  it("convergence: two passes inspect more than 25 entries total", async () => {
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    for (let i = 0; i < 30; i++) {
+      db.entries.push({
+        id: `job-${i}`,
+        content: `Person ${i} works at Company ${i}`,
+        tags: "[]",
+        source: "api",
+        created_at: old + i,
+        updated_at: old + i,
+        vector_ids: "[]",
+      });
+    }
+    const env = makeTestEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+    const afterFirst = db.entries.filter(e => e.staleness_checked_at != null).length;
+    expect(afterFirst).toBe(STALENESS_PASS_LIMIT);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+    const afterSecond = db.entries.filter(e => e.staleness_checked_at != null).length;
+    expect(afterSecond).toBeGreaterThan(25);
+  });
+
+  it("flags volatile (task) entries with stale:as-of", async () => {
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "task-entry",
+      content: "Finish the quarterly report",
+      tags: '["task"]',
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    const env = makeTestEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const tags: string[] = JSON.parse(db.entries.find(e => e.id === "task-entry")!.tags);
+    expect(tags).toContain("volatility:volatile");
+    expect(tags).toContain("stale:as-of");
+  });
+});
+
+describe("scheduled handler staleness wiring", () => {
+  it("runs staleness pass alongside other nightly jobs", async () => {
+    const db = makeTestDb();
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "job",
+      content: "Bob works at Example Inc",
+      tags: "[]",
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    const env = makeTestEnv(db, { VECTORIZE: { query: vi.fn(), getByIds: vi.fn(), upsert: vi.fn(), insert: vi.fn(), deleteByIds: vi.fn() } as any });
+    const pending: Promise<any>[] = [];
+    const ctx = { waitUntil: (p: Promise<any>) => pending.push(p) } as any;
+
+    await (worker as any).scheduled({} as any, env, ctx);
+    await Promise.allSettled(pending);
+
+    const tags: string[] = JSON.parse(db.entries.find(e => e.id === "job")!.tags);
+    expect(tags).toContain("stale:as-of");
+  });
+});

--- a/test/unit/updated-at-coalesced.test.ts
+++ b/test/unit/updated-at-coalesced.test.ts
@@ -1,0 +1,252 @@
+/**
+ * entries.updated_at nullability guard.
+ *
+ * The column is added by a runtime ALTER (src/db/init.ts) and is deliberately never
+ * backfilled, so every row that predates the staleness feature reads NULL forever. That
+ * is safe only while every reader coalesces it to created_at — a reader that stops is
+ * not a type error and not a test failure anywhere else, it just silently misbehaves on
+ * old memories. `ORDER BY updated_at DESC` is the sharp edge: SQLite sorts NULL first,
+ * so descending order puts every never-updated row last, behind rows from 1970.
+ *
+ * So this classifies every occurrence of the column by its syntactic position rather
+ * than pattern-matching whole statements — a substring allow-list exempts the entire
+ * literal, which lets a raw read ride along inside an otherwise-legitimate write.
+ *
+ * Scope is src/. The dashboard (public/js/) reads updated_at only from API responses,
+ * which are already coalesced server-side by the rules enforced here.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join, relative } from "node:path";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+
+// Every source extension that could hold a query, not just .ts — a .js/.mjs helper under
+// src/ would otherwise be skipped silently.
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".js", ".mjs", ".cjs", ".jsx"];
+
+function allSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...allSourceFiles(p));
+    else if (SOURCE_EXTENSIONS.some(ext => entry.name.endsWith(ext))) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * The single literal permitted to select the column bare, because the TypeScript that
+ * consumes its rows coalesces at the boundary (`?? row.created_at`). Scoped to this one
+ * statement: exempting the whole file would wave through the next query added to it.
+ */
+const HYDRATION_EXEMPTION = {
+  file: "src/recall/search.ts",
+  marker: "SELECT id, content, tags, source, created_at, updated_at FROM entries WHERE id IN",
+};
+
+type Finding = { kind: string; detail: string };
+
+/** SQL string literals in a source file, normalised to one line. */
+function sqlLiterals(source: string): string[] {
+  return [...source.matchAll(/`([^`]*)`/g)]
+    .map(m => m[1].replace(/\s+/g, " ").trim())
+    .filter(s => /\bupdated_at\b/.test(s));
+}
+
+function spans(sql: string, re: RegExp): [number, number][] {
+  return [...sql.matchAll(re)].map(m => [m.index!, m.index! + m[0].length] as [number, number]);
+}
+const inAny = (i: number, ranges: [number, number][]) => ranges.some(([a, b]) => i >= a && i < b);
+
+/**
+ * Classifies each `updated_at` occurrence in one SQL literal and returns the raw reads.
+ * A raw read is any occurrence that is not a declaration, not an INSERT column-list
+ * target, not a SET assignment target, and not wrapped in COALESCE(updated_at, created_at).
+ */
+function rawSqlReads(sql: string, relPath: string): Finding[] {
+  // Only `edges` statements are exempt by table — that column is declared NOT NULL, so it
+  // can never be NULL. A fragment naming NO table is NOT exempt: `ORDER BY updated_at
+  // DESC` assigned to a constant and interpolated into a query elsewhere is the single
+  // most likely way this bug gets reintroduced, and it names no table at all.
+  if (/\bedges\b/.test(sql) && !/\bentries\b/.test(sql)) return [];
+
+  const declarations = spans(sql, /ADD\s+COLUMN\s+updated_at/gi);
+  // COALESCE or the equivalent IFNULL, with or without a table qualifier — a JOIN forces
+  // qualified names, and rejecting them would block correct code.
+  const coalesced = spans(
+    sql,
+    /(?:COALESCE|IFNULL)\s*\(\s*(?:\w+\s*\.\s*)?updated_at\s*,\s*(?:\w+\s*\.\s*)?created_at\s*\)/gi,
+  );
+  // The parenthesised column list of an INSERT — names the target, never reads a value.
+  const insertColumns = spans(sql, /INSERT(?:\s+OR\s+\w+)?\s+INTO\s+entries\s*\([^)]*\)/gi);
+  // The SET clause of an UPDATE, up to WHERE. Assignment targets live here; the WHERE
+  // that follows does not, which is what makes `SET updated_at = ? WHERE updated_at < ?`
+  // resolve to one write and one raw read rather than being exempted wholesale.
+  const setClauses = spans(sql, /\bSET\b[\s\S]*?(?=\bWHERE\b|$)/gi);
+
+  const findings: Finding[] = [];
+  for (const m of sql.matchAll(/\bupdated_at\b/g)) {
+    const i = m.index!;
+    if (inAny(i, declarations) || inAny(i, coalesced) || inAny(i, insertColumns)) continue;
+    // In a SET clause and followed by `=` — an assignment target.
+    if (inAny(i, setClauses) && /^\s*=/.test(sql.slice(i + "updated_at".length))) continue;
+    if (relPath === HYDRATION_EXEMPTION.file && sql.includes(HYDRATION_EXEMPTION.marker)) continue;
+
+    const at = sql.slice(Math.max(0, i - 45), i + 45);
+    const clause = /\bORDER\s+BY\b/i.test(sql.slice(0, i)) ? "ORDER BY"
+      : /\bWHERE\b/i.test(sql.slice(0, i)) ? "WHERE"
+        : "projection";
+    findings.push({ kind: `raw read in ${clause}`, detail: `…${at}…` });
+  }
+  return findings;
+}
+
+/**
+ * TypeScript reads of a raw D1 row column: `row.updated_at`, `row["updated_at"]`, and
+ * `{ updated_at }` destructuring. Object-literal keys (`updated_at: value`) are writes
+ * into a response shape, not reads, so they are excluded. SQL literals and comments are
+ * stripped first so column references inside them are not double-counted here.
+ */
+function rawTsReads(source: string): { text: string; coalesced: boolean }[] {
+  const code = source
+    .replace(/`[^`]*`/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter(l => !l.trim().startsWith("//") && !l.trim().startsWith("*"))
+    .join("\n");
+
+  const out: { text: string; coalesced: boolean }[] = [];
+  for (const m of code.matchAll(/\bupdated_at\b/g)) {
+    const at = m.index! + "updated_at".length;
+    const after = code.slice(at);
+    if (/^\s*:/.test(after)) continue; // object-literal key, not a read
+    // The fallback has to be attached to THIS read. A created_at mention anywhere on the
+    // line is not enough: an adjacent field in the same object literal, or a sort
+    // tiebreaker, satisfies that while coalescing nothing. Require `?? … created_at`
+    // close by — and specifically `??`, since `||` is not null-coalescing.
+    const coalesced = /^[\s\S]{0,80}?\?\?[\s\S]{0,60}?created_at/.test(after);
+    out.push({ text: code.slice(Math.max(0, m.index! - 60), at + 60).replace(/\s+/g, " ").trim(), coalesced });
+  }
+  return out;
+}
+
+describe("entries.updated_at is never read without a created_at fallback", () => {
+  const files = allSourceFiles(resolve(ROOT, "src"));
+
+  it("no SQL in src/ reads entries.updated_at outside COALESCE", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const rel = relative(ROOT, file);
+      for (const sql of sqlLiterals(readFileSync(file, "utf8"))) {
+        for (const f of rawSqlReads(sql, rel)) offenders.push(`${rel} — ${f.kind}: ${f.detail}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("every TypeScript read of a raw updated_at column falls back to created_at", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      for (const read of rawTsReads(readFileSync(file, "utf8"))) {
+        if (read.coalesced) continue;
+        offenders.push(`${relative(ROOT, file)} — uncoalesced read: ${read.text.slice(0, 110)}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("initializeDatabase never reads or writes entries.updated_at", () => {
+    // The column is migrated by ALTER alone — no backfill, no probe. Anything else here
+    // runs on every cold isolate against an unindexed column.
+    const init = readFileSync(resolve(ROOT, "src/db/init.ts"), "utf8");
+    for (const sql of sqlLiterals(init)) {
+      if (!/\bentries\b/.test(sql)) continue;
+      expect(sql).toBe("ALTER TABLE entries ADD COLUMN updated_at INTEGER");
+    }
+    expect(init).not.toMatch(/SET updated_at = created_at/);
+  });
+
+  it("the exempted hydration literal still exists and its consumer still coalesces", () => {
+    // If a refactor moves or renames it, the exemption must be revisited rather than
+    // silently protecting nothing.
+    const search = readFileSync(resolve(ROOT, HYDRATION_EXEMPTION.file), "utf8");
+    expect(sqlLiterals(search).some(s => s.includes(HYDRATION_EXEMPTION.marker))).toBe(true);
+    const tsReads = rawTsReads(search);
+    expect(tsReads.length).toBeGreaterThan(0);
+    expect(tsReads.every(r => r.coalesced)).toBe(true);
+  });
+
+  // The guard is only worth having if it catches the constructs that motivated it.
+  // These are the bypasses an earlier substring-based version waved through.
+  describe("guard self-tests", () => {
+    const OTHER = "src/somewhere/else.ts";
+
+    it.each([
+      ["ORDER BY, in the exempted file — NULLs sort last on DESC",
+        HYDRATION_EXEMPTION.file,
+        "SELECT id, content, updated_at FROM entries ORDER BY updated_at DESC LIMIT ?"],
+      ["bare projection in a non-exempt file",
+        OTHER,
+        "SELECT id, content, updated_at FROM entries WHERE id = ?"],
+      ["raw read in the WHERE of an otherwise-legitimate write",
+        OTHER,
+        "UPDATE entries SET updated_at = ? WHERE updated_at < ?"],
+      ["INSERT ... SELECT copying the column through",
+        OTHER,
+        "INSERT INTO entries (id, content, updated_at) SELECT id, content, updated_at FROM entries"],
+      ["WHERE updated_at IS NULL probe",
+        OTHER,
+        "SELECT 1 AS n FROM entries WHERE updated_at IS NULL LIMIT 1"],
+      // Fragments that name no table at all. These are the realistic way the ORDER BY
+      // bug returns — a sort constant or a dynamically appended clause — and an earlier
+      // version of this guard dropped every one of them before classification.
+      ["a bare ORDER BY constant", OTHER, "ORDER BY updated_at DESC"],
+      ["a dynamically appended sort clause", OTHER, " ORDER BY updated_at DESC"],
+      ["an exported sort fragment with a tiebreaker", OTHER, "ORDER BY updated_at DESC, id ASC"],
+      ["a bare column name used as a sort key", OTHER, "updated_at"],
+    ])("flags: %s", (_label, file, sql) => {
+      expect(rawSqlReads(sql, file)).not.toEqual([]);
+    });
+
+    it.each([
+      ["the ALTER that creates the column", "ALTER TABLE entries ADD COLUMN updated_at INTEGER"],
+      ["a COALESCEd read", "SELECT id FROM entries WHERE COALESCE(updated_at, created_at) < ?"],
+      ["a plain write", "UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?"],
+      ["a write whose column order differs", "UPDATE entries SET importance_score = ?, updated_at = ? WHERE id = ?"],
+      ["INSERT OR REPLACE naming the column", "INSERT OR REPLACE INTO entries (id, content, updated_at) VALUES (?, ?, ?)"],
+      ["an INSERT column list", "INSERT INTO entries (id, content, tags, source, created_at, updated_at, vector_ids) VALUES (?, ?, ?, ?, ?, ?, ?)"],
+      ["the edges table's own NOT NULL column", "DELETE FROM edges WHERE provenance = 'inferred' AND weight < ? AND updated_at < ?"],
+      // Correct code a stricter matcher would wrongly reject.
+      ["a table-qualified COALESCE, as any JOIN forces", "SELECT e.id FROM entries e JOIN edges g ON g.source_id = e.id WHERE COALESCE(e.updated_at, e.created_at) < ?"],
+      ["IFNULL, the idiomatic SQLite equivalent", "SELECT id FROM entries WHERE IFNULL(updated_at, created_at) < ?"],
+    ])("allows: %s", (_label, sql) => {
+      expect(rawSqlReads(sql, OTHER)).toEqual([]);
+    });
+
+    it.each([
+      ["bracket access", `return row["updated_at"];`],
+      ["destructured read", `const { updated_at } = row;`],
+      ["destructured in a callback", `results.map(({ updated_at }) => updated_at);`],
+      ["property access", `const v = row.updated_at;`],
+      // Co-occurrence on the same line is not coalescing — these are the two shapes an
+      // earlier version of this guard exempted by looking for created_at anywhere.
+      ["a sibling field in the same object literal", `return { id: row.id, createdAt: row.created_at, updatedAt: row.updated_at };`],
+      ["a sort with a created_at tiebreaker", `rows.sort((a, b) => (b.updated_at - a.updated_at) || (b.created_at - a.created_at));`],
+    ])("flags uncoalesced TypeScript read: %s", (_label, line) => {
+      const reads = rawTsReads(line);
+      expect(reads).not.toEqual([]);
+      expect(reads.some(r => !r.coalesced)).toBe(true);
+    });
+
+    it("accepts a genuine nullish-coalescing fallback", () => {
+      const reads = rawTsReads(`updatedAt: (row.updated_at as number | null) ?? (row.created_at as number),`);
+      expect(reads).not.toEqual([]);
+      expect(reads.every(r => r.coalesced)).toBe(true);
+    });
+
+    it("does not mistake an object-literal key for a read", () => {
+      expect(rawTsReads(`return { updated_at: m.updatedAt };`)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add nightly staleness pass (90-day age gate, 25-entry bound) with heuristic volatility classification (`volatility:*`, `stale:as-of`)
- Track `updated_at` on writes; clear `stale:as-of` on append/merge/replace/update
- Surface per-match and compound staleness in HTTP recall JSON, MCP recall text, and dashboard
- Use volatility tags for recency floors in ranking; protect reserved tags from compression
- Regression tests for pass edge cases, write-path clears, recall JSON/MCP output, compress reserved tags, and volatile floor override

## Scope
Single commit on top of `main` — staleness only (#228). Unrelated refactor/i18n/#223 commits removed from this branch.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] Verify nightly cron flags old state/volatile memories and skips durable ones
- [ ] Confirm append/merge/replace clears `stale:as-of` and bumps `updated_at`
- [ ] Check GET `/recall` returns `stale_as_of`, `updated_at`, `compound_stale`
- [ ] Check MCP `recall` tool shows staleness warning for 2+ stale matches

Closes #228