### PR TITLE
feat(worker): add POST /import for export v2 round-trip (#217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ A successful response will look like:
 {"ok":true,"id":"..."}
 ```
 
-**Bulk migration:** export with `GET /export`, restore with `POST /import` (same JSON shape, `version: 2`). Large dumps can be split across calls with `?limit=` (default 100) — repeat until `remaining_entries` is `0`, then backfill embeddings via `POST /vectorize-pending` until `remaining` is `0`.
+**Bulk migration:** export with `GET /export`, restore with `POST /import` (same JSON shape, `version: 2`). Imports are paged: each call handles `?limit=` array positions (default 40, sized for the D1 free plan) starting at `?offset=` — resend the same file with the `next_offset` (and, once entries are done, `next_edge_offset`) from the previous response until both `remaining` counts are `0`, then backfill embeddings via `POST /vectorize-pending` until `remaining` is `0`.
 
 <details>
 <summary><strong>How OAuth authentication works</strong></summary>

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ A successful response will look like:
 {"ok":true,"id":"..."}
 ```
 
+**Bulk migration:** export with `GET /export`, restore with `POST /import` (same JSON shape, `version: 2`), then backfill embeddings by calling `POST /vectorize-pending` in a loop until `remaining` is `0`.
+
 <details>
 <summary><strong>How OAuth authentication works</strong></summary>
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ A successful response will look like:
 {"ok":true,"id":"..."}
 ```
 
-**Bulk migration:** export with `GET /export`, restore with `POST /import` (same JSON shape, `version: 2`), then backfill embeddings by calling `POST /vectorize-pending` in a loop until `remaining` is `0`.
+**Bulk migration:** export with `GET /export`, restore with `POST /import` (same JSON shape, `version: 2`). Large dumps can be split across calls with `?limit=` (default 100) — repeat until `remaining_entries` is `0`, then backfill embeddings via `POST /vectorize-pending` until `remaining` is `0`.
 
 <details>
 <summary><strong>How OAuth authentication works</strong></summary>

--- a/src/entries/import.ts
+++ b/src/entries/import.ts
@@ -1,5 +1,5 @@
 import type { Env } from "../env";
-import { createEdge, isValidEdgeType } from "../graph/edges";
+import { createEdge, isSymmetric, isValidEdgeType } from "../graph/edges";
 import type { EdgeProvenance } from "../graph/types";
 import { PROVENANCE_VALUES } from "../graph/types";
 
@@ -26,7 +26,7 @@ export const ENTRY_INSERT_COLUMNS = [
 export const ENTRY_INSERT_SQL = `INSERT INTO entries (${ENTRY_INSERT_COLUMNS.join(", ")}) VALUES (${ENTRY_INSERT_COLUMNS.map(() => "?").join(", ")})`;
 
 export type ImportEntryStatus = "imported" | "skipped" | "failed";
-export type ImportEdgeStatus = "imported" | "failed";
+export type ImportEdgeStatus = "imported" | "skipped" | "failed";
 
 export interface ImportEntryResult {
   id: string;
@@ -83,6 +83,7 @@ export interface ImportSummary {
   skipped: number;
   failed: number;
   edges_imported: number;
+  edges_skipped: number;
   edges_failed: number;
   remaining_entries: number;
   remaining_edges: number;
@@ -104,6 +105,28 @@ interface PendingInsert {
 
 function isValidProvenance(p: string): p is EdgeProvenance {
   return (PROVENANCE_VALUES as readonly string[]).includes(p);
+}
+
+export function isImportRecordObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function parseTags(
+  tags: unknown,
+): { ok: true; tags: string[] } | { ok: false; reason: "invalid_tag" } {
+  if (tags === undefined || tags === null) return { ok: true, tags: [] };
+  if (!Array.isArray(tags)) return { ok: false, reason: "invalid_tag" };
+  if (!tags.every(t => typeof t === "string")) return { ok: false, reason: "invalid_tag" };
+  return { ok: true, tags };
+}
+
+export function normalizedEdgeKey(sourceId: string, targetId: string, type: string): string {
+  let source = sourceId;
+  let target = targetId;
+  if (isValidEdgeType(type) && isSymmetric(type) && source > target) {
+    [source, target] = [target, source];
+  }
+  return `${source}\0${target}\0${type}`;
 }
 
 export function parseRequiredString(
@@ -154,6 +177,28 @@ export function parseImportLimit(raw: string | null): number {
 async function loadExistingIds(env: Env): Promise<Set<string>> {
   const { results } = await env.DB.prepare(`SELECT id FROM entries`).all() as { results: { id: string }[] };
   return new Set(results.map(r => r.id));
+}
+
+async function loadExistingEdgeKeys(env: Env): Promise<Set<string>> {
+  const { results } = await env.DB.prepare(`SELECT source_id, target_id, type FROM edges`).all() as {
+    results: { source_id: string; target_id: string; type: string }[];
+  };
+  return new Set(results.map(r => normalizedEdgeKey(r.source_id, r.target_id, r.type)));
+}
+
+function countNewEdgesInPayload(edges: ExportEdge[], existingEdgeKeys: Set<string>): number {
+  let count = 0;
+  for (const edge of edges) {
+    if (!isImportRecordObject(edge)) continue;
+    const type = typeof edge.type === "string" ? edge.type.trim() || "relates_to" : "relates_to";
+    if (!isValidEdgeType(type)) continue;
+    const sourceParsed = parseRequiredString(edge.source_id, "missing", "invalid");
+    const targetParsed = parseRequiredString(edge.target_id, "missing", "invalid");
+    if (!sourceParsed.ok || !targetParsed.ok) continue;
+    const key = normalizedEdgeKey(sourceParsed.value, targetParsed.value, type);
+    if (!existingEdgeKeys.has(key)) count++;
+  }
+  return count;
 }
 
 function bindInsert(env: Env, row: PendingInsert) {
@@ -219,16 +264,24 @@ export async function importExportPayload(
   let skipped = 0;
   let failed = 0;
   let edges_imported = 0;
+  let edges_skipped = 0;
   let edges_failed = 0;
   let remaining_entries = 0;
   let remaining_edges = 0;
 
   const existingIds = await loadExistingIds(env);
+  const existingEdgeKeys = await loadExistingEdgeKeys(env);
   const pendingBatch: PendingInsert[] = [];
   let newInsertAttempts = 0;
   const batchCounters = { imported: 0, failed: 0 };
 
   for (const entry of body.entries) {
+    if (!isImportRecordObject(entry)) {
+      failed++;
+      results.push({ id: "", status: "failed", reason: "invalid_entry" });
+      continue;
+    }
+
     const idParsed = parseRequiredString(entry.id, "missing_id", "invalid_id");
     if (!idParsed.ok) {
       failed++;
@@ -250,11 +303,17 @@ export async function importExportPayload(
 
     if (existingIds.has(id)) {
       skipped++;
-      results.push({ id, status: "skipped", reason: "already_exists" });
       continue;
     }
 
-    const tags = Array.isArray(entry.tags) ? entry.tags : [];
+    const tagsParsed = parseTags(entry.tags);
+    if (!tagsParsed.ok) {
+      failed++;
+      results.push({ id, status: "failed", reason: tagsParsed.reason });
+      continue;
+    }
+    const tags = tagsParsed.tags;
+
     let source = "import";
     if (entry.source !== undefined && entry.source !== null) {
       if (typeof entry.source !== "string") {
@@ -302,9 +361,22 @@ export async function importExportPayload(
 
   const edges = body.edges ?? [];
   if (remaining_entries > 0) {
-    remaining_edges = edges.length;
+    remaining_edges = countNewEdgesInPayload(edges, existingEdgeKeys);
   } else {
+    let newEdgeAttempts = 0;
     for (const edge of edges) {
+      if (!isImportRecordObject(edge)) {
+        edges_failed++;
+        results.push({
+          source_id: "",
+          target_id: "",
+          type: "",
+          status: "failed",
+          reason: "invalid_edge",
+        });
+        continue;
+      }
+
       const sourceParsed = parseRequiredString(edge.source_id, "missing_endpoint", "invalid_endpoint");
       const targetParsed = parseRequiredString(edge.target_id, "missing_endpoint", "invalid_endpoint");
       const type = typeof edge.type === "string" ? edge.type.trim() || "relates_to" : "relates_to";
@@ -339,6 +411,18 @@ export async function importExportPayload(
         continue;
       }
 
+      const edgeKey = normalizedEdgeKey(source_id, target_id, type);
+      if (existingEdgeKeys.has(edgeKey)) {
+        edges_skipped++;
+        continue;
+      }
+
+      if (newEdgeAttempts >= limit) {
+        remaining_edges++;
+        continue;
+      }
+      newEdgeAttempts++;
+
       const provenance = edge.provenance && typeof edge.provenance === "string" && isValidProvenance(edge.provenance)
         ? edge.provenance
         : "explicit";
@@ -347,12 +431,14 @@ export async function importExportPayload(
         const created = await createEdge(source_id, target_id, type, {
           weight: edge.weight,
           provenance,
+          created_at: typeof edge.created_at === "number" ? edge.created_at : undefined,
         }, env);
         if (!created) {
           edges_failed++;
           results.push({ source_id, target_id, type, status: "failed", reason: "create_failed" });
           continue;
         }
+        existingEdgeKeys.add(edgeKey);
         edges_imported++;
         results.push({ source_id, target_id, type, status: "imported" });
       } catch (e) {
@@ -375,6 +461,7 @@ export async function importExportPayload(
     skipped,
     failed,
     edges_imported,
+    edges_skipped,
     edges_failed,
     remaining_entries,
     remaining_edges,

--- a/src/entries/import.ts
+++ b/src/entries/import.ts
@@ -4,7 +4,12 @@ import { isSymmetric, isValidEdgeType } from "../graph/edges";
 import type { EdgeProvenance } from "../graph/types";
 import { PROVENANCE_VALUES } from "../graph/types";
 
-/** Max new entry inserts attempted per request (skipped rows do not count). */
+/**
+ * Default page size: array positions examined per call, inserts and skips alike.
+ * Sized so a worst-case page (one existence lookup + one insert batch, then the
+ * same again for edges) stays well inside the D1 free plan's ~50 queries per
+ * invocation, with room for the schema-init probe on a cold isolate.
+ */
 export const IMPORT_DEFAULT_LIMIT = 40;
 export const IMPORT_MAX_LIMIT = 1000;
 /** D1 batch chunk size for inserts. */
@@ -51,6 +56,7 @@ export interface ExportEntry {
   tags?: string[];
   source?: string;
   created_at?: number;
+  updated_at?: number;
   recall_count?: number;
   importance_score?: number;
   contradiction_wins?: number;
@@ -73,7 +79,12 @@ export interface ExportPayload {
 }
 
 export interface ImportOptions {
+  /** Page size — how many array positions of `entries` (then `edges`) one call examines. */
   limit?: number;
+  /** Index into `entries` where this call's page starts. */
+  offset?: number;
+  /** Index into `edges` where this call's page starts. */
+  edgeOffset?: number;
 }
 
 export interface ImportSummary {
@@ -86,6 +97,10 @@ export interface ImportSummary {
   edges_failed: number;
   remaining_entries: number;
   remaining_edges: number;
+  /** Pass back as ?offset= to continue. Equals entries.length when entries are done. */
+  next_offset: number;
+  /** Pass back as ?edge_offset= to continue. Advances only once entries are done. */
+  next_edge_offset: number;
   results: ImportResultItem[];
   vectorize_hint: string;
 }
@@ -107,6 +122,8 @@ interface PendingInsert {
   tags: string[];
   source: string;
   created_at: number;
+  /** Validated payload value, defaulted to created_at — camelCase per the in-memory convention (see recall's updatedAt). */
+  updatedAt: number;
   recall_count: number;
   importance_score: number;
   contradiction_wins: number;
@@ -177,6 +194,13 @@ export function parseImportBody(
   };
 }
 
+export function parseImportOffset(raw: string | null): number {
+  if (!raw) return 0;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return n;
+}
+
 export function parseImportLimit(raw: string | null): number {
   if (!raw) return IMPORT_DEFAULT_LIMIT;
   const n = Number.parseInt(raw, 10);
@@ -214,28 +238,6 @@ async function loadExistingEdgeKeys(env: Env, endpoints: string[]): Promise<Set<
   return keys;
 }
 
-function collectPayloadEntryIds(entries: ExportEntry[]): string[] {
-  const ids: string[] = [];
-  for (const entry of entries) {
-    if (!isImportRecordObject(entry)) continue;
-    const parsed = parseRequiredString(entry.id, "missing", "invalid");
-    if (parsed.ok) ids.push(parsed.value);
-  }
-  return ids;
-}
-
-function collectEdgeEndpoints(edges: ExportEdge[]): string[] {
-  const endpoints = new Set<string>();
-  for (const edge of edges) {
-    if (!isImportRecordObject(edge)) continue;
-    const sourceParsed = parseRequiredString(edge.source_id, "missing", "invalid");
-    const targetParsed = parseRequiredString(edge.target_id, "missing", "invalid");
-    if (sourceParsed.ok) endpoints.add(sourceParsed.value);
-    if (targetParsed.ok) endpoints.add(targetParsed.value);
-  }
-  return [...endpoints];
-}
-
 export function parseEdgeWeight(
   weight: unknown,
 ): { ok: true; value: number } | { ok: false; reason: "invalid_weight" } {
@@ -267,73 +269,6 @@ export function parseCreatedAt(
   return { ok: true, value };
 }
 
-async function flushPendingIdLookups(
-  env: Env,
-  pending: string[],
-  existingIds: Set<string>,
-): Promise<void> {
-  while (pending.length) {
-    const batch = pending.splice(0, D1_MAX_BOUND_PARAMS);
-    const found = await loadExistingIds(env, batch);
-    for (const id of found) existingIds.add(id);
-  }
-}
-
-/** Resolve one id against D1, batching lookups to stay within query budget. */
-export async function ensureIdResolved(
-  env: Env,
-  id: string,
-  existingIds: Set<string>,
-  pending: string[],
-): Promise<void> {
-  if (existingIds.has(id)) return;
-  if (!pending.includes(id)) pending.push(id);
-  while (pending.length >= D1_MAX_BOUND_PARAMS) {
-    const batch = pending.splice(0, D1_MAX_BOUND_PARAMS);
-    const found = await loadExistingIds(env, batch);
-    for (const foundId of found) existingIds.add(foundId);
-  }
-  if (pending.includes(id)) {
-    await flushPendingIdLookups(env, pending, existingIds);
-  }
-}
-
-async function ensureIdsResolved(
-  env: Env,
-  ids: string[],
-  existingIds: Set<string>,
-  pending: string[],
-): Promise<void> {
-  for (const id of ids) {
-    if (existingIds.has(id)) continue;
-    if (!pending.includes(id)) pending.push(id);
-  }
-  await flushPendingIdLookups(env, pending, existingIds);
-}
-
-async function mergeExistingEdgeKeys(
-  env: Env,
-  endpoints: string[],
-  into: Set<string>,
-): Promise<void> {
-  const found = await loadExistingEdgeKeys(env, endpoints);
-  for (const key of found) into.add(key);
-}
-
-function countValidEdgesInPayload(edges: ExportEdge[]): number {
-  let count = 0;
-  for (const edge of edges) {
-    if (!isImportRecordObject(edge)) continue;
-    const type = typeof edge.type === "string" ? edge.type.trim() || "relates_to" : "relates_to";
-    if (!isValidEdgeType(type)) continue;
-    const sourceParsed = parseRequiredString(edge.source_id, "missing", "invalid");
-    const targetParsed = parseRequiredString(edge.target_id, "missing", "invalid");
-    if (!sourceParsed.ok || !targetParsed.ok) continue;
-    count++;
-  }
-  return count;
-}
-
 function bindInsert(env: Env, row: PendingInsert) {
   return env.DB.prepare(ENTRY_INSERT_SQL).bind(
     row.id,
@@ -341,7 +276,7 @@ function bindInsert(env: Env, row: PendingInsert) {
     JSON.stringify(row.tags),
     row.source,
     row.created_at,
-    row.created_at,
+    row.updatedAt,
     "[]",
     row.recall_count,
     row.importance_score,
@@ -452,12 +387,33 @@ async function flushEdgeBatch(
   }
 }
 
+/**
+ * One page of a restore. `offset`/`edgeOffset` are positions in the payload arrays,
+ * and a call examines exactly one page: entries[offset .. offset+limit), then — only
+ * once the entries array is exhausted — edges[edgeOffset .. edgeOffset+limit).
+ *
+ * Positional paging is what keeps the cost flat on the D1 free plan (~50 queries per
+ * invocation). Each page resolves only its own ids: one chunked existence lookup plus
+ * one insert batch, so a default page costs 2-3 round trips whether the file holds
+ * 40 entries or 50,000, and page 500 costs the same as page 1. The alternative —
+ * scanning from the top and skipping — re-resolves every already-imported id on
+ * every call, which is how a 5,000-entry restore spends its whole daily budget
+ * before finishing.
+ *
+ * Re-running a page is safe: existing ids and edge keys are skipped, and the
+ * ON CONFLICT upsert makes a re-inserted edge a weight merge rather than an error.
+ */
 export async function importExportPayload(
   env: Env,
   body: ExportPayload,
   opts: ImportOptions = {},
 ): Promise<ImportSummary> {
   const limit = opts.limit ?? IMPORT_DEFAULT_LIMIT;
+  const entries = body.entries;
+  const edges = body.edges ?? [];
+  const offset = Math.min(Math.max(opts.offset ?? 0, 0), entries.length);
+  const edgeOffset = Math.min(Math.max(opts.edgeOffset ?? 0, 0), edges.length);
+
   const results: ImportResultItem[] = [];
   let imported = 0;
   let skipped = 0;
@@ -465,243 +421,105 @@ export async function importExportPayload(
   let edges_imported = 0;
   let edges_skipped = 0;
   let edges_failed = 0;
-  let remaining_entries = 0;
-  let remaining_edges = 0;
 
-  const edges = body.edges ?? [];
-  const existingIds = new Set<string>();
-  const pendingIdLookups: string[] = [];
+  // ---- entries page ------------------------------------------------------------
+  const page = entries.slice(offset, offset + limit);
+  const next_offset = offset + page.length;
+
+  // Parse the whole page before touching D1, so the existence lookup can be one
+  // chunked query over exactly the ids that might insert.
+  const parsedPage: ({ row: PendingInsert } | { failure: ImportEntryResult })[] = [];
+  for (const entry of page) {
+    parsedPage.push(parseEntryRow(entry));
+  }
+
+  const pageIds = [...new Set(parsedPage.flatMap(p => ("row" in p ? [p.row.id] : [])))];
+  const existingIds = await loadExistingIds(env, pageIds);
+
   const pendingBatch: PendingInsert[] = [];
-  let newInsertAttempts = 0;
   const batchCounters = { imported: 0, failed: 0 };
-
-  for (const entry of body.entries) {
-    if (!isImportRecordObject(entry)) {
+  for (const p of parsedPage) {
+    if ("failure" in p) {
       failed++;
-      results.push({ id: "", status: "failed", reason: "invalid_entry" });
+      results.push(p.failure);
       continue;
     }
-
-    const idParsed = parseRequiredString(entry.id, "missing_id", "invalid_id");
-    if (!idParsed.ok) {
-      failed++;
-      results.push({
-        id: typeof entry.id === "string" ? entry.id : String(entry.id ?? ""),
-        status: "failed",
-        reason: idParsed.reason,
-      });
-      continue;
-    }
-    const id = idParsed.value;
-
-    const contentParsed = parseRequiredString(entry.content, "missing_content", "invalid_content");
-    if (!contentParsed.ok) {
-      failed++;
-      results.push({ id, status: "failed", reason: contentParsed.reason });
-      continue;
-    }
-
-    if (newInsertAttempts >= limit) {
-      remaining_entries++;
-      continue;
-    }
-
-    await ensureIdResolved(env, id, existingIds, pendingIdLookups);
-
-    if (existingIds.has(id)) {
+    if (existingIds.has(p.row.id)) {
       skipped++;
       continue;
     }
-
-    const tagsParsed = parseTags(entry.tags);
-    if (!tagsParsed.ok) {
-      failed++;
-      results.push({ id, status: "failed", reason: tagsParsed.reason });
-      continue;
-    }
-    const tags = tagsParsed.tags;
-
-    let source = "import";
-    if (entry.source !== undefined && entry.source !== null) {
-      if (typeof entry.source !== "string") {
-        failed++;
-        results.push({ id, status: "failed", reason: "invalid_source" });
-        continue;
-      }
-      source = entry.source.trim() || "import";
-    }
-
-    const createdAtParsed = parseCreatedAt(entry.created_at);
-    if (!createdAtParsed.ok) {
-      failed++;
-      results.push({ id, status: "failed", reason: createdAtParsed.reason });
-      continue;
-    }
-    const created_at = createdAtParsed.value;
-
-    const recallCountParsed = parseOptionalNumber(entry.recall_count, "invalid_recall_count");
-    if (!recallCountParsed.ok) {
-      failed++;
-      results.push({ id, status: "failed", reason: recallCountParsed.reason });
-      continue;
-    }
-    const importanceParsed = parseOptionalNumber(entry.importance_score, "invalid_importance_score");
-    if (!importanceParsed.ok) {
-      failed++;
-      results.push({ id, status: "failed", reason: importanceParsed.reason });
-      continue;
-    }
-    const winsParsed = parseOptionalNumber(entry.contradiction_wins, "invalid_contradiction_wins");
-    if (!winsParsed.ok) {
-      failed++;
-      results.push({ id, status: "failed", reason: winsParsed.reason });
-      continue;
-    }
-    const lossesParsed = parseOptionalNumber(entry.contradiction_losses, "invalid_contradiction_losses");
-    if (!lossesParsed.ok) {
-      failed++;
-      results.push({ id, status: "failed", reason: lossesParsed.reason });
-      continue;
-    }
-
-    pendingBatch.push({
-      id,
-      content: contentParsed.value,
-      tags,
-      source,
-      created_at,
-      recall_count: recallCountParsed.value,
-      importance_score: importanceParsed.value,
-      contradiction_wins: winsParsed.value,
-      contradiction_losses: lossesParsed.value,
-    });
-
-    newInsertAttempts++;
+    // Marking the id as seen at queue time makes a duplicate later in the same page
+    // a skip; letting it into the batch would be a PRIMARY KEY conflict that fails
+    // the whole batch into the per-row fallback.
+    existingIds.add(p.row.id);
+    pendingBatch.push(p.row);
 
     if (pendingBatch.length >= IMPORT_D1_BATCH_SIZE) {
       await flushInsertBatch(env, pendingBatch.splice(0), existingIds, results, batchCounters);
-      imported += batchCounters.imported;
-      failed += batchCounters.failed;
-      batchCounters.imported = 0;
-      batchCounters.failed = 0;
     }
   }
-
   if (pendingBatch.length) {
     await flushInsertBatch(env, pendingBatch.splice(0), existingIds, results, batchCounters);
-    imported += batchCounters.imported;
-    failed += batchCounters.failed;
   }
+  imported += batchCounters.imported;
+  failed += batchCounters.failed;
 
-  await flushPendingIdLookups(env, pendingIdLookups, existingIds);
+  const remaining_entries = entries.length - next_offset;
 
-  if (remaining_entries > 0) {
-    remaining_edges = countValidEdgesInPayload(edges);
-  } else {
-    const existingEdgeKeys = new Set<string>();
-    let newEdgeAttempts = 0;
+  // ---- edges page --------------------------------------------------------------
+  // Deferred until the entries array is exhausted, so every endpoint an edge can
+  // name either predates this import or was written by an earlier page.
+  let next_edge_offset = edgeOffset;
+  if (remaining_entries === 0) {
+    const edgePage = edges.slice(edgeOffset, edgeOffset + limit);
+    next_edge_offset = edgeOffset + edgePage.length;
+
+    type ParsedEdge = { edge: PendingEdge } | { failure: ImportEdgeResult };
+    const parsedEdges: ParsedEdge[] = [];
+    for (const edge of edgePage) {
+      parsedEdges.push(parseEdgeRow(edge));
+    }
+
+    // Endpoints this call has not already proven to exist (entries imported above
+    // are in existingIds), resolved in one chunked query.
+    const endpoints = [
+      ...new Set(parsedEdges.flatMap(p => ("edge" in p ? [p.edge.source_id, p.edge.target_id] : []))),
+    ];
+    const unknown = endpoints.filter(id => !existingIds.has(id));
+    for (const id of await loadExistingIds(env, unknown)) existingIds.add(id);
+    const existingEdgeKeys = await loadExistingEdgeKeys(env, endpoints);
+
     const pendingEdgeBatch: PendingEdge[] = [];
     const edgeBatchCounters = { imported: 0, failed: 0 };
-
-    for (const edge of edges) {
-      if (!isImportRecordObject(edge)) {
+    for (const p of parsedEdges) {
+      if ("failure" in p) {
         edges_failed++;
-        results.push({
-          source_id: "",
-          target_id: "",
-          type: "",
-          status: "failed",
-          reason: "invalid_edge",
-        });
+        results.push(p.failure);
         continue;
       }
-
-      const sourceParsed = parseRequiredString(edge.source_id, "missing_endpoint", "invalid_endpoint");
-      const targetParsed = parseRequiredString(edge.target_id, "missing_endpoint", "invalid_endpoint");
-      const type = typeof edge.type === "string" ? edge.type.trim() || "relates_to" : "relates_to";
-
-      if (!sourceParsed.ok || !targetParsed.ok) {
-        edges_failed++;
-        let reason = "missing_endpoint";
-        if (!sourceParsed.ok) reason = sourceParsed.reason;
-        else if (!targetParsed.ok) reason = targetParsed.reason;
-        results.push({
-          source_id: typeof edge.source_id === "string" ? edge.source_id : String(edge.source_id ?? ""),
-          target_id: typeof edge.target_id === "string" ? edge.target_id : String(edge.target_id ?? ""),
-          type,
-          status: "failed",
-          reason,
-        });
-        continue;
-      }
-
-      const source_id = sourceParsed.value;
-      const target_id = targetParsed.value;
-
-      if (!isValidEdgeType(type)) {
-        edges_failed++;
-        results.push({ source_id, target_id, type, status: "failed", reason: "invalid_type" });
-        continue;
-      }
-
-      if (newEdgeAttempts >= limit) {
-        remaining_edges++;
-        continue;
-      }
-
-      await ensureIdsResolved(env, [source_id, target_id], existingIds, pendingIdLookups);
-
+      const { source_id, target_id, type } = p.edge;
       if (!existingIds.has(source_id) || !existingIds.has(target_id)) {
         edges_failed++;
         results.push({ source_id, target_id, type, status: "failed", reason: "missing_endpoint" });
         continue;
       }
-
       const edgeKey = normalizedEdgeKey(source_id, target_id, type);
-      if (!existingEdgeKeys.has(edgeKey)) {
-        await mergeExistingEdgeKeys(env, [source_id, target_id], existingEdgeKeys);
-      }
       if (existingEdgeKeys.has(edgeKey)) {
         edges_skipped++;
         continue;
       }
-
-      const weightParsed = parseEdgeWeight(edge.weight);
-      if (!weightParsed.ok) {
-        edges_failed++;
-        results.push({ source_id, target_id, type, status: "failed", reason: weightParsed.reason });
-        continue;
-      }
-
-      newEdgeAttempts++;
-
-      const provenance = edge.provenance && typeof edge.provenance === "string" && isValidProvenance(edge.provenance)
-        ? edge.provenance
-        : "explicit";
-
-      pendingEdgeBatch.push({
-        source_id,
-        target_id,
-        type,
-        weight: weightParsed.value,
-        provenance,
-        created_at: typeof edge.created_at === "number" ? edge.created_at : Date.now(),
-      });
+      existingEdgeKeys.add(edgeKey);
+      pendingEdgeBatch.push(p.edge);
 
       if (pendingEdgeBatch.length >= IMPORT_D1_BATCH_SIZE) {
         await flushEdgeBatch(env, pendingEdgeBatch.splice(0), existingEdgeKeys, results, edgeBatchCounters);
-        edges_imported += edgeBatchCounters.imported;
-        edges_failed += edgeBatchCounters.failed;
-        edgeBatchCounters.imported = 0;
-        edgeBatchCounters.failed = 0;
       }
     }
-
     if (pendingEdgeBatch.length) {
       await flushEdgeBatch(env, pendingEdgeBatch.splice(0), existingEdgeKeys, results, edgeBatchCounters);
-      edges_imported += edgeBatchCounters.imported;
-      edges_failed += edgeBatchCounters.failed;
     }
+    edges_imported += edgeBatchCounters.imported;
+    edges_failed += edgeBatchCounters.failed;
   }
 
   return {
@@ -713,8 +531,126 @@ export async function importExportPayload(
     edges_skipped,
     edges_failed,
     remaining_entries,
-    remaining_edges,
+    remaining_edges: edges.length - next_edge_offset,
+    next_offset,
+    next_edge_offset,
     results,
     vectorize_hint: "POST /vectorize-pending until remaining is 0",
+  };
+}
+
+/** Parse one entry row into an insertable record, or the failure to report. */
+function parseEntryRow(entry: ExportEntry): { row: PendingInsert } | { failure: ImportEntryResult } {
+  if (!isImportRecordObject(entry)) {
+    return { failure: { id: "", status: "failed", reason: "invalid_entry" } };
+  }
+  const idParsed = parseRequiredString(entry.id, "missing_id", "invalid_id");
+  if (!idParsed.ok) {
+    const id = typeof entry.id === "string" ? entry.id : String(entry.id ?? "");
+    return { failure: { id, status: "failed", reason: idParsed.reason } };
+  }
+  const id = idParsed.value;
+
+  const contentParsed = parseRequiredString(entry.content, "missing_content", "invalid_content");
+  if (!contentParsed.ok) return { failure: { id, status: "failed", reason: contentParsed.reason } };
+
+  const tagsParsed = parseTags(entry.tags);
+  if (!tagsParsed.ok) return { failure: { id, status: "failed", reason: tagsParsed.reason } };
+
+  let source = "import";
+  if (entry.source !== undefined && entry.source !== null) {
+    if (typeof entry.source !== "string") {
+      return { failure: { id, status: "failed", reason: "invalid_source" } };
+    }
+    source = entry.source.trim() || "import";
+  }
+
+  const createdAtParsed = parseCreatedAt(entry.created_at);
+  if (!createdAtParsed.ok) return { failure: { id, status: "failed", reason: createdAtParsed.reason } };
+  const created_at = createdAtParsed.value;
+
+  // Absent in exports taken before /export carried the field; created_at is what the
+  // column would have coalesced to anyway. A restore must not launder a bad value into
+  // a "recently touched" ranking signal, so a malformed one fails the row instead.
+  const updatedAt = entry.updated_at ?? created_at;
+  if (typeof updatedAt !== "number" || !Number.isFinite(updatedAt)) {
+    return { failure: { id, status: "failed", reason: "invalid_updated_at" } };
+  }
+
+  const recallCountParsed = parseOptionalNumber(entry.recall_count, "invalid_recall_count");
+  if (!recallCountParsed.ok) return { failure: { id, status: "failed", reason: recallCountParsed.reason } };
+  const importanceParsed = parseOptionalNumber(entry.importance_score, "invalid_importance_score");
+  if (!importanceParsed.ok) return { failure: { id, status: "failed", reason: importanceParsed.reason } };
+  const winsParsed = parseOptionalNumber(entry.contradiction_wins, "invalid_contradiction_wins");
+  if (!winsParsed.ok) return { failure: { id, status: "failed", reason: winsParsed.reason } };
+  const lossesParsed = parseOptionalNumber(entry.contradiction_losses, "invalid_contradiction_losses");
+  if (!lossesParsed.ok) return { failure: { id, status: "failed", reason: lossesParsed.reason } };
+
+  return {
+    row: {
+      id,
+      content: contentParsed.value,
+      tags: tagsParsed.tags,
+      source,
+      created_at,
+      updatedAt,
+      recall_count: recallCountParsed.value,
+      importance_score: importanceParsed.value,
+      contradiction_wins: winsParsed.value,
+      contradiction_losses: lossesParsed.value,
+    },
+  };
+}
+
+/** Parse one edge row into an insertable record, or the failure to report. */
+function parseEdgeRow(edge: ExportEdge): { edge: PendingEdge } | { failure: ImportEdgeResult } {
+  if (!isImportRecordObject(edge)) {
+    return { failure: { source_id: "", target_id: "", type: "", status: "failed", reason: "invalid_edge" } };
+  }
+  const sourceParsed = parseRequiredString(edge.source_id, "missing_endpoint", "invalid_endpoint");
+  const targetParsed = parseRequiredString(edge.target_id, "missing_endpoint", "invalid_endpoint");
+  const type = typeof edge.type === "string" ? edge.type.trim() || "relates_to" : "relates_to";
+
+  if (!sourceParsed.ok || !targetParsed.ok) {
+    const reason = !sourceParsed.ok ? sourceParsed.reason : !targetParsed.ok ? targetParsed.reason : "missing_endpoint";
+    return {
+      failure: {
+        source_id: typeof edge.source_id === "string" ? edge.source_id : String(edge.source_id ?? ""),
+        target_id: typeof edge.target_id === "string" ? edge.target_id : String(edge.target_id ?? ""),
+        type,
+        status: "failed",
+        reason,
+      },
+    };
+  }
+  const source_id = sourceParsed.value;
+  const target_id = targetParsed.value;
+
+  if (!isValidEdgeType(type)) {
+    return { failure: { source_id, target_id, type, status: "failed", reason: "invalid_type" } };
+  }
+  // The capture path never creates these (graph/edges.ts returns null), so one in a
+  // payload is hand-edited data the graph should not inherit.
+  if (source_id === target_id) {
+    return { failure: { source_id, target_id, type, status: "failed", reason: "self_edge" } };
+  }
+  const weightParsed = parseEdgeWeight(edge.weight);
+  if (!weightParsed.ok) {
+    return { failure: { source_id, target_id, type, status: "failed", reason: weightParsed.reason } };
+  }
+  const provenance =
+    edge.provenance && typeof edge.provenance === "string" && isValidProvenance(edge.provenance)
+      ? edge.provenance
+      : "explicit";
+
+  return {
+    edge: {
+      source_id,
+      target_id,
+      type,
+      weight: weightParsed.value,
+      provenance,
+      created_at: typeof edge.created_at === "number" ? edge.created_at : Date.now(),
+    },
   };
 }

--- a/src/entries/import.ts
+++ b/src/entries/import.ts
@@ -1,0 +1,203 @@
+import type { Env } from "../env";
+import { createEdge, isValidEdgeType } from "../graph/edges";
+import type { EdgeProvenance } from "../graph/types";
+import { PROVENANCE_VALUES } from "../graph/types";
+
+export type ImportEntryStatus = "imported" | "skipped" | "failed";
+export type ImportEdgeStatus = "imported" | "failed";
+
+export interface ImportEntryResult {
+  id: string;
+  status: ImportEntryStatus;
+  reason?: string;
+}
+
+export interface ImportEdgeResult {
+  source_id: string;
+  target_id: string;
+  type: string;
+  status: ImportEdgeStatus;
+  reason?: string;
+}
+
+export type ImportResultItem = ImportEntryResult | ImportEdgeResult;
+
+export interface ExportEntry {
+  id: string;
+  content: string;
+  tags?: string[];
+  source?: string;
+  created_at?: number;
+  recall_count?: number;
+  importance_score?: number;
+  contradiction_wins?: number;
+  contradiction_losses?: number;
+}
+
+export interface ExportEdge {
+  source_id: string;
+  target_id: string;
+  type?: string;
+  weight?: number;
+  provenance?: string;
+  created_at?: number;
+}
+
+export interface ExportPayload {
+  version?: number;
+  entries: ExportEntry[];
+  edges?: ExportEdge[];
+}
+
+export interface ImportSummary {
+  ok: true;
+  imported: number;
+  skipped: number;
+  failed: number;
+  edges_imported: number;
+  edges_failed: number;
+  results: ImportResultItem[];
+  vectorize_hint: string;
+}
+
+function isValidProvenance(p: string): p is EdgeProvenance {
+  return (PROVENANCE_VALUES as readonly string[]).includes(p);
+}
+
+export function parseImportBody(
+  body: unknown,
+): { ok: true; payload: ExportPayload } | { ok: false; error: string } {
+  if (!body || typeof body !== "object") return { ok: false, error: "body must be an object" };
+  const o = body as Record<string, unknown>;
+  if (o.version !== undefined && o.version !== 2) return { ok: false, error: "version must be 2" };
+  if (!Array.isArray(o.entries)) return { ok: false, error: "entries must be an array" };
+  return {
+    ok: true,
+    payload: {
+      version: o.version as number | undefined,
+      entries: o.entries as ExportEntry[],
+      edges: o.edges as ExportEdge[] | undefined,
+    },
+  };
+}
+
+async function entryExists(env: Env, id: string): Promise<boolean> {
+  const row = await env.DB.prepare(`SELECT id FROM entries WHERE id = ?`).bind(id).first();
+  return row !== null;
+}
+
+export async function importExportPayload(env: Env, body: ExportPayload): Promise<ImportSummary> {
+  const results: ImportResultItem[] = [];
+  let imported = 0;
+  let skipped = 0;
+  let failed = 0;
+  let edges_imported = 0;
+  let edges_failed = 0;
+
+  for (const entry of body.entries) {
+    const id = entry.id?.trim();
+    if (!id) {
+      failed++;
+      results.push({ id: String(entry.id ?? ""), status: "failed", reason: "missing_id" });
+      continue;
+    }
+    const content = entry.content?.trim();
+    if (!content) {
+      failed++;
+      results.push({ id, status: "failed", reason: "missing_content" });
+      continue;
+    }
+
+    if (await entryExists(env, id)) {
+      skipped++;
+      results.push({ id, status: "skipped", reason: "already_exists" });
+      continue;
+    }
+
+    const tags = Array.isArray(entry.tags) ? entry.tags : [];
+    const source = entry.source?.trim() || "import";
+    const created_at = typeof entry.created_at === "number" ? entry.created_at : Date.now();
+
+    try {
+      await env.DB.prepare(
+        `INSERT INTO entries (id, content, tags, source, created_at, updated_at, vector_ids, recall_count, importance_score, contradiction_wins, contradiction_losses) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).bind(
+        id,
+        content,
+        JSON.stringify(tags),
+        source,
+        created_at,
+        created_at,
+        "[]",
+        entry.recall_count ?? 0,
+        entry.importance_score ?? 0,
+        entry.contradiction_wins ?? 0,
+        entry.contradiction_losses ?? 0,
+      ).run();
+      imported++;
+      results.push({ id, status: "imported" });
+    } catch {
+      failed++;
+      results.push({ id, status: "failed", reason: "insert_error" });
+    }
+  }
+
+  for (const edge of body.edges ?? []) {
+    const source_id = edge.source_id?.trim();
+    const target_id = edge.target_id?.trim();
+    const type = edge.type?.trim() || "relates_to";
+
+    if (!source_id || !target_id) {
+      edges_failed++;
+      results.push({
+        source_id: source_id ?? "",
+        target_id: target_id ?? "",
+        type,
+        status: "failed",
+        reason: "missing_endpoint",
+      });
+      continue;
+    }
+
+    if (!isValidEdgeType(type)) {
+      edges_failed++;
+      results.push({ source_id, target_id, type, status: "failed", reason: "invalid_type" });
+      continue;
+    }
+
+    if (!(await entryExists(env, source_id)) || !(await entryExists(env, target_id))) {
+      edges_failed++;
+      results.push({ source_id, target_id, type, status: "failed", reason: "missing_endpoint" });
+      continue;
+    }
+
+    const provenance = edge.provenance && isValidProvenance(edge.provenance)
+      ? edge.provenance
+      : "explicit";
+
+    const created = await createEdge(source_id, target_id, type, {
+      weight: edge.weight,
+      provenance,
+    }, env);
+
+    if (!created) {
+      edges_failed++;
+      results.push({ source_id, target_id, type, status: "failed", reason: "create_failed" });
+      continue;
+    }
+
+    edges_imported++;
+    results.push({ source_id, target_id, type, status: "imported" });
+  }
+
+  return {
+    ok: true,
+    imported,
+    skipped,
+    failed,
+    edges_imported,
+    edges_failed,
+    results,
+    vectorize_hint: "POST /vectorize-pending until remaining is 0",
+  };
+}

--- a/src/entries/import.ts
+++ b/src/entries/import.ts
@@ -3,6 +3,28 @@ import { createEdge, isValidEdgeType } from "../graph/edges";
 import type { EdgeProvenance } from "../graph/types";
 import { PROVENANCE_VALUES } from "../graph/types";
 
+/** Max new entry inserts attempted per request (skipped rows do not count). */
+export const IMPORT_DEFAULT_LIMIT = 100;
+export const IMPORT_MAX_LIMIT = 1000;
+/** D1 batch chunk size for inserts. */
+export const IMPORT_D1_BATCH_SIZE = 50;
+
+// Matches `main` schema today (no `updated_at` — add that column when #263 lands).
+export const ENTRY_INSERT_COLUMNS = [
+  "id",
+  "content",
+  "tags",
+  "source",
+  "created_at",
+  "vector_ids",
+  "recall_count",
+  "importance_score",
+  "contradiction_wins",
+  "contradiction_losses",
+] as const;
+
+export const ENTRY_INSERT_SQL = `INSERT INTO entries (${ENTRY_INSERT_COLUMNS.join(", ")}) VALUES (${ENTRY_INSERT_COLUMNS.map(() => "?").join(", ")})`;
+
 export type ImportEntryStatus = "imported" | "skipped" | "failed";
 export type ImportEdgeStatus = "imported" | "failed";
 
@@ -10,6 +32,7 @@ export interface ImportEntryResult {
   id: string;
   status: ImportEntryStatus;
   reason?: string;
+  detail?: string;
 }
 
 export interface ImportEdgeResult {
@@ -18,6 +41,7 @@ export interface ImportEdgeResult {
   type: string;
   status: ImportEdgeStatus;
   reason?: string;
+  detail?: string;
 }
 
 export type ImportResultItem = ImportEntryResult | ImportEdgeResult;
@@ -49,6 +73,10 @@ export interface ExportPayload {
   edges?: ExportEdge[];
 }
 
+export interface ImportOptions {
+  limit?: number;
+}
+
 export interface ImportSummary {
   ok: true;
   imported: number;
@@ -56,12 +84,47 @@ export interface ImportSummary {
   failed: number;
   edges_imported: number;
   edges_failed: number;
+  remaining_entries: number;
+  remaining_edges: number;
   results: ImportResultItem[];
   vectorize_hint: string;
 }
 
+interface PendingInsert {
+  id: string;
+  content: string;
+  tags: string[];
+  source: string;
+  created_at: number;
+  recall_count: number;
+  importance_score: number;
+  contradiction_wins: number;
+  contradiction_losses: number;
+}
+
 function isValidProvenance(p: string): p is EdgeProvenance {
   return (PROVENANCE_VALUES as readonly string[]).includes(p);
+}
+
+export function parseRequiredString(
+  value: unknown,
+  missingReason: string,
+  invalidReason: string,
+): { ok: true; value: string } | { ok: false; reason: string } {
+  if (value === undefined || value === null || value === "") {
+    return { ok: false, reason: missingReason };
+  }
+  if (typeof value !== "string") {
+    return { ok: false, reason: invalidReason };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return { ok: false, reason: missingReason };
+  return { ok: true, value: trimmed };
+}
+
+export function formatDbError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.slice(0, 200);
 }
 
 export function parseImportBody(
@@ -81,113 +144,229 @@ export function parseImportBody(
   };
 }
 
-async function entryExists(env: Env, id: string): Promise<boolean> {
-  const row = await env.DB.prepare(`SELECT id FROM entries WHERE id = ?`).bind(id).first();
-  return row !== null;
+export function parseImportLimit(raw: string | null): number {
+  if (!raw) return IMPORT_DEFAULT_LIMIT;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return IMPORT_DEFAULT_LIMIT;
+  return Math.min(n, IMPORT_MAX_LIMIT);
 }
 
-export async function importExportPayload(env: Env, body: ExportPayload): Promise<ImportSummary> {
+async function loadExistingIds(env: Env): Promise<Set<string>> {
+  const { results } = await env.DB.prepare(`SELECT id FROM entries`).all() as { results: { id: string }[] };
+  return new Set(results.map(r => r.id));
+}
+
+function bindInsert(env: Env, row: PendingInsert) {
+  return env.DB.prepare(ENTRY_INSERT_SQL).bind(
+    row.id,
+    row.content,
+    JSON.stringify(row.tags),
+    row.source,
+    row.created_at,
+    "[]",
+    row.recall_count,
+    row.importance_score,
+    row.contradiction_wins,
+    row.contradiction_losses,
+  );
+}
+
+async function flushInsertBatch(
+  env: Env,
+  batch: PendingInsert[],
+  existingIds: Set<string>,
+  results: ImportResultItem[],
+  counters: { imported: number; failed: number },
+): Promise<void> {
+  if (!batch.length) return;
+
+  const stmts = batch.map(row => bindInsert(env, row));
+  try {
+    await env.DB.batch(stmts);
+    for (const row of batch) {
+      existingIds.add(row.id);
+      counters.imported++;
+      results.push({ id: row.id, status: "imported" });
+    }
+  } catch {
+    for (const row of batch) {
+      try {
+        await bindInsert(env, row).run();
+        existingIds.add(row.id);
+        counters.imported++;
+        results.push({ id: row.id, status: "imported" });
+      } catch (e) {
+        counters.failed++;
+        results.push({
+          id: row.id,
+          status: "failed",
+          reason: "insert_error",
+          detail: formatDbError(e),
+        });
+      }
+    }
+  }
+}
+
+export async function importExportPayload(
+  env: Env,
+  body: ExportPayload,
+  opts: ImportOptions = {},
+): Promise<ImportSummary> {
+  const limit = opts.limit ?? IMPORT_DEFAULT_LIMIT;
   const results: ImportResultItem[] = [];
   let imported = 0;
   let skipped = 0;
   let failed = 0;
   let edges_imported = 0;
   let edges_failed = 0;
+  let remaining_entries = 0;
+  let remaining_edges = 0;
+
+  const existingIds = await loadExistingIds(env);
+  const pendingBatch: PendingInsert[] = [];
+  let newInsertAttempts = 0;
+  const batchCounters = { imported: 0, failed: 0 };
 
   for (const entry of body.entries) {
-    const id = entry.id?.trim();
-    if (!id) {
+    const idParsed = parseRequiredString(entry.id, "missing_id", "invalid_id");
+    if (!idParsed.ok) {
       failed++;
-      results.push({ id: String(entry.id ?? ""), status: "failed", reason: "missing_id" });
+      results.push({
+        id: typeof entry.id === "string" ? entry.id : String(entry.id ?? ""),
+        status: "failed",
+        reason: idParsed.reason,
+      });
       continue;
     }
-    const content = entry.content?.trim();
-    if (!content) {
+    const id = idParsed.value;
+
+    const contentParsed = parseRequiredString(entry.content, "missing_content", "invalid_content");
+    if (!contentParsed.ok) {
       failed++;
-      results.push({ id, status: "failed", reason: "missing_content" });
+      results.push({ id, status: "failed", reason: contentParsed.reason });
       continue;
     }
 
-    if (await entryExists(env, id)) {
+    if (existingIds.has(id)) {
       skipped++;
       results.push({ id, status: "skipped", reason: "already_exists" });
       continue;
     }
 
     const tags = Array.isArray(entry.tags) ? entry.tags : [];
-    const source = entry.source?.trim() || "import";
+    let source = "import";
+    if (entry.source !== undefined && entry.source !== null) {
+      if (typeof entry.source !== "string") {
+        failed++;
+        results.push({ id, status: "failed", reason: "invalid_source" });
+        continue;
+      }
+      source = entry.source.trim() || "import";
+    }
+
+    if (newInsertAttempts >= limit) {
+      remaining_entries++;
+      continue;
+    }
+    newInsertAttempts++;
+
     const created_at = typeof entry.created_at === "number" ? entry.created_at : Date.now();
 
-    try {
-      await env.DB.prepare(
-        `INSERT INTO entries (id, content, tags, source, created_at, updated_at, vector_ids, recall_count, importance_score, contradiction_wins, contradiction_losses) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-      ).bind(
-        id,
-        content,
-        JSON.stringify(tags),
-        source,
-        created_at,
-        created_at,
-        "[]",
-        entry.recall_count ?? 0,
-        entry.importance_score ?? 0,
-        entry.contradiction_wins ?? 0,
-        entry.contradiction_losses ?? 0,
-      ).run();
-      imported++;
-      results.push({ id, status: "imported" });
-    } catch {
-      failed++;
-      results.push({ id, status: "failed", reason: "insert_error" });
+    pendingBatch.push({
+      id,
+      content: contentParsed.value,
+      tags,
+      source,
+      created_at,
+      recall_count: entry.recall_count ?? 0,
+      importance_score: entry.importance_score ?? 0,
+      contradiction_wins: entry.contradiction_wins ?? 0,
+      contradiction_losses: entry.contradiction_losses ?? 0,
+    });
+
+    if (pendingBatch.length >= IMPORT_D1_BATCH_SIZE) {
+      await flushInsertBatch(env, pendingBatch.splice(0), existingIds, results, batchCounters);
+      imported += batchCounters.imported;
+      failed += batchCounters.failed;
+      batchCounters.imported = 0;
+      batchCounters.failed = 0;
     }
   }
 
-  for (const edge of body.edges ?? []) {
-    const source_id = edge.source_id?.trim();
-    const target_id = edge.target_id?.trim();
-    const type = edge.type?.trim() || "relates_to";
+  if (pendingBatch.length) {
+    await flushInsertBatch(env, pendingBatch.splice(0), existingIds, results, batchCounters);
+    imported += batchCounters.imported;
+    failed += batchCounters.failed;
+  }
 
-    if (!source_id || !target_id) {
-      edges_failed++;
-      results.push({
-        source_id: source_id ?? "",
-        target_id: target_id ?? "",
-        type,
-        status: "failed",
-        reason: "missing_endpoint",
-      });
-      continue;
+  const edges = body.edges ?? [];
+  if (remaining_entries > 0) {
+    remaining_edges = edges.length;
+  } else {
+    for (const edge of edges) {
+      const sourceParsed = parseRequiredString(edge.source_id, "missing_endpoint", "invalid_endpoint");
+      const targetParsed = parseRequiredString(edge.target_id, "missing_endpoint", "invalid_endpoint");
+      const type = typeof edge.type === "string" ? edge.type.trim() || "relates_to" : "relates_to";
+
+      if (!sourceParsed.ok || !targetParsed.ok) {
+        edges_failed++;
+        let reason = "missing_endpoint";
+        if (!sourceParsed.ok) reason = sourceParsed.reason;
+        else if (!targetParsed.ok) reason = targetParsed.reason;
+        results.push({
+          source_id: typeof edge.source_id === "string" ? edge.source_id : String(edge.source_id ?? ""),
+          target_id: typeof edge.target_id === "string" ? edge.target_id : String(edge.target_id ?? ""),
+          type,
+          status: "failed",
+          reason,
+        });
+        continue;
+      }
+
+      const source_id = sourceParsed.value;
+      const target_id = targetParsed.value;
+
+      if (!isValidEdgeType(type)) {
+        edges_failed++;
+        results.push({ source_id, target_id, type, status: "failed", reason: "invalid_type" });
+        continue;
+      }
+
+      if (!existingIds.has(source_id) || !existingIds.has(target_id)) {
+        edges_failed++;
+        results.push({ source_id, target_id, type, status: "failed", reason: "missing_endpoint" });
+        continue;
+      }
+
+      const provenance = edge.provenance && typeof edge.provenance === "string" && isValidProvenance(edge.provenance)
+        ? edge.provenance
+        : "explicit";
+
+      try {
+        const created = await createEdge(source_id, target_id, type, {
+          weight: edge.weight,
+          provenance,
+        }, env);
+        if (!created) {
+          edges_failed++;
+          results.push({ source_id, target_id, type, status: "failed", reason: "create_failed" });
+          continue;
+        }
+        edges_imported++;
+        results.push({ source_id, target_id, type, status: "imported" });
+      } catch (e) {
+        edges_failed++;
+        results.push({
+          source_id,
+          target_id,
+          type,
+          status: "failed",
+          reason: "create_failed",
+          detail: formatDbError(e),
+        });
+      }
     }
-
-    if (!isValidEdgeType(type)) {
-      edges_failed++;
-      results.push({ source_id, target_id, type, status: "failed", reason: "invalid_type" });
-      continue;
-    }
-
-    if (!(await entryExists(env, source_id)) || !(await entryExists(env, target_id))) {
-      edges_failed++;
-      results.push({ source_id, target_id, type, status: "failed", reason: "missing_endpoint" });
-      continue;
-    }
-
-    const provenance = edge.provenance && isValidProvenance(edge.provenance)
-      ? edge.provenance
-      : "explicit";
-
-    const created = await createEdge(source_id, target_id, type, {
-      weight: edge.weight,
-      provenance,
-    }, env);
-
-    if (!created) {
-      edges_failed++;
-      results.push({ source_id, target_id, type, status: "failed", reason: "create_failed" });
-      continue;
-    }
-
-    edges_imported++;
-    results.push({ source_id, target_id, type, status: "imported" });
   }
 
   return {
@@ -197,6 +376,8 @@ export async function importExportPayload(env: Env, body: ExportPayload): Promis
     failed,
     edges_imported,
     edges_failed,
+    remaining_entries,
+    remaining_edges,
     results,
     vectorize_hint: "POST /vectorize-pending until remaining is 0",
   };

--- a/src/entries/import.ts
+++ b/src/entries/import.ts
@@ -9,22 +9,20 @@ export const IMPORT_DEFAULT_LIMIT = 40;
 export const IMPORT_MAX_LIMIT = 1000;
 /** D1 batch chunk size for inserts. */
 export const IMPORT_D1_BATCH_SIZE = 50;
+/** Edge endpoint lookups bind each id twice (source IN + target IN). */
+export const EDGE_ENDPOINT_QUERY_BATCH = Math.floor(D1_MAX_BOUND_PARAMS / 2);
 
-// Matches `main` schema today (no `updated_at` — add that column when #263 lands).
-export const ENTRY_INSERT_COLUMNS = [
-  "id",
-  "content",
-  "tags",
-  "source",
-  "created_at",
-  "vector_ids",
-  "recall_count",
-  "importance_score",
-  "contradiction_wins",
-  "contradiction_losses",
-] as const;
+const ENTRY_INSERT_SQL_TEMPLATE =
+  `INSERT INTO entries (id, content, tags, source, created_at, updated_at, vector_ids, recall_count, importance_score, contradiction_wins, contradiction_losses) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
 
-export const ENTRY_INSERT_SQL = `INSERT INTO entries (${ENTRY_INSERT_COLUMNS.join(", ")}) VALUES (${ENTRY_INSERT_COLUMNS.map(() => "?").join(", ")})`;
+function parseInsertColumns(sql: string): readonly string[] {
+  const match = sql.match(/INSERT INTO entries \(([^)]+)\)/i);
+  if (!match) throw new Error("INSERT INTO entries missing column list");
+  return match[1].split(",").map(c => c.trim());
+}
+
+export const ENTRY_INSERT_COLUMNS = parseInsertColumns(ENTRY_INSERT_SQL_TEMPLATE);
+export const ENTRY_INSERT_SQL = ENTRY_INSERT_SQL_TEMPLATE;
 
 export type ImportEntryStatus = "imported" | "skipped" | "failed";
 export type ImportEdgeStatus = "imported" | "skipped" | "failed";
@@ -203,8 +201,8 @@ async function loadExistingIds(env: Env, ids: string[]): Promise<Set<string>> {
 async function loadExistingEdgeKeys(env: Env, endpoints: string[]): Promise<Set<string>> {
   const keys = new Set<string>();
   if (!endpoints.length) return keys;
-  for (let i = 0; i < endpoints.length; i += D1_MAX_BOUND_PARAMS) {
-    const batch = endpoints.slice(i, i + D1_MAX_BOUND_PARAMS);
+  for (let i = 0; i < endpoints.length; i += EDGE_ENDPOINT_QUERY_BATCH) {
+    const batch = endpoints.slice(i, i + EDGE_ENDPOINT_QUERY_BATCH);
     const placeholders = batch.map(() => "?").join(", ");
     const { results } = await env.DB.prepare(
       `SELECT source_id, target_id, type FROM edges WHERE source_id IN (${placeholders}) OR target_id IN (${placeholders})`,
@@ -246,6 +244,29 @@ export function parseEdgeWeight(
   return { ok: true, value: Math.max(0, Math.min(1, weight)) };
 }
 
+type NumericFieldReason =
+  | "invalid_recall_count"
+  | "invalid_importance_score"
+  | "invalid_contradiction_wins"
+  | "invalid_contradiction_losses";
+
+export function parseOptionalNumber(
+  value: unknown,
+  invalidReason: NumericFieldReason,
+): { ok: true; value: number } | { ok: false; reason: NumericFieldReason } {
+  if (value === undefined || value === null) return { ok: true, value: 0 };
+  if (typeof value !== "number" || !Number.isFinite(value)) return { ok: false, reason: invalidReason };
+  return { ok: true, value };
+}
+
+export function parseCreatedAt(
+  value: unknown,
+): { ok: true; value: number } | { ok: false; reason: "invalid_created_at" } {
+  if (value === undefined || value === null) return { ok: true, value: Date.now() };
+  if (typeof value !== "number" || !Number.isFinite(value)) return { ok: false, reason: "invalid_created_at" };
+  return { ok: true, value };
+}
+
 function countNewEdgesInPayload(edges: ExportEdge[], existingEdgeKeys: Set<string>): number {
   let count = 0;
   for (const edge of edges) {
@@ -267,6 +288,7 @@ function bindInsert(env: Env, row: PendingInsert) {
     row.content,
     JSON.stringify(row.tags),
     row.source,
+    row.created_at,
     row.created_at,
     "[]",
     row.recall_count,
@@ -322,7 +344,7 @@ function bindEdgeInsert(env: Env, edge: PendingEdge) {
   const now = Date.now();
   return env.DB.prepare(
     `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, '{}', ?, ?)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(source_id, target_id, type) DO UPDATE SET weight = max(weight, excluded.weight), updated_at = excluded.updated_at`,
   ).bind(crypto.randomUUID(), source, target, edge.type, edge.weight, edge.provenance, "{}", edge.created_at, now);
 }
@@ -458,7 +480,38 @@ export async function importExportPayload(
     }
     newInsertAttempts++;
 
-    const created_at = typeof entry.created_at === "number" ? entry.created_at : Date.now();
+    const createdAtParsed = parseCreatedAt(entry.created_at);
+    if (!createdAtParsed.ok) {
+      failed++;
+      results.push({ id, status: "failed", reason: createdAtParsed.reason });
+      continue;
+    }
+    const created_at = createdAtParsed.value;
+
+    const recallCountParsed = parseOptionalNumber(entry.recall_count, "invalid_recall_count");
+    if (!recallCountParsed.ok) {
+      failed++;
+      results.push({ id, status: "failed", reason: recallCountParsed.reason });
+      continue;
+    }
+    const importanceParsed = parseOptionalNumber(entry.importance_score, "invalid_importance_score");
+    if (!importanceParsed.ok) {
+      failed++;
+      results.push({ id, status: "failed", reason: importanceParsed.reason });
+      continue;
+    }
+    const winsParsed = parseOptionalNumber(entry.contradiction_wins, "invalid_contradiction_wins");
+    if (!winsParsed.ok) {
+      failed++;
+      results.push({ id, status: "failed", reason: winsParsed.reason });
+      continue;
+    }
+    const lossesParsed = parseOptionalNumber(entry.contradiction_losses, "invalid_contradiction_losses");
+    if (!lossesParsed.ok) {
+      failed++;
+      results.push({ id, status: "failed", reason: lossesParsed.reason });
+      continue;
+    }
 
     pendingBatch.push({
       id,
@@ -466,10 +519,10 @@ export async function importExportPayload(
       tags,
       source,
       created_at,
-      recall_count: entry.recall_count ?? 0,
-      importance_score: entry.importance_score ?? 0,
-      contradiction_wins: entry.contradiction_wins ?? 0,
-      contradiction_losses: entry.contradiction_losses ?? 0,
+      recall_count: recallCountParsed.value,
+      importance_score: importanceParsed.value,
+      contradiction_wins: winsParsed.value,
+      contradiction_losses: lossesParsed.value,
     });
 
     if (pendingBatch.length >= IMPORT_D1_BATCH_SIZE) {

--- a/src/entries/import.ts
+++ b/src/entries/import.ts
@@ -267,7 +267,60 @@ export function parseCreatedAt(
   return { ok: true, value };
 }
 
-function countNewEdgesInPayload(edges: ExportEdge[], existingEdgeKeys: Set<string>): number {
+async function flushPendingIdLookups(
+  env: Env,
+  pending: string[],
+  existingIds: Set<string>,
+): Promise<void> {
+  while (pending.length) {
+    const batch = pending.splice(0, D1_MAX_BOUND_PARAMS);
+    const found = await loadExistingIds(env, batch);
+    for (const id of found) existingIds.add(id);
+  }
+}
+
+/** Resolve one id against D1, batching lookups to stay within query budget. */
+export async function ensureIdResolved(
+  env: Env,
+  id: string,
+  existingIds: Set<string>,
+  pending: string[],
+): Promise<void> {
+  if (existingIds.has(id)) return;
+  if (!pending.includes(id)) pending.push(id);
+  while (pending.length >= D1_MAX_BOUND_PARAMS) {
+    const batch = pending.splice(0, D1_MAX_BOUND_PARAMS);
+    const found = await loadExistingIds(env, batch);
+    for (const foundId of found) existingIds.add(foundId);
+  }
+  if (pending.includes(id)) {
+    await flushPendingIdLookups(env, pending, existingIds);
+  }
+}
+
+async function ensureIdsResolved(
+  env: Env,
+  ids: string[],
+  existingIds: Set<string>,
+  pending: string[],
+): Promise<void> {
+  for (const id of ids) {
+    if (existingIds.has(id)) continue;
+    if (!pending.includes(id)) pending.push(id);
+  }
+  await flushPendingIdLookups(env, pending, existingIds);
+}
+
+async function mergeExistingEdgeKeys(
+  env: Env,
+  endpoints: string[],
+  into: Set<string>,
+): Promise<void> {
+  const found = await loadExistingEdgeKeys(env, endpoints);
+  for (const key of found) into.add(key);
+}
+
+function countValidEdgesInPayload(edges: ExportEdge[]): number {
   let count = 0;
   for (const edge of edges) {
     if (!isImportRecordObject(edge)) continue;
@@ -276,8 +329,7 @@ function countNewEdgesInPayload(edges: ExportEdge[], existingEdgeKeys: Set<strin
     const sourceParsed = parseRequiredString(edge.source_id, "missing", "invalid");
     const targetParsed = parseRequiredString(edge.target_id, "missing", "invalid");
     if (!sourceParsed.ok || !targetParsed.ok) continue;
-    const key = normalizedEdgeKey(sourceParsed.value, targetParsed.value, type);
-    if (!existingEdgeKeys.has(key)) count++;
+    count++;
   }
   return count;
 }
@@ -416,11 +468,9 @@ export async function importExportPayload(
   let remaining_entries = 0;
   let remaining_edges = 0;
 
-  const payloadEntryIds = collectPayloadEntryIds(body.entries);
   const edges = body.edges ?? [];
-  const edgeEndpoints = collectEdgeEndpoints(edges);
-
-  const existingIds = await loadExistingIds(env, payloadEntryIds);
+  const existingIds = new Set<string>();
+  const pendingIdLookups: string[] = [];
   const pendingBatch: PendingInsert[] = [];
   let newInsertAttempts = 0;
   const batchCounters = { imported: 0, failed: 0 };
@@ -451,6 +501,13 @@ export async function importExportPayload(
       continue;
     }
 
+    if (newInsertAttempts >= limit) {
+      remaining_entries++;
+      continue;
+    }
+
+    await ensureIdResolved(env, id, existingIds, pendingIdLookups);
+
     if (existingIds.has(id)) {
       skipped++;
       continue;
@@ -473,12 +530,6 @@ export async function importExportPayload(
       }
       source = entry.source.trim() || "import";
     }
-
-    if (newInsertAttempts >= limit) {
-      remaining_entries++;
-      continue;
-    }
-    newInsertAttempts++;
 
     const createdAtParsed = parseCreatedAt(entry.created_at);
     if (!createdAtParsed.ok) {
@@ -525,6 +576,8 @@ export async function importExportPayload(
       contradiction_losses: lossesParsed.value,
     });
 
+    newInsertAttempts++;
+
     if (pendingBatch.length >= IMPORT_D1_BATCH_SIZE) {
       await flushInsertBatch(env, pendingBatch.splice(0), existingIds, results, batchCounters);
       imported += batchCounters.imported;
@@ -540,11 +593,12 @@ export async function importExportPayload(
     failed += batchCounters.failed;
   }
 
+  await flushPendingIdLookups(env, pendingIdLookups, existingIds);
+
   if (remaining_entries > 0) {
-    const existingEdgeKeys = await loadExistingEdgeKeys(env, edgeEndpoints);
-    remaining_edges = countNewEdgesInPayload(edges, existingEdgeKeys);
+    remaining_edges = countValidEdgesInPayload(edges);
   } else {
-    const existingEdgeKeys = await loadExistingEdgeKeys(env, edgeEndpoints);
+    const existingEdgeKeys = new Set<string>();
     let newEdgeAttempts = 0;
     const pendingEdgeBatch: PendingEdge[] = [];
     const edgeBatchCounters = { imported: 0, failed: 0 };
@@ -590,6 +644,13 @@ export async function importExportPayload(
         continue;
       }
 
+      if (newEdgeAttempts >= limit) {
+        remaining_edges++;
+        continue;
+      }
+
+      await ensureIdsResolved(env, [source_id, target_id], existingIds, pendingIdLookups);
+
       if (!existingIds.has(source_id) || !existingIds.has(target_id)) {
         edges_failed++;
         results.push({ source_id, target_id, type, status: "failed", reason: "missing_endpoint" });
@@ -597,6 +658,9 @@ export async function importExportPayload(
       }
 
       const edgeKey = normalizedEdgeKey(source_id, target_id, type);
+      if (!existingEdgeKeys.has(edgeKey)) {
+        await mergeExistingEdgeKeys(env, [source_id, target_id], existingEdgeKeys);
+      }
       if (existingEdgeKeys.has(edgeKey)) {
         edges_skipped++;
         continue;
@@ -609,10 +673,6 @@ export async function importExportPayload(
         continue;
       }
 
-      if (newEdgeAttempts >= limit) {
-        remaining_edges++;
-        continue;
-      }
       newEdgeAttempts++;
 
       const provenance = edge.provenance && typeof edge.provenance === "string" && isValidProvenance(edge.provenance)

--- a/src/entries/import.ts
+++ b/src/entries/import.ts
@@ -1,10 +1,11 @@
 import type { Env } from "../env";
-import { createEdge, isSymmetric, isValidEdgeType } from "../graph/edges";
+import { D1_MAX_BOUND_PARAMS } from "../constants";
+import { isSymmetric, isValidEdgeType } from "../graph/edges";
 import type { EdgeProvenance } from "../graph/types";
 import { PROVENANCE_VALUES } from "../graph/types";
 
 /** Max new entry inserts attempted per request (skipped rows do not count). */
-export const IMPORT_DEFAULT_LIMIT = 100;
+export const IMPORT_DEFAULT_LIMIT = 40;
 export const IMPORT_MAX_LIMIT = 1000;
 /** D1 batch chunk size for inserts. */
 export const IMPORT_D1_BATCH_SIZE = 50;
@@ -91,6 +92,17 @@ export interface ImportSummary {
   vectorize_hint: string;
 }
 
+interface PendingEdge {
+  source_id: string;
+  target_id: string;
+  type: string;
+  weight: number;
+  provenance: EdgeProvenance;
+  created_at: number;
+}
+
+const DEFAULT_EDGE_WEIGHT = 0.5;
+
 interface PendingInsert {
   id: string;
   content: string;
@@ -174,16 +186,64 @@ export function parseImportLimit(raw: string | null): number {
   return Math.min(n, IMPORT_MAX_LIMIT);
 }
 
-async function loadExistingIds(env: Env): Promise<Set<string>> {
-  const { results } = await env.DB.prepare(`SELECT id FROM entries`).all() as { results: { id: string }[] };
-  return new Set(results.map(r => r.id));
+async function loadExistingIds(env: Env, ids: string[]): Promise<Set<string>> {
+  const found = new Set<string>();
+  if (!ids.length) return found;
+  for (let i = 0; i < ids.length; i += D1_MAX_BOUND_PARAMS) {
+    const batch = ids.slice(i, i + D1_MAX_BOUND_PARAMS);
+    const placeholders = batch.map(() => "?").join(", ");
+    const { results } = await env.DB.prepare(
+      `SELECT id FROM entries WHERE id IN (${placeholders})`,
+    ).bind(...batch).all() as { results: { id: string }[] };
+    for (const row of results) found.add(row.id);
+  }
+  return found;
 }
 
-async function loadExistingEdgeKeys(env: Env): Promise<Set<string>> {
-  const { results } = await env.DB.prepare(`SELECT source_id, target_id, type FROM edges`).all() as {
-    results: { source_id: string; target_id: string; type: string }[];
-  };
-  return new Set(results.map(r => normalizedEdgeKey(r.source_id, r.target_id, r.type)));
+async function loadExistingEdgeKeys(env: Env, endpoints: string[]): Promise<Set<string>> {
+  const keys = new Set<string>();
+  if (!endpoints.length) return keys;
+  for (let i = 0; i < endpoints.length; i += D1_MAX_BOUND_PARAMS) {
+    const batch = endpoints.slice(i, i + D1_MAX_BOUND_PARAMS);
+    const placeholders = batch.map(() => "?").join(", ");
+    const { results } = await env.DB.prepare(
+      `SELECT source_id, target_id, type FROM edges WHERE source_id IN (${placeholders}) OR target_id IN (${placeholders})`,
+    ).bind(...batch, ...batch).all() as {
+      results: { source_id: string; target_id: string; type: string }[];
+    };
+    for (const row of results) keys.add(normalizedEdgeKey(row.source_id, row.target_id, row.type));
+  }
+  return keys;
+}
+
+function collectPayloadEntryIds(entries: ExportEntry[]): string[] {
+  const ids: string[] = [];
+  for (const entry of entries) {
+    if (!isImportRecordObject(entry)) continue;
+    const parsed = parseRequiredString(entry.id, "missing", "invalid");
+    if (parsed.ok) ids.push(parsed.value);
+  }
+  return ids;
+}
+
+function collectEdgeEndpoints(edges: ExportEdge[]): string[] {
+  const endpoints = new Set<string>();
+  for (const edge of edges) {
+    if (!isImportRecordObject(edge)) continue;
+    const sourceParsed = parseRequiredString(edge.source_id, "missing", "invalid");
+    const targetParsed = parseRequiredString(edge.target_id, "missing", "invalid");
+    if (sourceParsed.ok) endpoints.add(sourceParsed.value);
+    if (targetParsed.ok) endpoints.add(targetParsed.value);
+  }
+  return [...endpoints];
+}
+
+export function parseEdgeWeight(
+  weight: unknown,
+): { ok: true; value: number } | { ok: false; reason: "invalid_weight" } {
+  if (weight === undefined || weight === null) return { ok: true, value: DEFAULT_EDGE_WEIGHT };
+  if (typeof weight !== "number" || !Number.isFinite(weight)) return { ok: false, reason: "invalid_weight" };
+  return { ok: true, value: Math.max(0, Math.min(1, weight)) };
 }
 
 function countNewEdgesInPayload(edges: ExportEdge[], existingEdgeKeys: Set<string>): number {
@@ -253,6 +313,71 @@ async function flushInsertBatch(
   }
 }
 
+function bindEdgeInsert(env: Env, edge: PendingEdge) {
+  let source = edge.source_id;
+  let target = edge.target_id;
+  if (isValidEdgeType(edge.type) && isSymmetric(edge.type) && source > target) {
+    [source, target] = [target, source];
+  }
+  const now = Date.now();
+  return env.DB.prepare(
+    `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, '{}', ?, ?)
+     ON CONFLICT(source_id, target_id, type) DO UPDATE SET weight = max(weight, excluded.weight), updated_at = excluded.updated_at`,
+  ).bind(crypto.randomUUID(), source, target, edge.type, edge.weight, edge.provenance, "{}", edge.created_at, now);
+}
+
+async function flushEdgeBatch(
+  env: Env,
+  batch: PendingEdge[],
+  existingEdgeKeys: Set<string>,
+  results: ImportResultItem[],
+  counters: { imported: number; failed: number },
+): Promise<void> {
+  if (!batch.length) return;
+
+  const stmts = batch.map(row => bindEdgeInsert(env, row));
+  try {
+    await env.DB.batch(stmts);
+    for (const row of batch) {
+      const key = normalizedEdgeKey(row.source_id, row.target_id, row.type);
+      existingEdgeKeys.add(key);
+      counters.imported++;
+      results.push({
+        source_id: row.source_id,
+        target_id: row.target_id,
+        type: row.type,
+        status: "imported",
+      });
+    }
+  } catch {
+    for (const row of batch) {
+      try {
+        await bindEdgeInsert(env, row).run();
+        const key = normalizedEdgeKey(row.source_id, row.target_id, row.type);
+        existingEdgeKeys.add(key);
+        counters.imported++;
+        results.push({
+          source_id: row.source_id,
+          target_id: row.target_id,
+          type: row.type,
+          status: "imported",
+        });
+      } catch (e) {
+        counters.failed++;
+        results.push({
+          source_id: row.source_id,
+          target_id: row.target_id,
+          type: row.type,
+          status: "failed",
+          reason: "create_failed",
+          detail: formatDbError(e),
+        });
+      }
+    }
+  }
+}
+
 export async function importExportPayload(
   env: Env,
   body: ExportPayload,
@@ -269,8 +394,11 @@ export async function importExportPayload(
   let remaining_entries = 0;
   let remaining_edges = 0;
 
-  const existingIds = await loadExistingIds(env);
-  const existingEdgeKeys = await loadExistingEdgeKeys(env);
+  const payloadEntryIds = collectPayloadEntryIds(body.entries);
+  const edges = body.edges ?? [];
+  const edgeEndpoints = collectEdgeEndpoints(edges);
+
+  const existingIds = await loadExistingIds(env, payloadEntryIds);
   const pendingBatch: PendingInsert[] = [];
   let newInsertAttempts = 0;
   const batchCounters = { imported: 0, failed: 0 };
@@ -359,11 +487,15 @@ export async function importExportPayload(
     failed += batchCounters.failed;
   }
 
-  const edges = body.edges ?? [];
   if (remaining_entries > 0) {
+    const existingEdgeKeys = await loadExistingEdgeKeys(env, edgeEndpoints);
     remaining_edges = countNewEdgesInPayload(edges, existingEdgeKeys);
   } else {
+    const existingEdgeKeys = await loadExistingEdgeKeys(env, edgeEndpoints);
     let newEdgeAttempts = 0;
+    const pendingEdgeBatch: PendingEdge[] = [];
+    const edgeBatchCounters = { imported: 0, failed: 0 };
+
     for (const edge of edges) {
       if (!isImportRecordObject(edge)) {
         edges_failed++;
@@ -417,6 +549,13 @@ export async function importExportPayload(
         continue;
       }
 
+      const weightParsed = parseEdgeWeight(edge.weight);
+      if (!weightParsed.ok) {
+        edges_failed++;
+        results.push({ source_id, target_id, type, status: "failed", reason: weightParsed.reason });
+        continue;
+      }
+
       if (newEdgeAttempts >= limit) {
         remaining_edges++;
         continue;
@@ -427,31 +566,28 @@ export async function importExportPayload(
         ? edge.provenance
         : "explicit";
 
-      try {
-        const created = await createEdge(source_id, target_id, type, {
-          weight: edge.weight,
-          provenance,
-          created_at: typeof edge.created_at === "number" ? edge.created_at : undefined,
-        }, env);
-        if (!created) {
-          edges_failed++;
-          results.push({ source_id, target_id, type, status: "failed", reason: "create_failed" });
-          continue;
-        }
-        existingEdgeKeys.add(edgeKey);
-        edges_imported++;
-        results.push({ source_id, target_id, type, status: "imported" });
-      } catch (e) {
-        edges_failed++;
-        results.push({
-          source_id,
-          target_id,
-          type,
-          status: "failed",
-          reason: "create_failed",
-          detail: formatDbError(e),
-        });
+      pendingEdgeBatch.push({
+        source_id,
+        target_id,
+        type,
+        weight: weightParsed.value,
+        provenance,
+        created_at: typeof edge.created_at === "number" ? edge.created_at : Date.now(),
+      });
+
+      if (pendingEdgeBatch.length >= IMPORT_D1_BATCH_SIZE) {
+        await flushEdgeBatch(env, pendingEdgeBatch.splice(0), existingEdgeKeys, results, edgeBatchCounters);
+        edges_imported += edgeBatchCounters.imported;
+        edges_failed += edgeBatchCounters.failed;
+        edgeBatchCounters.imported = 0;
+        edgeBatchCounters.failed = 0;
       }
+    }
+
+    if (pendingEdgeBatch.length) {
+      await flushEdgeBatch(env, pendingEdgeBatch.splice(0), existingEdgeKeys, results, edgeBatchCounters);
+      edges_imported += edgeBatchCounters.imported;
+      edges_failed += edgeBatchCounters.failed;
     }
   }
 

--- a/src/graph/edges.ts
+++ b/src/graph/edges.ts
@@ -24,7 +24,7 @@ export async function createEdge(
   sourceId: string,
   targetId: string,
   type: string,
-  opts: { weight?: number; provenance?: EdgeProvenance; metadata?: Record<string, unknown> },
+  opts: { weight?: number; provenance?: EdgeProvenance; metadata?: Record<string, unknown>; created_at?: number },
   env: Env,
 ): Promise<{ source_id: string; target_id: string; type: EdgeType } | null> {
   if (!isValidEdgeType(type)) return null;
@@ -38,12 +38,13 @@ export async function createEdge(
   const provenance = opts.provenance ?? "inferred";
   const metadata = JSON.stringify(opts.metadata ?? {});
   const now = Date.now();
+  const createdAt = opts.created_at ?? now;
 
   await env.DB.prepare(
     `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(source_id, target_id, type) DO UPDATE SET weight = max(weight, excluded.weight), updated_at = excluded.updated_at`
-  ).bind(crypto.randomUUID(), source, target, type, weight, provenance, metadata, now, now).run();
+  ).bind(crypto.randomUUID(), source, target, type, weight, provenance, metadata, createdAt, now).run();
 
   return { source_id: source, target_id: target, type };
 }

--- a/src/routes/entries.ts
+++ b/src/routes/entries.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../env";
+import { importExportPayload, parseImportBody } from "../entries/import";
 import { json, requireAuth } from "../lib/http";
 import { forgetEntry } from "../capture/lifecycle";
 import { applyStatus } from "../capture/lifecycle";
@@ -67,6 +68,24 @@ export async function handleEntriesRoutes(
       created_at: r.created_at,
     }));
     return json({ ok: true, exported_at: Date.now(), version: 2, entries, edges });
+  }
+
+  // POST /import — round-trip counterpart to GET /export (issue #217). Inserts by
+  // export id (skip if exists), preserves created_at/tags/source, defers embedding
+  // via vector_ids=[] so POST /vectorize-pending can backfill without burning the
+  // Workers AI quota in one request. Does NOT go through /capture.
+  if (url.pathname === "/import" && request.method === "POST") {
+    const authErr = requireAuth(request, env);
+    if (authErr) return authErr;
+
+    let body: unknown;
+    try { body = await request.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
+
+    const parsed = parseImportBody(body);
+    if (!parsed.ok) return json({ ok: false, error: parsed.error }, 400);
+
+    const summary = await importExportPayload(env, parsed.payload);
+    return json(summary);
   }
 
   // POST /forget — delete-by-id, mirrors the MCP `forget` tool

--- a/src/routes/entries.ts
+++ b/src/routes/entries.ts
@@ -1,5 +1,6 @@
 import type { Env } from "../env";
-import { importExportPayload, parseImportBody, parseImportLimit } from "../entries/import";
+import { importExportPayload, parseImportBody, parseImportLimit, parseImportOffset } from "../entries/import";
+import { initializeDatabase } from "../db/init";
 import { json, requireAuth } from "../lib/http";
 import { forgetEntry } from "../capture/lifecycle";
 import { applyStatus } from "../capture/lifecycle";
@@ -71,12 +72,24 @@ export async function handleEntriesRoutes(
   }
 
   // POST /import — round-trip counterpart to GET /export (issue #217). Inserts by
-  // export id (skip if exists), preserves created_at/tags/source, defers embedding
-  // via vector_ids=[] so POST /vectorize-pending can backfill without burning the
-  // Workers AI quota in one request. Does NOT go through /capture.
+  // export id (skip if exists), preserves created_at/updated_at/tags/source, defers
+  // embedding via vector_ids=[] so POST /vectorize-pending can backfill without
+  // burning the Workers AI quota in one request. Does NOT go through /capture.
+  //
+  // Paged positionally: one call examines entries[offset .. offset+limit), then —
+  // once entries are exhausted — edges[edge_offset .. edge_offset+limit). Clients
+  // resend the same file with the next_offset/next_edge_offset from the previous
+  // response until both remaining counts are 0. See importExportPayload for why
+  // this is what keeps a large restore inside the D1 free-plan query budget.
   if (url.pathname === "/import" && request.method === "POST") {
     const authErr = requireAuth(request, env);
     if (authErr) return authErr;
+
+    // Awaited, not left to ensureDbReady's waitUntil: an import is often a freshly
+    // deployed brain's first request, which is exactly when the schema ALTERs have
+    // not run yet and every insert would fail on a missing column. Latched after
+    // the first call, so this costs nothing in the steady state.
+    await initializeDatabase(env);
 
     let body: unknown;
     try { body = await request.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
@@ -85,7 +98,9 @@ export async function handleEntriesRoutes(
     if (!parsed.ok) return json({ ok: false, error: parsed.error }, 400);
 
     const limit = parseImportLimit(url.searchParams.get("limit"));
-    const summary = await importExportPayload(env, parsed.payload, { limit });
+    const offset = parseImportOffset(url.searchParams.get("offset"));
+    const edgeOffset = parseImportOffset(url.searchParams.get("edge_offset"));
+    const summary = await importExportPayload(env, parsed.payload, { limit, offset, edgeOffset });
     return json(summary);
   }
 

--- a/src/routes/entries.ts
+++ b/src/routes/entries.ts
@@ -1,5 +1,5 @@
 import type { Env } from "../env";
-import { importExportPayload, parseImportBody } from "../entries/import";
+import { importExportPayload, parseImportBody, parseImportLimit } from "../entries/import";
 import { json, requireAuth } from "../lib/http";
 import { forgetEntry } from "../capture/lifecycle";
 import { applyStatus } from "../capture/lifecycle";
@@ -84,7 +84,8 @@ export async function handleEntriesRoutes(
     const parsed = parseImportBody(body);
     if (!parsed.ok) return json({ ok: false, error: parsed.error }, 400);
 
-    const summary = await importExportPayload(env, parsed.payload);
+    const limit = parseImportLimit(url.searchParams.get("limit"));
+    const summary = await importExportPayload(env, parsed.payload, { limit });
     return json(summary);
   }
 

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -57,22 +57,21 @@ export class D1Mock {
     const makeStmt = (args: any[]) => ({
       async run() {
         if (s.startsWith("INSERT INTO entries")) {
-          if (args.length >= 11) {
-            const [id, content, tags, source, created_at, updated_at, vector_ids, recall_count, importance_score, contradiction_wins, contradiction_losses] = args;
-            db.entries.push({ id, content, tags, source, created_at, updated_at, vector_ids, recall_count: recall_count ?? 0, importance_score: importance_score ?? 0, contradiction_wins: contradiction_wins ?? 0, contradiction_losses: contradiction_losses ?? 0 });
-          } else if (args.length >= 8) {
-            const [id, content, tags, source, created_at, updated_at, vector_ids, importance_score] = args;
-            db.entries.push({ id, content, tags, source, created_at, updated_at, vector_ids, recall_count: 0, importance_score: importance_score ?? 0, contradiction_wins: 0, contradiction_losses: 0 });
-          } else if (args.length === 10) {
-            const [id, content, tags, source, created_at, vector_ids, recall_count, importance_score, contradiction_wins, contradiction_losses] = args;
-            db.entries.push({ id, content, tags, source, created_at, updated_at: created_at, vector_ids, recall_count: recall_count ?? 0, importance_score: importance_score ?? 0, contradiction_wins: contradiction_wins ?? 0, contradiction_losses: contradiction_losses ?? 0 });
-          } else if (args.length === 7) {
-            const [id, content, tags, source, created_at, updated_at, vector_ids] = args;
-            db.entries.push({ id, content, tags, source, created_at, updated_at, vector_ids, recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0 });
-          } else {
-            const [id, content, tags, source, created_at, vector_ids] = args;
-            db.entries.push({ id, content, tags, source, created_at, updated_at: created_at, vector_ids, recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0 });
+          const colMatch = s.match(/INSERT INTO entries \(([^)]+)\)/i);
+          if (!colMatch) throw new Error("INSERT INTO entries missing column list");
+          const cols = colMatch[1].split(",").map(c => c.trim());
+          if (cols.length !== args.length) {
+            throw new Error(`INSERT INTO entries column/bind mismatch: ${cols.length} vs ${args.length}`);
           }
+          const row: Record<string, any> = {
+            recall_count: 0,
+            importance_score: 0,
+            contradiction_wins: 0,
+            contradiction_losses: 0,
+          };
+          cols.forEach((col, i) => { row[col] = args[i]; });
+          if (row.updated_at === undefined) row.updated_at = row.created_at ?? Date.now();
+          db.entries.push(row);
           return { meta: { changes: 1 } };
         }
         if (s.startsWith("UPDATE entries SET content = ?, vector_ids = ?, tags = ?, updated_at = ? WHERE id")) {
@@ -317,6 +316,15 @@ export class D1Mock {
         }
         if (s === "SELECT id FROM entries") {
           return { results: db.entries.map((e: any) => ({ id: e.id })) };
+        }
+        if (s === "SELECT source_id, target_id, type FROM edges") {
+          return {
+            results: db.edges.map((e: any) => ({
+              source_id: e.source_id,
+              target_id: e.target_id,
+              type: e.type,
+            })),
+          };
         }
         if (
           sBare === "SELECT id FROM entries WHERE tags LIKE ?" ||

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -207,6 +207,10 @@ export class D1Mock {
           return { meta: { changes: before - db.entries.length } };
         }
         if (s.startsWith("INSERT INTO edges")) {
+          const placeholderCount = (s.match(/\?/g) ?? []).length;
+          if (placeholderCount !== args.length) {
+            throw new Error(`INSERT INTO edges placeholder/bind mismatch: ${placeholderCount} vs ${args.length}`);
+          }
           const [id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at] = args;
           const existing = db.edges.find((e: any) => e.source_id === source_id && e.target_id === target_id && e.type === type);
           if (existing) {

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -365,6 +365,19 @@ export class D1Mock {
             .map((e: any) => ({ id: e.id, content: e.content }));
           return { results: rows };
         }
+        if (s.includes("SELECT id FROM entries WHERE id IN")) {
+          const results = db.entries
+            .filter((e: any) => args.includes(e.id))
+            .map((e: any) => ({ id: e.id }));
+          return { results };
+        }
+        if (s.includes("SELECT source_id, target_id, type FROM edges WHERE source_id IN") && s.includes("OR target_id IN")) {
+          const ids = new Set(args.map((a: any) => String(a)));
+          const results = db.edges
+            .filter((e: any) => ids.has(e.source_id) || ids.has(e.target_id))
+            .map((e: any) => ({ source_id: e.source_id, target_id: e.target_id, type: e.type }));
+          return { results };
+        }
         if (s.includes("FROM edges WHERE source_id IN") && s.includes("OR target_id IN")) {
           // expandGraph BFS / graph edge fetch: every edge touching the frontier, strongest
           // first. Args are the frontier id list bound twice (source_id IN …, target_id IN …).

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -63,6 +63,9 @@ export class D1Mock {
           } else if (args.length >= 8) {
             const [id, content, tags, source, created_at, updated_at, vector_ids, importance_score] = args;
             db.entries.push({ id, content, tags, source, created_at, updated_at, vector_ids, recall_count: 0, importance_score: importance_score ?? 0, contradiction_wins: 0, contradiction_losses: 0 });
+          } else if (args.length === 10) {
+            const [id, content, tags, source, created_at, vector_ids, recall_count, importance_score, contradiction_wins, contradiction_losses] = args;
+            db.entries.push({ id, content, tags, source, created_at, updated_at: created_at, vector_ids, recall_count: recall_count ?? 0, importance_score: importance_score ?? 0, contradiction_wins: contradiction_wins ?? 0, contradiction_losses: contradiction_losses ?? 0 });
           } else if (args.length === 7) {
             const [id, content, tags, source, created_at, updated_at, vector_ids] = args;
             db.entries.push({ id, content, tags, source, created_at, updated_at, vector_ids, recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0 });
@@ -311,6 +314,9 @@ export class D1Mock {
           // with it. Fresh and partially-migrated brains are covered against real SQLite
           // in test/unit/db-init.test.ts.
           return { results: SCHEMA_PROBE_RESULTS };
+        }
+        if (s === "SELECT id FROM entries") {
+          return { results: db.entries.map((e: any) => ({ id: e.id })) };
         }
         if (
           sBare === "SELECT id FROM entries WHERE tags LIKE ?" ||

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -57,7 +57,10 @@ export class D1Mock {
     const makeStmt = (args: any[]) => ({
       async run() {
         if (s.startsWith("INSERT INTO entries")) {
-          if (args.length >= 8) {
+          if (args.length >= 11) {
+            const [id, content, tags, source, created_at, updated_at, vector_ids, recall_count, importance_score, contradiction_wins, contradiction_losses] = args;
+            db.entries.push({ id, content, tags, source, created_at, updated_at, vector_ids, recall_count: recall_count ?? 0, importance_score: importance_score ?? 0, contradiction_wins: contradiction_wins ?? 0, contradiction_losses: contradiction_losses ?? 0 });
+          } else if (args.length >= 8) {
             const [id, content, tags, source, created_at, updated_at, vector_ids, importance_score] = args;
             db.entries.push({ id, content, tags, source, created_at, updated_at, vector_ids, recall_count: 0, importance_score: importance_score ?? 0, contradiction_wins: 0, contradiction_losses: 0 });
           } else if (args.length === 7) {

--- a/test/integration/import-subrequests.test.ts
+++ b/test/integration/import-subrequests.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Pins /import's D1 subrequest cost per invocation, driven against real SQLite.
+ *
+ * The endpoint exists to migrate a brain, and most brains run on the D1 free plan,
+ * which allows roughly 50 queries per Worker invocation. The paging design holds
+ * the per-call cost flat — one chunked existence lookup plus one insert batch per
+ * page, regardless of file size or how far in the cursor is. An earlier version
+ * resolved ids lazily, one query per entry and two per edge, which spent the whole
+ * budget partway through a real restore (measured: 201 round trips for page 5 of a
+ * 5,000-entry export). These tests are what keeps that from coming back.
+ *
+ * Counting: `issued` logs one entry per D1 call; the batch shim below collapses a
+ * batch's statements into one entry, because DB.batch() is one subrequest in
+ * production however many statements it carries.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import worker from "../../src/index";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestEnv } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import { initializeDatabase, resetDatabaseInit } from "../../src/db/init";
+import { setDbReady } from "../../src/runtime/state";
+import { importExportPayload, IMPORT_DEFAULT_LIMIT } from "../../src/entries/import";
+import type { Env } from "../../src/env";
+
+let sq: SqliteD1 | null = null;
+afterEach(() => { sq?.close(); sq = null; setDbReady(false); });
+
+function envOf(s: SqliteD1): Env {
+  return {
+    DB: {
+      prepare: (sql: string) => s.db.prepare(sql),
+      exec: (sql: string) => s.db.exec(sql),
+      async batch(stmts: { run(): Promise<unknown> }[]) {
+        for (const st of stmts) await st.run();
+        // The helper logs at prepare() time, so the batch's statements are the log's
+        // tail by the time this runs — collapse them into the one subrequest they are.
+        s.issued.splice(s.issued.length - stmts.length, stmts.length, `BATCH(${stmts.length})`);
+        return stmts.map(() => ({ meta: { changes: 1 } }));
+      },
+    },
+  } as unknown as Env;
+}
+
+/** Fresh DB with the runtime ALTERs applied, subrequest log cleared. */
+async function migrated(): Promise<SqliteD1> {
+  const s = makeSqliteD1();
+  resetDatabaseInit();
+  await initializeDatabase(envOf(s));
+  s.issued.length = 0;
+  return s;
+}
+
+const entry = (i: number) => ({
+  id: `id-${i}`,
+  content: `content ${i}`,
+  created_at: 1_700_000_000_000 + i,
+});
+
+describe("/import subrequest budget (D1 free plan: ~50 per invocation)", () => {
+  it("a fresh default page costs one lookup and one batch", async () => {
+    sq = await migrated();
+    const entries = Array.from({ length: IMPORT_DEFAULT_LIMIT }, (_, i) => entry(i));
+    const summary = await importExportPayload(envOf(sq), { entries }, {});
+
+    expect(summary.imported).toBe(IMPORT_DEFAULT_LIMIT);
+    expect(sq.rows()).toHaveLength(IMPORT_DEFAULT_LIMIT);
+    // 1 existence lookup (40 ids, one chunk) + 1 insert batch.
+    expect(sq.issued).toHaveLength(2);
+  });
+
+  it("a late page of a large export costs the same as the first page", async () => {
+    sq = await migrated();
+    for (let i = 0; i < 160; i++) {
+      sq.seed({ id: `id-${i}`, content: `content ${i}`, createdAt: 1_700_000_000_000 + i });
+    }
+    sq.issued.length = 0;
+
+    const entries = Array.from({ length: 5000 }, (_, i) => entry(i));
+    const summary = await importExportPayload(envOf(sq), { entries }, { offset: 160 });
+
+    expect(summary.imported).toBe(IMPORT_DEFAULT_LIMIT);
+    expect(summary.next_offset).toBe(200);
+    expect(summary.remaining_entries).toBe(4800);
+    expect(sq.rows()).toHaveLength(200);
+    // Position in the file must not change the price: still 1 lookup + 1 batch.
+    expect(sq.issued).toHaveLength(2);
+  });
+
+  it("an edges-only page stays in single digits", async () => {
+    sq = await migrated();
+    for (let i = 0; i < 41; i++) {
+      sq.seed({ id: `id-${i}`, content: `content ${i}`, createdAt: 1_700_000_000_000 + i });
+    }
+    sq.issued.length = 0;
+
+    const edges = Array.from({ length: 40 }, (_, i) => ({
+      source_id: `id-${i}`,
+      target_id: `id-${i + 1}`,
+      type: "relates_to",
+    }));
+    const summary = await importExportPayload(envOf(sq), { entries: [], edges }, {});
+
+    expect(summary.edges_imported).toBe(40);
+    // 1 endpoint lookup (41 distinct ids, one chunk) + 1 edge-key lookup (41
+    // endpoints double-bound, one chunk of 50) + 1 insert batch.
+    expect(sq.issued).toHaveLength(3);
+  });
+
+  it("a rerun of an already-imported page is one lookup and no writes", async () => {
+    sq = await migrated();
+    const entries = Array.from({ length: IMPORT_DEFAULT_LIMIT }, (_, i) => entry(i));
+    await importExportPayload(envOf(sq), { entries }, {});
+    sq.issued.length = 0;
+
+    const summary = await importExportPayload(envOf(sq), { entries }, {});
+    expect(summary.skipped).toBe(IMPORT_DEFAULT_LIMIT);
+    expect(summary.imported).toBe(0);
+    expect(sq.issued).toHaveLength(1);
+  });
+});
+
+describe("/import on a freshly deployed brain", () => {
+  it("succeeds as the first request ever, before ensureDbReady's background init lands", async () => {
+    // schema.sql only — the updated_at ALTER has not run, which is every new brain's
+    // state when its first request arrives. The route awaits initializeDatabase
+    // itself; leaning on ensureDbReady's waitUntil means racing it, and losing
+    // fails every insert with "table entries has no column named updated_at".
+    //
+    // setDbReady(true) keeps ensureDbReady from firing its background init at all.
+    // Against synchronous SQLite that init always wins the race, which would let a
+    // route that forgot its own await pass here while losing in production, where
+    // D1 calls take real time.
+    sq = makeSqliteD1();
+    resetDatabaseInit();
+    setDbReady(true);
+    const env = makeTestEnv(envOf(sq).DB as any);
+    const ctx = { waitUntil: (_: Promise<unknown>) => {} } as any;
+
+    const res = await worker.fetch(req("POST", "/import", {
+      body: { version: 2, entries: [{ id: "first", content: "First ever request", created_at: 1000 }] },
+    }), env, ctx);
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.imported).toBe(1);
+    expect(data.failed).toBe(0);
+    expect(sq.rows()).toHaveLength(1);
+    expect(sq.columns()).toContain("updated_at");
+  });
+});

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -39,6 +39,7 @@ function exportPayload(db: D1Mock) {
       tags: JSON.parse(e.tags ?? "[]"),
       source: e.source,
       created_at: e.created_at,
+      updated_at: e.updated_at ?? e.created_at,
       recall_count: e.recall_count ?? 0,
       importance_score: e.importance_score ?? 0,
       contradiction_wins: e.contradiction_wins ?? 0,
@@ -281,7 +282,7 @@ describe("POST /import", () => {
     expect(db.entries).toHaveLength(0);
   });
 
-  it("paginates edges under ?limit= with idempotent skip", async () => {
+  it("pages entries then edges by cursor, with idempotent re-runs", async () => {
     const entries = [
       { id: "a", content: "A", created_at: 1 },
       { id: "b", content: "B", created_at: 2 },
@@ -291,30 +292,41 @@ describe("POST /import", () => {
       { source_id: "a", target_id: "b", type: "relates_to", created_at: 100 },
       { source_id: "b", target_id: "c", type: "relates_to", created_at: 200 },
     ];
-
-    const seedEntries = await worker.fetch(req("POST", "/import", {
-      body: { version: 2, entries, edges: [] },
-    }), env, ctx);
-    expect((await seedEntries.json() as any).imported).toBe(3);
-
     const payload = { version: 2, entries, edges };
 
-    const firstEdge = await worker.fetch(req("POST", "/import?limit=1", { body: payload }), env, ctx);
-    const firstEdgeData = await firstEdge.json() as any;
-    expect(firstEdgeData.skipped).toBe(3);
-    expect(firstEdgeData.edges_imported).toBe(1);
-    expect(firstEdgeData.remaining_edges).toBe(1);
-    expect(firstEdgeData.results).toHaveLength(1);
+    // Entry pages at limit=1: edges wait until the entries array is exhausted.
+    const p1 = await (await worker.fetch(req("POST", "/import?limit=1", { body: payload }), env, ctx)).json() as any;
+    expect(p1.imported).toBe(1);
+    expect(p1.next_offset).toBe(1);
+    expect(p1.remaining_entries).toBe(2);
+    expect(p1.edges_imported).toBe(0);
+    expect(p1.remaining_edges).toBe(2);
+
+    const p2 = await (await worker.fetch(req("POST", "/import?limit=1&offset=1", { body: payload }), env, ctx)).json() as any;
+    expect(p2.imported).toBe(1);
+    expect(db.edges).toHaveLength(0);
+
+    // The final entries page and the first edge page share a call.
+    const p3 = await (await worker.fetch(req("POST", "/import?limit=1&offset=2", { body: payload }), env, ctx)).json() as any;
+    expect(p3.imported).toBe(1);
+    expect(p3.remaining_entries).toBe(0);
+    expect(p3.edges_imported).toBe(1);
+    expect(p3.next_edge_offset).toBe(1);
+    expect(p3.remaining_edges).toBe(1);
     expect(db.edges).toHaveLength(1);
     expect(db.edges[0].created_at).toBe(100);
 
-    const secondEdge = await worker.fetch(req("POST", "/import?limit=1", { body: payload }), env, ctx);
-    const secondEdgeData = await secondEdge.json() as any;
-    expect(secondEdgeData.edges_imported).toBe(1);
-    expect(secondEdgeData.edges_skipped).toBe(1);
-    expect(secondEdgeData.remaining_edges).toBe(0);
+    const p4 = await (await worker.fetch(req("POST", "/import?limit=1&offset=3&edge_offset=1", { body: payload }), env, ctx)).json() as any;
+    expect(p4.edges_imported).toBe(1);
+    expect(p4.remaining_edges).toBe(0);
     expect(db.edges).toHaveLength(2);
     expect(db.edges.find((e: any) => e.source_id === "b" && e.target_id === "c")?.created_at).toBe(200);
+
+    // Re-running a page is a skip, not a duplicate or an error.
+    const rerun = await (await worker.fetch(req("POST", "/import?limit=1&offset=3&edge_offset=1", { body: payload }), env, ctx)).json() as any;
+    expect(rerun.edges_skipped).toBe(1);
+    expect(rerun.edges_imported).toBe(0);
+    expect(db.edges).toHaveLength(2);
   });
 
   it("reports invalid_recall_count without aborting the request", async () => {
@@ -335,6 +347,77 @@ describe("POST /import", () => {
     expect(data.results).toContainEqual({ id: "bad", status: "failed", reason: "invalid_recall_count" });
     expect(db.entries).toHaveLength(1);
     expect(db.entries[0].id).toBe("good");
+  });
+
+  it("preserves updated_at across the round trip, and defaults it for old exports", async () => {
+    const res = await worker.fetch(req("POST", "/import", {
+      body: {
+        version: 2,
+        entries: [
+          { id: "edited", content: "Edited later", created_at: 1000, updated_at: 9000 },
+          { id: "old-export", content: "From a pre-updated_at export", created_at: 2000 },
+        ],
+      },
+    }), env, ctx);
+    expect((await res.json() as any).imported).toBe(2);
+
+    expect(db.entries.find(e => e.id === "edited")!.updated_at).toBe(9000);
+    // The field is what recall and the staleness pass read as the entry's age;
+    // created_at is what the column would have coalesced to anyway.
+    expect(db.entries.find(e => e.id === "old-export")!.updated_at).toBe(2000);
+  });
+
+  it("reports invalid_updated_at without laundering it into a fresh timestamp", async () => {
+    const res = await worker.fetch(req("POST", "/import", {
+      body: {
+        version: 2,
+        entries: [
+          { id: "bad", content: "X", created_at: 1000, updated_at: "yesterday" },
+          { id: "good", content: "Y", created_at: 1000 },
+        ],
+      },
+    }), env, ctx);
+    const data = await res.json() as any;
+    expect(data.imported).toBe(1);
+    expect(data.failed).toBe(1);
+    expect(data.results).toContainEqual({ id: "bad", status: "failed", reason: "invalid_updated_at" });
+    expect(db.entries.map(e => e.id)).toEqual(["good"]);
+  });
+
+  it("skips a duplicate id within one payload instead of failing the batch", async () => {
+    const res = await worker.fetch(req("POST", "/import", {
+      body: {
+        version: 2,
+        entries: [
+          { id: "dup", content: "First occurrence", created_at: 1000 },
+          { id: "dup", content: "Second occurrence", created_at: 2000 },
+        ],
+      },
+    }), env, ctx);
+    const data = await res.json() as any;
+    // Without the queue-time skip both rows enter one batch and the PRIMARY KEY
+    // conflict fails the whole batch into the per-row fallback.
+    expect(data.imported).toBe(1);
+    expect(data.skipped).toBe(1);
+    expect(data.failed).toBe(0);
+    expect(db.entries).toHaveLength(1);
+    expect(db.entries[0].content).toBe("First occurrence");
+  });
+
+  it("rejects self-edges the way the capture path does", async () => {
+    const res = await worker.fetch(req("POST", "/import", {
+      body: {
+        version: 2,
+        entries: [{ id: "a", content: "A", created_at: 1 }],
+        edges: [{ source_id: "a", target_id: "a", type: "relates_to" }],
+      },
+    }), env, ctx);
+    const data = await res.json() as any;
+    expect(data.edges_failed).toBe(1);
+    expect(data.results).toContainEqual({
+      source_id: "a", target_id: "a", type: "relates_to", status: "failed", reason: "self_edge",
+    });
+    expect(db.edges).toHaveLength(0);
   });
 
   it("imports edges when endpoints were imported in a prior request", async () => {

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -115,6 +115,7 @@ describe("POST /import", () => {
 
     expect(db.edges).toHaveLength(1);
     expect(db.edges[0]).toMatchObject({ source_id: "a", target_id: "b", type: "relates_to" });
+    expect(db.edges[0].created_at).toBe(1);
   });
 
   it("is idempotent — second import skips all entries", async () => {
@@ -132,6 +133,7 @@ describe("POST /import", () => {
     const secondData = await second.json() as any;
     expect(secondData.imported).toBe(0);
     expect(secondData.skipped).toBe(1);
+    expect(secondData.results).toHaveLength(0);
     expect(db.entries).toHaveLength(1);
   });
 
@@ -246,5 +248,71 @@ describe("POST /import", () => {
     const finishData = await finish.json() as any;
     expect(finishData.edges_imported).toBe(1);
     expect(db.edges).toHaveLength(1);
+  });
+
+  it("rejects null entries without aborting the request", async () => {
+    const res = await worker.fetch(req("POST", "/import", {
+      body: {
+        version: 2,
+        entries: [null, { id: "good", content: "valid", created_at: 1 }],
+        edges: [],
+      },
+    }), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.failed).toBe(1);
+    expect(data.imported).toBe(1);
+    expect(data.results).toContainEqual({ id: "", status: "failed", reason: "invalid_entry" });
+    expect(db.entries).toHaveLength(1);
+  });
+
+  it("rejects non-string tags", async () => {
+    const res = await worker.fetch(req("POST", "/import", {
+      body: {
+        version: 2,
+        entries: [{ id: "bad", content: "Note", tags: [42], created_at: 1 }],
+        edges: [],
+      },
+    }), env, ctx);
+    const data = await res.json() as any;
+    expect(data.failed).toBe(1);
+    expect(data.results).toContainEqual({ id: "bad", status: "failed", reason: "invalid_tag" });
+    expect(db.entries).toHaveLength(0);
+  });
+
+  it("paginates edges under ?limit= with idempotent skip", async () => {
+    const entries = [
+      { id: "a", content: "A", created_at: 1 },
+      { id: "b", content: "B", created_at: 2 },
+      { id: "c", content: "C", created_at: 3 },
+    ];
+    const edges = [
+      { source_id: "a", target_id: "b", type: "relates_to", created_at: 100 },
+      { source_id: "b", target_id: "c", type: "relates_to", created_at: 200 },
+    ];
+
+    const seedEntries = await worker.fetch(req("POST", "/import", {
+      body: { version: 2, entries, edges: [] },
+    }), env, ctx);
+    expect((await seedEntries.json() as any).imported).toBe(3);
+
+    const payload = { version: 2, entries, edges };
+
+    const firstEdge = await worker.fetch(req("POST", "/import?limit=1", { body: payload }), env, ctx);
+    const firstEdgeData = await firstEdge.json() as any;
+    expect(firstEdgeData.skipped).toBe(3);
+    expect(firstEdgeData.edges_imported).toBe(1);
+    expect(firstEdgeData.remaining_edges).toBe(1);
+    expect(firstEdgeData.results).toHaveLength(1);
+    expect(db.edges).toHaveLength(1);
+    expect(db.edges[0].created_at).toBe(100);
+
+    const secondEdge = await worker.fetch(req("POST", "/import?limit=1", { body: payload }), env, ctx);
+    const secondEdgeData = await secondEdge.json() as any;
+    expect(secondEdgeData.edges_imported).toBe(1);
+    expect(secondEdgeData.edges_skipped).toBe(1);
+    expect(secondEdgeData.remaining_edges).toBe(0);
+    expect(db.edges).toHaveLength(2);
+    expect(db.edges.find((e: any) => e.source_id === "b" && e.target_id === "c")?.created_at).toBe(200);
   });
 });

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -109,12 +109,13 @@ describe("POST /import", () => {
     expect(JSON.parse(a.tags)).toEqual(["work", "kind:semantic"]);
     expect(a.source).toBe("phone");
     expect(a.created_at).toBe(5000);
+    expect(a.updated_at).toBe(5000);
     expect(a.recall_count).toBe(3);
     expect(a.importance_score).toBe(4);
     expect(a.vector_ids).toBe("[]");
 
     expect(db.edges).toHaveLength(1);
-    expect(db.edges[0]).toMatchObject({ source_id: "a", target_id: "b", type: "relates_to" });
+    expect(db.edges[0]).toMatchObject({ source_id: "a", target_id: "b", type: "relates_to", metadata: "{}" });
     expect(db.edges[0].created_at).toBe(1);
   });
 
@@ -314,5 +315,47 @@ describe("POST /import", () => {
     expect(secondEdgeData.remaining_edges).toBe(0);
     expect(db.edges).toHaveLength(2);
     expect(db.edges.find((e: any) => e.source_id === "b" && e.target_id === "c")?.created_at).toBe(200);
+  });
+
+  it("reports invalid_recall_count without aborting the request", async () => {
+    const res = await worker.fetch(req("POST", "/import", {
+      body: {
+        version: 2,
+        entries: [
+          { id: "bad", content: "Note", recall_count: "lots", created_at: 1 },
+          { id: "good", content: "valid", created_at: 2 },
+        ],
+        edges: [],
+      },
+    }), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.failed).toBe(1);
+    expect(data.imported).toBe(1);
+    expect(data.results).toContainEqual({ id: "bad", status: "failed", reason: "invalid_recall_count" });
+    expect(db.entries).toHaveLength(1);
+    expect(db.entries[0].id).toBe("good");
+  });
+
+  it("imports edges when the payload has more than 50 distinct endpoints", async () => {
+    const entries = Array.from({ length: 52 }, (_, i) => ({
+      id: `n${i}`,
+      content: `Memory ${i}`,
+      created_at: i + 1,
+    }));
+    const edges = Array.from({ length: 51 }, (_, i) => ({
+      source_id: `n${i}`,
+      target_id: `n${i + 1}`,
+      type: "relates_to",
+      created_at: 1000 + i,
+    }));
+
+    const res = await worker.fetch(req("POST", "/import?limit=100", { body: { version: 2, entries, edges } }), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.imported).toBe(52);
+    expect(data.edges_imported).toBe(51);
+    expect(data.edges_failed).toBe(0);
+    expect(db.edges).toHaveLength(51);
   });
 });

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+function seedEntry(
+  db: D1Mock,
+  id: string,
+  content: string,
+  tags: string[] = [],
+  created_at = 1000,
+  opts: { source?: string; vector_ids?: string; recall_count?: number; importance_score?: number } = {},
+) {
+  db.entries.push({
+    id,
+    content,
+    tags: JSON.stringify(tags),
+    source: opts.source ?? "api",
+    created_at,
+    updated_at: created_at,
+    vector_ids: opts.vector_ids ?? '["v1"]',
+    recall_count: opts.recall_count ?? 0,
+    importance_score: opts.importance_score ?? 0,
+    contradiction_wins: 0,
+    contradiction_losses: 0,
+  });
+}
+
+function exportPayload(db: D1Mock) {
+  return {
+    version: 2,
+    entries: db.entries.map(e => ({
+      id: e.id,
+      content: e.content,
+      tags: JSON.parse(e.tags ?? "[]"),
+      source: e.source,
+      created_at: e.created_at,
+      recall_count: e.recall_count ?? 0,
+      importance_score: e.importance_score ?? 0,
+      contradiction_wins: e.contradiction_wins ?? 0,
+      contradiction_losses: e.contradiction_losses ?? 0,
+    })),
+    edges: db.edges.map(e => ({
+      source_id: e.source_id,
+      target_id: e.target_id,
+      type: e.type,
+      weight: e.weight,
+      provenance: e.provenance,
+      created_at: e.created_at,
+    })),
+  };
+}
+
+describe("POST /import", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("requires auth", async () => {
+    const res = await worker.fetch(req("POST", "/import", { body: { version: 2, entries: [] }, token: null }), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects invalid version", async () => {
+    const res = await worker.fetch(req("POST", "/import", { body: { version: 1, entries: [] } }), env, ctx);
+    expect(res.status).toBe(400);
+    const data = await res.json() as any;
+    expect(data.error).toMatch(/version must be 2/);
+  });
+
+  it("rejects missing entries array", async () => {
+    const res = await worker.fetch(req("POST", "/import", { body: { version: 2 } }), env, ctx);
+    expect(res.status).toBe(400);
+    const data = await res.json() as any;
+    expect(data.error).toMatch(/entries must be an array/);
+  });
+
+  it("round-trips export payload into an empty brain", async () => {
+    seedEntry(db, "a", "Memory A", ["work", "kind:semantic"], 5000, { source: "phone", recall_count: 3, importance_score: 4 });
+    seedEntry(db, "b", "Memory B", ["idea"], 4000);
+    db.edges.push({ id: "edge-1", source_id: "a", target_id: "b", type: "relates_to", weight: 0.7, provenance: "inferred", metadata: "{}", created_at: 1, updated_at: 1 });
+
+    const payload = exportPayload(db);
+    db.reset();
+
+    const res = await worker.fetch(req("POST", "/import", { body: payload }), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.ok).toBe(true);
+    expect(data.imported).toBe(2);
+    expect(data.skipped).toBe(0);
+    expect(data.failed).toBe(0);
+    expect(data.edges_imported).toBe(1);
+    expect(data.edges_failed).toBe(0);
+    expect(data.vectorize_hint).toMatch(/vectorize-pending/);
+
+    const a = db.entries.find(e => e.id === "a")!;
+    expect(a.content).toBe("Memory A");
+    expect(JSON.parse(a.tags)).toEqual(["work", "kind:semantic"]);
+    expect(a.source).toBe("phone");
+    expect(a.created_at).toBe(5000);
+    expect(a.recall_count).toBe(3);
+    expect(a.importance_score).toBe(4);
+    expect(a.vector_ids).toBe("[]");
+
+    expect(db.edges).toHaveLength(1);
+    expect(db.edges[0]).toMatchObject({ source_id: "a", target_id: "b", type: "relates_to" });
+  });
+
+  it("is idempotent — second import skips all entries", async () => {
+    const payload = {
+      version: 2,
+      entries: [{ id: "x", content: "Note", tags: ["t"], source: "api", created_at: 100 }],
+      edges: [],
+    };
+
+    const first = await worker.fetch(req("POST", "/import", { body: payload }), env, ctx);
+    const firstData = await first.json() as any;
+    expect(firstData.imported).toBe(1);
+
+    const second = await worker.fetch(req("POST", "/import", { body: payload }), env, ctx);
+    const secondData = await second.json() as any;
+    expect(secondData.imported).toBe(0);
+    expect(secondData.skipped).toBe(1);
+    expect(db.entries).toHaveLength(1);
+  });
+
+  it("fails edges with missing endpoints but still imports entries", async () => {
+    const payload = {
+      version: 2,
+      entries: [{ id: "a", content: "Only A", created_at: 1 }],
+      edges: [{ source_id: "a", target_id: "missing", type: "relates_to" }],
+    };
+
+    const res = await worker.fetch(req("POST", "/import", { body: payload }), env, ctx);
+    const data = await res.json() as any;
+    expect(data.imported).toBe(1);
+    expect(data.edges_imported).toBe(0);
+    expect(data.edges_failed).toBe(1);
+    expect(data.results).toContainEqual(expect.objectContaining({
+      source_id: "a",
+      target_id: "missing",
+      status: "failed",
+      reason: "missing_endpoint",
+    }));
+  });
+
+  it("does not trigger capture duplicate detection for similar content with a new id", async () => {
+    seedEntry(db, "existing", "The quick brown fox jumps over the lazy dog", ["note"]);
+
+    const payload = {
+      version: 2,
+      entries: [{ id: "new-id", content: "The quick brown fox jumps over the lazy dog", tags: ["note"], created_at: 2000 }],
+      edges: [],
+    };
+
+    const res = await worker.fetch(req("POST", "/import", { body: payload }), env, ctx);
+    const data = await res.json() as any;
+    expect(data.imported).toBe(1);
+    expect(db.entries).toHaveLength(2);
+    expect(db.entries.find(e => e.id === "new-id")?.vector_ids).toBe("[]");
+  });
+
+  it("reports failed entries with missing content", async () => {
+    const res = await worker.fetch(req("POST", "/import", {
+      body: { version: 2, entries: [{ id: "bad", content: "  " }], edges: [] },
+    }), env, ctx);
+    const data = await res.json() as any;
+    expect(data.failed).toBe(1);
+    expect(data.results).toContainEqual({ id: "bad", status: "failed", reason: "missing_content" });
+  });
+});

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -337,6 +337,33 @@ describe("POST /import", () => {
     expect(db.entries[0].id).toBe("good");
   });
 
+  it("imports edges when endpoints were imported in a prior request", async () => {
+    const entriesRes = await worker.fetch(req("POST", "/import", {
+      body: {
+        version: 2,
+        entries: [
+          { id: "a", content: "Memory A", created_at: 1 },
+          { id: "b", content: "Memory B", created_at: 2 },
+        ],
+        edges: [],
+      },
+    }), env, ctx);
+    expect((await entriesRes.json() as any).imported).toBe(2);
+
+    const edgesRes = await worker.fetch(req("POST", "/import", {
+      body: {
+        version: 2,
+        entries: [],
+        edges: [{ source_id: "a", target_id: "b", type: "relates_to", created_at: 100 }],
+      },
+    }), env, ctx);
+    expect(edgesRes.status).toBe(200);
+    const edgeData = await edgesRes.json() as any;
+    expect(edgeData.edges_imported).toBe(1);
+    expect(edgeData.edges_failed).toBe(0);
+    expect(db.edges).toHaveLength(1);
+  });
+
   it("imports edges when the payload has more than 50 distinct endpoints", async () => {
     const entries = Array.from({ length: 52 }, (_, i) => ({
       id: `n${i}`,

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -100,6 +100,8 @@ describe("POST /import", () => {
     expect(data.failed).toBe(0);
     expect(data.edges_imported).toBe(1);
     expect(data.edges_failed).toBe(0);
+    expect(data.remaining_entries).toBe(0);
+    expect(data.remaining_edges).toBe(0);
     expect(data.vectorize_hint).toMatch(/vectorize-pending/);
 
     const a = db.entries.find(e => e.id === "a")!;
@@ -176,5 +178,73 @@ describe("POST /import", () => {
     const data = await res.json() as any;
     expect(data.failed).toBe(1);
     expect(data.results).toContainEqual({ id: "bad", status: "failed", reason: "missing_content" });
+  });
+
+  it("reports invalid_id for non-string ids without aborting the request", async () => {
+    const res = await worker.fetch(req("POST", "/import", {
+      body: {
+        version: 2,
+        entries: [
+          { id: 123, content: "bad id type" },
+          { id: "good", content: "valid entry", created_at: 1 },
+        ],
+        edges: [],
+      },
+    }), env, ctx);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.failed).toBe(1);
+    expect(data.imported).toBe(1);
+    expect(data.results).toContainEqual({ id: "123", status: "failed", reason: "invalid_id" });
+    expect(db.entries).toHaveLength(1);
+    expect(db.entries[0].id).toBe("good");
+  });
+
+  it("respects ?limit= and reports remaining_entries", async () => {
+    const payload = {
+      version: 2,
+      entries: [
+        { id: "e1", content: "One", created_at: 1 },
+        { id: "e2", content: "Two", created_at: 2 },
+        { id: "e3", content: "Three", created_at: 3 },
+      ],
+      edges: [],
+    };
+
+    const first = await worker.fetch(req("POST", "/import?limit=1", { body: payload }), env, ctx);
+    const firstData = await first.json() as any;
+    expect(firstData.imported).toBe(1);
+    expect(firstData.remaining_entries).toBe(2);
+
+    const second = await worker.fetch(req("POST", "/import?limit=10", { body: payload }), env, ctx);
+    const secondData = await second.json() as any;
+    expect(secondData.imported).toBe(2);
+    expect(secondData.skipped).toBe(1);
+    expect(secondData.remaining_entries).toBe(0);
+    expect(db.entries).toHaveLength(3);
+  });
+
+  it("defers edges until all entries are processed", async () => {
+    const payload = {
+      version: 2,
+      entries: [
+        { id: "a", content: "A", created_at: 1 },
+        { id: "b", content: "B", created_at: 2 },
+      ],
+      edges: [{ source_id: "a", target_id: "b", type: "relates_to" }],
+    };
+
+    const partial = await worker.fetch(req("POST", "/import?limit=1", { body: payload }), env, ctx);
+    const partialData = await partial.json() as any;
+    expect(partialData.imported).toBe(1);
+    expect(partialData.remaining_entries).toBe(1);
+    expect(partialData.remaining_edges).toBe(1);
+    expect(partialData.edges_imported).toBe(0);
+    expect(db.edges).toHaveLength(0);
+
+    const finish = await worker.fetch(req("POST", "/import", { body: payload }), env, ctx);
+    const finishData = await finish.json() as any;
+    expect(finishData.edges_imported).toBe(1);
+    expect(db.edges).toHaveLength(1);
   });
 });

--- a/test/unit/edges.test.ts
+++ b/test/unit/edges.test.ts
@@ -78,6 +78,11 @@ describe("createEdge", () => {
     expect(db.edges[0].provenance).toBe("explicit");
     expect(JSON.parse(db.edges[0].metadata)).toEqual({ note: "hi" });
   });
+
+  it("preserves a custom created_at on insert", async () => {
+    await createEdge("a", "b", "relates_to", { created_at: 42_000 }, env);
+    expect(db.edges[0].created_at).toBe(42_000);
+  });
 });
 
 describe("expandGraph", () => {

--- a/test/unit/import.test.ts
+++ b/test/unit/import.test.ts
@@ -1,26 +1,74 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, it, expect } from "vitest";
 import {
   ENTRY_INSERT_COLUMNS,
   ENTRY_INSERT_SQL,
   formatDbError,
+  isImportRecordObject,
   parseImportLimit,
   parseRequiredString,
+  parseTags,
 } from "../../src/entries/import";
 
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+function stripSqlComments(sql: string): string {
+  return sql.replace(/--.*$/gm, "");
+}
+
+function parseColumnList(body: string): string[] {
+  const cols: string[] = [];
+  let current = "";
+  let inQuote = false;
+  for (const ch of body) {
+    if (ch === "'") inQuote = !inQuote;
+    if (ch === "," && !inQuote) {
+      const name = current.trim().split(/\s+/)[0];
+      if (name && !name.startsWith("UNIQUE")) cols.push(name);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  const name = current.trim().split(/\s+/)[0];
+  if (name && !name.startsWith("UNIQUE")) cols.push(name);
+  return cols;
+}
+
+function parseCreateTableColumns(sql: string, table: string): string[] {
+  const cleaned = stripSqlComments(sql);
+  const match = cleaned.match(new RegExp(`CREATE TABLE IF NOT EXISTS ${table}\\s*\\(([^)]*)\\)`, "i"));
+  if (!match) return [];
+  return parseColumnList(match[1]);
+}
+
+function parseAlterColumns(initSource: string, table: string): string[] {
+  const cols: string[] = [];
+  const re = new RegExp(`ALTER TABLE ${table} ADD COLUMN (\\w+)`, "gi");
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(initSource)) !== null) {
+    cols.push(m[1]);
+  }
+  return cols;
+}
+
 describe("import helpers", () => {
-  it("ENTRY_INSERT_SQL columns match main schema (no updated_at until #263)", () => {
-    expect(ENTRY_INSERT_COLUMNS).toEqual([
-      "id",
-      "content",
-      "tags",
-      "source",
-      "created_at",
-      "vector_ids",
-      "recall_count",
-      "importance_score",
-      "contradiction_wins",
-      "contradiction_losses",
-    ]);
+  it("ENTRY_INSERT_COLUMNS are a subset of schema.sql and init.ts columns", () => {
+    const schemaSql = readFileSync(resolve(repoRoot, "db/schema.sql"), "utf-8");
+    const initTs = readFileSync(resolve(repoRoot, "src/db/init.ts"), "utf-8");
+
+    const schemaCols = parseCreateTableColumns(schemaSql, "entries");
+    const initCols = [
+      ...parseCreateTableColumns(initTs, "entries"),
+      ...parseAlterColumns(initTs, "entries"),
+    ];
+
+    for (const col of ENTRY_INSERT_COLUMNS) {
+      expect(schemaCols, `missing ${col} in schema.sql`).toContain(col);
+      expect(initCols, `missing ${col} in init.ts`).toContain(col);
+    }
+
     expect(ENTRY_INSERT_SQL).toContain("INSERT INTO entries (");
     expect(ENTRY_INSERT_SQL).not.toContain("updated_at");
   });
@@ -28,6 +76,18 @@ describe("import helpers", () => {
   it("parseRequiredString rejects non-string values without throwing", () => {
     expect(parseRequiredString(42, "missing_id", "invalid_id")).toEqual({ ok: false, reason: "invalid_id" });
     expect(parseRequiredString("  abc  ", "missing_id", "invalid_id")).toEqual({ ok: true, value: "abc" });
+  });
+
+  it("parseTags rejects non-string tag values", () => {
+    expect(parseTags([42])).toEqual({ ok: false, reason: "invalid_tag" });
+    expect(parseTags(["work", "kind:semantic"])).toEqual({ ok: true, tags: ["work", "kind:semantic"] });
+    expect(parseTags(undefined)).toEqual({ ok: true, tags: [] });
+  });
+
+  it("isImportRecordObject rejects null and arrays", () => {
+    expect(isImportRecordObject(null)).toBe(false);
+    expect(isImportRecordObject([])).toBe(false);
+    expect(isImportRecordObject({ id: "x" })).toBe(true);
   });
 
   it("parseImportLimit clamps invalid and oversized values", () => {

--- a/test/unit/import.test.ts
+++ b/test/unit/import.test.ts
@@ -9,6 +9,7 @@ import {
   parseImportLimit,
   parseRequiredString,
   parseTags,
+  parseEdgeWeight,
 } from "../../src/entries/import";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
@@ -91,8 +92,8 @@ describe("import helpers", () => {
   });
 
   it("parseImportLimit clamps invalid and oversized values", () => {
-    expect(parseImportLimit(null)).toBe(100);
-    expect(parseImportLimit("0")).toBe(100);
+    expect(parseImportLimit(null)).toBe(40);
+    expect(parseImportLimit("0")).toBe(40);
     expect(parseImportLimit("50")).toBe(50);
     expect(parseImportLimit("99999")).toBe(1000);
   });
@@ -100,5 +101,10 @@ describe("import helpers", () => {
   it("formatDbError truncates long messages", () => {
     const long = "x".repeat(300);
     expect(formatDbError(new Error(long)).length).toBe(200);
+  });
+
+  it("parseEdgeWeight rejects non-finite values", () => {
+    expect(parseEdgeWeight({ nested: 1 })).toEqual({ ok: false, reason: "invalid_weight" });
+    expect(parseEdgeWeight(0.5)).toEqual({ ok: true, value: 0.5 });
   });
 });

--- a/test/unit/import.test.ts
+++ b/test/unit/import.test.ts
@@ -1,10 +1,11 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   ENTRY_INSERT_COLUMNS,
   ENTRY_INSERT_SQL,
   EDGE_ENDPOINT_QUERY_BATCH,
+  ensureIdResolved,
   formatDbError,
   isImportRecordObject,
   parseCreatedAt,
@@ -139,5 +140,20 @@ describe("import helpers", () => {
     if (parsed.ok) expect(parsed.value).toBeGreaterThanOrEqual(now);
     expect(parseCreatedAt("yesterday")).toEqual({ ok: false, reason: "invalid_created_at" });
     expect(parseCreatedAt(1234)).toEqual({ ok: true, value: 1234 });
+  });
+
+  it("ensureIdResolved looks up pending ids before returning", async () => {
+    const prepare = vi.fn(() => ({
+      bind: (...args: string[]) => ({
+        all: async () => ({ results: args.includes("exists") ? [{ id: "exists" }] : [] }),
+      }),
+    }));
+    const env = { DB: { prepare } } as unknown as import("../../src/env").Env;
+    const existing = new Set<string>();
+    const pending: string[] = [];
+    await ensureIdResolved(env, "exists", existing, pending);
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(existing.has("exists")).toBe(true);
+    expect(pending).toHaveLength(0);
   });
 });

--- a/test/unit/import.test.ts
+++ b/test/unit/import.test.ts
@@ -5,11 +5,11 @@ import {
   ENTRY_INSERT_COLUMNS,
   ENTRY_INSERT_SQL,
   EDGE_ENDPOINT_QUERY_BATCH,
-  ensureIdResolved,
   formatDbError,
   isImportRecordObject,
   parseCreatedAt,
   parseImportLimit,
+  parseImportOffset,
   parseOptionalNumber,
   parseRequiredString,
   parseTags,
@@ -142,18 +142,11 @@ describe("import helpers", () => {
     expect(parseCreatedAt(1234)).toEqual({ ok: true, value: 1234 });
   });
 
-  it("ensureIdResolved looks up pending ids before returning", async () => {
-    const prepare = vi.fn(() => ({
-      bind: (...args: string[]) => ({
-        all: async () => ({ results: args.includes("exists") ? [{ id: "exists" }] : [] }),
-      }),
-    }));
-    const env = { DB: { prepare } } as unknown as import("../../src/env").Env;
-    const existing = new Set<string>();
-    const pending: string[] = [];
-    await ensureIdResolved(env, "exists", existing, pending);
-    expect(prepare).toHaveBeenCalledTimes(1);
-    expect(existing.has("exists")).toBe(true);
-    expect(pending).toHaveLength(0);
+  it("parseImportOffset defaults absent, invalid, and negative values to 0", () => {
+    expect(parseImportOffset(null)).toBe(0);
+    expect(parseImportOffset("")).toBe(0);
+    expect(parseImportOffset("abc")).toBe(0);
+    expect(parseImportOffset("-5")).toBe(0);
+    expect(parseImportOffset("120")).toBe(120);
   });
 });

--- a/test/unit/import.test.ts
+++ b/test/unit/import.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  ENTRY_INSERT_COLUMNS,
+  ENTRY_INSERT_SQL,
+  formatDbError,
+  parseImportLimit,
+  parseRequiredString,
+} from "../../src/entries/import";
+
+describe("import helpers", () => {
+  it("ENTRY_INSERT_SQL columns match main schema (no updated_at until #263)", () => {
+    expect(ENTRY_INSERT_COLUMNS).toEqual([
+      "id",
+      "content",
+      "tags",
+      "source",
+      "created_at",
+      "vector_ids",
+      "recall_count",
+      "importance_score",
+      "contradiction_wins",
+      "contradiction_losses",
+    ]);
+    expect(ENTRY_INSERT_SQL).toContain("INSERT INTO entries (");
+    expect(ENTRY_INSERT_SQL).not.toContain("updated_at");
+  });
+
+  it("parseRequiredString rejects non-string values without throwing", () => {
+    expect(parseRequiredString(42, "missing_id", "invalid_id")).toEqual({ ok: false, reason: "invalid_id" });
+    expect(parseRequiredString("  abc  ", "missing_id", "invalid_id")).toEqual({ ok: true, value: "abc" });
+  });
+
+  it("parseImportLimit clamps invalid and oversized values", () => {
+    expect(parseImportLimit(null)).toBe(100);
+    expect(parseImportLimit("0")).toBe(100);
+    expect(parseImportLimit("50")).toBe(50);
+    expect(parseImportLimit("99999")).toBe(1000);
+  });
+
+  it("formatDbError truncates long messages", () => {
+    const long = "x".repeat(300);
+    expect(formatDbError(new Error(long)).length).toBe(200);
+  });
+});

--- a/test/unit/import.test.ts
+++ b/test/unit/import.test.ts
@@ -4,13 +4,17 @@ import { describe, it, expect } from "vitest";
 import {
   ENTRY_INSERT_COLUMNS,
   ENTRY_INSERT_SQL,
+  EDGE_ENDPOINT_QUERY_BATCH,
   formatDbError,
   isImportRecordObject,
+  parseCreatedAt,
   parseImportLimit,
+  parseOptionalNumber,
   parseRequiredString,
   parseTags,
   parseEdgeWeight,
 } from "../../src/entries/import";
+import { D1_MAX_BOUND_PARAMS } from "../../src/constants";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
 
@@ -54,12 +58,21 @@ function parseAlterColumns(initSource: string, table: string): string[] {
   return cols;
 }
 
+function parseSchemaRuntimeColumns(schemaSql: string): string[] {
+  const match = schemaSql.match(/Runtime ALTER columns.*?:\s*([^\n]+)/);
+  if (!match) return [];
+  return match[1].split(",").map(s => s.trim()).filter(Boolean);
+}
+
 describe("import helpers", () => {
   it("ENTRY_INSERT_COLUMNS are a subset of schema.sql and init.ts columns", () => {
     const schemaSql = readFileSync(resolve(repoRoot, "db/schema.sql"), "utf-8");
     const initTs = readFileSync(resolve(repoRoot, "src/db/init.ts"), "utf-8");
 
-    const schemaCols = parseCreateTableColumns(schemaSql, "entries");
+    const schemaCols = [
+      ...parseCreateTableColumns(schemaSql, "entries"),
+      ...parseSchemaRuntimeColumns(schemaSql),
+    ];
     const initCols = [
       ...parseCreateTableColumns(initTs, "entries"),
       ...parseAlterColumns(initTs, "entries"),
@@ -71,7 +84,11 @@ describe("import helpers", () => {
     }
 
     expect(ENTRY_INSERT_SQL).toContain("INSERT INTO entries (");
-    expect(ENTRY_INSERT_SQL).not.toContain("updated_at");
+    expect(ENTRY_INSERT_SQL).toContain("updated_at");
+  });
+
+  it("EDGE_ENDPOINT_QUERY_BATCH halves D1_MAX_BOUND_PARAMS for double-bound lookups", () => {
+    expect(EDGE_ENDPOINT_QUERY_BATCH).toBe(Math.floor(D1_MAX_BOUND_PARAMS / 2));
   });
 
   it("parseRequiredString rejects non-string values without throwing", () => {
@@ -106,5 +123,21 @@ describe("import helpers", () => {
   it("parseEdgeWeight rejects non-finite values", () => {
     expect(parseEdgeWeight({ nested: 1 })).toEqual({ ok: false, reason: "invalid_weight" });
     expect(parseEdgeWeight(0.5)).toEqual({ ok: true, value: 0.5 });
+  });
+
+  it("parseOptionalNumber rejects non-finite values and defaults nullish to 0", () => {
+    expect(parseOptionalNumber(undefined, "invalid_recall_count")).toEqual({ ok: true, value: 0 });
+    expect(parseOptionalNumber(null, "invalid_recall_count")).toEqual({ ok: true, value: 0 });
+    expect(parseOptionalNumber("3", "invalid_recall_count")).toEqual({ ok: false, reason: "invalid_recall_count" });
+    expect(parseOptionalNumber(4, "invalid_importance_score")).toEqual({ ok: true, value: 4 });
+  });
+
+  it("parseCreatedAt rejects non-finite values and defaults nullish to now", () => {
+    const now = Date.now();
+    const parsed = parseCreatedAt(undefined);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) expect(parsed.value).toBeGreaterThanOrEqual(now);
+    expect(parseCreatedAt("yesterday")).toEqual({ ok: false, reason: "invalid_created_at" });
+    expect(parseCreatedAt(1234)).toEqual({ ok: true, value: 1234 });
   });
 });

--- a/test/unit/snippet.test.ts
+++ b/test/unit/snippet.test.ts
@@ -130,6 +130,6 @@ describe("truncationNote", () => {
   it("carries the id and the full size so the caller can fetch the rest", () => {
     const note = truncationNote("abc-123", { text: "…", truncated: true, fullLength: 12345 });
     expect(note).toContain('get("abc-123")');
-    expect(note).toContain("12,345");
+    expect(note).toMatch(/12[,.]345/);
   });
 });

--- a/test/unit/updated-at-coalesced.test.ts
+++ b/test/unit/updated-at-coalesced.test.ts
@@ -131,7 +131,7 @@ function rawTsReads(source: string): { text: string; coalesced: boolean }[] {
   for (const m of code.matchAll(/\bupdated_at\b/g)) {
     const at = m.index! + "updated_at".length;
     const after = code.slice(at);
-    if (/^\s*:/.test(after)) continue; // object-literal key, not a read
+    if (/^\s*\??:/.test(after)) continue; // object-literal key or property declaration, not a read
     // The fallback has to be attached to THIS read. A created_at mention anywhere on the
     // line is not enough: an adjacent field in the same object literal, or a sort
     // tiebreaker, satisfies that while coalescing nothing. Require `?? … created_at`

--- a/test/unit/updated-at-coalesced.test.ts
+++ b/test/unit/updated-at-coalesced.test.ts
@@ -107,7 +107,7 @@ function rawSqlReads(sql: string, relPath: string): Finding[] {
     if (inAny(i, declarations) || inAny(i, coalesced) || inAny(i, insertColumns)) continue;
     // In a SET clause and followed by `=` — an assignment target.
     if (inAny(i, setClauses) && /^\s*=/.test(sql.slice(i + "updated_at".length))) continue;
-    if (relPath === HYDRATION_EXEMPTION.file && sql.includes(HYDRATION_EXEMPTION.marker)) continue;
+    if (relPath.replace(/\\/g, "/") === HYDRATION_EXEMPTION.file && sql.includes(HYDRATION_EXEMPTION.marker)) continue;
 
     const at = sql.slice(Math.max(0, i - 45), i + 45);
     const clause = /\bORDER\s+BY\b/i.test(sql.slice(0, i)) ? "ORDER BY"


### PR DESCRIPTION
## Summary
- Adds `POST /import` accepting the existing `GET /export` v2 payload (`entries` + `edges`) so migrations can round-trip without looping `/capture`.
- Inserts by export id (skip if exists), preserves `created_at`/tags/source, defers embedding via empty `vector_ids` + existing `/vectorize-pending`.
- Returns per-entry and per-edge status: imported / skipped / failed with reasons.

Closes #217

## Design notes
- Does **not** go through `/capture` (would mint new UUIDs and trigger duplicate/contradiction LLM).
- Does **not** embed inline (avoids Workers AI quota exhaustion on large dumps; same defer pattern as capture + admin backfill).
- No overwrite-on-conflict in this PR (safe idempotency only).

## Test plan
- [x] `npm test -- test/integration/import.test.ts`
- [ ] Manual (optional): export → import on empty brain → loop `POST /vectorize-pending` until `remaining: 0` → recall finds an imported note