### PR TITLE
fix(worker): write paths degrade to keyword-only when Vectorize is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Prefer to run it yourself? Use the one-click **[Deploy to Cloudflare](https://de
 
 * **Notion sync.** Connect your Notion workspace from **Settings → Integrations** in the dashboard. Pages you share with the connection sync into memory, stay updated as they change in Notion, and surface in recall alongside everything else. Nightly automatic sync, or on demand with **Sync now**.
 
-* **Graceful degradation.** If the Vectorize index is missing, recall now falls back to keyword search with a clear notice instead of failing, a new `/health` endpoint reports index status, and the dashboard shows a banner with the exact fix.
+* **Graceful degradation.** If the Vectorize index is missing, the whole brain keeps working keyword-only: recall falls back to keyword search with a clear notice, and captures, appends and updates are still committed rather than rejected. A `/health` endpoint reports index status, and the dashboard shows a banner with the exact fix.
 
 ## See it in action
 

--- a/src/capture/duplicate.ts
+++ b/src/capture/duplicate.ts
@@ -49,7 +49,17 @@ export async function checkDuplicateAndContradiction(
 }> {
   const sample = getDuplicateCheckSample(content);
   const values = await embed(sample, env, config);
-  const { matches } = await env.VECTORIZE.query(values, { topK: 5, returnMetadata: "all" });
+
+  // Duplicate detection, contradiction detection and neighbour edges are all
+  // advisory — a capture without them is still correct, just less enriched. This
+  // runs before the D1 insert, so throwing here rejected the write entirely (#270)
+  // on deployments the read path already serves keyword-only (recall/search.ts).
+  let matches: VectorizeMatch[] = [];
+  try {
+    ({ matches } = await env.VECTORIZE.query(values, { topK: 5, returnMetadata: "all" }));
+  } catch (e) {
+    console.error("Vectorize query failed (capturing without duplicate/contradiction checks):", e);
+  }
 
   const neighborScores = new Map<string, number>();
   for (const m of matches) {

--- a/src/capture/store.ts
+++ b/src/capture/store.ts
@@ -5,6 +5,7 @@ import { embed } from "../lib/ai";
 import { inferEdgesOnWrite } from "../graph/edges";
 import { neighborsFromVectorQuery } from "../graph/traverse";
 import { chunkText } from "../text/chunk";
+import { isVectorizeUnavailable } from "../vectorize/health";
 
 export async function storeEntry(
   env: Env,
@@ -64,6 +65,25 @@ export async function reembedOrThrow(env: Env, id: string, content: string, tags
   return ids;
 }
 
+/**
+ * Re-embed for a content mutation. Returns the new vector ids, or null when
+ * Vectorize is unreachable and the caller should commit the content keyword-only
+ * (#270). Rethrows every other failure so #212's fail-loud contract survives:
+ * a transient embed failure must not commit content against stale vectors.
+ *
+ * Callers that get null MUST NOT retire the old vectors — they are the entry's
+ * only remaining semantic index until Vectorize returns.
+ */
+export async function reembedOrDegrade(env: Env, id: string, content: string, tags: string[], source: string, config: Readonly<Config> = DEFAULTS): Promise<string[] | null> {
+  try {
+    return await reembedOrThrow(env, id, content, tags, source, config);
+  } catch (e) {
+    if (!(await isVectorizeUnavailable(env))) throw e;
+    console.error("Vectorize unavailable — committing content without re-embedding:", e);
+    return null;
+  }
+}
+
 export async function appendToEntry(
   env: Env,
   id: string,
@@ -72,7 +92,7 @@ export async function appendToEntry(
   tags: string[],
   source: string,
   config: Readonly<Config> = DEFAULTS
-): Promise<void> {
+): Promise<boolean> {
   const row = await env.DB.prepare(
     `SELECT vector_ids FROM entries WHERE id = ?`
   ).bind(id).first() as Record<string, any> | null;
@@ -84,15 +104,19 @@ export async function appendToEntry(
   const newContent = existingContent + separator + addition;
 
   if (newContent.length > CHUNK_MAX_CHARS) {
-    const newVectorIds = await reembedOrThrow(env, id, newContent, tags, source, config);
+    const newVectorIds = await reembedOrDegrade(env, id, newContent, tags, source, config);
 
     await env.DB.prepare(`UPDATE entries SET content = ? WHERE id = ?`)
       .bind(newContent, id).run();
 
-    try {
-      await deleteStaleVectors(env, existingVectorIds, newVectorIds);
-    } catch (e) {
-      console.error("Old vector cleanup failed (non-fatal):", e);
+    // Skipped when Vectorize is unavailable: the old vectors are the entry's only
+    // remaining semantic index, and retiring them would leave it unsearchable.
+    if (newVectorIds) {
+      try {
+        await deleteStaleVectors(env, existingVectorIds, newVectorIds);
+      } catch (e) {
+        console.error("Old vector cleanup failed (non-fatal):", e);
+      }
     }
 
     try {
@@ -101,7 +125,7 @@ export async function appendToEntry(
       console.error("Append auto-link failed (non-fatal):", e);
     }
 
-    return;
+    return newVectorIds !== null;
   }
 
   const newChunkId = `${id}-update-${Date.now()}`;
@@ -121,19 +145,31 @@ export async function appendToEntry(
     metadata[`tag_${t.replace(/[."]/g, "_")}`] = true;
   });
 
-  await env.VECTORIZE.insert([{
-    id: newChunkId,
-    values,
-    metadata,
-  }]);
+  // Committed either way: keyword search reads entries.content, so an unindexed
+  // addition is still recallable, whereas rejecting the append loses it outright.
+  // A transient failure still throws — nothing is written yet, so the retry is safe.
+  let indexed = true;
+  try {
+    await env.VECTORIZE.insert([{
+      id: newChunkId,
+      values,
+      metadata,
+    }]);
+  } catch (e) {
+    if (!(await isVectorizeUnavailable(env))) throw e;
+    console.error("Vectorize unavailable — appending without indexing the addition:", e);
+    indexed = false;
+  }
 
   await env.DB.prepare(
     `UPDATE entries SET content = ?, vector_ids = ? WHERE id = ?`
-  ).bind(newContent, JSON.stringify([...existingVectorIds, newChunkId]), id).run();
+  ).bind(newContent, JSON.stringify(indexed ? [...existingVectorIds, newChunkId] : existingVectorIds), id).run();
 
   try {
     await inferEdgesOnWrite(id, await neighborsFromVectorQuery(values, env), env);
   } catch (e) {
     console.error("Append auto-link failed (non-fatal):", e);
   }
+
+  return indexed;
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -90,8 +90,9 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         return { content: [{ type: "text", text: mirrorEditError(source) }] };
       }
 
+      let indexed: boolean;
       try {
-        await appendToEntry(env, id, existingContent, a, tags, source, await resolveConfig(env));
+        indexed = await appendToEntry(env, id, existingContent, a, tags, source, await resolveConfig(env));
       } catch (e) {
         console.error("Append failed:", e);
         return {
@@ -102,7 +103,8 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       return {
         content: [{
           type: "text",
-          text: `Appended to entry ${id}. The original content is preserved and your update has been added with today's date.`,
+          text: `Appended to entry ${id}. The original content is preserved and your update has been added with today's date.`
+            + (indexed ? "" : ` Note: it was not indexed for semantic search because the Vectorize index is missing, so it is findable by keyword only. Fix: ${VECTORIZE_FIX_HINT}.`),
         }],
       };
     }

--- a/src/routes/capture.ts
+++ b/src/routes/capture.ts
@@ -1,8 +1,9 @@
 import type { Env } from "../env";
 import { resolveConfig } from "../config";
+import { VECTORIZE_FIX_HINT } from "../constants";
 import { json, requireAuth } from "../lib/http";
 import { captureEntry } from "../capture/entry";
-import { appendToEntry, deleteStaleVectors, reembedOrThrow } from "../capture/store";
+import { appendToEntry, deleteStaleVectors, reembedOrDegrade } from "../capture/store";
 import { isManagedMirror, mirrorEditError } from "../integrations/mirror";
 import { extractHashtags } from "../text/hashtags";
 
@@ -86,8 +87,9 @@ export async function handleCaptureRoutes(
       return json({ ok: false, error: mirrorEditError(source) }, 409);
     }
 
+    let indexed: boolean;
     try {
-      await appendToEntry(env, id, existingContent, addition, tags, source, await resolveConfig(env));
+      indexed = await appendToEntry(env, id, existingContent, addition, tags, source, await resolveConfig(env));
     } catch (e) {
       return json({ ok: false, error: `Append failed: ${(e as Error).message}` }, 500);
     }
@@ -95,7 +97,10 @@ export async function handleCaptureRoutes(
     return json({
       ok: true,
       id,
-      message: "Update appended successfully with timestamp",
+      semantic_unavailable: !indexed,
+      message: indexed
+        ? "Update appended successfully with timestamp"
+        : `Update appended, but not indexed for semantic search (Vectorize unavailable) — it is still findable by keyword. Fix: ${VECTORIZE_FIX_HINT}.`,
     });
   }
 
@@ -132,22 +137,36 @@ export async function handleCaptureRoutes(
     // Re-embed FIRST (#212): if it fails, leave the entry's content and vectors
     // untouched and surface an error, instead of committing new content and then
     // deleting every vector — which would leave the entry silently unsearchable.
-    let newVectorIds: string[];
+    // null means Vectorize is unreachable (#270), not that this embed failed.
+    let newVectorIds: string[] | null;
     try {
-      newVectorIds = await reembedOrThrow(env, id, finalContent, mergedTags, source, await resolveConfig(env));
+      newVectorIds = await reembedOrDegrade(env, id, finalContent, mergedTags, source, await resolveConfig(env));
     } catch (e) {
       console.error("Re-embed failed — entry left unchanged:", e);
       return json({ ok: false, error: "Couldn't update: search re-index failed. Your memory is unchanged — please try again." }, 500);
     }
 
-    // Embed succeeded → safe to commit the new content and retire stale vectors.
+    // Safe to commit: either the embed succeeded, or Vectorize is unavailable and
+    // the old vectors are kept below rather than retired.
     await env.DB.prepare(`UPDATE entries SET content = ?, tags = ? WHERE id = ?`)
       .bind(finalContent, JSON.stringify(mergedTags), id).run();
 
-    try {
-      await deleteStaleVectors(env, oldVectorIds, newVectorIds);
-    } catch (e) {
-      console.error("Old vector cleanup failed (non-fatal):", e);
+    if (newVectorIds) {
+      try {
+        await deleteStaleVectors(env, oldVectorIds, newVectorIds);
+      } catch (e) {
+        console.error("Old vector cleanup failed (non-fatal):", e);
+      }
+    }
+
+    if (!newVectorIds) {
+      return json({
+        ok: true,
+        id,
+        vectors: 0,
+        semantic_unavailable: true,
+        message: `Updated, but not re-indexed for semantic search (Vectorize unavailable) — the previous index is kept and it is still findable by keyword. Fix: ${VECTORIZE_FIX_HINT}.`,
+      });
     }
 
     return json({ ok: true, id, vectors: newVectorIds.length });

--- a/src/vectorize/health.ts
+++ b/src/vectorize/health.ts
@@ -22,6 +22,21 @@ export interface VectorizeHealth {
   error?: string;
 }
 
+/**
+ * True when Vectorize itself is unreachable — binding absent, index not created,
+ * or the deploying token lacks Vectorize permission. This is a supported
+ * keyword-only deployment, so write paths degrade rather than fail.
+ *
+ * Deliberately distinct from "this one embed failed" (#212): a transient
+ * failure must still fail loudly so the caller retries, or we would commit new
+ * content against stale vectors and report success. Only called on an error
+ * path, so the extra describe() costs nothing in the healthy case.
+ */
+export async function isVectorizeUnavailable(env: Env): Promise<boolean> {
+  if (!env.VECTORIZE) return true;
+  return !(await checkVectorizeHealth(env)).ok;
+}
+
 export async function checkVectorizeHealth(env: Env): Promise<VectorizeHealth> {
   try {
     const info = (await env.VECTORIZE.describe()) as any;

--- a/test/integration/vectorize-unavailable.test.ts
+++ b/test/integration/vectorize-unavailable.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb, makeVectorizeMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+import { D1Mock } from "../helpers/d1-mock";
+
+function makeCtx() {
+  const pending: Promise<any>[] = [];
+  return {
+    ctx: { waitUntil: (p: Promise<any>) => pending.push(p) } as any,
+    drain: () => Promise.allSettled(pending),
+  };
+}
+
+const denied = () => Promise.reject(new Error("VECTORIZE_QUERY_ERROR (code = 40001): Authentication error"));
+
+// The two ways Vectorize actually goes away in a deployment: never bound (index
+// not created), or bound but every call rejected (token lacks Vectorize Edit).
+const UNAVAILABLE: [string, () => Partial<Env>][] = [
+  ["binding absent", () => ({ VECTORIZE: undefined as any })],
+  ["calls denied", () => ({
+    VECTORIZE: makeVectorizeMock({
+      query: vi.fn(denied), insert: vi.fn(denied), upsert: vi.fn(denied),
+      deleteByIds: vi.fn(denied), getByIds: vi.fn(denied), describe: vi.fn(denied),
+    } as any),
+  })],
+];
+
+async function seed(db: D1Mock, content: string) {
+  const { ctx, drain } = makeCtx();
+  await worker.fetch(req("POST", "/capture", { body: { content } }), makeTestEnv(db), ctx);
+  await drain();
+  return db.entries[0];
+}
+
+describe("Vectorize unavailable — writes degrade to keyword-only (#270)", () => {
+  let db: D1Mock;
+  beforeEach(() => { db = makeTestDb(); });
+
+  for (const [label, overrides] of UNAVAILABLE) {
+    describe(label, () => {
+      it("POST /capture stores the entry instead of throwing", async () => {
+        const env = makeTestEnv(db, overrides());
+        const { ctx, drain } = makeCtx();
+        const res = await worker.fetch(req("POST", "/capture", { body: { content: "keyword only capture" } }), env, ctx);
+        await drain();
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toMatchObject({ ok: true });
+        expect(db.entries).toHaveLength(1);
+        expect(db.entries[0].content).toBe("keyword only capture");
+      });
+
+      it("POST /append commits the addition and flags it unindexed", async () => {
+        const { id } = await seed(db, "original content");
+        const env = makeTestEnv(db, overrides());
+        const { ctx, drain } = makeCtx();
+        const res = await worker.fetch(req("POST", "/append", { body: { id, addition: "appended text" } }), env, ctx);
+        await drain();
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toMatchObject({ ok: true, semantic_unavailable: true });
+        expect(db.entries[0].content).toContain("appended text");
+      });
+
+      it("POST /update commits new content and keeps the old vectors", async () => {
+        const { id } = await seed(db, "original content");
+        const oldVectorIds = db.entries[0].vector_ids;
+        expect(JSON.parse(oldVectorIds).length).toBeGreaterThan(0);
+
+        const env = makeTestEnv(db, overrides());
+        const { ctx, drain } = makeCtx();
+        const res = await worker.fetch(req("POST", "/update", { body: { id, content: "replacement content" } }), env, ctx);
+        await drain();
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toMatchObject({ ok: true, vectors: 0, semantic_unavailable: true });
+        expect(db.entries[0].content).toBe("replacement content");
+        // #212: with Vectorize gone the old index is the entry's only remaining
+        // searchability — retiring it would leave the entry silently unfindable.
+        expect(db.entries[0].vector_ids).toBe(oldVectorIds);
+      });
+
+      it("GET /recall still degrades to keyword-only", async () => {
+        await seed(db, "findable by keyword");
+        const env = makeTestEnv(db, overrides());
+        const { ctx } = makeCtx();
+        const res = await worker.fetch(req("GET", "/recall?query=findable"), env, ctx);
+
+        expect(res.status).toBe(200);
+        const body = await res.json() as any;
+        expect(body.ok).toBe(true);
+        expect(body.results.length).toBeGreaterThan(0);
+      });
+    });
+  }
+
+  it("captures without duplicate detection rather than rejecting the write", async () => {
+    // Only the duplicate query fails: capture must proceed on the advisory check
+    // alone, without consulting index health or touching the primary embed.
+    const env = makeTestEnv(db, { VECTORIZE: makeVectorizeMock({ query: vi.fn(denied) } as any) });
+    const { ctx, drain } = makeCtx();
+    const res = await worker.fetch(req("POST", "/capture", { body: { content: "advisory check skipped" } }), env, ctx);
+    await drain();
+
+    expect(res.status).toBe(200);
+    expect(db.entries).toHaveLength(1);
+    expect(JSON.parse(db.entries[0].vector_ids).length).toBeGreaterThan(0);
+  });
+
+  it("still fails loudly when the embed fails but Vectorize is healthy (#212)", async () => {
+    // The distinction the fix turns on: a failing embed against a reachable index
+    // is a transient fault, not a keyword-only deployment. Committing here would
+    // report success for content the index never received.
+    const { id, content, vector_ids } = await seed(db, "original content");
+    const env = makeTestEnv(db, {
+      AI: { run: vi.fn().mockRejectedValue(new Error("Neurons daily limit exceeded (code 4006)")) } as any,
+    });
+    const { ctx, drain } = makeCtx();
+    const res = await worker.fetch(req("POST", "/update", { body: { id, content: "replacement content" } }), env, ctx);
+    await drain();
+
+    expect(res.status).toBe(500);
+    expect(db.entries[0].content).toBe(content);
+    expect(db.entries[0].vector_ids).toBe(vector_ids);
+  });
+});


### PR DESCRIPTION
Closes #270

## The report

When the Vectorize binding is absent, because the index has not been created yet or the deploying token lacks Vectorize permission, the read path already degrades to keyword-only and sets `semantic_unavailable`. The write path did not. `POST /capture` returned 500.

## The fault was the duplicate check, not the upsert

`captureEntry` calls `checkDuplicateAndContradiction` before the D1 insert, and `duplicate.ts` issued an unguarded `VECTORIZE.query`. So capture threw before writing anything: every capture was rejected outright, not merely stored without semantic enrichment. The `upsert` in `storeEntry` was already non-fatal there, wrapped in `ctx.waitUntil().catch()`.

The same fault was breaking the nightly compression pass, which captures through `compressTag` and `derivePattern`.

## Degraded is not the same as failed

The naive fix, wrapping every Vectorize call site in try/catch, would have regressed #212 back into silent unsearchability. The useful distinction is not which call site, it is whether Vectorize is gone or whether one embed failed:

- Vectorize unreachable: a supported keyword-only deployment. Commit the write and skip indexing.
- Embed failed against a healthy index: transient. Keep failing loudly, or we report success for content the index never received.

`isVectorizeUnavailable` in `vectorize/health.ts` draws that line, reusing the existing `describe()` probe. It only runs on an error path, so healthy writes pay nothing.

## Changes

- `duplicate.ts` guards the query. Duplicate detection, contradiction detection and neighbour edges are advisory, so this degrades on any failure exactly as recall and the graph pass already do.
- `store.ts` gains `reembedOrDegrade`, returning null when Vectorize is unreachable and rethrowing otherwise. Callers that get null skip `deleteStaleVectors`, because with Vectorize gone the old vectors are the entry's only remaining searchability.
- `appendToEntry` commits the addition even when it cannot be indexed. Keyword search reads `entries.content`, so an unindexed append stays recallable, whereas rejecting it loses it. It now returns whether it indexed.
- `POST /update` commits and keeps the previous index instead of failing forever on a keyword-only deployment. Its #212 500 for transient failures is unchanged.
- `/append`, `/update` and the MCP `append` tool report `semantic_unavailable` with the existing fix hint, matching the recall convention.
- README: the graceful degradation bullet claimed only recall degraded.

## Tests

`test/integration/vectorize-unavailable.test.ts`, table driven over both real failure modes, binding absent and every call denied, across capture, append, update and recall. Two guards beyond the reported bug:

- the old vectors survive a degraded update
- a failing embed against a healthy index still 500s with the entry untouched (#212)

Mutation tested: seven of the ten fail against the unfixed source. The three that pass are the regression guards, which is correct since they assert behaviour that already worked.

991 tests pass, `tsc` clean.

## Note on the mocks

This class of bug is invisible to the suite because `makeVectorizeMock` is stateless and never fails, which is also how #208, #210 and #212 got through. This PR adds the first tests that exercise an absent or erroring binding, but the mocks themselves are still optimistic by default.
