### PR TITLE
perf(compression): bound tags per nightly run and batch the rolled-up marks (#278)

### DIFF
--- a/src/compression/digest.ts
+++ b/src/compression/digest.ts
@@ -45,6 +45,41 @@ State of "${tag}":`;
   return digest.trim();
 }
 
+/**
+ * Mark the entries a digest was built from, so they stop being eligible for compression.
+ *
+ * One statement per source used to be issued serially, which was roughly 88% of the whole
+ * nightly cron's D1 cost — all four jobs share one invocation and therefore one subrequest
+ * budget (#278). A batch is a single subrequest whatever it carries.
+ *
+ * batch() is atomic, and that matters more than it looks here: the digest entry has already
+ * been written by this point, so a source that misses its `rolled-up` mark stays eligible
+ * and gets compressed again on a later night, producing a duplicate digest. Letting one bad
+ * row roll back the whole batch would turn one duplicate into a tag's worth, so a failed
+ * batch falls back to per-row writes — the behaviour this replaced, at the cost it used to
+ * pay, on the path that used to be the only path.
+ */
+async function markSourcesRolledUp(env: Env, ids: string[], digestId: string): Promise<void> {
+  if (!ids.length) return;
+  const note = `\n\n[Digest: ${digestId}]`;
+  const mark = (id: string) => env.DB.prepare(
+    `UPDATE entries SET tags = json_insert(tags, '$[#]', 'rolled-up'), content = content || ? WHERE id = ?`
+  ).bind(note, id);
+
+  try {
+    await env.DB.batch(ids.map(mark));
+  } catch (e) {
+    console.error("Batched rolled-up mark failed; retrying per row (non-fatal):", e);
+    for (const id of ids) {
+      try {
+        await mark(id).run();
+      } catch (err) {
+        console.error(`Failed to update source entry ${id} (non-fatal):`, err);
+      }
+    }
+  }
+}
+
 export async function compressTag(
   tag: string,
   env: Env,
@@ -95,15 +130,7 @@ export async function compressTag(
     return { synthesizedId: null, entriesUsed: 0, text };
   }
 
-  for (const id of rows.map(r => r.id)) {
-    try {
-      await env.DB.prepare(
-        `UPDATE entries SET tags = json_insert(tags, '$[#]', 'rolled-up'), content = content || ? WHERE id = ?`
-      ).bind(`\n\n[Digest: ${result.id}]`, id).run();
-    } catch (e) {
-      console.error(`Failed to update source entry ${id} (non-fatal):`, e);
-    }
-  }
+  await markSourcesRolledUp(env, rows.map(r => r.id), result.id);
 
   return { synthesizedId: result.id, entriesUsed: rows.length, text };
 }

--- a/src/compression/nightly.ts
+++ b/src/compression/nightly.ts
@@ -4,6 +4,61 @@ import { initializeDatabase } from "../db/init";
 import { COMPRESSION_MIN_AGE_MS, compressionEligibilitySql } from "./eligibility";
 import { compressTag } from "./digest";
 
+/**
+ * How many tags one nightly run may compress.
+ *
+ * This bound is what keeps the cron inside a free-plan invocation, and it is protecting
+ * two independent ceilings, not one — raising it needs both re-measured:
+ *
+ *   - D1 subrequests. All four nightly jobs share a single scheduled() invocation and
+ *     therefore one budget. Each compressed tag costs about six.
+ *   - CPU. Cron Triggers get 10 ms on the free plan, and the work per tag is linear:
+ *     measured 1.6 ms at 7 tags, 9.6 ms at 30, 20.2 ms at 60.
+ *
+ * Nothing bounded this before: every tag with more than ten eligible entries was
+ * compressed on every run, so both costs grew with how many distinct tags a user had.
+ */
+export const COMPRESSION_MAX_TAGS_PER_RUN = 4;
+
+/** Where the rotation resumes from. Operational state, so KV rather than a tags value. */
+const TAG_CURSOR_KEY = "compression:tag-cursor";
+
+/**
+ * Pick this run's tags, resuming after the last one processed.
+ *
+ * Deferring rather than truncating is the whole point: a plain `LIMIT` would compress the
+ * same head of the list every night and never reach the tail. The cursor stores a tag NAME
+ * rather than an index because the candidate list is re-derived each run and its ordering
+ * shifts as entries are rolled up — an index would silently skip whatever moved.
+ * An unknown or missing cursor starts from the top, which is also the first-run path.
+ */
+async function selectTagsForRun(env: Env, tags: string[]): Promise<string[]> {
+  if (tags.length <= COMPRESSION_MAX_TAGS_PER_RUN) return tags;
+
+  let start = 0;
+  try {
+    const last = await env.OAUTH_KV.get(TAG_CURSOR_KEY);
+    const at = last ? tags.indexOf(last) : -1;
+    if (at >= 0) start = (at + 1) % tags.length;
+  } catch (e) {
+    console.error("Compression tag cursor read failed; starting from the top (non-fatal):", e);
+  }
+
+  const picked = Array.from(
+    { length: Math.min(COMPRESSION_MAX_TAGS_PER_RUN, tags.length) },
+    (_, i) => tags[(start + i) % tags.length],
+  );
+
+  try {
+    await env.OAUTH_KV.put(TAG_CURSOR_KEY, picked[picked.length - 1]);
+  } catch (e) {
+    // A lost cursor repeats this run's tags next time rather than losing any, so it is
+    // safe to continue — the 24h guard in compressTag makes the repeat a cheap no-op.
+    console.error("Compression tag cursor write failed (non-fatal):", e);
+  }
+  return picked;
+}
+
 export async function runNightlyCompression(env: Env, ctx: ExecutionContext): Promise<void> {
   const cfg = await resolveConfig(env);
   await initializeDatabase(env);
@@ -23,8 +78,9 @@ export async function runNightlyCompression(env: Env, ctx: ExecutionContext): Pr
     ORDER BY count DESC
   `).bind(Date.now() - cfg.COMPRESSION_MIN_AGE_MS).all();
 
-  for (const row of results) {
-    const tag = row.tag as string;
+  const tags = await selectTagsForRun(env, results.map(r => r.tag as string));
+
+  for (const tag of tags) {
     try {
       await compressTag(tag, env, ctx);
     } catch (e) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -8,4 +8,4 @@ export interface Env extends Omit<Cloudflare.Env, "VECTORIZE_GRACE_MS"> {
 // Worker version, echoed by GET /health. The desktop app compares this against
 // the version it bundles to offer a one-click "update your Second Brain".
 // Bump (semver) when the Worker changes; see installer/README "Worker versioning".
-export const SB_VERSION = "2.2.0";
+export const SB_VERSION = "2.2.1";

--- a/test/unit/compress-tag.test.ts
+++ b/test/unit/compress-tag.test.ts
@@ -269,4 +269,84 @@ describe("compressTag()", () => {
     expect(result.synthesizedId).toBeNull();
     expect(env.AI.run).not.toHaveBeenCalled();
   });
+
+  // ── Marking sources rolled-up (#278) ─────────────────────────────────────────
+  //
+  // All four nightly jobs share one scheduled() invocation and therefore one
+  // subrequest budget, and marking sources one statement at a time was ~88% of the
+  // whole cron's D1 cost. These pin the batching, and the per-row fallback that
+  // keeps a single bad row from rolling back a whole tag's worth of marks.
+
+  /** Counts subrequests the way D1 bills them: a batch is one, whatever it carries. */
+  function countingDb(db: D1Mock, failBatch = false, failRowIds: string[] = []) {
+    const calls = { batches: 0, batchedStatements: 0, individualRuns: 0 };
+    const wrap = (stmt: any, boundId?: string): any => ({
+      bind: (...args: any[]) => wrap(stmt.bind(...args), args[args.length - 1]),
+      run: async () => {
+        calls.individualRuns++;
+        if (boundId && failRowIds.includes(boundId)) throw new Error(`row ${boundId} rejected`);
+        return stmt.run();
+      },
+      first: () => stmt.first(),
+      all: () => stmt.all(),
+      __inner: stmt,
+    });
+    const DB = {
+      prepare: (sql: string) => wrap(db.prepare(sql)),
+      exec: (sql: string) => db.exec(sql),
+      batch: (stmts: any[]) => {
+        calls.batches++;
+        calls.batchedStatements += stmts.length;
+        if (failBatch) throw new Error("batch rejected");
+        return db.batch(stmts.map(s => s.__inner ?? s));
+      },
+    } as unknown as D1Database;
+    return { DB, calls };
+  }
+
+  const rolledUp = (db: D1Mock) =>
+    db.entries.filter(e => JSON.parse(e.tags ?? "[]").includes("rolled-up")).map(e => e.id).sort();
+
+  it("marks every source in a single batch rather than one statement per row", async () => {
+    seedEntries(db, "work", 15, { recall_count: 0 });
+    const { DB, calls } = countingDb(db);
+    const { ctx, drain } = makeCtx();
+
+    const result = await compressTag("work", makeTestEnv(db, { AI: makeDigestAI(), DB }), ctx);
+    await drain();
+
+    expect(result.synthesizedId).not.toBeNull();
+    expect(calls.batches).toBe(1);
+    expect(calls.batchedStatements).toBe(15);
+    expect(rolledUp(db)).toHaveLength(15);
+  });
+
+  it("falls back to per-row writes when the batch is rejected", async () => {
+    // batch() is atomic, so without this fallback one bad row would un-mark every
+    // source for the tag — and an unmarked source is compressed again later,
+    // turning one duplicate digest into a whole tag's worth.
+    seedEntries(db, "work", 15, { recall_count: 0 });
+    const { DB, calls } = countingDb(db, true);
+    const { ctx, drain } = makeCtx();
+
+    const result = await compressTag("work", makeTestEnv(db, { AI: makeDigestAI(), DB }), ctx);
+    await drain();
+
+    expect(result.synthesizedId).not.toBeNull();
+    expect(calls.batches).toBe(1);
+    expect(rolledUp(db)).toHaveLength(15);
+  });
+
+  it("keeps marking the rest when one row fails during the fallback", async () => {
+    seedEntries(db, "work", 15, { recall_count: 0 });
+    const { DB } = countingDb(db, true, ["entry-7"]);
+    const { ctx, drain } = makeCtx();
+
+    await compressTag("work", makeTestEnv(db, { AI: makeDigestAI(), DB }), ctx);
+    await drain();
+
+    const marked = rolledUp(db);
+    expect(marked).toHaveLength(14);
+    expect(marked).not.toContain("entry-7");
+  });
 });

--- a/test/unit/nightly-compression.test.ts
+++ b/test/unit/nightly-compression.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The nightly jobs all run inside one scheduled() invocation and share its budget, so
+ * how much work compression takes per run is a correctness property, not a tuning knob.
+ *
+ * Before this bound existed, every tag with more than ten eligible entries was compressed
+ * on every run — so both the D1 subrequest count and the CPU time grew with how many
+ * distinct tags a user had, and a heavily-tagged brain blew the free-plan ceilings. The
+ * tests that matter here are the two that bounding could plausibly get wrong: that it
+ * defers rather than drops, and that the rotation actually reaches every tag.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runNightlyCompression, COMPRESSION_MAX_TAGS_PER_RUN } from "../../src/compression/nightly";
+import { resetDatabaseInit } from "../../src/db/init";
+import { makeTestDb, makeTestEnv, makeMemoryKV } from "../helpers/make-env";
+import { D1Mock } from "../helpers/d1-mock";
+import type { Env } from "../../src/env";
+
+function makeSseStream(response: string) {
+  return new ReadableStream({
+    start(c) {
+      c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+      c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+      c.close();
+    },
+  });
+}
+
+function makeDigestAI() {
+  return {
+    run: vi.fn().mockImplementation(async (model: string, opts: any) => {
+      if (model === "@cf/baai/bge-small-en-v1.5") return { data: [new Array(384).fill(0.1)] };
+      if (opts?.stream) return makeSseStream("A digest of the tagged memories.");
+      return { response: "3" };
+    }),
+  } as unknown as Ai;
+}
+
+function seedTags(db: D1Mock, tagCount: number, perTag = 15) {
+  const old = Date.now() - 200 * 24 * 3600 * 1000;
+  let i = 0;
+  for (let t = 0; t < tagCount; t++) {
+    for (let k = 0; k < perTag; k++, i++) {
+      db.entries.push({
+        id: `e-${i}`, content: `Memory ${i} about topic ${t}`, tags: JSON.stringify([`tag-${t}`]),
+        source: "api", created_at: old + i, updated_at: old + i, vector_ids: "[]",
+        recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+      });
+    }
+  }
+}
+
+/** Which tags have had a digest built for them so far. */
+function digestedTags(db: D1Mock): Set<string> {
+  const out = new Set<string>();
+  for (const e of db.entries) {
+    const tags: string[] = JSON.parse(e.tags ?? "[]");
+    if (!tags.includes("synthesized")) continue;
+    for (const t of tags) if (t.startsWith("tag-")) out.add(t);
+  }
+  return out;
+}
+
+async function runCron(env: Env) {
+  const pending: Promise<any>[] = [];
+  const ctx = { waitUntil: (p: Promise<any>) => pending.push(p) } as any as ExecutionContext;
+  await runNightlyCompression(env, ctx);
+  await Promise.allSettled(pending);
+}
+
+describe("runNightlyCompression() tag bound", () => {
+  let db: D1Mock;
+  let env: Env;
+
+  beforeEach(() => {
+    resetDatabaseInit();
+    db = makeTestDb();
+    env = makeTestEnv(db, { AI: makeDigestAI(), OAUTH_KV: makeMemoryKV() });
+  });
+
+  it(`compresses at most ${COMPRESSION_MAX_TAGS_PER_RUN} tags in one run`, async () => {
+    seedTags(db, 20);
+
+    await runCron(env);
+
+    expect(digestedTags(db).size).toBe(COMPRESSION_MAX_TAGS_PER_RUN);
+  });
+
+  it("resumes after the last tag it processed rather than repeating the head", async () => {
+    seedTags(db, 20);
+
+    await runCron(env);
+    const first = digestedTags(db);
+    await runCron(env);
+    const afterSecond = digestedTags(db);
+
+    // The second run must have done new work, not re-done the first run's.
+    expect(afterSecond.size).toBeGreaterThan(first.size);
+    for (const t of first) expect(afterSecond.has(t)).toBe(true);
+  });
+
+  it("reaches every tag across enough runs — bounding defers, it never drops", async () => {
+    const TAGS = 20;
+    seedTags(db, TAGS);
+
+    // Ceil(20/4) runs would suffice if nothing repeated; allow slack and assert coverage.
+    for (let i = 0; i < 10; i++) await runCron(env);
+
+    expect(digestedTags(db).size).toBe(TAGS);
+  });
+
+  it("takes every tag in one run when there are fewer than the bound", async () => {
+    const under = COMPRESSION_MAX_TAGS_PER_RUN - 1;
+    seedTags(db, under);
+    const put = vi.spyOn(env.OAUTH_KV, "put");
+
+    await runCron(env);
+
+    expect(digestedTags(db).size).toBe(under);
+    // No rotation is needed, so no cursor is written — there is nothing to resume from.
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("starts from the top when the cursor cannot be read", async () => {
+    seedTags(db, 20);
+    const failingKV = {
+      get: vi.fn().mockRejectedValue(new Error("KV unavailable")),
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn(), list: vi.fn(),
+    } as unknown as KVNamespace;
+    env = makeTestEnv(db, { AI: makeDigestAI(), OAUTH_KV: failingKV });
+
+    await runCron(env);
+
+    expect(digestedTags(db).size).toBe(COMPRESSION_MAX_TAGS_PER_RUN);
+  });
+});


### PR DESCRIPTION
## Summary

The nightly cron could exceed **both** of the free plan's per-invocation ceilings on an ordinary brain. All four nightly jobs fire inside one `scheduled()` invocation, so they share one budget. Two causes, both in compression:

1. Each source entry was marked `rolled-up` with its own `UPDATE`, serially — up to 50 per tag.
2. **Nothing bounded how many tags a run compressed.** Every tag with more than ten eligible entries was processed, so cost grew linearly with how many distinct tags a user had. `LIMIT 50` bounded rows *per tag*; tag count was unbounded.

Refs #278.

## Measured

Whole `scheduled()` run. Subrequests counted the way D1 bills them (a `batch()` is one, whatever it carries); CPU with I/O mocked, so compute only.

| | before | after |
|---|---|---|
| 7 tags | 119 subreq, 1.6 ms | **101 subreq, 1.8 ms** |
| 30 tags | 257 subreq, 9.6 ms | **101 subreq, 2.6 ms** |
| 60 tags | 437 subreq, 20.2 ms | **101 subreq, 4.3 ms** |
| 120 tags | — | **101 subreq, 2.9 ms** |

Both costs are now **flat in tag count** rather than linear.

## The CPU ceiling was the one that was definitely broken

Cron Triggers get **10 ms CPU** on the free plan. The old numbers crossed that around 30 tags and were 2× over at 60. That is now resolved with a wide margin at any brain shape, and it is the ceiling I am most confident about — the subrequest one is not (see below).

## Rotation, not truncation

A plain `LIMIT` would compress the same head of the list every night and never reach the tail. A cursor in KV records the last tag processed and the next run resumes after it, wrapping around.

It stores a tag **name** rather than an index, because the candidate list is re-derived each run and reorders as entries are rolled up — an index would silently skip whatever moved. A missing or unknown cursor starts from the top, which is also the first-run path. A KV failure at either end degrades to "start from the top" rather than throwing; the worst case is repeating a run's tags, which the existing 24h guard makes a cheap no-op.

## Batching the `rolled-up` marks

`batch()` is atomic, which matters more than usual here: the digest entry has **already** been written when sources are marked, so a source that misses its mark stays eligible and gets compressed again later, producing a duplicate digest. Letting one bad row roll back the batch would turn one duplicate into a whole tag's worth — so a rejected batch falls back to per-row writes.

## Also: SB_VERSION → 2.2.1

It was last set for the 2.2.0 release, so the desktop app has not been offering the Worker changes merged since — including the staleness pass from #228.

## What this does not do, and why I stopped here

**It does not bring a run under 50 D1 subrequests.** The remaining 101 is now dominated by the staleness pass's per-row CAS updates. Those can be batched — each is a conditional `UPDATE`, and `batch()` returns per-statement `meta.changes` so a lost CAS is still detectable — which would land around 40.

I have not done it here. That code landed recently after several rounds of review, its CAS semantics (content guard, fresh re-read on retry, cursor advance on total failure) are subtle, and bolting a rewrite onto this PR is how a related PR became unmergeable. It deserves its own change and its own validation.

It is also not clear 50 is the operative number. D1's limits page says "Queries per Worker invocation ... 50 (Free)" and was last updated 21 Apr 2026; the Workers limits page and the 11 Feb 2026 changelog say free gets 50 *external* subrequests but **~1,000 to Cloudflare services**, and D1 is one. Under the second reading, 101 is 10% of budget and nothing further is needed.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:coverage` — 1090 passing
- [x] `npx wrangler deploy --dry-run`
- [x] New tests verified against the unbounded version: 3 of 5 go red. The other two ("reaches every tag across enough runs", "takes every tag when under the bound") pass either way — they are behaviour-preservation guards, not regression tests for the bound, and are labelled as such rather than counted as coverage.
