### PR TITLE
fix(recall): cap the keyword clause so a long query on a new brain cannot 500 (#276)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -51,6 +51,20 @@ export const KEYWORD_CANDIDATE_LIMIT = 500;
 // genuine word-boundary matches.
 export const SUBSTRING_MATCH_WEIGHT = 0.25;
 export const KEYWORD_MIN_TOKEN_LEN = 2;
+// The most LIKE terms this codebase will put into a single D1 statement: the
+// frequency scan's SUM columns (distill.ts) and the keyword arm's OR chain
+// (search.ts). The keyword arm needs the ceiling because distillToRareTerms
+// normally hands it MAX_QUERY_TERMS but two of its exits return the query
+// whole, and one of those needs nothing worse than an empty corpus to fire — so
+// a fresh install's first long query built a clause D1 rejected outright
+// (#276). Both of D1's limits bind at 99 terms: one parameter per term plus the
+// row limit against a budget of D1_MAX_BOUND_PARAMS, and an OR chain one
+// expression node deep per term against a tree-depth ceiling of 100 (measured:
+// 99 terms accepted, 100 rejected on depth first). 16 leaves 6x margin for a
+// future predicate, and keeps the two call sites agreeing by construction — the
+// widest set the scan ranks is the widest set the clause can carry, so no query
+// distillation can rank is ever truncated by the backstop.
+export const KEYWORD_MAX_TOKENS = 16;
 export const QUERY_SATURATION_FRACTION = 0.3;
 export const MAX_QUERY_TERMS = 3;
 export const KEYWORD_STOPWORDS = new Set([

--- a/src/recall/distill.ts
+++ b/src/recall/distill.ts
@@ -1,6 +1,7 @@
 import type { Env } from "../env";
 import { DEFAULTS, type Config } from "../config";
 import {
+  KEYWORD_MAX_TOKENS,
   KEYWORD_MIN_TOKEN_LEN,
   KEYWORD_STOPWORDS,
   MAX_QUERY_TERMS,
@@ -69,7 +70,11 @@ export async function distillToRareTerms(query: string, env: Env, config: Readon
     return { query: content.length ? content.join(" ") : query, df: null, total: null };
   }
 
-  const uniq = [...new Set(content.map(norm))].slice(0, 16);
+  // One bound parameter and one SUM column per term, so this scan is bounded by
+  // the same ceiling as the keyword clause it feeds. Sharing the constant is
+  // what makes that true rather than coincidental: the widest set ranked here
+  // is the widest set search.ts can carry, in either direction.
+  const uniq = [...new Set(content.map(norm))].slice(0, KEYWORD_MAX_TOKENS);
   try {
     const sums = uniq.map((_, i) => `SUM(CASE WHEN content LIKE ? THEN 1 ELSE 0 END) AS d${i}`).join(", ");
     const row = await env.DB.prepare(`SELECT COUNT(*) AS total, ${sums} FROM entries`)

--- a/src/recall/search.ts
+++ b/src/recall/search.ts
@@ -1,6 +1,7 @@
 import type { Env } from "../env";
 import {
   D1_MAX_BOUND_PARAMS,
+  KEYWORD_MAX_TOKENS,
   VECTORIZE_GET_BY_IDS_BATCH,
   VECTORIZE_TOP_K_MULTIPLIER,
 } from "../constants";
@@ -22,10 +23,16 @@ import type { KeywordRow, RecallMatch, RecallSearchResult } from "./types";
 
 async function keywordSearch(tokens: string[], env: Env, limit: number): Promise<KeywordRow[]> {
   if (!tokens.length) return [];
-  const where = tokens.map(() => "content LIKE ?").join(" OR ");
+  // Capped here rather than at distillation's uncapped exits because this is
+  // the only place a token count becomes SQL, and there are two such exits —
+  // one of which needs nothing worse than an empty corpus to fire (#276). Query
+  // order is the only ordering available on those paths: they are exactly the
+  // paths where the frequencies that would rank the terms are missing.
+  const terms = tokens.slice(0, KEYWORD_MAX_TOKENS);
+  const where = terms.map(() => "content LIKE ?").join(" OR ");
   const { results } = await env.DB.prepare(
     `SELECT id, content, tags, source, created_at FROM entries WHERE ${where} ORDER BY created_at DESC LIMIT ?`
-  ).bind(...tokens.map(t => `%${t}%`), limit).all();
+  ).bind(...terms.map(t => `%${t}%`), limit).all();
   return results as unknown as KeywordRow[];
 }
 
@@ -236,16 +243,31 @@ export async function recallEntries(
     }));
   }
 
+  // Chunked like the recall-count fetch above. This id list is the seeds plus
+  // whatever the graph expansion returned, so its length is the sum of two caps
+  // this query does not own — topK and GRAPH_MAX_NODES. They sum to 70 today,
+  // which fits one statement; the loop is what makes raising either of them a
+  // tuning change here rather than a query D1 rejects. One consequence if a
+  // second batch ever runs: d1Rows is then batch order, not one result set's
+  // order, which derivePattern's rows.slice(0, 20) below samples from.
   const allParentIds = [...seedParentIds, ...expandedScored.map(e => e.parentId)];
-  const placeholders = allParentIds.map(() => "?").join(", ");
-  const d1Bindings: (string | number)[] = [...allParentIds];
-  let d1Sql = `SELECT id, content, tags, source, created_at, updated_at FROM entries WHERE id IN (${placeholders}) AND tags NOT LIKE '%"auto-pattern"%' AND tags NOT LIKE '%"status:deprecated"%'`;
+  let d1Filters = ` AND tags NOT LIKE '%"auto-pattern"%' AND tags NOT LIKE '%"status:deprecated"%'`;
+  const filterBindings: number[] = [];
   if (kind && (KIND_VALUES as readonly string[]).includes(kind)) {
-    d1Sql += ` AND tags LIKE '%"kind:${kind}"%'`;
+    d1Filters += ` AND tags LIKE '%"kind:${kind}"%'`;
   }
-  if (after !== undefined) { d1Sql += ` AND created_at >= ?`; d1Bindings.push(after); }
-  if (before !== undefined) { d1Sql += ` AND created_at <= ?`; d1Bindings.push(before); }
-  const { results: d1Rows } = await env.DB.prepare(d1Sql).bind(...d1Bindings).all() as { results: Record<string, any>[] };
+  if (after !== undefined) { d1Filters += ` AND created_at >= ?`; filterBindings.push(after); }
+  if (before !== undefined) { d1Filters += ` AND created_at <= ?`; filterBindings.push(before); }
+  const d1Rows: Record<string, any>[] = [];
+  const idBatchSize = D1_MAX_BOUND_PARAMS - filterBindings.length;
+  for (let i = 0; i < allParentIds.length; i += idBatchSize) {
+    const batch = allParentIds.slice(i, i + idBatchSize);
+    const placeholders = batch.map(() => "?").join(", ");
+    const { results } = await env.DB.prepare(
+      `SELECT id, content, tags, source, created_at, updated_at FROM entries WHERE id IN (${placeholders})${d1Filters}`
+    ).bind(...batch, ...filterBindings).all() as { results: Record<string, any>[] };
+    d1Rows.push(...results);
+  }
 
   const d1Map = new Map(d1Rows.map((r) => [r.id as string, r]));
 

--- a/test/integration/recall-d1-limits.test.ts
+++ b/test/integration/recall-d1-limits.test.ts
@@ -1,0 +1,241 @@
+/**
+ * The two statements in recall whose size is decided by data rather than by the
+ * code that builds them: the keyword arm's OR chain of `content LIKE ?` terms,
+ * and the hydration `id IN (…)` list. D1 caps bound parameters at 100 and
+ * expression-tree depth at 100, and both statements are one constant away from
+ * either ceiling.
+ *
+ * #276 is what that looks like in production. `distillToRareTerms` narrows a
+ * query to its MAX_QUERY_TERMS rarest terms by counting how often each occurs
+ * across the corpus; with no rows to count it hands the query back whole, the
+ * keyword arm turns every token into its own LIKE clause, and past roughly 120
+ * words the request fails outright. A fresh install was one long question away
+ * from a recall that could not answer, until the user saved their first memory.
+ *
+ * Driven against real SQLite (`test/helpers/sqlite-d1.ts`) so the empty corpus
+ * is genuinely empty — the frequency aggregate returns `total: 0` because there
+ * is nothing to count, not because a mock said so. The D1 limits are layered on
+ * top, because nothing else here enforces them: the D1 mock evaluates no SQL,
+ * and `node:sqlite` accepts 999 OR'd terms against its own depth ceiling of
+ * 1000. A test run against either would pass while the Worker returned a 500.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import worker from "../../src/index";
+import { recallEntries } from "../../src/recall/search";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestEnv, makeVectorizeMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+
+// Measured against the Workers runtime for this issue: 119 words recalled, 120
+// (100 tokens) returned a 500, and depth was the limit that bound first.
+const D1_MAX_BOUND_PARAMS = 100;
+const D1_MAX_EXPR_DEPTH = 100;
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+// 120 coined words: every one clears the minimum token length and none is a
+// stopword, so the token count is exactly the word count. A real 120-word
+// question lands on the same 100 tokens once stopwords are stripped.
+const LONG_QUERY = Array.from({ length: 120 }, (_, i) => `topic${i}`).join(" ");
+
+interface Executed { sql: string; params: unknown[] }
+
+/**
+ * A D1 facade that enforces the two limits the real one enforces, and records
+ * what was executed. `failWhen` fails a single statement, for the exit that
+ * needs a database error rather than an empty corpus to fire.
+ */
+function withD1Limits(
+  inner: SqliteD1["db"],
+  executed: Executed[],
+  failWhen: (sql: string) => boolean = () => false,
+) {
+  const check = (sql: string, params: unknown[]) => {
+    executed.push({ sql, params });
+    if (failWhen(sql)) throw new Error("D1_ERROR: network error: SQLITE_ERROR");
+    // An N-way OR chain parses one level deeper than N, which is why 99 LIKE
+    // terms are accepted and 100 are not. "ORDER BY" cannot match: the "OR"
+    // there is not followed by whitespace. Checked before the parameter budget
+    // because that is the order the runtime reported them in — parsing first.
+    if (exprDepth(sql) > D1_MAX_EXPR_DEPTH) {
+      throw new Error(`D1_ERROR: Expression tree is too large (maximum depth ${D1_MAX_EXPR_DEPTH}): SQLITE_ERROR`);
+    }
+    if (params.length > D1_MAX_BOUND_PARAMS) {
+      throw new Error("D1_ERROR: too many SQL variables: SQLITE_ERROR");
+    }
+  };
+  const wrap = (sql: string, stmt: any, params: unknown[]): any => ({
+    bind: (...args: unknown[]) => wrap(sql, stmt.bind(...args), args),
+    all: async () => { check(sql, params); return stmt.all(); },
+    first: async () => { check(sql, params); return stmt.first(); },
+    run: async () => { check(sql, params); return stmt.run(); },
+  });
+  return { prepare: (sql: string) => wrap(sql, inner.prepare(sql), []) };
+}
+
+const exprDepth = (sql: string) => sql.split(/\s+OR\s+/i).length + 1;
+
+const keywordStatements = (executed: Executed[]) =>
+  executed.filter(e => e.sql.includes("FROM entries WHERE content LIKE"));
+
+const hydrationStatements = (executed: Executed[]) =>
+  executed.filter(e => e.sql.includes("created_at, updated_at FROM entries WHERE id IN"));
+
+describe("recall stays inside D1's statement limits", () => {
+  let sqlite: SqliteD1;
+  let executed: Executed[];
+
+  beforeEach(async () => {
+    sqlite = makeSqliteD1();
+    executed = [];
+    // `updated_at` is one of the columns src/db/init.ts adds by ALTER at
+    // runtime rather than in schema.sql, and that path goes through `exec`,
+    // which this facade does not implement. Recall's hydration selects it.
+    await sqlite.db.prepare(`ALTER TABLE entries ADD COLUMN updated_at INTEGER`).run();
+  });
+
+  afterEach(() => sqlite.close());
+
+  const envWith = (failWhen?: (sql: string) => boolean, overrides: Partial<Env> = {}): Env =>
+    makeTestEnv(undefined, {
+      DB: withD1Limits(sqlite.db, executed, failWhen) as unknown as D1Database,
+      ...overrides,
+    });
+
+  describe("the keyword clause, on an empty brain (#276)", () => {
+    it("answers a 120-word query with no memories stored", async () => {
+      const res = await worker.fetch(
+        req("GET", `/recall?query=${encodeURIComponent(LONG_QUERY)}`),
+        envWith(),
+        ctx,
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json() as any;
+      expect(data.ok).toBe(true);
+      expect(data.results).toEqual([]);
+
+      const [keyword] = keywordStatements(executed);
+      expect(keyword).toBeDefined();
+      // One parameter per LIKE term plus the row limit.
+      expect(keyword.params.length).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS);
+      expect(exprDepth(keyword.sql)).toBeLessThanOrEqual(D1_MAX_EXPR_DEPTH);
+    });
+
+    it("answers a 120-word query when the frequency scan itself fails", async () => {
+      // The other exit that returns the query uncapped, and the reason the cap
+      // lives where the clause is built rather than at one distillation exit:
+      // here the corpus is not empty, the statistics are simply unavailable.
+      sqlite.seed({ id: "e1", content: "topic0 is written down", createdAt: 1000 });
+      const scanFailed = (sql: string) => sql.includes("SUM(CASE WHEN content LIKE");
+
+      const res = await worker.fetch(
+        req("GET", `/recall?query=${encodeURIComponent(LONG_QUERY)}`),
+        envWith(scanFailed),
+        ctx,
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json() as any;
+      expect(data.ok).toBe(true);
+      expect(data.results.map((r: any) => r.id)).toEqual(["e1"]);
+
+      const [keyword] = keywordStatements(executed);
+      expect(keyword.params.length).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS);
+      expect(exprDepth(keyword.sql)).toBeLessThanOrEqual(D1_MAX_EXPR_DEPTH);
+    });
+
+    it("still distills to the rarest terms, and still finds them, once a memory exists", async () => {
+      sqlite.seed({ id: "e1", content: "topic0 is written down", createdAt: 1000 });
+      const env = envWith();
+
+      const long = await worker.fetch(
+        req("GET", `/recall?query=${encodeURIComponent(LONG_QUERY)}`),
+        env,
+        ctx,
+      );
+      expect(long.status).toBe(200);
+      // Distillation can rank terms again, so the keyword arm sees three of them
+      // plus the row limit — the cap is a backstop, not the narrowing.
+      expect(keywordStatements(executed)[0].params.length).toBe(4);
+
+      executed.length = 0;
+      const short = await worker.fetch(req("GET", "/recall?query=topic0"), env, ctx);
+      expect(short.status).toBe(200);
+      const data = await short.json() as any;
+      expect(data.results.map((r: any) => r.id)).toEqual(["e1"]);
+    });
+  });
+
+  describe("the hydration id list", () => {
+    // Today this list cannot outgrow one statement: the route and the MCP tool
+    // both clamp topK to 20, and expandGraph stops at GRAPH_MAX_NODES (50), so
+    // the worst case is 70 ids. recallEntries itself does not clamp, so calling
+    // it directly is the honest way to ask what the query does when the list
+    // does outgrow one statement — which is one constant in another file away.
+    const N = 150;
+    const ids = Array.from({ length: N }, (_, i) => `e${i}`);
+
+    it("chunks the ids rather than binding them all in one statement", async () => {
+      for (const [i, id] of ids.entries()) {
+        sqlite.seed({ id, content: `memory ${i} about topic0`, createdAt: 1000 + i });
+      }
+      const env = envWith(undefined, {
+        VECTORIZE: makeVectorizeMock({
+          query: vi.fn().mockResolvedValue({
+            matches: ids.map((id, i) => ({
+              id,
+              score: 1 - i / (N * 2),
+              metadata: { parentId: id, created_at: 1000 + i },
+            })),
+          }),
+        }),
+      });
+
+      const { matches } = await recallEntries(
+        { query: "topic0", topK: N, synthesize: false }, env, ctx,
+      );
+
+      // Every seed hydrated exactly once: nothing dropped at a batch boundary,
+      // nothing counted twice by an overlapping slice.
+      expect(matches.length).toBe(N);
+      expect(new Set(matches.map(m => m.id)).size).toBe(N);
+      expect([...matches.map(m => m.id)].sort()).toEqual([...ids].sort());
+      expect(matches.every(m => m.content === `memory ${ids.indexOf(m.id)} about topic0`)).toBe(true);
+
+      const hydration = hydrationStatements(executed);
+      expect(hydration.length).toBe(2);
+      expect(hydration.map(h => h.params.length)).toEqual([100, 50]);
+      expect(Math.max(...hydration.map(h => h.params.length))).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS);
+    });
+
+    it("leaves room for the time-filter bindings it shares the budget with", async () => {
+      for (const [i, id] of ids.entries()) {
+        sqlite.seed({ id, content: `memory ${i} about topic0`, createdAt: 1000 + i });
+      }
+      const env = envWith(undefined, {
+        VECTORIZE: makeVectorizeMock({
+          query: vi.fn().mockResolvedValue({
+            matches: ids.map((id, i) => ({
+              id,
+              score: 1 - i / (N * 2),
+              metadata: { parentId: id, created_at: 1000 + i },
+            })),
+          }),
+        }),
+      });
+
+      // `after` and `before` are bound on every batch, so the id slice has to be
+      // smaller than the parameter budget, not equal to it.
+      const { matches } = await recallEntries(
+        { query: "topic0", topK: N, after: 1000, before: 1000 + N, synthesize: false }, env, ctx,
+      );
+
+      expect(matches.length).toBe(N);
+      const hydration = hydrationStatements(executed);
+      expect(hydration.map(h => h.params.length)).toEqual([100, 54]);
+      expect(Math.max(...hydration.map(h => h.params.length))).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS);
+    });
+  });
+});

--- a/test/unit/config-parity.test.ts
+++ b/test/unit/config-parity.test.ts
@@ -93,8 +93,9 @@ describe("config rule coverage", () => {
 
   it("platform limits are absent from the config surface", () => {
     // Exposing these guarantees breakage rather than risking it: Vectorize
-    // rejects >20 ids per call, D1 caps bound params at 100.
-    for (const forbidden of ["VECTORIZE_GET_BY_IDS_BATCH", "D1_MAX_BOUND_PARAMS", "EDGE_QUERY_BATCH"]) {
+    // rejects >20 ids per call, D1 caps bound params at 100 and refuses an
+    // expression tree deeper than 100 (#276).
+    for (const forbidden of ["VECTORIZE_GET_BY_IDS_BATCH", "D1_MAX_BOUND_PARAMS", "EDGE_QUERY_BATCH", "KEYWORD_MAX_TOKENS"]) {
       expect(DEFAULTS).not.toHaveProperty(forbidden);
     }
   });


### PR DESCRIPTION
## Summary

On an empty brain, a recall query of ~120 words or more returned **HTTP 500**. Closes #276.

`distillToRareTerms` narrows a query to its 3 rarest terms by counting term frequency across the corpus. On an empty corpus that count is zero, so it takes an early exit and returns the query **whole**. That reaches `keywordSearch`, which ORs one `content LIKE ?` per token, and SQLite refuses to parse a 100-deep expression tree.

Measured against a real Workers runtime: **119 words → 200, 120 words → 500**. The trigger is exact — it only holds while `COUNT(*) FROM entries` is zero, so storing one memory fixes it permanently. So every fresh install was one long paste away from a broken recall, via both `GET /recall` and the MCP tool, until the user saved their first memory.

## The cap

Applied in `keywordSearch` rather than at distillation's exits, because that is the only place a token count becomes SQL — one cap covers all of them.

The real ceiling is **99 terms**, and it is *expression depth*, not the bound-parameter budget. Verified both ways on real D1:

```
 99 OR-terms + LIMIT (100 params)   OK
100 OR-terms + LIMIT (101 params)   Expression tree is too large
100 OR-terms, ZERO bound params     same error   <- depth is what binds
IN (?×100) / IN (?×101)             OK / too many SQL variables
```

`KEYWORD_MAX_TOKENS = 16` is a sixth of that. Distillation hands over `MAX_QUERY_TERMS` (3) on the normal path, so **no query it can rank is truncated here** — and `distill.ts` now shares the constant so that stays true by construction rather than by coincidence.

## Also chunks `allParentIds`

That hydration query was bounded only by arithmetic it did not own: `topK` (≤20) plus `GRAPH_MAX_NODES` (50) = 70, against a 100-parameter limit. Raising either would have broken it silently. It is now chunked, so that becomes a tuning change.

## Test infrastructure

**Neither the D1 mock nor `node:sqlite` enforces the limits that matter** — `node:sqlite` accepts 999 OR'd terms and `IN (?×1000)`. A test against either passes green while the deployed Worker 500s. So the tests run against a facade imposing D1's real limits over real SQLite, verified to reject at exactly the same thresholds workerd does, with a byte-identical error string.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:coverage` — 1095 passing
- [x] `npx wrangler deploy --dry-run`
- [x] Adversarially validated: **SHIP**, could not be broken. Limits re-derived independently on real workerd; confirmed `search.ts` holds the only `join(" OR ")` in the repo, so there is no bypass; 4,000 fuzzed queries confirm max 3 tokens reach SQL on the success path.
- [x] Discrimination: reverting the cap reproduces the production error verbatim; reverting the chunking fails with `too many SQL variables`. One test is a pure control and is labelled as such.

## Known and not addressed here

The tag-scoped recall path (`search.ts:141`) loads every entry with a given tag and scans each one — unbounded by design, and the recall path most likely to hit the Worker CPU limit on a large brain. Different shape from this bug; worth its own issue.
