### PR TITLE
fix(routes): validate integer query params and bound the graph view (#277)

### DIFF
--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -9,6 +9,35 @@ import type { Connection, EdgeProvenance, GraphNeighbor, GraphView } from "./typ
 export const GRAPH_MAX_HOPS = 3;
 const GRAPH_FANOUT_CAP = 8;
 const GRAPH_MAX_NODES = 50;
+// Ceiling on the /graph view's node set, applied even when the caller asks for
+// no cap. The binding constraint is the Workers free-plan limit of 50
+// subrequests per invocation, not row reads. buildGraph costs
+//
+//   1 (edge scan) + ceil(N/D1_MAX_BOUND_PARAMS) (node hydration)
+//                 + ceil(N/EDGE_QUERY_BATCH)    (edge hydration)
+//
+// D1 queries for N nodes, plus one KV read for the config. At N=1500 that is
+// 1 + 15 + 30 = 46, or 47 with the KV read. N=1600 lands on exactly 50 with
+// nothing spare, and anything from 1634 up exceeds it outright — which would be
+// a deterministically dead graph tab for every free-plan brain that large, and
+// runGraphPass backfills edges nightly, so a brain arrives there on its own.
+//
+// 47 is the WARM figure. On a cold isolate the budget is shared with
+// initializeDatabase, which fires under waitUntil and spends about 12 more on
+// its DDL, so the first request against a fresh isolate costs ~59 and is over
+// the limit — 1500 buys margin on the warm path, it does not clear the cold one.
+// That is #282 (probe sqlite_master once instead of issuing twelve blind
+// statements, taking cold /graph from 59 to 48), not something a lower cap here
+// can fix: the tax is fixed, so it eats any N.
+//
+// Recompute the formula above before raising this, and count the cold case as
+// well as the warm one. D1's 5M rows/day cap is the secondary bound and is
+// nowhere near binding here; sizing against it is what produced a number that
+// broke the free plan.
+//
+// It is a legibility limit too: the packed-cluster canvas is unreadable well
+// before 1500 nodes.
+export const GRAPH_VIEW_MAX_NODES = 1500;
 export const GRAPH_HOP_DECAY = 0.6;
 const EDGE_QUERY_BATCH = Math.floor(D1_MAX_BOUND_PARAMS / 2);
 
@@ -128,18 +157,29 @@ export async function getConnections(id: string, type: string | undefined, env: 
 }
 
 export async function buildGraph(opts: { seed?: string; limit?: number }, env: Env, config: Readonly<Config> = DEFAULTS): Promise<GraphView> {
-  const limit = opts.limit && opts.limit > 0 ? opts.limit : Infinity;
+  // "No cap" resolves to GRAPH_VIEW_MAX_NODES, never to Infinity. Anything that
+  // is not a positive finite number — absent, 0, negative, NaN — takes that
+  // branch, so a caller who reaches here past the route's own validation still
+  // cannot ask for an unbounded result set. Keeping `limit` a finite integer is
+  // also what makes it safe to interpolate into the SQL below.
+  //
+  // The LIMIT bounds rows *returned*, not rows read: `weight` has no index, so
+  // SQLite full-scans and sorts `edges` either way and rows_read is unchanged.
+  // Bounding the result is still the point — it is what caps the node set, and
+  // the node set is what drives the query count above.
+  const asked = Number.isFinite(opts.limit) && (opts.limit as number) > 0
+    ? Math.floor(opts.limit as number)
+    : GRAPH_VIEW_MAX_NODES;
+  const limit = Math.min(asked, GRAPH_VIEW_MAX_NODES);
 
   let nodeIds: string[];
   if (opts.seed) {
     const neighbors = await expandGraph([opts.seed], { hops: 2, maxNodes: limit, includeDeprecated: true }, env, config);
     nodeIds = [opts.seed, ...neighbors.map(n => n.id)].slice(0, limit);
   } else {
-    const sql = Number.isFinite(limit)
-      ? `SELECT source_id, target_id FROM edges ORDER BY weight DESC LIMIT ${limit * 4}`
-      : `SELECT source_id, target_id FROM edges ORDER BY weight DESC`;
-    const { results } = await env.DB.prepare(sql)
-      .all() as { results: { source_id: string; target_id: string }[] };
+    const { results } = await env.DB.prepare(
+      `SELECT source_id, target_id FROM edges ORDER BY weight DESC LIMIT ${limit * 4}`
+    ).all() as { results: { source_id: string; target_id: string }[] };
     const ids: string[] = [];
     const seenIds = new Set<string>();
     for (const r of results) {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -24,3 +24,60 @@ export function requireAuth(request: Request, env: Env): Response | null {
   if (isAuthorized(request, env)) return null;
   return json({ ok: false, error: "Unauthorized" }, 401);
 }
+
+// Anchored so the whole value has to be an integer. parseInt stops at the first
+// character it cannot use, which is how "7abc" became 7, "1e3" became 1 and
+// "0x10" became 0 — each of them a value the caller never wrote, accepted
+// silently. Whatever it could not salvage became NaN, and NaN survives every
+// Math.min/Math.max clamp, so the bad value reached the database: bound as a
+// LIMIT it is a D1 SQLITE_MISMATCH (an HTTP 500), and compared against
+// created_at it matches nothing, so a malformed date filter reads to the caller
+// as an empty brain rather than a bad request.
+const INTEGER = /^[+-]?\d+$/;
+
+/**
+ * Reads an integer query parameter, or returns the 400 to send back.
+ *
+ * Malformed is rejected rather than defaulted, which is how every other bad
+ * value on this surface is already treated (an unknown `type`, `status` or
+ * `action` is a 400, as is any bad value on the config write path) and how the
+ * MCP twins of these routes behave, since zod rejects a non-integer outright.
+ * `after` and `before` have no default to fall back to either — defaulting them
+ * would drop the filter and answer with more rows than were asked for, which is
+ * wrong data wearing a 200, the one failure a caller cannot detect.
+ *
+ * Out of range is still clamped, not rejected: `?n=200` means "as many as
+ * you'll give me" and has always been answered with 100.
+ *
+ * Only an absent parameter gets the default. A present one must parse, and that
+ * includes the empty forms `?after=` and `?after` — for the same reason as
+ * above, since defaulting them drops the filter. It also means `?n=$UNSET` from
+ * a shell says so instead of quietly becoming 20. This is a deliberate
+ * divergence from the string parameters beside these, where `?tag=` reads as
+ * absent: an empty tag filter has one obvious meaning, an empty timestamp does
+ * not.
+ *
+ * Used as `const n = intParam(url, "n", …); if (n instanceof Response) return n;`
+ * — the same early-return shape as requireAuth above.
+ */
+export function intParam(url: URL, name: string, opts: { fallback: number; min?: number; max?: number }): number | Response;
+export function intParam(url: URL, name: string, opts?: { min?: number; max?: number }): number | undefined | Response;
+export function intParam(
+  url: URL,
+  name: string,
+  opts: { fallback?: number; min?: number; max?: number } = {},
+): number | undefined | Response {
+  const raw = url.searchParams.get(name);
+  if (raw === null) return opts.fallback;
+
+  // An empty value falls through to the check below and is rejected: it is
+  // present, so it has to parse.
+  const text = raw.trim();
+  const value = Number(text);
+  if (!INTEGER.test(text) || !Number.isSafeInteger(value)) {
+    return json({ ok: false, error: `${name} must be an integer` }, 400);
+  }
+
+  const floored = opts.min === undefined ? value : Math.max(opts.min, value);
+  return opts.max === undefined ? floored : Math.min(opts.max, floored);
+}

--- a/src/routes/graph.ts
+++ b/src/routes/graph.ts
@@ -1,5 +1,5 @@
 import type { Env } from "../env";
-import { json, requireAuth } from "../lib/http";
+import { intParam, json, requireAuth } from "../lib/http";
 import { createEdge, deleteEdge, isValidEdgeType } from "../graph/edges";
 import { EDGE_TYPES } from "../graph/types";
 import { buildGraph, getConnections } from "../graph/traverse";
@@ -72,8 +72,10 @@ export async function handleGraphRoutes(
     if (authErr) return authErr;
 
     const seed = url.searchParams.get("seed")?.trim() || undefined;
-    const limitParam = url.searchParams.get("limit");
-    const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+    // Omitted still means the whole graph, up to buildGraph's own ceiling. The
+    // floor of 1 is what stops `?limit=0` and `?limit=-1` from meaning that too.
+    const limit = intParam(url, "limit", { min: 1 });
+    if (limit instanceof Response) return limit;
 
     const { nodes, edges } = await buildGraph({ seed, limit }, env, await resolveConfig(env));
     return json({ ok: true, nodes, edges });

--- a/src/routes/recall.ts
+++ b/src/routes/recall.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../env";
 import { resolveConfig } from "../config";
 import { LLM_MODEL, VECTORIZE_FIX_HINT } from "../constants";
-import { CORS_HEADERS, json, requireAuth } from "../lib/http";
+import { CORS_HEADERS, intParam, json, requireAuth } from "../lib/http";
 import { buildEntryFilterQuery } from "../capture/entry";
 import { compressTag } from "../compression/digest";
 import { KIND_VALUES, type MemoryKind } from "../memory/kind";
@@ -18,10 +18,15 @@ export async function handleRecallRoutes(
   if (url.pathname === "/list" && request.method === "GET") {
     const authErr = requireAuth(request, env);
     if (authErr) return authErr;
-    const n = Math.min(parseInt(url.searchParams.get("n") ?? "20", 10), 100);
+    // Floor of 0 as well as the cap: SQLite reads a negative LIMIT as no limit
+    // at all, so `?n=-1` used to return the whole entries table.
+    const n = intParam(url, "n", { fallback: 20, min: 0, max: 100 });
+    if (n instanceof Response) return n;
     const tag = url.searchParams.get("tag")?.trim() || undefined;
-    const after = url.searchParams.has("after") ? parseInt(url.searchParams.get("after")!, 10) : undefined;
-    const before = url.searchParams.has("before") ? parseInt(url.searchParams.get("before")!, 10) : undefined;
+    const after = intParam(url, "after");
+    if (after instanceof Response) return after;
+    const before = intParam(url, "before");
+    if (before instanceof Response) return before;
 
     const { sql, bindings } = buildEntryFilterQuery({ n, tag, after, before });
     const { results } = await env.DB.prepare(sql).bind(...bindings).all();
@@ -36,13 +41,17 @@ export async function handleRecallRoutes(
     const query = url.searchParams.get("query")?.trim();
     if (!query) return json({ ok: false, error: "query is required" }, 400);
 
-    const topK = Math.min(Math.max(parseInt(url.searchParams.get("topK") ?? "5", 10), 1), 20);
+    const topK = intParam(url, "topK", { fallback: 5, min: 1, max: 20 });
+    if (topK instanceof Response) return topK;
     const tag = url.searchParams.get("tag")?.trim() || undefined;
-    const after = url.searchParams.has("after") ? parseInt(url.searchParams.get("after")!, 10) : undefined;
-    const before = url.searchParams.has("before") ? parseInt(url.searchParams.get("before")!, 10) : undefined;
+    const after = intParam(url, "after");
+    if (after instanceof Response) return after;
+    const before = intParam(url, "before");
+    if (before instanceof Response) return before;
     const kindParam = url.searchParams.get("kind")?.trim();
     const kind = kindParam && (KIND_VALUES as readonly string[]).includes(kindParam) ? kindParam as MemoryKind : undefined;
-    const hops = Math.min(Math.max(parseInt(url.searchParams.get("hops") ?? "0", 10), 0), 3);
+    const hops = intParam(url, "hops", { fallback: 0, min: 0, max: 3 });
+    if (hops instanceof Response) return hops;
     // Long memories are shortened by default so API/CLI consumers get a bounded
     // payload. Renderers that show the whole memory (the dashboard) pass full=1.
     const full = ["1", "true", "yes"].includes((url.searchParams.get("full") ?? "").toLowerCase());

--- a/test/helpers/sqlite-d1.ts
+++ b/test/helpers/sqlite-d1.ts
@@ -50,7 +50,7 @@ class SqliteStatement {
 
 export interface SqliteD1 {
   /** Shaped like `env.DB`. */
-  db: { prepare(sql: string): SqliteStatement };
+  db: { prepare(sql: string): SqliteStatement; exec(sql: string): Promise<void> };
   /** Insert an entry directly, bypassing the capture pipeline. */
   seed(entry: {
     id: string;
@@ -99,7 +99,14 @@ export function makeSqliteD1(): SqliteD1 {
   }
 
   return {
-    db: { prepare: (sql: string) => new SqliteStatement(raw, sql) },
+    db: {
+      prepare: (sql: string) => new SqliteStatement(raw, sql),
+      // Present so a whole-Worker request against this facade runs the real
+      // initializeDatabase path rather than failing on a missing method. The
+      // schema is already applied above; that DDL is idempotent, and the ALTERs
+      // raise the same "duplicate column name" D1 does, which init.ts expects.
+      exec: async (sql: string) => { raw.exec(sql); },
+    },
     seed({ id, content, createdAt, tags = [], source = "api", vectorIds = [] }) {
       raw
         .prepare(

--- a/test/integration/list.test.ts
+++ b/test/integration/list.test.ts
@@ -56,13 +56,17 @@ describe("GET /list", () => {
     expect(data.length).toBeLessThanOrEqual(100);
   });
 
-  it("returns a valid response when ?n= is non-numeric", async () => {
+  // This used to assert a 200 with an array body, which only ever held because
+  // D1Mock reads the bound LIMIT with Number() and slices by it. Real D1 rejects
+  // a NaN LIMIT at execution with SQLITE_MISMATCH, so the route answered 500 —
+  // see test/integration/query-param-validation.test.ts, which runs the same
+  // request against real SQLite.
+  it("rejects a non-numeric ?n= rather than passing it to the database", async () => {
     db.entries.push({ id: "x", content: "One", tags: "[]", source: "api", created_at: 1000, vector_ids: "[]" });
 
     const res = await worker.fetch(req("GET", "/list?n=abc"), env, ctx);
-    expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(Array.isArray(data)).toBe(true);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ ok: false, error: "n must be an integer" });
   });
 
   // ── Filter parity with list_recent (?tag, ?after, ?before) ──────────────────

--- a/test/integration/query-param-validation.test.ts
+++ b/test/integration/query-param-validation.test.ts
@@ -1,0 +1,264 @@
+/**
+ * #277 — every integer query parameter reached the database unvalidated.
+ *
+ * `parseInt` returns NaN for a non-numeric value and the Math.min/Math.max
+ * clamps around it do not sanitise that (`Math.min(NaN, 100)` is NaN), so the
+ * bad value went through to D1. Where it landed decided what the caller saw:
+ *
+ *   GET /list?n=abc        HTTP 500 — NaN bound as LIMIT ? is SQLITE_MISMATCH
+ *   GET /list?after=abc    200 with [] — created_at >= NaN matches nothing
+ *   GET /recall?after=abc  the same empty result, reported as a success
+ *   GET /recall?hops=abc   graph expansion silently skipped (h < NaN is false)
+ *   GET /recall?topK=abc   .slice(0, NaN) — no results
+ *   GET /graph?limit=abc   every row in `edges` returned, no LIMIT clause
+ *
+ * The silent ones are the reason this is a 400 and not a fallback: a caller
+ * filtering by a malformed date got "you have no matching memories" instead of
+ * "your request was malformed", and could not tell the difference.
+ *
+ * The /list cases run against real SQLite rather than D1Mock. The mock reads a
+ * bound LIMIT with Number() and slices by it, which turns the 500 into a quiet
+ * empty array — the bug is invisible to it. node:sqlite is the same engine D1
+ * runs, and it raises the same "datatype mismatch" on a NaN LIMIT, so removing
+ * the guard makes these tests fail the way production did.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import worker from "../../src/index";
+import { buildGraph, GRAPH_VIEW_MAX_NODES } from "../../src/graph/traverse";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+describe("integer query parameters (#277)", () => {
+  // ── GET /list, against real SQLite ─────────────────────────────────────────
+
+  describe("GET /list", () => {
+    let sqlite: SqliteD1;
+    let env: Env;
+
+    beforeEach(() => {
+      sqlite = makeSqliteD1();
+      for (let i = 0; i < 5; i++) {
+        sqlite.seed({ id: `e${i}`, content: `Entry ${i}`, createdAt: 1000 + i * 1000 });
+      }
+      env = makeTestEnv(undefined, { DB: sqlite.db as unknown as D1Database });
+    });
+
+    afterEach(() => sqlite.close());
+
+    it("answers 400 instead of the D1 datatype mismatch that made ?n= a 500", async () => {
+      const res = await worker.fetch(req("GET", "/list?n=abc"), env, ctx);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ ok: false, error: "n must be an integer" });
+    });
+
+    // The one that mattered most: this used to be a 200 carrying [], which reads
+    // as an empty brain rather than a rejected request.
+    it("answers 400 instead of an empty list when ?after= is not a timestamp", async () => {
+      const res = await worker.fetch(req("GET", "/list?after=yesterday"), env, ctx);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ ok: false, error: "after must be an integer" });
+    });
+
+    it("answers 400 instead of an empty list when ?before= is not a timestamp", async () => {
+      const res = await worker.fetch(req("GET", "/list?before=2026-01-01"), env, ctx);
+      expect(res.status).toBe(400);
+    });
+
+    // SQLite reads a negative LIMIT as no limit at all, so this was a second way
+    // to ask an authenticated route for an unbounded read of `entries`.
+    it("does not read the whole table for a negative ?n=", async () => {
+      const res = await worker.fetch(req("GET", "/list?n=-1"), env, ctx);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual([]);
+    });
+
+    it("still answers valid parameters against real SQL", async () => {
+      const res = await worker.fetch(req("GET", "/list?n=2&after=2000&before=4000"), env, ctx);
+      expect(res.status).toBe(200);
+      const data = await res.json() as any[];
+      expect(data.map(e => e.id)).toEqual(["e3", "e2"]);
+    });
+
+    it("still caps ?n= at 100 rather than rejecting it", async () => {
+      const res = await worker.fetch(req("GET", "/list?n=100000"), env, ctx);
+      expect(res.status).toBe(200);
+      expect((await res.json() as any[]).length).toBe(5);
+    });
+  });
+
+  // ── GET /recall ────────────────────────────────────────────────────────────
+
+  describe("GET /recall", () => {
+    let env: Env;
+
+    beforeEach(() => {
+      env = makeTestEnv(makeTestDb());
+    });
+
+    it.each([
+      ["after", "/recall?query=memory&after=yesterday"],
+      ["before", "/recall?query=memory&before=soon"],
+      ["topK", "/recall?query=memory&topK=lots"],
+      ["hops", "/recall?query=memory&hops=deep"],
+    ])("answers 400 for a malformed ?%s=", async (name, path) => {
+      const res = await worker.fetch(req("GET", path), env, ctx);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ ok: false, error: `${name} must be an integer` });
+    });
+
+    it("rejects before running the search, so nothing is billed for a bad request", async () => {
+      const db = makeTestDb();
+      env = makeTestEnv(db);
+      const vectorize = env.VECTORIZE as any;
+      await worker.fetch(req("GET", "/recall?query=memory&topK=lots"), env, ctx);
+      expect(vectorize.query).not.toHaveBeenCalled();
+    });
+
+    it("still accepts and clamps valid parameters", async () => {
+      const res = await worker.fetch(req("GET", "/recall?query=memory&topK=999&hops=99&after=1"), env, ctx);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── GET /graph ─────────────────────────────────────────────────────────────
+
+  describe("GET /graph", () => {
+    it("answers 400 for a malformed ?limit= rather than returning every edge", async () => {
+      const env = makeTestEnv(makeTestDb());
+      const res = await worker.fetch(req("GET", "/graph?limit=all"), env, ctx);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ ok: false, error: "limit must be an integer" });
+    });
+  });
+
+  // ── buildGraph's own ceiling ───────────────────────────────────────────────
+  //
+  // Defence in depth, independent of the route. buildGraph resolved "no usable
+  // limit" to Infinity, and Number.isFinite(Infinity) is false, so it chose the
+  // branch with no LIMIT clause and took back every row in `edges`. The LIMIT
+  // bounds rows returned rather than rows read — `weight` is unindexed, so the
+  // scan happens either way — but the returned rows are what fix the node set,
+  // and the node set is what decides how many D1 queries the request costs:
+  // 1 + ceil(N/100) + ceil(N/50), against a 50-subrequest free-plan budget.
+
+  describe("buildGraph", () => {
+    class RecordingD1 extends D1Mock {
+      sql: string[] = [];
+      prepare(sql: string) {
+        this.sql.push(sql.replace(/\s+/g, " ").trim());
+        return super.prepare(sql);
+      }
+    }
+
+    let db: RecordingD1;
+    let env: Env;
+
+    beforeEach(() => {
+      db = new RecordingD1();
+      for (let i = 0; i < 6; i++) {
+        db.entries.push({ id: `n${i}`, content: `Memory ${i}`, tags: "[]", source: "api", created_at: 1000, vector_ids: "[]", importance_score: 0 });
+      }
+      for (let i = 0; i < 5; i++) {
+        db.edges.push({ id: `e${i}`, source_id: `n${i}`, target_id: `n${i + 1}`, type: "relates_to", weight: 0.7, provenance: "inferred", metadata: "{}", created_at: 1, updated_at: 1 });
+      }
+      env = makeTestEnv(db as unknown as D1Mock);
+    });
+
+    const edgeScan = (recorded: string[]) =>
+      recorded.find(s => s.startsWith("SELECT source_id, target_id FROM edges"));
+
+    it.each([
+      ["omitted", undefined],
+      ["NaN", NaN],
+      ["Infinity", Infinity],
+      ["zero", 0],
+      ["negative", -5],
+    ])("always bounds the edge scan when limit is %s", async (_label, limit) => {
+      await buildGraph({ limit }, env);
+      expect(edgeScan(db.sql)).toBe(
+        `SELECT source_id, target_id FROM edges ORDER BY weight DESC LIMIT ${GRAPH_VIEW_MAX_NODES * 4}`,
+      );
+    });
+
+    it("still honours a caller's smaller limit", async () => {
+      const { nodes } = await buildGraph({ limit: 3 }, env);
+      expect(nodes).toHaveLength(3);
+      expect(edgeScan(db.sql)).toBe("SELECT source_id, target_id FROM edges ORDER BY weight DESC LIMIT 12");
+    });
+
+    it("caps a caller's oversized limit at the ceiling", async () => {
+      await buildGraph({ limit: GRAPH_VIEW_MAX_NODES * 10 }, env);
+      expect(edgeScan(db.sql)).toBe(
+        `SELECT source_id, target_id FROM edges ORDER BY weight DESC LIMIT ${GRAPH_VIEW_MAX_NODES * 4}`,
+      );
+    });
+
+    function seedOversized() {
+      const big = new RecordingD1();
+      const total = GRAPH_VIEW_MAX_NODES + 500;
+      for (let i = 0; i < total; i++) {
+        big.entries.push({ id: `n${i}`, content: `Memory ${i}`, tags: "[]", source: "api", created_at: 1000, vector_ids: "[]", importance_score: 0 });
+      }
+      for (let i = 0; i < total - 1; i++) {
+        big.edges.push({ id: `e${i}`, source_id: `n${i}`, target_id: `n${i + 1}`, type: "relates_to", weight: 0.7, provenance: "inferred", metadata: "{}", created_at: 1, updated_at: 1 });
+      }
+      return big;
+    }
+
+    it("caps the node set itself, not only the edge scan", async () => {
+      const big = seedOversized();
+      const { nodes } = await buildGraph({}, makeTestEnv(big as unknown as D1Mock));
+      expect(nodes).toHaveLength(GRAPH_VIEW_MAX_NODES);
+    });
+
+    // Truncation has to be partial, not corrupt: a node the view drops must not
+    // leave an edge pointing at it.
+    it("returns a self-consistent graph when it truncates", async () => {
+      const big = seedOversized();
+      const { nodes, edges } = await buildGraph({}, makeTestEnv(big as unknown as D1Mock));
+      const ids = new Set(nodes.map(n => n.id));
+      expect(edges.every(e => ids.has(e.source) && ids.has(e.target))).toBe(true);
+    });
+
+    /**
+     * The constraint that sets GRAPH_VIEW_MAX_NODES. Workers allow 50
+     * subrequests per invocation on the free plan, and buildGraph spends
+     * 1 + ceil(N/100) + ceil(N/50) D1 queries for N nodes plus one KV read for
+     * the config. That is what makes the node cap a hard limit rather than a
+     * taste question: at N=1634 the request exceeds the budget and the graph tab
+     * is dead for every free-plan brain that size, with runGraphPass adding the
+     * edges that get it there on its own.
+     *
+     * Raising the cap without recomputing this is the mistake this test exists
+     * to catch, so it asserts the measured cost rather than a ratio.
+     *
+     * SCOPE: this measures the request's own D1 and KV calls on a warm isolate.
+     * It deliberately does not cover the cold-isolate path, where
+     * initializeDatabase fires under waitUntil and spends ~12 more from the same
+     * budget, putting the first request against a fresh isolate at ~59 — over
+     * the limit. Green here is not evidence that case is safe; it is #282.
+     */
+    it("keeps a full-size /graph request inside the free-plan subrequest budget", async () => {
+      const FREE_PLAN_SUBREQUESTS = 50;
+      const big = seedOversized();
+
+      let kvReads = 0;
+      const kv = makeTestEnv().OAUTH_KV;
+      const countingKv = { ...kv, get: async (...args: any[]) => { kvReads++; return (kv.get as any)(...args); } };
+      const bigEnv = makeTestEnv(big as unknown as D1Mock, { OAUTH_KV: countingKv as unknown as KVNamespace });
+
+      const res = await worker.fetch(req("GET", "/graph"), bigEnv, ctx);
+      expect(res.status).toBe(200);
+
+      const N = GRAPH_VIEW_MAX_NODES;
+      const predicted = 1 + Math.ceil(N / 100) + Math.ceil(N / 50);
+      expect(big.sql).toHaveLength(predicted);
+      expect(big.sql.length + kvReads).toBeLessThanOrEqual(FREE_PLAN_SUBREQUESTS);
+    });
+  });
+});

--- a/test/unit/int-param.test.ts
+++ b/test/unit/int-param.test.ts
@@ -1,0 +1,113 @@
+/**
+ * #277 — integer query parameters reached the database unvalidated.
+ *
+ * `parseInt` yields NaN for anything it cannot start reading, and NaN survives
+ * every clamp (`Math.min(NaN, 100)` is NaN), so the bad value landed in D1:
+ * `LIMIT NaN` is a SQLITE_MISMATCH, and `created_at >= NaN` matches nothing, so
+ * a malformed date filter answered 200 with an empty list.
+ *
+ * These are the parser's own rules. The end-to-end consequences are covered in
+ * test/integration/query-param-validation.test.ts.
+ */
+import { describe, it, expect } from "vitest";
+import { intParam } from "../../src/lib/http";
+
+function parse(query: string, name: string, opts?: any) {
+  const url = new URL(`http://localhost/list?${query}`);
+  return intParam(url, name, opts);
+}
+
+async function errorOf(res: Response): Promise<unknown> {
+  return res.json();
+}
+
+describe("intParam", () => {
+  it("reads a plain integer", () => {
+    expect(parse("n=42", "n")).toBe(42);
+  });
+
+  it("returns the documented default when the parameter is absent", () => {
+    expect(parse("", "n", { fallback: 20 })).toBe(20);
+  });
+
+  it("returns undefined for an absent parameter that has no default", () => {
+    expect(parse("", "after")).toBeUndefined();
+  });
+
+  // Only absence gets the default. Treating `?after=` as absent would drop the
+  // filter and answer with more rows than were asked for — the exact failure the
+  // 400 exists to prevent — so a present-but-empty value is rejected instead.
+  it("rejects a present-but-empty value rather than defaulting it", () => {
+    expect(parse("n=", "n", { fallback: 20 })).toBeInstanceOf(Response);
+    expect(parse("after=", "after")).toBeInstanceOf(Response);
+  });
+
+  // `?after` with no `=` parses to the same empty value.
+  it("rejects a valueless parameter", () => {
+    expect(parse("after", "after")).toBeInstanceOf(Response);
+  });
+
+  it("rejects a whitespace-only value", () => {
+    expect(parse("n=%20%20", "n", { fallback: 20 })).toBeInstanceOf(Response);
+  });
+
+  it("clamps rather than rejects an out-of-range value", () => {
+    expect(parse("n=200", "n", { fallback: 20, min: 0, max: 100 })).toBe(100);
+    expect(parse("topK=999", "topK", { fallback: 5, min: 1, max: 20 })).toBe(20);
+    expect(parse("hops=-4", "hops", { fallback: 0, min: 0, max: 3 })).toBe(0);
+  });
+
+  it("rejects a non-numeric value with a 400 naming the parameter", async () => {
+    const res = parse("after=abc", "after");
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(400);
+    expect(await errorOf(res as Response)).toEqual({ ok: false, error: "after must be an integer" });
+  });
+
+  it("rejects a fractional value", () => {
+    expect(parse("n=2.5", "n", { fallback: 20 })).toBeInstanceOf(Response);
+  });
+
+  // Beyond 2^53 the arithmetic that follows is no longer exact, so the value
+  // that would reach D1 is not the one the caller wrote.
+  it("rejects an integer too large to represent exactly", () => {
+    expect(parse("after=99999999999999999999", "after")).toBeInstanceOf(Response);
+  });
+
+  /**
+   * The parameter values called out on #277, old parsing against new.
+   *
+   * Every value that is a well-formed integer is unchanged, including the
+   * whitespace-padded and explicitly-signed forms. The four that change are the
+   * four where `parseInt` returned a number the caller never wrote: it stops at
+   * the first character it cannot use, so "7abc" was 7, "1e3" was 1 and "0x10"
+   * was 0 — the same silent-substitution failure #277 is about, one layer up.
+   */
+  const CASES: { raw: string; old: number; now: number | "400" }[] = [
+    { raw: "5",     old: 5,    now: 5 },
+    { raw: "0",     old: 0,    now: 0 },
+    { raw: "-3",    old: -3,   now: -3 },
+    { raw: "100",   old: 100,  now: 100 },
+    { raw: "1000",  old: 1000, now: 1000 },
+    { raw: "  7  ", old: 7,    now: 7 },
+    { raw: "7abc",  old: 7,    now: "400" },
+    { raw: "1e3",   old: 1,    now: "400" },
+    { raw: "0x10",  old: 0,    now: "400" },
+    { raw: "+5",    old: 5,    now: 5 },
+  ];
+
+  it.each(CASES)("parses $raw the same way parseInt did, or rejects it ($now)", ({ raw, old, now }) => {
+    // The old expression, verbatim, so the comparison is against real behaviour
+    // rather than a description of it.
+    expect(parseInt(raw, 10)).toBe(old);
+
+    const result = parse(`v=${encodeURIComponent(raw)}`, "v");
+    if (now === "400") {
+      expect(result).toBeInstanceOf(Response);
+      expect((result as Response).status).toBe(400);
+    } else {
+      expect(result).toBe(now);
+      expect(result).toBe(old); // unchanged from the old parsing
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`parseInt` returns `NaN` for a non-numeric value, and the `Math.min`/`Math.max` clamps **propagate** it rather than catching it — `Math.min(NaN, 100)` is `NaN`. So bad values reached D1. Closes #277.

Verified against a real Workers runtime, the consequences differed by where the value landed:

| request | before |
|---|---|
| `GET /list?n=abc` | **500** — `NaN` bound as `LIMIT`, `datatype mismatch` |
| `GET /list?after=abc` | **200 with zero rows** — filter silently matched nothing |
| `GET /recall?hops=abc` | graph expansion silently did not run |
| `GET /graph?limit=abc` | **read the entire `edges` table** |

The silent ones are the worse half: a caller filtering by a malformed date gets `[]` and a `200`, which reads as "you have no matching memories" rather than "your request was malformed".

`/graph?limit=abc` is the one with teeth. `NaN > 0` is false, so `buildGraph` fell back to `Infinity`; `Number.isFinite(Infinity)` is false, so the query took the branch with **no `LIMIT` at all**. An authenticated caller could trigger a full table read repeatedly, and exhausting D1's daily rows-read cap returns errors for every query **account-wide** until 00:00 UTC.

## 400, not fall back

`after`/`before` have no default, so falling back **drops the filter and answers with more rows than were asked for** — wrong data wearing a `200`, the one failure a caller cannot detect. Rejecting also matches what this surface already does for every other bad value, and what the MCP twins do via zod. One rule for all six params.

An empty value (`?after=`) is rejected too: a present parameter must parse. That keeps the rule statable in one line rather than needing an exception.

## A second unbounded read, found while probing real D1

**`LIMIT` bound to a negative number returns every row.** So `GET /list?n=-1` was a full read of `entries` — the largest table — sitting right next to the one this issue describes. Closed by a `min` of 0.

`D1Mock` cannot see this class of bug at all (it slices by `Number(limit)`), so the `/list` regression tests run against real SQLite.

## Bounding the graph view

`buildGraph` no longer resolves to `Infinity`; the edge query always carries a `LIMIT`. `GRAPH_VIEW_MAX_NODES = 1500`, sized against the free plan's **50 subrequests per invocation** — not the rows-read cap, which was the wrong limit and produced a number 24% over:

```
  cap   D1 queries  +KV   vs 50
  1500          46   47   ok
  1600          49   50   no margin
  1634          51   52   OVER
  2000          61   62   OVER
```

A test asserts the measured cost matches `1 + ceil(N/100) + ceil(N/50)` and stays ≤ 50, so this cannot regress silently.

**The `LIMIT` bounds rows returned, not rows read** — `weight` is unindexed, so the scan happens either way (#281). Bounding the result is still the point, because it caps the node set that drives the query count.

## Compatibility

Swept `public/`, `src/` (incl. MCP), `installer/` (TS and Rust), `scripts/`, `integrations/` and the docs: **no production caller can now receive a 400.** Every one passes an integer literal, and none sends `after`, `before` or `limit` at all. Truncation is partial, not corrupt — 2300 nodes → 1500 nodes, 1499 edges, 0 dangling.

Behaviour changes: `?n=7abc` → 400 (was 7), `?n=1e3` → 400 (was 1), `?n=0x10` → 400 (was 0, i.e. silently `LIMIT 0`). Every well-formed integer parses identically, including whitespace-padded and signed.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:coverage` — 1133 passing
- [x] `npx wrangler deploy --dry-run`
- [x] Adversarially validated. The parser survived 17 hostile inputs end-to-end against real D1, including `\d` correctly rejecting Arabic-Indic and full-width digits, no ReDoS, and sound overload types.
- [x] Discrimination: reverting the route sites fails 11 tests; reverting the graph bound fails 8.

## Known and not addressed here

**On a cold isolate this still exceeds the budget**: 47 + ~12 from `initializeDatabase` firing under `waitUntil` = 59. A lower cap here cannot fix it — the 12-statement tax is fixed, so it eats any N. That is #282, and it applies to every route, not just this one. Documented in the code and in the budget test's scope note so a green test is not mistaken for coverage of that path.
