### PR TITLE
perf(cron): batch the staleness pass, and stop reserved tags eating digest slots (#278)

### DIFF
--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -24,6 +24,7 @@ Incremental split of the former monolithic `index.ts`. Entry point remains `src/
 | embed, readStreamText, graceMs | `lib/ai.ts` |
 | initializeDatabase | `db/init.ts` |
 | status/kind tags | `memory/status.ts`, `memory/kind.ts` |
+| tag LIKE pattern + escaping | `memory/tag-sql.ts` |
 | compression eligibility | `compression/eligibility.ts` |
 | chunk, hashtags, temporal, tokenize | `text/*` |
 | cosineSim, rerank, mmr | `recall/math.ts` |

--- a/src/capture/entry.ts
+++ b/src/capture/entry.ts
@@ -8,6 +8,7 @@ import { checkDuplicateAndContradiction } from "./duplicate";
 import { deprecateEntry } from "./lifecycle";
 import { deleteStaleVectors, reembedOrThrow, storeEntry } from "./store";
 import { tagsAfterWrite } from "../memory/stale";
+import { TAG_LIKE_ESCAPE, tagLikePattern } from "../memory/tag-sql";
 
 export function buildEntryFilterQuery(params: {
   n: number;
@@ -17,7 +18,11 @@ export function buildEntryFilterQuery(params: {
 }): { sql: string; bindings: (string | number)[] } {
   const conds: string[] = [];
   const bindings: (string | number)[] = [];
-  if (params.tag) { conds.push(`tags LIKE ?`); bindings.push(`%"${params.tag}"%`); }
+  // Escaped for the same reason as the recall path: `_` and `%` in a tag are LIKE
+  // wildcards, so `#q3_planning` would also list `q3-planning` entries and `?tag=%` would
+  // list everything. A read, so over-broad rather than destructive — but a filter that
+  // silently stops filtering is worse than one that returns nothing.
+  if (params.tag) { conds.push(`tags LIKE ? ${TAG_LIKE_ESCAPE}`); bindings.push(tagLikePattern(params.tag)); }
   if (params.after !== undefined) { conds.push(`created_at >= ?`); bindings.push(params.after); }
   if (params.before !== undefined) { conds.push(`created_at <= ?`); bindings.push(params.before); }
 

--- a/src/compression/digest.ts
+++ b/src/compression/digest.ts
@@ -3,12 +3,10 @@ import { DEFAULTS, resolveConfig, type Config } from "../config";
 import { captureEntry } from "../capture/entry";
 import { DIGEST_MAX_TOKENS, LLM_MODEL } from "../constants";
 import { readStreamText } from "../lib/ai";
-import { KIND_PREFIX } from "../memory/kind";
-import { STATUS_PREFIX } from "../memory/status";
-import { VOLATILITY_PREFIX } from "../memory/volatility";
-import { STALE_AS_OF } from "../memory/stale";
+import { TAG_LIKE_ESCAPE, tagLikePattern } from "../memory/tag-sql";
 import {
   compressionEligibilitySql,
+  isTopicTag,
 } from "./eligibility";
 
 export async function synthesizeDigest(
@@ -86,8 +84,12 @@ export async function compressTag(
   ctx: ExecutionContext
 ): Promise<{ synthesizedId: string | null; entriesUsed: number; text: string }> {
   // Guard before resolveConfig: that is a KV read, and a system tag never compresses, so
-  // paying for it first is a wasted subrequest per skipped tag per night.
-  if (tag.startsWith(STATUS_PREFIX) || tag.startsWith(KIND_PREFIX) || tag.startsWith(VOLATILITY_PREFIX) || tag === STALE_AS_OF) {
+  // paying for it first is a wasted subrequest per skipped tag per night. The candidate
+  // query excludes these already; this is the backstop for a tag arriving another way, and
+  // GET /digest?tag= hands this function an arbitrary user string. isTopicTag rather than
+  // isReservedTag, because the bookkeeping tags are not "reserved" but are just as
+  // destructive to compress: `duplicate-candidate` has no row-level exclusion either.
+  if (!isTopicTag(tag)) {
     return { synthesizedId: null, entriesUsed: 0, text: "" };
   }
   const cfg = await resolveConfig(env);
@@ -95,10 +97,10 @@ export async function compressTag(
   const recentSynth = await env.DB.prepare(`
     SELECT id FROM entries
     WHERE tags LIKE '%"synthesized"%'
-      AND tags LIKE ?
+      AND tags LIKE ? ${TAG_LIKE_ESCAPE}
       AND created_at > ?
     LIMIT 1
-  `).bind(`%"${tag}"%`, Date.now() - 86400000).first();
+  `).bind(tagLikePattern(tag), Date.now() - 86400000).first();
 
   if (recentSynth) {
     return { synthesizedId: null, entriesUsed: 0, text: "" };
@@ -106,14 +108,14 @@ export async function compressTag(
 
   const { results: rawEntries } = await env.DB.prepare(`
     SELECT id, content FROM entries
-    WHERE tags LIKE ?
+    WHERE tags LIKE ? ${TAG_LIKE_ESCAPE}
       AND tags NOT LIKE '%"synthesized"%'
       AND tags NOT LIKE '%"auto-pattern"%'
       AND tags NOT LIKE '%"rolled-up"%'
       AND ${compressionEligibilitySql("", cfg)}
     ORDER BY created_at DESC
     LIMIT 50
-  `).bind(`%"${tag}"%`, Date.now() - cfg.COMPRESSION_MIN_AGE_MS).all();
+  `).bind(tagLikePattern(tag), Date.now() - cfg.COMPRESSION_MIN_AGE_MS).all();
 
   if (rawEntries.length < 10) {
     return { synthesizedId: null, entriesUsed: 0, text: "" };

--- a/src/compression/eligibility.ts
+++ b/src/compression/eligibility.ts
@@ -2,10 +2,78 @@
 // not proven-useful by recall, and not a contradiction survivor. Strictly more
 // protective than the old `importance_score < 4` filter — it can only exempt MORE.
 import { DEFAULTS, type Config } from "../config";
+import { STATUS_PREFIX } from "../memory/status";
+import { KIND_PREFIX } from "../memory/kind";
+import { VOLATILITY_PREFIX } from "../memory/volatility";
+import { STALE_AS_OF } from "../memory/stale";
 
 export const COMPRESSION_IMPORTANCE_THRESHOLD = 4;   // importance >= this → protected
 export const COMPRESSION_MIN_RECALL = 2;             // recalled >= this many times → protected
 export const COMPRESSION_MIN_AGE_MS = 60 * 86400000; // entries with fewer than COMPRESSION_MIN_RECALL recalls protected until this old (60 days)
+
+/**
+ * Tags the system writes ABOUT an entry, as opposed to tags describing what it is about.
+ *
+ * They are never digest candidates, and getting that wrong is not merely a wasted check:
+ * a nightly run compresses at most COMPRESSION_MAX_TAGS_PER_RUN tags, chosen by descending
+ * entry count, so a reserved tag in the candidate list takes a slot a real topic would have
+ * had. These tags are applied in bulk — the staleness pass alone writes volatility: and
+ * stale:as-of across up to 25 entries a night — so they outrank ordinary topics easily, and
+ * the symptom is compression appearing to stop working with nothing in the logs to say why.
+ *
+ * Derived from the prefixes themselves so the SQL below, the guard in compressTag, and the
+ * test double all agree by construction rather than by three copies staying in step.
+ *
+ * MATCHING IS CASE-INSENSITIVE, deliberately, and this is the dangerous half to get wrong.
+ * compressTag selects the entries it will roll up with `tags LIKE '%"<tag>"%'`, and SQLite's
+ * LIKE ignores ASCII case — so a candidate tag `Kind:Semantic` does not select the entries
+ * carrying `Kind:Semantic`, it selects every entry carrying `kind:semantic` in any case.
+ * Admitting one mixed-case reserved tag therefore does not cost a digest slot, it rolls up
+ * whatever unrelated entries happen to share the lowercase system tag: content permanently
+ * appended to, recall penalised, and the entries dropped from staleness, future compression
+ * and /stats. Nothing lowercases the tags src/integrations/mirror.ts inserts, so this is
+ * reachable, and it was reproduced: 9 entries tagged `holiday-plans` rolled up by a
+ * candidate tag they never carried.
+ *
+ * The two directions are not symmetric. Wrongly reserving a user's `Status:Active` costs one
+ * tag that never gets a digest. Wrongly admitting it costs up to 50 memories, irreversibly.
+ */
+const RESERVED_TAG_PREFIXES = [STATUS_PREFIX, KIND_PREFIX, VOLATILITY_PREFIX];
+const RESERVED_TAGS = [STALE_AS_OF];
+
+/** Bookkeeping tags that mark an entry's role in compression rather than its subject. */
+const NON_TOPIC_TAGS = ["synthesized", "auto-pattern", "duplicate-candidate", "contradiction-resolved", "rolled-up"];
+
+export function isReservedTag(tag: string): boolean {
+  const t = tag.toLowerCase();
+  return RESERVED_TAG_PREFIXES.some(prefix => t.startsWith(prefix)) || RESERVED_TAGS.includes(t);
+}
+
+export function isTopicTag(tag: string): boolean {
+  return !isReservedTag(tag) && !NON_TOPIC_TAGS.includes(tag.toLowerCase());
+}
+
+/**
+ * SQL boolean fragment for isTopicTag, applied to a json_each() tag value. No placeholders.
+ *
+ * Every clause is case-insensitive, matching the predicate above: LIKE ignores ASCII case,
+ * and the set membership is compared through lower(). The constants are all lowercase, and
+ * none may contain a LIKE metacharacter (% or _) — LIKE would read it as a wildcard. That
+ * is an invariant now, not an observation, and test/unit/compression-eligibility.test.ts
+ * enforces it.
+ *
+ * Note lower() is ASCII-only in SQLite while JavaScript's toLowerCase is Unicode-aware, so
+ * for a non-ASCII tag the predicate can reserve something the SQL admits. That direction is
+ * harmless: the candidate query offers the tag, compressTag's backstop declines it, and the
+ * cost is a spent slot rather than a wrong rollup.
+ */
+export function isTopicTagSql(column = "value"): string {
+  return [
+    `lower(${column}) NOT IN (${NON_TOPIC_TAGS.map(t => `'${t}'`).join(", ")})`,
+    ...RESERVED_TAG_PREFIXES.map(prefix => `${column} NOT LIKE '${prefix}%'`),
+    ...RESERVED_TAGS.map(t => `${column} NOT LIKE '${t}'`),
+  ].join("\n      AND ");
+}
 
 // Returns a SQL boolean fragment for "this entry is eligible for compression".
 // Contains exactly one `?` placeholder — bind `Date.now() - COMPRESSION_MIN_AGE_MS`.

--- a/src/compression/nightly.ts
+++ b/src/compression/nightly.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../env";
 import { resolveConfig } from "../config";
 import { initializeDatabase } from "../db/init";
-import { COMPRESSION_MIN_AGE_MS, compressionEligibilitySql } from "./eligibility";
+import { COMPRESSION_MIN_AGE_MS, compressionEligibilitySql, isTopicTagSql } from "./eligibility";
 import { compressTag } from "./digest";
 
 /**
@@ -66,9 +66,7 @@ export async function runNightlyCompression(env: Env, ctx: ExecutionContext): Pr
   const { results } = await env.DB.prepare(`
     SELECT value as tag, COUNT(*) as count
     FROM entries, json_each(entries.tags)
-    WHERE value NOT IN ('synthesized', 'auto-pattern', 'duplicate-candidate', 'contradiction-resolved', 'rolled-up')
-      AND value NOT LIKE 'status:%'
-      AND value NOT LIKE 'kind:%'
+    WHERE ${isTopicTagSql()}
       AND entries.tags NOT LIKE '%"rolled-up"%'
       AND entries.tags NOT LIKE '%"synthesized"%'
       AND entries.tags NOT LIKE '%"auto-pattern"%'

--- a/src/memory/tag-sql.ts
+++ b/src/memory/tag-sql.ts
@@ -15,6 +15,14 @@
  * compressTag rolls up every row its selector returns, appending to their content and
  * marking them `rolled-up`.
  *
+ * Known and deliberately not handled: `tags` is JSON, so a tag containing `"` or `\` is
+ * stored escaped (`a"b` as `a\"b`) and this pattern will not match it. The unescaped form
+ * did not match it either — it just failed differently — and neither character can arrive
+ * through a hashtag, since src/text/hashtags.ts matches \w. Escaping for LIKE and escaping
+ * for JSON are two different transforms; doing the second properly means building the
+ * pattern from the JSON encoding of the tag, not from the tag. Failing closed is the right
+ * side to be wrong on for a selector that decides what gets rolled up.
+ *
  * Lives here rather than with any one caller because four modules across three concerns
  * need it, and it is the tag vocabulary's own business how a tag is encoded and matched.
  * Pure by the rules in src/ARCHITECTURE.md — it imports nothing.

--- a/src/memory/tag-sql.ts
+++ b/src/memory/tag-sql.ts
@@ -1,0 +1,35 @@
+/**
+ * Matching a single tag inside the JSON `tags` column.
+ *
+ * Tags are stored as a JSON array, so every reader finds one with `tags LIKE '%"<tag>"%'`.
+ * That makes the tag part of a LIKE pattern, where `_` matches any character and `%`
+ * matches everything — and a tag is user data. Interpolated raw, the pattern does not
+ * select the entries carrying the tag: `q3_planning` also selects `q3-planning`, and `%`
+ * selects the whole table.
+ *
+ * Neither character is exotic. src/text/hashtags.ts matches \w, so writing `#q3_planning`
+ * in a memory creates the tag `q3_planning`; the API's tags[] array and the integrations
+ * mirror accept any string at all.
+ *
+ * On read paths the cost is over-broad results. On the compression path it is permanent:
+ * compressTag rolls up every row its selector returns, appending to their content and
+ * marking them `rolled-up`.
+ *
+ * Lives here rather than with any one caller because four modules across three concerns
+ * need it, and it is the tag vocabulary's own business how a tag is encoded and matched.
+ * Pure by the rules in src/ARCHITECTURE.md — it imports nothing.
+ */
+
+/**
+ * The `tags LIKE` pattern that matches exactly the given tag.
+ *
+ * Must be paired with TAG_LIKE_ESCAPE on the clause. Without it the backslashes are
+ * literal and the pattern matches nothing instead of too much — wrong in the safe
+ * direction, but still wrong, which is why the two are exported together.
+ */
+export function tagLikePattern(tag: string): string {
+  return `%"${tag.replace(/([%_\\])/g, "\\$1")}"%`;
+}
+
+/** Goes immediately after any `LIKE ?` whose parameter came from tagLikePattern. */
+export const TAG_LIKE_ESCAPE = `ESCAPE '\\'`;

--- a/src/recall/search.ts
+++ b/src/recall/search.ts
@@ -20,6 +20,7 @@ import { cosineSim, mmrRerank, rerankWithTimeDecay, type VectorizeMatch } from "
 import { rrfFuse } from "./rrf";
 import { computeCompoundStale } from "./compound-stale";
 import type { KeywordRow, RecallMatch, RecallSearchResult } from "./types";
+import { TAG_LIKE_ESCAPE, tagLikePattern } from "../memory/tag-sql";
 
 async function keywordSearch(tokens: string[], env: Env, limit: number): Promise<KeywordRow[]> {
   if (!tokens.length) return [];
@@ -138,9 +139,13 @@ export async function recallEntries(
   let keywordRows: KeywordRow[] = [];
   let results: { matches: VectorizeMatch[] };
   if (tag) {
+    // Escaped: a tag is user data and LIKE reads _ and % as wildcards. This is a read, so
+    // the failure is over-broad results rather than the permanent rollup the same bug
+    // caused in compressTag — but `?tag=%` silently defeats the filter entirely and
+    // returns the whole brain, which is not a recoverable-looking answer either.
     const { results: tagRows } = await env.DB.prepare(
-      `SELECT id, vector_ids, content, tags, source, created_at FROM entries WHERE tags LIKE ?`
-    ).bind(`%"${tag}"%`).all();
+      `SELECT id, vector_ids, content, tags, source, created_at FROM entries WHERE tags LIKE ? ${TAG_LIKE_ESCAPE}`
+    ).bind(tagLikePattern(tag)).all();
     if (!tagRows.length) return { matches: [], insight: "", semanticUnavailable };
     keywordRows = tagRows as unknown as KeywordRow[];
 

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../env";
 import { resolveConfig } from "../config";
 import { SB_VERSION } from "../env";
-import { COMPRESSION_MIN_AGE_MS, compressionEligibilitySql } from "../compression/eligibility";
+import { COMPRESSION_MIN_AGE_MS, compressionEligibilitySql, isTopicTagSql } from "../compression/eligibility";
 import { json, requireAuth } from "../lib/http";
 import { graceMs } from "../lib/ai";
 import { classifyEntry } from "../capture/classify";
@@ -10,6 +10,7 @@ import { deprecateEntry } from "../capture/lifecycle";
 import { getStatus, withStatus } from "../memory/status";
 import { withKind } from "../memory/kind";
 import { checkVectorizeHealth } from "../vectorize/health";
+import { TAG_LIKE_ESCAPE, tagLikePattern } from "../memory/tag-sql";
 
 export async function handleAdminRoutes(
   request: Request,
@@ -34,9 +35,7 @@ export async function handleAdminRoutes(
       env.DB.prepare(`
         SELECT value as tag, COUNT(*) as count
         FROM entries, json_each(entries.tags)
-        WHERE value NOT IN ('synthesized', 'auto-pattern', 'duplicate-candidate', 'contradiction-resolved', 'rolled-up')
-          AND value NOT LIKE 'status:%'
-          AND value NOT LIKE 'kind:%'
+        WHERE ${isTopicTagSql()}
           AND entries.tags NOT LIKE '%"rolled-up"%'
           AND entries.tags NOT LIKE '%"synthesized"%'
           AND entries.tags NOT LIKE '%"auto-pattern"%'
@@ -52,8 +51,8 @@ export async function handleAdminRoutes(
     const digestCandidates: { tag: string; count: number }[] = [];
     for (const row of candidateRows.results as any[]) {
       const existing = await env.DB.prepare(
-        `SELECT id FROM entries WHERE tags LIKE '%"synthesized"%' AND tags LIKE ? AND created_at > ? LIMIT 1`
-      ).bind(`%"${row.tag}"%`, cutoff).first();
+        `SELECT id FROM entries WHERE tags LIKE '%"synthesized"%' AND tags LIKE ? ${TAG_LIKE_ESCAPE} AND created_at > ? LIMIT 1`
+      ).bind(tagLikePattern(row.tag as string), cutoff).first();
       if (!existing) digestCandidates.push({ tag: row.tag as string, count: row.count as number });
     }
 

--- a/src/staleness/pass.ts
+++ b/src/staleness/pass.ts
@@ -6,7 +6,21 @@ import { hasStaleAsOf, withStaleAsOf, withoutStaleAsOf } from "../memory/stale";
 import { classifyVolatility, shouldFlagStale } from "./heuristic";
 
 export const STALENESS_AGE_MS = 90 * 24 * 60 * 60 * 1000;
+
+/**
+ * How many candidates one pass inspects.
+ *
+ * Raising this past 100 breaks the retry re-read: rereadSnapshots binds one parameter per
+ * unsettled row into a single `WHERE id IN (…)`, and D1 allows at most 100 bound parameters
+ * per query. It fails only under contention, which is the hard case to notice. Chunk that
+ * read before raising this.
+ */
 export const STALENESS_PASS_LIMIT = 25;
+
+// Unchanged from when every row retried on its own. What changed is the price: a whole
+// round of retries now costs one re-read plus one batch, not one of each per row, so the
+// depth is bounded by correctness rather than by budget.
+const STALENESS_CAS_ATTEMPTS = 3;
 
 const SYSTEM_TAG_EXCLUSIONS = [
   `tags NOT LIKE '%"status:deprecated"%'`,
@@ -15,45 +29,137 @@ const SYSTEM_TAG_EXCLUSIONS = [
   `tags NOT LIKE '%"rolled-up"%'`,
 ].join(" AND ");
 
-// `known` lets the caller spend the row it already selected on the first attempt instead
-// of re-reading it; a lost CAS drops back to a fresh read for the retry.
-//
+/** The row as the pass last saw it — the CAS guard is built from exactly these values. */
+type Snapshot = { id: string; tags: string; content: string };
+
+/** `retryable` marks a CAS, whose result decides whether the row needs another attempt. */
+type Write = { id: string; stmt: D1PreparedStatement; retryable: boolean };
+
+function classify(tags: string[], content: string): string[] {
+  const classified = classifyVolatility(content, tags);
+  const existing = getVolatility(tags);
+
+  if (classified && !existing) {
+    tags = withVolatility(tags, classified);
+  }
+
+  const volatility = getVolatility(tags);
+
+  if (shouldFlagStale(volatility)) {
+    if (!hasStaleAsOf(tags)) tags = withStaleAsOf(tags);
+  } else if (volatility === "durable") {
+    tags = withoutStaleAsOf(tags);
+  }
+
+  return tags;
+}
+
 // The guard covers content as well as tags because the classification is derived from
 // content. Guarding tags alone is not enough: for an entry carrying neither a volatility:
 // nor a stale:as-of tag — the common case — the mutation is a no-op on tags, so a
 // concurrent rewrite would leave the guard satisfied and the CAS would commit a verdict
 // about content that no longer exists. That misfire does not self-correct either, since
 // the concurrent write also bumps updated_at past the staleness cutoff.
-async function casUpdateEntry(
-  env: Env,
-  id: string,
-  mutate: (row: { tags: string[]; content: string }) => { tags: string[] },
-  extraSets: Record<string, unknown> = {},
-  known?: { tags: string; content: string },
-): Promise<boolean> {
-  let current = known;
-  for (let attempt = 0; attempt < 3; attempt++) {
-    if (current === undefined) {
-      const row = await env.DB.prepare(`SELECT tags, content FROM entries WHERE id = ?`).bind(id).first() as { tags: string; content: string } | null;
-      if (!row) return false;
-      current = { tags: row.tags ?? "[]", content: row.content };
+//
+// Binding content per row means a batch of these carries every candidate's body at once.
+// D1 applies its per-statement limits to each statement inside a batch, not to the batch,
+// and the ones that could bite are comfortable: the SQL text is a fixed ~110 bytes because
+// content and tags are bound rather than interpolated, and 5 bound parameters is far under
+// the 100 allowed. Size is bounded too — D1 caps a row at 2 MB, so 25 statements carrying
+// content plus tags twice cannot approach the 100 MB request ceiling in any arrangement
+// that a 128 MB isolate could have built. The candidate query already materialises all 25
+// bodies in one response, so the write side is not the first place this would break;
+// STALENESS_PASS_LIMIT is the knob if it ever does.
+function casWrite(env: Env, snap: Snapshot, now: number): D1PreparedStatement {
+  const nextTags = JSON.stringify(classify(JSON.parse(snap.tags), snap.content));
+  return env.DB.prepare(
+    `UPDATE entries SET tags = ?, staleness_checked_at = ? WHERE id = ? AND tags = ? AND content = ?`,
+  ).bind(nextTags, now, snap.id, snap.tags, snap.content);
+}
+
+// The candidate query orders by COALESCE(staleness_checked_at, 0) ASC, so a row left NULL
+// sorts first on every future pass and camps one of the 25 slots indefinitely. Any row the
+// pass inspects must have its cursor moved, verdict or no verdict.
+function cursorWrite(env: Env, id: string, now: number): D1PreparedStatement {
+  return env.DB.prepare(`UPDATE entries SET staleness_checked_at = ? WHERE id = ?`).bind(now, id);
+}
+
+function planWrite(env: Env, snap: Snapshot, now: number): Write {
+  try {
+    // A deprecated row is never classified; it only needs to stop being a candidate.
+    if (getStatus(JSON.parse(snap.tags)) === "deprecated") {
+      return { id: snap.id, stmt: cursorWrite(env, snap.id, now), retryable: false };
     }
-    const next = mutate({ tags: JSON.parse(current.tags), content: current.content });
-    const nextTagsJson = JSON.stringify(next.tags);
-    const setClauses = ["tags = ?"];
-    const bindings: unknown[] = [nextTagsJson];
-    for (const [col, val] of Object.entries(extraSets)) {
-      setClauses.push(`${col} = ?`);
-      bindings.push(val);
-    }
-    bindings.push(id, current.tags, current.content);
-    const result = await env.DB.prepare(
-      `UPDATE entries SET ${setClauses.join(", ")} WHERE id = ? AND tags = ? AND content = ?`,
-    ).bind(...bindings).run();
-    if ((result.meta.changes ?? 0) > 0) return true;
-    current = undefined; // CAS lost (or the row is gone) — retry against a fresh read
+    return { id: snap.id, stmt: casWrite(env, snap, now), retryable: true };
+  } catch (e) {
+    // Tags that will not parse cannot be classified on this attempt or any other, so there
+    // is nothing to retry — but the cursor still has to move, or the row parks at the front
+    // of the queue forever.
+    console.error(`Staleness pass failed for ${snap.id} (non-fatal):`, e);
+    return { id: snap.id, stmt: cursorWrite(env, snap.id, now), retryable: false };
   }
-  return false;
+}
+
+/**
+ * One round of writes as a single subrequest, keeping the per-row path as a fallback.
+ *
+ * All four nightly jobs fire from one scheduled() invocation and share its budget (#278),
+ * and at one UPDATE per candidate — plus retries, plus cursor advances — this pass was the
+ * largest consumer of it. A batch costs one subrequest whatever it carries.
+ *
+ * batch() is atomic, and the two ways a statement can come back have to be told apart. A
+ * CAS that loses reports changes: 0 and does not roll the batch back (verified against
+ * workerd, not assumed), so contention is free here. A genuine SQL error does roll back
+ * everything, which would leave up to 25 inspected rows with a NULL cursor sitting at the
+ * front of the next run's queue — so a rejected batch replays per row: the behaviour this
+ * replaced, at the cost it used to pay, on the path that used to be the only path.
+ *
+ * That fallback is deliberately not free. If every batch is rejected AND every per-row
+ * replay also fails, the pass degenerates to about 107 subrequests — 1 candidate query,
+ * then a rejected batch plus 25 replays on each of three attempts and again on the cursor
+ * advance. That is well over the free plan's 50, but it only happens when D1 is refusing
+ * writes outright, and a pass that spends the budget failing is strictly better than one
+ * that abandons 25 rows with NULL cursors for every later run to trip over.
+ */
+async function runWrites(env: Env, writes: Write[]): Promise<number[]> {
+  if (!writes.length) return [];
+  try {
+    const results = await env.DB.batch(writes.map(w => w.stmt));
+    return results.map(r => r.meta.changes ?? 0);
+  } catch (e) {
+    console.error("Batched staleness writes failed; retrying per row (non-fatal):", e);
+    const changes: number[] = [];
+    for (const w of writes) {
+      try {
+        const result = await w.stmt.run();
+        changes.push(result.meta.changes ?? 0);
+      } catch (err) {
+        console.error(`Staleness pass failed for ${w.id} (non-fatal):`, err);
+        // Indistinguishable from a lost CAS from here, and treated as one: retried, and
+        // cursor-advanced if it never lands. No row is left owed a write it never gets.
+        changes.push(0);
+      }
+    }
+    return changes;
+  }
+}
+
+/**
+ * Fresh tags AND content for every loser, in one read rather than one read each.
+ *
+ * One bound parameter per id, against D1's limit of 100 per query — safe only because
+ * STALENESS_PASS_LIMIT caps the caller at 25. See the note on that constant.
+ */
+async function rereadSnapshots(env: Env, ids: string[]): Promise<Snapshot[] | null> {
+  try {
+    const { results } = await env.DB.prepare(
+      `SELECT id, tags, content FROM entries WHERE id IN (${ids.map(() => "?").join(", ")})`,
+    ).bind(...ids).all() as { results: { id: string; tags: string; content: string }[] };
+    return results.map(r => ({ id: r.id, tags: r.tags ?? "[]", content: r.content }));
+  } catch (e) {
+    console.error("Staleness retry re-read failed (non-fatal):", e);
+    return null;
+  }
 }
 
 export async function runStalenessPass(env: Env, _ctx: ExecutionContext): Promise<void> {
@@ -61,7 +167,7 @@ export async function runStalenessPass(env: Env, _ctx: ExecutionContext): Promis
 
   const cutoff = Date.now() - STALENESS_AGE_MS;
   const now = Date.now();
-  let candidates: { id: string; content: string; tags: string }[] = [];
+  let candidates: Snapshot[] = [];
 
   try {
     const { results } = await env.DB.prepare(
@@ -71,47 +177,48 @@ export async function runStalenessPass(env: Env, _ctx: ExecutionContext): Promis
        ORDER BY COALESCE(staleness_checked_at, 0) ASC
        LIMIT ${STALENESS_PASS_LIMIT}`,
     ).bind(cutoff).all() as { results: { id: string; content: string; tags: string }[] };
-    candidates = results;
+    candidates = results.map(r => ({ id: r.id, tags: r.tags ?? "[]", content: r.content }));
   } catch (e) {
     console.error("Staleness pass query failed (non-fatal):", e);
     return;
   }
 
-  for (const row of candidates) {
-    try {
-      if (getStatus(JSON.parse(row.tags ?? "[]")) === "deprecated") {
-        await env.DB.prepare(`UPDATE entries SET staleness_checked_at = ? WHERE id = ?`).bind(now, row.id).run();
-        continue;
-      }
+  // Rows still owed a write. A row leaves this list only by landing its CAS, by being
+  // deleted underneath the pass, or — below the loop — by having its cursor advanced.
+  let unsettled = candidates;
+  // Rows whose cursor write itself failed. There is no verdict left to retry for these, but
+  // the cursor is still owed: a row that keeps a NULL cursor sorts first on every future
+  // pass forever, so dropping it here would be exactly the camping bug the cursor prevents.
+  const cursorFailed: string[] = [];
 
-      const settled = await casUpdateEntry(env, row.id, ({ tags, content }) => {
-        const classified = classifyVolatility(content, tags);
-        const existing = getVolatility(tags);
-
-        if (classified && !existing) {
-          tags = withVolatility(tags, classified);
-        }
-
-        const volatility = getVolatility(tags);
-
-        if (shouldFlagStale(volatility)) {
-          if (!hasStaleAsOf(tags)) tags = withStaleAsOf(tags);
-        } else if (volatility === "durable") {
-          tags = withoutStaleAsOf(tags);
-        }
-
-        return { tags };
-      }, { staleness_checked_at: now }, { tags: row.tags ?? "[]", content: row.content });
-
-      if (!settled) {
-        // Every CAS attempt lost, or the row is gone. Advance the cursor anyway: the
-        // candidate query orders by COALESCE(staleness_checked_at, 0) ASC, so leaving it
-        // NULL would put this row first on every future pass, camping one of the 25 slots
-        // indefinitely. The next pass will pick it up again on its merits.
-        await env.DB.prepare(`UPDATE entries SET staleness_checked_at = ? WHERE id = ?`).bind(now, row.id).run();
-      }
-    } catch (e) {
-      console.error(`Staleness pass failed for ${row.id} (non-fatal):`, e);
+  for (let attempt = 0; attempt < STALENESS_CAS_ATTEMPTS && unsettled.length; attempt++) {
+    if (attempt > 0) {
+      // A lost CAS means someone else wrote the row, so the retry re-classifies from the
+      // fresh tags and content rather than from the snapshot that just lost. Ids that do
+      // not come back were deleted mid-pass: no verdict and no cursor to write.
+      const fresh = await rereadSnapshots(env, unsettled.map(r => r.id));
+      if (!fresh) break; // read failed — stop retrying, but still advance the cursors below
+      unsettled = fresh;
     }
+
+    const writes = unsettled.map(snap => planWrite(env, snap, now));
+    const changes = await runWrites(env, writes);
+    const lost = new Set<string>();
+    writes.forEach((w, i) => {
+      if (changes[i] !== 0) return;
+      // A CAS reporting no change usually lost a race and is worth re-reading. A cursor
+      // write reporting none only ever means the write failed — the row is not a candidate
+      // for reclassification, it just still needs its cursor moved.
+      if (w.retryable) lost.add(w.id); else cursorFailed.push(w.id);
+    });
+    unsettled = unsettled.filter(snap => lost.has(snap.id));
+  }
+
+  // Everything still owed a cursor: rows whose every CAS attempt lost, and rows whose
+  // cursor write failed earlier. One more batch is the last attempt either gets — a cursor
+  // UPDATE on a row deleted meanwhile is a harmless no-op, so nothing needs excluding.
+  const owed = [...unsettled.map(snap => snap.id), ...cursorFailed];
+  if (owed.length) {
+    await runWrites(env, owed.map(id => ({ id, stmt: cursorWrite(env, id, now), retryable: false })));
   }
 }

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -235,6 +235,11 @@ export class D1Mock {
           const row = db.entries.find((e: any) => e.id === args[0]);
           return row ? { vector_ids: row.vector_ids } : null;
         }
+        // These branches match `as count` in lower case only. src/migration/embedding.ts
+        // writes `AS count`, so three of its queries fall through here and return null
+        // rather than a row — pre-existing, and those paths are covered against real SQLite
+        // in test/integration/embedding-migration.test.ts. Worth knowing before adding a
+        // fourth caller and trusting the double.
         if (s.includes("COUNT(*) as count") && s.includes("AVG(importance_score)")) {
           const count = db.entries.length;
           const scored = db.entries.filter((e: any) => typeof e.importance_score === "number");

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -1,4 +1,36 @@
-import { COMPRESSION_IMPORTANCE_THRESHOLD, COMPRESSION_MIN_RECALL } from "../../src/compression/eligibility";
+import { COMPRESSION_IMPORTANCE_THRESHOLD, COMPRESSION_MIN_RECALL, isTopicTag } from "../../src/compression/eligibility";
+
+/**
+ * Decode a `%"tag"%` bind parameter back to the tag, undoing tagLikePattern's escaping.
+ *
+ * Production escapes % and _ in the tag and pairs the clause with ESCAPE '\\', so a tag
+ * `q3_planning` arrives here as `%"q3\\_planning"%`. Without this the double would look for
+ * a tag spelled with a backslash and silently match nothing.
+ */
+const tagFromLikePattern = (pattern: string) =>
+  pattern.replace(/%"/g, "").replace(/"%/g, "").replace(/\\([%_\\])/g, "$1");
+
+/**
+ * Does this tag array satisfy `tags LIKE '%"<tag>"%'`?
+ *
+ * MODELS: ASCII case-insensitivity. SQLite's LIKE matches `Work` for `%"work"%`, and
+ * comparing case-sensitively here would make the double disagree with production on exactly
+ * the inputs behind #278's rollup bug, where the candidate `Kind:Semantic` selected — and
+ * rolled up — every entry carrying `kind:semantic`. test/unit/d1-mock-fidelity.test.ts pins
+ * this; do not "simplify" it back to Array.includes.
+ *
+ * DOES NOT MODEL, so a green test here is NOT coverage of any of these:
+ *   - LIKE wildcards in the tag. Real `%"q3_planning"%` also matches `q3-planning`, and
+ *     `%"%"%` matches every row; this matches exactly one tag either way. That is why P1's
+ *     escaping bug is covered against real SQLite in test/integration/, not here.
+ *   - JSON escaping. A tag containing a quote is stored as \\" so real LIKE misses it;
+ *     this compares the decoded strings and matches.
+ *   - Unicode case folding. SQLite's LIKE is ASCII-only; toLowerCase is not, so this
+ *     matches `Σ`/`σ` where real LIKE does not.
+ * Anything whose subject is the pattern rather than the tag belongs in a real-SQLite test.
+ */
+const tagMatchesLike = (tags: string[], tag: string) =>
+  tags.some(t => t.toLowerCase() === tag.toLowerCase());
 
 export class D1Mock {
   entries: any[] = [];
@@ -6,6 +38,10 @@ export class D1Mock {
 
   prepare(sql: string) {
     const s = sql.replace(/\s+/g, " ").trim();
+    // Production pairs every tag LIKE clause with `ESCAPE '\\'` (see tagLikePattern). The
+    // escape clause never changes which query a statement IS, so branches that identify a
+    // query by its exact text compare against this form rather than each growing a suffix.
+    const sBare = s.replace(/ ESCAPE '\\'/g, "");
     const db = this;
 
     const makeStmt = (args: any[]) => ({
@@ -238,8 +274,8 @@ export class D1Mock {
             const tags: string[] = JSON.parse(e.tags ?? "[]");
             if (!hardcoded.every(t => tags.includes(t))) return false;
             return likePatterns.every((p: string) => {
-              const tag = p.replace(/%"/g, "").replace(/"%/g, "");
-              return tags.includes(tag);
+              const tag = tagFromLikePattern(p);
+              return tagMatchesLike(tags, tag);
             });
           });
           return match ? { id: match.id } : null;
@@ -248,14 +284,14 @@ export class D1Mock {
       },
       async all() {
         if (
-          s === "SELECT id FROM entries WHERE tags LIKE ?" ||
-          s === "SELECT id, vector_ids FROM entries WHERE tags LIKE ?" ||
-          s === "SELECT id, vector_ids, content, tags, source, created_at FROM entries WHERE tags LIKE ?"
+          sBare === "SELECT id FROM entries WHERE tags LIKE ?" ||
+          sBare === "SELECT id, vector_ids FROM entries WHERE tags LIKE ?" ||
+          sBare === "SELECT id, vector_ids, content, tags, source, created_at FROM entries WHERE tags LIKE ?"
         ) {
           const pattern = String(args[0]);
-          const tag = pattern.replace(/%"/g, "").replace(/"%/g, "");
+          const tag = tagFromLikePattern(pattern);
           const results = db.entries
-            .filter((e: any) => (JSON.parse(e.tags ?? "[]") as string[]).includes(tag))
+            .filter((e: any) => tagMatchesLike(JSON.parse(e.tags ?? "[]"), tag))
             .map((e: any) => ({ id: e.id, vector_ids: e.vector_ids ?? "[]", content: e.content, tags: e.tags, source: e.source, created_at: e.created_at }));
           return { results };
         }
@@ -346,6 +382,14 @@ export class D1Mock {
           const row = db.entries.find((e: any) => e.id === args[0]);
           return { results: row ? [{ tags: row.tags }] : [] };
         }
+        if (s.startsWith("SELECT id, tags, content FROM entries WHERE id IN")) {
+          // Staleness retry re-read: fresh tags and content for every row whose CAS lost,
+          // in one statement. Rows deleted mid-pass simply do not come back.
+          const results = db.entries
+            .filter((e: any) => args.includes(e.id))
+            .map((e: any) => ({ id: e.id, tags: e.tags, content: e.content }));
+          return { results };
+        }
         if (s.includes("COALESCE(updated_at, created_at) < ?") && s.includes("SELECT id, content, tags FROM entries")) {
           const cutoff = Number(args[0]);
           const limitMatch = s.match(/LIMIT (\d+)/);
@@ -429,12 +473,12 @@ export class D1Mock {
           // compressTag raw entries query — tag match, system-tag exclusion, and the
           // recall/age/contradiction eligibility predicate (cutoff is the 2nd bind param).
           const tagPattern = args[0] as string;
-          const tag = tagPattern.replace(/%"/g, "").replace(/"%/g, "");
+          const tag = tagFromLikePattern(tagPattern);
           const cutoff = Number(args[1]);
           const results = [...db.entries]
             .filter((e: any) => {
               const tags: string[] = JSON.parse(e.tags ?? "[]");
-              if (!tags.includes(tag)) return false;
+              if (!tagMatchesLike(tags, tag)) return false;
               if (tags.includes("synthesized") || tags.includes("auto-pattern") || tags.includes("rolled-up")) return false;
               if (!(e.importance_score == null || e.importance_score < COMPRESSION_IMPORTANCE_THRESHOLD)) return false;
               const rc = e.recall_count; // NULL/undefined → recall clause is falsy → protected (matches SQL)
@@ -457,7 +501,6 @@ export class D1Mock {
           // Digest-candidate query (nightly compression + /stats): per-tag count of
           // entries that pass the compression eligibility predicate. Cutoff is args[0].
           const cutoff = Number(args[0]);
-          const SYSTEM = ["synthesized", "auto-pattern", "duplicate-candidate", "contradiction-resolved", "rolled-up"];
           const counts = new Map<string, number>();
           for (const e of db.entries as any[]) {
             const tags: string[] = JSON.parse(e.tags ?? "[]");
@@ -467,8 +510,10 @@ export class D1Mock {
             if (!(rc === 0 || (rc < COMPRESSION_MIN_RECALL && e.created_at < cutoff))) continue;
             if (!(e.contradiction_wins == null || e.contradiction_wins === 0)) continue;
             for (const t of tags) {
-              if (SYSTEM.includes(t)) continue;
-              if (t.startsWith("status:") || t.startsWith("kind:")) continue;
+              // The same predicate isTopicTagSql() is generated from, rather than a second
+              // copy of the rule: a double that filters differently from production hides
+              // exactly the bugs it is supposed to catch.
+              if (!isTopicTag(t)) continue;
               counts.set(t, (counts.get(t) ?? 0) + 1);
             }
           }
@@ -542,8 +587,8 @@ export class D1Mock {
           let rows = [...db.entries];
           if (s.includes("tags LIKE ?")) {
             const pattern = String(filterArgs[argIdx++]);
-            const tag = pattern.replace(/%"/g, "").replace(/"%/g, "");
-            rows = rows.filter((e: any) => (JSON.parse(e.tags ?? "[]") as string[]).includes(tag));
+            const tag = tagFromLikePattern(pattern);
+            rows = rows.filter((e: any) => tagMatchesLike(JSON.parse(e.tags ?? "[]"), tag));
           }
           if (s.includes("created_at >= ?")) {
             const after = Number(filterArgs[argIdx++]);

--- a/test/integration/digest-candidates.test.ts
+++ b/test/integration/digest-candidates.test.ts
@@ -1,0 +1,154 @@
+/**
+ * The digest-candidate query, run for real.
+ *
+ * Its correctness IS the SQL: which tags come back decides which tags get compressed, and
+ * a nightly run only compresses COMPRESSION_MAX_TAGS_PER_RUN of them. `test/helpers/d1-mock.ts`
+ * cannot evaluate SQL — its digest-candidate branch calls isTopicTag(), the TypeScript half
+ * of the rule — so a WHERE clause that drifted from that predicate would pass every
+ * mock-based test in the suite. This runs the clause itself against real SQLite.
+ *
+ * The WHERE fragments are imported rather than retyped, so this exercises the same strings
+ * src/compression/nightly.ts and src/routes/admin.ts embed.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  compressionEligibilitySql,
+  isTopicTag,
+  isTopicTagSql,
+  COMPRESSION_MIN_AGE_MS,
+} from "../../src/compression/eligibility";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { tagLikePattern, TAG_LIKE_ESCAPE } from "../../src/memory/tag-sql";
+
+let sqlite: SqliteD1 | null = null;
+
+afterEach(() => {
+  sqlite?.close();
+  sqlite = null;
+});
+
+async function candidateTags(seed: (s: SqliteD1) => void): Promise<string[]> {
+  sqlite = makeSqliteD1();
+  seed(sqlite);
+  const { results } = await sqlite.db.prepare(`
+    SELECT value as tag, COUNT(*) as count
+    FROM entries, json_each(entries.tags)
+    WHERE ${isTopicTagSql()}
+      AND entries.tags NOT LIKE '%"rolled-up"%'
+      AND entries.tags NOT LIKE '%"synthesized"%'
+      AND entries.tags NOT LIKE '%"auto-pattern"%'
+      AND ${compressionEligibilitySql("entries.")}
+    GROUP BY value
+    HAVING count > 10
+    ORDER BY count DESC
+  `).bind(Date.now() - COMPRESSION_MIN_AGE_MS).all();
+  return (results as { tag: string }[]).map(r => r.tag);
+}
+
+describe("digest-candidate query", () => {
+  it("excludes the tags the system writes, and keeps the ones the user does", async () => {
+    const tags = await candidateTags(s => {
+      // Eleven entries carrying a real topic plus every reserved namespace, exactly as an
+      // entry looks after classification and a staleness pass have both run over it.
+      for (let i = 0; i < 11; i++) {
+        s.seed({
+          id: `e-${i}`, content: `memory ${i}`, createdAt: 1,
+          tags: ["work", "kind:semantic", "status:canonical", "volatility:state", "stale:as-of"],
+        });
+      }
+    });
+
+    expect(tags).toEqual(["work"]);
+  });
+
+  it("does not let a bulk-written system tag outrank a real topic", async () => {
+    const tags = await candidateTags(s => {
+      // Distinct counts, so ORDER BY fully determines the order — SQLite does not promise
+      // anything about ties, and the assertion below is about position.
+      for (let i = 0; i < 12; i++) s.seed({ id: `a-${i}`, content: "m", createdAt: 1, tags: ["work"] });
+      for (let i = 0; i < 11; i++) s.seed({ id: `b-${i}`, content: "m", createdAt: 1, tags: ["family"] });
+      // The staleness pass tags in bulk, so its tags carry the higher count.
+      for (let i = 0; i < 25; i++) {
+        s.seed({ id: `c-${i}`, content: "m", createdAt: 1, tags: ["volatility:state", "stale:as-of"] });
+      }
+    });
+
+    // Ordered by count DESC, so a failure here is the system tags sitting at the head of
+    // the list and taking the slots real topics would have had.
+    expect(tags).toEqual(["work", "family"]);
+  });
+
+  // A mixed-case reserved tag must never become a candidate. If one does, compressTag
+  // selects its sources with `tags LIKE '%"Kind:Semantic"%'` — LIKE ignores ASCII case — so
+  // it rolls up every entry carrying `kind:semantic`, which is most of the table. Nothing
+  // lowercases the tags src/integrations/mirror.ts inserts, so this is reachable.
+  //
+  // Only the tag-value predicate is under test. Mixed-case forms of the bookkeeping tags
+  // (`SYNTHESIZED`, `Rolled-Up`) are deliberately absent from this fixture: the surrounding
+  // row-level filters are `entries.tags NOT LIKE '%"synthesized"%'`, which already ignores
+  // case, so such a row is dropped whole before any tag value is considered.
+  it("reserves the namespace whatever its case", async () => {
+    const reserved = ["Status:Active", "Kind:Personal", "Volatility:High", "Stale:As-Of"];
+    const tags = await candidateTags(s => {
+      for (let i = 0; i < 11; i++) {
+        s.seed({ id: `e-${i}`, content: "m", createdAt: 1, tags: ["holiday-plans", ...reserved] });
+      }
+    });
+
+    expect(tags).toEqual(["holiday-plans"]);
+    for (const tag of reserved) expect(isTopicTag(tag)).toBe(false);
+  });
+
+  it("reserves the namespace rather than the bare word", async () => {
+    const tags = await candidateTags(s => {
+      for (let i = 0; i < 11; i++) {
+        s.seed({ id: `e-${i}`, content: "m", createdAt: 1, tags: ["volatility", "stale", "status", "kind"] });
+      }
+    });
+
+    expect(tags.sort()).toEqual(["kind", "stale", "status", "volatility"]);
+  });
+});
+
+/**
+ * The other half of compressTag: once a tag is chosen, this is the query that decides which
+ * entries get rolled up. Its correctness is also the SQL, and for a reason the D1 mock
+ * structurally cannot reach — the mock compares decoded tag strings, so LIKE wildcards in
+ * the tag itself simply do not exist there. Every row this selects has its content appended
+ * to and is marked `rolled-up`, permanently, so selecting one row too many is data loss.
+ */
+describe("compressTag source selector", () => {
+  async function selected(tag: string): Promise<string[]> {
+    sqlite = makeSqliteD1();
+    // 11 entries on the tag being compressed, 9 on a near-miss neighbour that differs only
+    // where a LIKE wildcard would paper over the difference.
+    for (let i = 0; i < 11; i++) sqlite.seed({ id: `own-${i}`, content: "m", createdAt: 1, tags: ["q3_planning"] });
+    for (let i = 0; i < 9; i++) sqlite.seed({ id: `other-${i}`, content: "m", createdAt: 1, tags: ["q3-planning"] });
+    // The clause from src/compression/digest.ts, built from the same exported pieces.
+    const { results } = await sqlite.db.prepare(
+      `SELECT id FROM entries WHERE tags LIKE ? ${TAG_LIKE_ESCAPE} ORDER BY id`,
+    ).bind(tagLikePattern(tag)).all();
+    return (results as { id: string }[]).map(r => r.id);
+  }
+
+  // `#q3_planning` is the ordinary multi-word hashtag convention and src/text/hashtags.ts
+  // matches \w, so underscore tags arrive without anyone doing anything unusual. Unescaped,
+  // `_` is a single-character wildcard and this also rolls up every `q3-planning` entry.
+  it("does not match a neighbouring tag through an underscore wildcard", async () => {
+    const ids = await selected("q3_planning");
+    expect(ids).toHaveLength(11);
+    expect(ids.every(id => id.startsWith("own-"))).toBe(true);
+  });
+
+  // Reachable through the API's tags[] array and the integrations mirror, neither of which
+  // constrains the characters in a tag. Unescaped this selects the entire table.
+  it("does not match everything through a percent wildcard", async () => {
+    expect(await selected("%")).toEqual([]);
+    expect(await selected("%planning%")).toEqual([]);
+  });
+
+  it("still matches the ordinary tag it is given", async () => {
+    expect(await selected("q3-planning")).toHaveLength(9);
+    expect(await selected("q3_planning")).toHaveLength(11);
+  });
+});

--- a/test/integration/digest.test.ts
+++ b/test/integration/digest.test.ts
@@ -1,0 +1,95 @@
+/**
+ * GET /digest hands compressTag an arbitrary user-supplied string, which makes it the one
+ * path where the guard inside compressTag is the ONLY thing standing between a request and
+ * a rollup. The nightly path is protected twice — the candidate query filters the tag list
+ * before compressTag ever sees it — so a guard that is too narrow shows up here and nowhere
+ * else. It went unnoticed because this route had no test at all.
+ *
+ * Compressing a system tag is not a no-op: compressTag selects sources with `tags LIKE
+ * '%"<tag>"%'` and marks every one of them `rolled-up` with a `[Digest: …]` suffix appended
+ * to its content, permanently. `duplicate-candidate` and `contradiction-resolved` are the
+ * dangerous ones — unlike synthesized/auto-pattern/rolled-up they have no row-level
+ * exclusion anywhere, so every entry carrying one is selectable.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+describe("GET /digest", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  function seed(tags: string[], n = 12) {
+    const old = Date.now() - 200 * 24 * 3600 * 1000;
+    for (let i = 0; i < n; i++) {
+      db.entries.push({
+        id: `e-${i}`, content: `Memory ${i}`, tags: JSON.stringify(tags), source: "api",
+        created_at: old + i, updated_at: old + i, vector_ids: "[]",
+        recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+      });
+    }
+  }
+
+  // Compared against the state before the request rather than against absolutes: some of
+  // these fixtures are seeded with the very tag under test, so "nothing changed" is the
+  // assertion — no row added, none marked, no content appended to.
+  const snapshot = () => db.entries.map(e => ({ id: e.id, tags: e.tags, content: e.content }));
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await worker.fetch(req("GET", "/digest?tag=work", { token: null }), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("requires a tag", async () => {
+    const res = await worker.fetch(req("GET", "/digest"), env, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    "duplicate-candidate",
+    "Duplicate-Candidate",
+    "contradiction-resolved",
+    "synthesized",
+    "rolled-up",
+    "stale:as-of",
+    "Stale:As-Of",
+    "kind:semantic",
+    "Kind:Semantic",
+    "status:canonical",
+    "volatility:state",
+  ])("refuses to compress the system tag %s", async (tag) => {
+    seed([tag, "work"]);
+    const before = snapshot();
+
+    const res = await worker.fetch(req("GET", `/digest?tag=${encodeURIComponent(tag)}`), env, ctx);
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.entry_id).toBeUndefined();
+    expect(data.source_count).toBe(0);
+    expect(env.AI.run).not.toHaveBeenCalled(); // rejected before any work at all
+    expect(snapshot()).toEqual(before);
+  });
+
+  // The guard must not have become a blanket refusal — an ordinary tag still compresses.
+  it("still compresses an ordinary tag", async () => {
+    seed(["holiday-plans"]);
+
+    const res = await worker.fetch(req("GET", "/digest?tag=holiday-plans"), env, ctx);
+
+    const data = await res.json() as any;
+    expect(data.entry_id).toBeTruthy();
+    expect(data.source_count).toBe(12);
+    expect(db.entries.filter(e => JSON.parse(e.tags).includes("rolled-up"))).toHaveLength(12);
+  });
+});

--- a/test/integration/stats.test.ts
+++ b/test/integration/stats.test.ts
@@ -192,11 +192,19 @@ describe("GET /stats — digest candidates", () => {
     expect(data.digest_candidates.some((c: any) => c.tag === "work")).toBe(false);
   });
 
-  it("excludes reserved namespaced tags (kind:* / status:*) from digest candidates", async () => {
+  // /stats reports what the nightly run would compress, so it has to apply the same rule.
+  // volatility:* and stale:as-of are written in bulk by the staleness pass, so they carry
+  // high counts and would otherwise sit at the top of a list of "digest candidates" that
+  // can never produce a digest.
+  //
+  // Scope: this runs against the D1 mock, whose digest-candidate branch calls isTopicTag(),
+  // so it covers the predicate rather than the SQL /stats actually issues. The query itself
+  // is covered by test/integration/digest-candidates.test.ts against real SQLite.
+  it("excludes reserved namespaced tags (kind:* / status:* / volatility:* / stale:as-of) from digest candidates", async () => {
     for (let i = 0; i < 12; i++) {
       db.entries.push({
         ...compressible(`e-${i}`, "work"),
-        tags: JSON.stringify(["work", "kind:semantic", "status:canonical"]),
+        tags: JSON.stringify(["work", "kind:semantic", "status:canonical", "volatility:state", "stale:as-of"]),
       });
     }
     const res = await worker.fetch(req("GET", "/stats"), env, ctx);
@@ -205,5 +213,7 @@ describe("GET /stats — digest candidates", () => {
     expect(tags).toContain("work");                  // topical tag still a candidate
     expect(tags).not.toContain("kind:semantic");     // namespaced excluded
     expect(tags).not.toContain("status:canonical");  // namespaced excluded
+    expect(tags).not.toContain("volatility:state");  // written by the staleness pass
+    expect(tags).not.toContain("stale:as-of");       // written by the staleness pass
   });
 });

--- a/test/integration/tag-filter-escaping.test.ts
+++ b/test/integration/tag-filter-escaping.test.ts
@@ -18,8 +18,12 @@ import { describe, it, expect, afterEach } from "vitest";
 import { buildEntryFilterQuery } from "../../src/capture/entry";
 import { recallEntries } from "../../src/recall/search";
 import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
-import { makeTestDb, makeTestEnv } from "../helpers/make-env";
-import { tagLikePattern, TAG_LIKE_ESCAPE } from "../../src/memory/tag-sql";
+import { initializeDatabase, resetDatabaseInit } from "../../src/db/init";
+import { makeTestDb, makeTestEnv, makeVectorizeMock } from "../helpers/make-env";
+import worker from "../../src/index";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+import { tagLikePattern } from "../../src/memory/tag-sql";
 
 const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
 
@@ -30,11 +34,53 @@ afterEach(() => {
   sqlite = null;
 });
 
-/** Eleven entries on an underscore tag, nine on the neighbour a `_` wildcard would reach. */
+/**
+ * An Env whose DB is real SQLite.
+ *
+ * `makeSqliteD1` applies db/schema.sql, which deliberately omits the columns
+ * initializeDatabase adds by ALTER (updated_at, staleness_checked_at, the counters) — so
+ * `exec` really executes and seedEnv runs the real initializeDatabase over it. Listing
+ * those columns here instead would be a second copy of the migration, wrong the moment one
+ * is added.
+ *
+ * `batch` runs sequentially, which is enough for the read paths under test. Vectorize
+ * returns one vector per requested id so the tag-scoped branch has something to score;
+ * WHICH ids it is asked for is decided entirely by the tag query, which is the point.
+ */
+function envOver(s: SqliteD1): Env {
+  const DB = {
+    prepare: (sql: string) => s.db.prepare(sql),
+    exec: async (sql: string) => s.db.prepare(sql).run(),
+    batch: async (stmts: any[]) => Promise.all(stmts.map(st => st.run())),
+  } as unknown as D1Database;
+  const VECTORIZE = {
+    ...makeVectorizeMock(),
+    getByIds: async (ids: string[]) =>
+      ids.map(id => ({ id, values: new Array(384).fill(0.1), metadata: { parentId: id.replace(/^v-/, "") } })),
+  } as unknown as VectorizeIndex;
+  return makeTestEnv(undefined, { DB, VECTORIZE });
+}
+
+/** Seeded SQLite plus an Env over it, with the real schema migration applied. */
+async function seedEnv(): Promise<Env> {
+  sqlite = seeded();
+  const env = envOver(sqlite);
+  resetDatabaseInit();
+  await initializeDatabase(env);
+  return env;
+}
+
+const OWN = Array.from({ length: 11 }, (_, i) => `own-${i}`).sort();
+const OTHER = Array.from({ length: 9 }, (_, i) => `other-${i}`).sort();
+
+/**
+ * Eleven entries on an underscore tag, nine on the neighbour a `_` wildcard would reach.
+ * Every entry carries a vector id so the tag-scoped recall path has something to fetch.
+ */
 function seeded(): SqliteD1 {
   const s = makeSqliteD1();
-  for (let i = 0; i < 11; i++) s.seed({ id: `own-${i}`, content: `m${i}`, createdAt: 1000 + i, tags: ["q3_planning"] });
-  for (let i = 0; i < 9; i++) s.seed({ id: `other-${i}`, content: `m${i}`, createdAt: 2000 + i, tags: ["q3-planning"] });
+  OWN.forEach((id, i) => s.seed({ id, content: `planning note ${i}`, createdAt: 1000 + i, tags: ["q3_planning"], vectorIds: [`v-${id}`] }));
+  OTHER.forEach((id, i) => s.seed({ id, content: `planning note ${i}`, createdAt: 2000 + i, tags: ["q3-planning"], vectorIds: [`v-${id}`] }));
   return s;
 }
 
@@ -49,9 +95,7 @@ describe("GET /entries and /list tag filter", () => {
   }
 
   it("does not reach a neighbouring tag through an underscore wildcard", async () => {
-    const matched = await ids("q3_planning");
-    expect(matched).toHaveLength(11);
-    expect(matched.every(id => id.startsWith("own-"))).toBe(true);
+    expect(await ids("q3_planning")).toEqual(OWN);
   });
 
   it("does not return everything for a percent tag", async () => {
@@ -60,8 +104,7 @@ describe("GET /entries and /list tag filter", () => {
   });
 
   it("still returns exactly the entries carrying the tag it was given", async () => {
-    expect(await ids("q3-planning")).toHaveLength(9);
-    expect(await ids("q3_planning")).toHaveLength(11);
+    expect(await ids("q3-planning")).toEqual(OTHER);
   });
 });
 
@@ -106,18 +149,64 @@ describe("tag-scoped recall candidate query", () => {
     expect(bound[0]?.[0]).not.toBe(`%"q3_planning"%`); // the unescaped form
   });
 
-  // The clause from src/recall/search.ts, built from the same exported pieces it uses.
-  async function ids(tag: string): Promise<string[]> {
-    sqlite = seeded();
-    const { results } = await sqlite.db.prepare(
-      `SELECT id, vector_ids, content, tags, source, created_at FROM entries WHERE tags LIKE ? ${TAG_LIKE_ESCAPE}`,
-    ).bind(tagLikePattern(tag)).all();
-    return (results as { id: string }[]).map(r => r.id).sort();
+  /**
+   * The behavioural half: the real recallEntries against real SQLite, asserting on the
+   * entries it comes back with.
+   *
+   * This deliberately does not rebuild the query. An earlier version of this test did, and
+   * it passed with search.ts's escaping removed — it was proving the helper works, not that
+   * recall uses it. Only the entry ids answer the question the test is named for.
+   */
+  async function recalled(tag: string): Promise<string[]> {
+    const env = await seedEnv();
+    const { matches } = await recallEntries(
+      { query: "planning", topK: 50, tag, synthesize: false },
+      env,
+      ctx,
+    );
+    return matches.map(m => m.id).sort();
   }
 
-  it("scopes recall to the tag it was given, wildcards and all", async () => {
-    expect((await ids("q3_planning")).every(id => id.startsWith("own-"))).toBe(true);
-    expect(await ids("%")).toEqual([]);
-    expect(await ids("q3-planning")).toHaveLength(9);
+  it("returns only the entries carrying an underscore tag", async () => {
+    expect(await recalled("q3_planning")).toEqual(OWN);
+  });
+
+  it("returns nothing for a percent tag rather than the whole brain", async () => {
+    expect(await recalled("%")).toEqual([]);
+    expect(await recalled("%planning%")).toEqual([]);
+  });
+
+  it("still returns the entries carrying an ordinary tag", async () => {
+    expect(await recalled("q3-planning")).toEqual(OTHER);
+  });
+});
+
+/**
+ * The route, end to end: a real HTTP request through the worker, against real SQLite,
+ * asserting on the response body. `?tag=%` returning the whole brain is the case that
+ * looks most like a valid answer and is therefore least likely to be noticed.
+ */
+describe("GET /list tag filter, end to end", () => {
+  async function listed(tag: string): Promise<string[]> {
+    const env = await seedEnv();
+    const res = await worker.fetch(
+      req("GET", `/list?n=100&tag=${encodeURIComponent(tag)}`),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    return ((await res.json()) as { id: string }[]).map(r => r.id).sort();
+  }
+
+  it("does not reach a neighbouring tag through an underscore wildcard", async () => {
+    expect(await listed("q3_planning")).toEqual(OWN);
+  });
+
+  it("does not return every entry for a percent tag", async () => {
+    expect(await listed("%")).toEqual([]);
+  });
+
+  it("still returns the entries carrying an ordinary tag", async () => {
+    expect(await listed("q3-planning")).toEqual(OTHER);
   });
 });

--- a/test/integration/tag-filter-escaping.test.ts
+++ b/test/integration/tag-filter-escaping.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tag filters, run for real.
+ *
+ * A tag is user data and it goes into a LIKE pattern, where `_` matches any character and
+ * `%` matches everything. `#q3_planning` is the ordinary multi-word hashtag convention and
+ * src/text/hashtags.ts matches \w, so underscore tags arrive without anyone doing anything
+ * unusual; the API's tags[] array and the integrations mirror accept any string at all.
+ *
+ * These are read paths, so the failure is over-broad results rather than the permanent
+ * rollup the same bug caused in compressTag — a `#q3_planning` filter also returning
+ * `q3-planning` entries is wrong but recoverable. `?tag=%` is the sharper one: the filter
+ * silently stops filtering and returns the whole brain, which looks like a valid answer.
+ *
+ * test/helpers/d1-mock.ts cannot cover any of this — it compares decoded tag strings, so
+ * LIKE wildcards in the tag do not exist there. That is stated on the helper itself.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { buildEntryFilterQuery } from "../../src/capture/entry";
+import { recallEntries } from "../../src/recall/search";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestDb, makeTestEnv } from "../helpers/make-env";
+import { tagLikePattern, TAG_LIKE_ESCAPE } from "../../src/memory/tag-sql";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+let sqlite: SqliteD1 | null = null;
+
+afterEach(() => {
+  sqlite?.close();
+  sqlite = null;
+});
+
+/** Eleven entries on an underscore tag, nine on the neighbour a `_` wildcard would reach. */
+function seeded(): SqliteD1 {
+  const s = makeSqliteD1();
+  for (let i = 0; i < 11; i++) s.seed({ id: `own-${i}`, content: `m${i}`, createdAt: 1000 + i, tags: ["q3_planning"] });
+  for (let i = 0; i < 9; i++) s.seed({ id: `other-${i}`, content: `m${i}`, createdAt: 2000 + i, tags: ["q3-planning"] });
+  return s;
+}
+
+describe("GET /entries and /list tag filter", () => {
+  // buildEntryFilterQuery is the real builder both routes use, so this exercises the
+  // shipped SQL and bindings rather than a copy of them.
+  async function ids(tag: string): Promise<string[]> {
+    sqlite = seeded();
+    const { sql, bindings } = buildEntryFilterQuery({ n: 100, tag });
+    const { results } = await sqlite.db.prepare(sql).bind(...bindings).all();
+    return (results as { id: string }[]).map(r => r.id).sort();
+  }
+
+  it("does not reach a neighbouring tag through an underscore wildcard", async () => {
+    const matched = await ids("q3_planning");
+    expect(matched).toHaveLength(11);
+    expect(matched.every(id => id.startsWith("own-"))).toBe(true);
+  });
+
+  it("does not return everything for a percent tag", async () => {
+    expect(await ids("%")).toEqual([]);
+    expect(await ids("%planning%")).toEqual([]);
+  });
+
+  it("still returns exactly the entries carrying the tag it was given", async () => {
+    expect(await ids("q3-planning")).toHaveLength(9);
+    expect(await ids("q3_planning")).toHaveLength(11);
+  });
+});
+
+describe("tag-scoped recall candidate query", () => {
+  /**
+   * Two halves, because neither alone is worth much. This half captures the statement
+   * recallEntries actually issues and checks it carries an escaped pattern and the ESCAPE
+   * clause; the half below proves that combination behaves correctly in SQLite. Asserting
+   * only the second would pass against a recallEntries that never adopted the helpers —
+   * it did, when this test was first written that way.
+   */
+  it("issues an escaped pattern and an ESCAPE clause", async () => {
+    const db = makeTestDb();
+    db.entries.push({
+      id: "e-0", content: "m", tags: JSON.stringify(["q3_planning"]), source: "api",
+      created_at: 1, updated_at: 1, vector_ids: JSON.stringify(["v-0"]),
+      recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+    });
+    const prepared: string[] = [];
+    const bound: unknown[][] = [];
+    const DB = {
+      prepare(sql: string) {
+        const flat = sql.replace(/\s+/g, " ").trim();
+        prepared.push(flat);
+        const stmt = db.prepare(sql);
+        return {
+          ...stmt,
+          bind: (...args: unknown[]) => { if (flat.includes("tags LIKE ?")) bound.push(args); return stmt.bind(...args); },
+        };
+      },
+      exec: (sql: string) => db.exec(sql),
+      batch: (stmts: any[]) => db.batch(stmts),
+    } as unknown as D1Database;
+    const env = makeTestEnv(db, { DB });
+
+    await recallEntries({ query: "planning", topK: 5, tag: "q3_planning" }, env, ctx);
+
+    const tagQuery = prepared.find(s => s.includes("FROM entries WHERE tags LIKE ?"));
+    expect(tagQuery).toBeDefined();
+    expect(tagQuery).toContain("ESCAPE");
+    expect(bound[0]?.[0]).toBe(tagLikePattern("q3_planning"));
+    expect(bound[0]?.[0]).not.toBe(`%"q3_planning"%`); // the unescaped form
+  });
+
+  // The clause from src/recall/search.ts, built from the same exported pieces it uses.
+  async function ids(tag: string): Promise<string[]> {
+    sqlite = seeded();
+    const { results } = await sqlite.db.prepare(
+      `SELECT id, vector_ids, content, tags, source, created_at FROM entries WHERE tags LIKE ? ${TAG_LIKE_ESCAPE}`,
+    ).bind(tagLikePattern(tag)).all();
+    return (results as { id: string }[]).map(r => r.id).sort();
+  }
+
+  it("scopes recall to the tag it was given, wildcards and all", async () => {
+    expect((await ids("q3_planning")).every(id => id.startsWith("own-"))).toBe(true);
+    expect(await ids("%")).toEqual([]);
+    expect(await ids("q3-planning")).toHaveLength(9);
+  });
+});

--- a/test/unit/compress-tag.test.ts
+++ b/test/unit/compress-tag.test.ts
@@ -270,6 +270,46 @@ describe("compressTag()", () => {
     expect(env.AI.run).not.toHaveBeenCalled();
   });
 
+  // The candidate query excludes these, so reaching here means something else called
+  // compressTag directly. It matters more than it looks: without the guard a digest gets
+  // built for "everything the staleness pass touched", and markSourcesRolledUp then rolls
+  // up every one of those sources — taking them out of the running for the real topics
+  // they were also tagged with.
+  it("refuses to compress a volatility:* namespaced tag", async () => {
+    seedEntries(db, "volatility:state", 15, { recall_count: 0 });
+    const { ctx } = makeCtx();
+    const result = await compressTag("volatility:state", env, ctx);
+    expect(result.synthesizedId).toBeNull();
+    expect(env.AI.run).not.toHaveBeenCalled();
+    for (const e of db.entries) expect(JSON.parse(e.tags)).not.toContain("rolled-up");
+  });
+
+  it("refuses to compress the stale:as-of tag", async () => {
+    seedEntries(db, "stale:as-of", 15, { recall_count: 0 });
+    const { ctx } = makeCtx();
+    const result = await compressTag("stale:as-of", env, ctx);
+    expect(result.synthesizedId).toBeNull();
+    expect(env.AI.run).not.toHaveBeenCalled();
+    for (const e of db.entries) expect(JSON.parse(e.tags)).not.toContain("rolled-up");
+  });
+
+  // Mixed case is the dangerous form, not a curiosity. The source selector below this guard
+  // is `tags LIKE '%"<tag>"%'`, and LIKE ignores ASCII case — so `Kind:Semantic` reaching
+  // compressTag does not roll up the entries tagged `Kind:Semantic`, it rolls up every
+  // entry tagged `kind:semantic`. The guard has to reject it before that query runs.
+  it.each(["Kind:Semantic", "Status:Active", "Volatility:State", "Stale:As-Of", "STALE:AS-OF"])(
+    "refuses to compress %s regardless of case",
+    async (tag) => {
+      seedEntries(db, tag.toLowerCase(), 15, { recall_count: 0 });
+      const { ctx } = makeCtx();
+      const result = await compressTag(tag, env, ctx);
+      expect(result.synthesizedId).toBeNull();
+      expect(result.entriesUsed).toBe(0);
+      expect(env.AI.run).not.toHaveBeenCalled();
+      for (const e of db.entries) expect(JSON.parse(e.tags)).not.toContain("rolled-up");
+    },
+  );
+
   // ── Marking sources rolled-up (#278) ─────────────────────────────────────────
   //
   // All four nightly jobs share one scheduled() invocation and therefore one

--- a/test/unit/compression-eligibility.test.ts
+++ b/test/unit/compression-eligibility.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { compressionEligibilitySql, COMPRESSION_MIN_RECALL } from "../../src/compression/eligibility";
+import { compressionEligibilitySql, COMPRESSION_MIN_RECALL, isReservedTag, isTopicTag, isTopicTagSql } from "../../src/compression/eligibility";
+import { STATUS_PREFIX } from "../../src/memory/status";
+import { KIND_PREFIX } from "../../src/memory/kind";
+import { VOLATILITY_PREFIX } from "../../src/memory/volatility";
+import { STALE_AS_OF } from "../../src/memory/stale";
 
 describe("compressionEligibilitySql", () => {
   it("includes the importance, recall+age, and contradiction-win clauses", () => {
@@ -29,5 +33,80 @@ describe("compressionEligibilitySql", () => {
   it("defaults to no prefix", () => {
     const sql = compressionEligibilitySql();
     expect(sql).not.toContain("entries.");
+  });
+});
+
+// The TS predicate and the SQL fragment are two encodings of one rule, and only the TS one
+// is reachable from the D1 mock — so a rule that exists in isTopicTag but not in
+// isTopicTagSql would pass every mock-based test while production kept the old behaviour.
+// These bind both encodings to the same constants.
+describe("reserved tags", () => {
+  const RESERVED = [`${STATUS_PREFIX}canonical`, `${KIND_PREFIX}semantic`, `${VOLATILITY_PREFIX}state`, STALE_AS_OF];
+
+  it("rejects every reserved namespace", () => {
+    for (const tag of RESERVED) {
+      expect(isReservedTag(tag)).toBe(true);
+      expect(isTopicTag(tag)).toBe(false);
+    }
+  });
+
+  it("excludes every reserved namespace from the SQL too", () => {
+    const sql = isTopicTagSql();
+    for (const prefix of [STATUS_PREFIX, KIND_PREFIX, VOLATILITY_PREFIX]) {
+      expect(sql).toContain(`value NOT LIKE '${prefix}%'`);
+    }
+    expect(sql).toContain(`value NOT LIKE '${STALE_AS_OF}'`);
+  });
+
+  // Reserving is case-INsensitive on both sides, and the asymmetry is the reason: a
+  // mixed-case reserved tag that reaches compressTag is matched against sources with
+  // `tags LIKE`, which ignores case, so it rolls up every entry carrying the lowercase
+  // system tag. Over-reserving costs one un-digested tag; under-reserving costs memories.
+  // GLOB or `<>` here would be case-sensitive and let those tags through.
+  it("reserves the namespace whatever its case", () => {
+    expect(isTopicTagSql()).not.toContain("GLOB");
+    expect(isTopicTagSql()).not.toContain("<>");
+    for (const tag of ["Status:Active", "Kind:Personal", "Volatility:High", "Stale:As-Of", "STALE:AS-OF"]) {
+      expect(isReservedTag(tag)).toBe(true);
+      expect(isTopicTag(tag)).toBe(false);
+    }
+  });
+
+  it("treats bookkeeping tags as non-topics whatever their case", () => {
+    for (const tag of ["SYNTHESIZED", "Duplicate-Candidate", "Rolled-Up", "Contradiction-Resolved"]) {
+      expect(isTopicTag(tag)).toBe(false);
+    }
+    expect(isTopicTagSql()).toContain("lower(value) NOT IN");
+  });
+
+  // The SQL now matches these with LIKE, where % and _ are wildcards. No constant contains
+  // one today; this keeps it that way, because a stray _ would silently widen the match.
+  it("keeps every constant free of LIKE metacharacters", () => {
+    const sql = isTopicTagSql();
+    const literals = [...sql.matchAll(/'([^']*)'/g)].map(m => m[1]);
+    expect(literals.length).toBeGreaterThan(0);
+    for (const literal of literals) {
+      expect(literal.replace(/%$/, "")).not.toMatch(/[%_]/);
+      expect(literal).toBe(literal.toLowerCase());
+    }
+  });
+
+  it("treats compression bookkeeping tags as non-topics without calling them reserved", () => {
+    for (const tag of ["synthesized", "auto-pattern", "duplicate-candidate", "contradiction-resolved", "rolled-up"]) {
+      expect(isTopicTag(tag)).toBe(false);
+      expect(isReservedTag(tag)).toBe(false); // compressTag's guard is about namespaces only
+      expect(isTopicTagSql()).toContain(`'${tag}'`);
+    }
+  });
+
+  it("reserves the namespace, not the bare word", () => {
+    for (const tag of ["volatility", "stale", "status", "kind", "work"]) {
+      expect(isTopicTag(tag)).toBe(true); // a user may legitimately tag something "stale"
+    }
+  });
+
+  it("applies to whatever column it is given", () => {
+    expect(isTopicTagSql("entries.tag")).toContain(`entries.tag NOT LIKE '${VOLATILITY_PREFIX}%'`);
+    expect(isTopicTagSql()).not.toContain("?"); // no placeholders — safe to inline anywhere
   });
 });

--- a/test/unit/cron-subrequest-budget.test.ts
+++ b/test/unit/cron-subrequest-budget.test.ts
@@ -16,14 +16,42 @@ import { D1Mock } from "../helpers/d1-mock";
 
 const FREE_PLAN_SUBREQUESTS = 50;
 
+// D1 bills EXECUTIONS: run/first/all/exec spend one each, and a batch() spends one however
+// many statements it carries. Counting prepares instead would price the batched writes in
+// the compression and staleness passes as if they were still one round trip per row —
+// which is exactly the cost this budget is meant to track.
 function countingEnv(db: D1Mock) {
   const statements: string[] = [];
+  const bill = (sql: string) => statements.push(sql.replace(/\s+/g, " ").trim());
+  const wrap = (stmt: any, sql: string): any => ({
+    bind: (...a: any[]) => wrap(stmt.bind(...a), sql),
+    run: () => { bill(sql); return stmt.run(); },
+    first: (...a: any[]) => { bill(sql); return stmt.first(...a); },
+    all: () => { bill(sql); return stmt.all(); },
+    __inner: stmt,
+  });
+  const prepared: string[] = [];
   const DB = {
-    prepare(sql: string) { statements.push(sql.replace(/\s+/g, " ").trim()); return db.prepare(sql); },
-    exec(sql: string) { statements.push(sql.replace(/\s+/g, " ").trim()); return db.exec(sql); },
-    batch: (stmts: any[]) => db.batch(stmts),
+    prepare(sql: string) { prepared.push(sql.replace(/\s+/g, " ").trim()); return wrap(db.prepare(sql), sql); },
+    exec(sql: string) { bill(sql); return db.exec(sql); },
+    batch: (stmts: any[]) => { bill("BATCH"); return db.batch(stmts.map((s: any) => s.__inner ?? s)); },
   } as unknown as D1Database;
-  return { env: makeTestEnv(db, { DB, VECTORIZE: makeVectorizeMock() }), statements };
+  return { env: makeTestEnv(db, { DB, VECTORIZE: makeVectorizeMock() }), statements, prepared };
+}
+
+// Each tag gets more than the ten eligible entries a digest needs, so nightly compression
+// actually runs. Without that the budget test measures a cron with its largest job idle.
+function seedCompressibleTags(db: D1Mock, tagCount: number) {
+  const old = Date.now() - STALENESS_AGE_MS - 86400000;
+  for (let t = 0; t < tagCount; t++) {
+    for (let i = 0; i < 11; i++) {
+      db.entries.push({
+        id: `t${t}-e${i}`, content: `Person ${i} works at Company ${t}`, tags: JSON.stringify([`topic-${t}`]),
+        source: "api", created_at: old + i, updated_at: old + i, vector_ids: "[]",
+        recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+      });
+    }
+  }
 }
 
 async function runCron(env: any) {
@@ -55,6 +83,22 @@ describe("nightly cron D1 subrequest cost", () => {
     // The signature statement of initializeDatabase, once for the whole cron.
     const ddl = statements.filter(s => s.startsWith("CREATE TABLE IF NOT EXISTS entries"));
     expect(ddl).toHaveLength(1);
+  });
+
+  // The staleness pass used to be the largest consumer of this budget: one CAS per
+  // candidate, and in situ it runs concurrently with the compression job's writes, so its
+  // guards lose and it pays for re-reads and retries on top. Batched, the whole pass is a
+  // candidate query and one write round trip.
+  it("keeps a nightly run with every job busy inside the budget", async () => {
+    const db = makeTestDb();
+    seedCompressibleTags(db, 7);
+    const { env, statements } = countingEnv(db);
+
+    await runCron(env);
+
+    expect(db.entries.filter(e => JSON.parse(e.tags).includes("synthesized")).length).toBeGreaterThan(0);
+    expect(db.entries.filter(e => e.staleness_checked_at != null)).toHaveLength(25);
+    expect(statements.length).toBeLessThanOrEqual(FREE_PLAN_SUBREQUESTS);
   });
 
   it("keeps a whole nightly run inside the free-plan subrequest budget", async () => {

--- a/test/unit/d1-mock-fidelity.test.ts
+++ b/test/unit/d1-mock-fidelity.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Pins the parts of test/helpers/d1-mock.ts whose whole job is to behave like D1 rather
+ * than to be convenient.
+ *
+ * A test double that filters differently from production does not fail — it passes, and
+ * takes the bug with it. Both properties below were added because that happened: the
+ * case-sensitive tag comparison hid a rollup bug where the candidate `Kind:Semantic`
+ * selected every entry tagged `kind:semantic`, and the pattern decoder was blind to the
+ * escaping compressTag now applies. Neither had anything pinning it, so reverting either
+ * one broke no test at all.
+ *
+ * The helper's own comment lists what it deliberately does NOT model. Those axes belong in
+ * a real-SQLite test — see test/integration/digest-candidates.test.ts.
+ */
+import { describe, it, expect } from "vitest";
+import { makeTestDb } from "../helpers/make-env";
+import { tagLikePattern } from "../../src/memory/tag-sql";
+
+describe("d1-mock LIKE fidelity", () => {
+  function seed(tags: string[]) {
+    const db = makeTestDb();
+    const old = Date.now() - 200 * 24 * 3600 * 1000;
+    tags.forEach((tag, i) => db.entries.push({
+      id: `e-${i}`, content: `Memory ${i}`, tags: JSON.stringify([tag]), source: "api",
+      created_at: old + i, updated_at: old + i, vector_ids: "[]",
+      recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+    }));
+    return db;
+  }
+
+  // `SELECT id FROM entries WHERE tags LIKE ?` — the shape compressTag uses to pick sources.
+  const select = (db: ReturnType<typeof makeTestDb>, pattern: string) =>
+    db.prepare("SELECT id FROM entries WHERE tags LIKE ?").bind(pattern).all();
+
+  it("matches tags case-insensitively, as SQLite's LIKE does", async () => {
+    const db = seed(["kind:semantic", "Kind:Semantic", "KIND:SEMANTIC", "unrelated"]);
+
+    const { results } = await select(db, `%"kind:semantic"%`);
+
+    expect((results as { id: string }[]).map(r => r.id)).toEqual(["e-0", "e-1", "e-2"]);
+  });
+
+  // compressTag escapes % and _ in the tag and pairs the clause with ESCAPE. A decoder that
+  // did not undo that would look for a tag spelled with a backslash and match nothing —
+  // silently turning every underscore-tagged fixture into an empty result.
+  it("decodes the escaping tagLikePattern applies", async () => {
+    const db = seed(["q3_planning", "q3-planning"]);
+
+    const { results } = await select(db, tagLikePattern("q3_planning"));
+
+    expect((results as { id: string }[]).map(r => r.id)).toEqual(["e-0"]);
+  });
+});

--- a/test/unit/nightly-compression.test.ts
+++ b/test/unit/nightly-compression.test.ts
@@ -120,6 +120,78 @@ describe("runNightlyCompression() tag bound", () => {
     expect(put).not.toHaveBeenCalled();
   });
 
+  /**
+   * The staleness pass writes volatility: and stale:as-of across up to 25 entries a night,
+   * so those tags carry a higher entry count than most real topics. They are not topics and
+   * never produce a digest — but the candidate list is ordered by count and only the first
+   * COMPRESSION_MAX_TAGS_PER_RUN are taken, so if they appear at all they take slots from
+   * the tags that would have produced one. The user-visible symptom is compression quietly
+   * doing half as much, with nothing logged.
+   *
+   * Scope: this covers the PREDICATE, not the query. The D1 mock's digest-candidate branch
+   * calls isTopicTag(), so a WHERE clause that drifted from it would leave this test green
+   * — verified by mutation. test/integration/digest-candidates.test.ts runs the clause
+   * itself against real SQLite and is what actually covers the SQL.
+   */
+  it("does not let system tags take digest slots from real topics", async () => {
+    seedTags(db, 5, 15);
+    // Mark entries the way the staleness pass does: on top of their existing topic tags.
+    for (const e of db.entries.slice(0, 25)) {
+      e.tags = JSON.stringify([...JSON.parse(e.tags), "volatility:state", "stale:as-of"]);
+    }
+
+    await runCron(env);
+
+    expect(digestedTags(db).size).toBe(COMPRESSION_MAX_TAGS_PER_RUN);
+    const synthesized = db.entries.filter(e => JSON.parse(e.tags ?? "[]").includes("synthesized"));
+    for (const e of synthesized) {
+      const tags: string[] = JSON.parse(e.tags);
+      expect(tags.some(t => t.startsWith("volatility:") || t === "stale:as-of")).toBe(false);
+    }
+  });
+
+  /**
+   * The damage, not the predicate.
+   *
+   * A reserved tag admitted in mixed case does not merely waste a digest slot. compressTag
+   * selects the entries it rolls up with `tags LIKE '%"<tag>"%'`, and LIKE ignores ASCII
+   * case, so the candidate `Kind:Semantic` selects every entry tagged `kind:semantic` —
+   * classified entries, which is most of them. Those entries get `rolled-up` and a
+   * `[Digest: …]` suffix appended to their content permanently, drop out of staleness and
+   * future compression, and lose recall weight. Here `holiday-plans` has only nine entries,
+   * far under the ten a digest needs, so nothing about it is a legitimate candidate — and
+   * yet it was the collateral when this regressed.
+   *
+   * The mirror path (src/integrations/mirror.ts) inserts tags without lowercasing, which is
+   * how a mixed-case system tag gets into the table in the first place.
+   */
+  it("does not roll up unrelated entries when a system tag arrives in mixed case", async () => {
+    const old = Date.now() - 200 * 24 * 3600 * 1000;
+    for (let i = 0; i < 11; i++) {
+      db.entries.push({
+        id: `mirror-${i}`, content: `Mirrored note ${i}`, tags: JSON.stringify(["Kind:Semantic"]),
+        source: "notion", created_at: old + i, updated_at: old + i, vector_ids: "[]",
+        recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+      });
+    }
+    for (let i = 0; i < 9; i++) {
+      db.entries.push({
+        id: `holiday-${i}`, content: `Holiday idea ${i}`, tags: JSON.stringify(["holiday-plans", "kind:semantic"]),
+        source: "api", created_at: old + i, updated_at: old + i, vector_ids: "[]",
+        recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+      });
+    }
+
+    await runCron(env);
+
+    for (let i = 0; i < 9; i++) {
+      const row = db.entries.find(e => e.id === `holiday-${i}`)!;
+      expect(JSON.parse(row.tags)).not.toContain("rolled-up");
+      expect(row.content).toBe(`Holiday idea ${i}`); // content never appended to
+    }
+    expect(db.entries.filter(e => JSON.parse(e.tags).includes("synthesized"))).toHaveLength(0);
+  });
+
   it("starts from the top when the cursor cannot be read", async () => {
     seedTags(db, 20);
     const failingKV = {

--- a/test/unit/staleness-pass.test.ts
+++ b/test/unit/staleness-pass.test.ts
@@ -228,21 +228,39 @@ describe("runStalenessPass", () => {
   });
 });
 
-// A free-plan Worker invocation gets 50 subrequests, and every D1 statement spends one.
-// The nightly cron already runs several jobs against that budget, so the staleness pass
-// has to be cheap or it never gets to run at all on a free deployment.
+// A free-plan Worker invocation gets 50 subrequests, and the nightly cron already runs
+// several jobs against that budget, so the staleness pass has to be cheap or it never gets
+// to run at all on a free deployment.
+//
+// What D1 bills is EXECUTIONS, not prepares: run/first/all/exec spend one each, and a
+// batch() spends one however many statements it carries. `billed` counts it that way —
+// counting prepares would price a batch as if it were still one write per row.
 describe("runStalenessPass D1 round-trip cost", () => {
   const SUBREQUEST_BUDGET = 50;
 
-  function countingEnv(db: D1Mock) {
+  function countingEnv(db: D1Mock, overrides: Partial<D1Database> = {}) {
     const prepared: string[] = [];
     const execd: string[] = [];
+    const billed = { run: 0, first: 0, all: 0, exec: 0, batch: 0, batched: [] as number[],
+      get total() { return this.run + this.first + this.all + this.exec + this.batch; } };
+    const wrap = (stmt: any): any => ({
+      bind: (...a: any[]) => wrap(stmt.bind(...a)),
+      run: () => { billed.run++; return stmt.run(); },
+      first: (...a: any[]) => { billed.first++; return stmt.first(...a); },
+      all: () => { billed.all++; return stmt.all(); },
+      __inner: stmt,
+    });
     const DB = {
-      prepare(sql: string) { prepared.push(sql); return db.prepare(sql); },
-      exec(sql: string) { execd.push(sql); return db.exec(sql); },
-      batch: (stmts: any[]) => db.batch(stmts),
+      prepare(sql: string) { prepared.push(sql); return wrap(db.prepare(sql)); },
+      exec(sql: string) { billed.exec++; execd.push(sql); return db.exec(sql); },
+      batch: (stmts: any[]) => {
+        billed.batch++;
+        billed.batched.push(stmts.length);
+        return db.batch(stmts.map((s: any) => s.__inner ?? s));
+      },
+      ...overrides,
     } as unknown as D1Database;
-    return { env: makeTestEnv(db, { DB }), prepared, execd };
+    return { env: makeTestEnv(db, { DB }), prepared, execd, billed };
   }
 
   function seedAged(db: D1Mock, n: number) {
@@ -260,35 +278,89 @@ describe("runStalenessPass D1 round-trip cost", () => {
     }
   }
 
-  it("re-reads no tags it already selected", async () => {
+  it("re-reads no row it already selected", async () => {
     const db = makeTestDb();
     seedAged(db, STALENESS_PASS_LIMIT);
     const { env, prepared } = countingEnv(db);
 
     await runStalenessPass(env, {} as ExecutionContext);
 
-    // The candidate query already returned tags for all 25 rows; a per-row SELECT is
-    // pure duplication. Optimistic concurrency is preserved by the CAS guard instead.
-    expect(prepared.filter(s => s.startsWith("SELECT tags, content FROM entries WHERE id = ?"))).toEqual([]);
+    // The candidate query already returned tags and content for all 25 rows; re-reading
+    // any of them is pure duplication. Optimistic concurrency is preserved by the CAS
+    // guard instead, and the retry re-read below only fires for rows that actually lost.
+    expect(prepared.filter(s => s.startsWith("SELECT id, tags, content FROM entries WHERE id IN"))).toEqual([]);
+    expect(prepared.filter(s => s.includes("FROM entries WHERE id = ?"))).toEqual([]);
     expect(db.entries.filter(e => e.staleness_checked_at != null)).toHaveLength(STALENESS_PASS_LIMIT);
   });
 
-  it("spends nothing per row beyond the write it has to make", async () => {
+  it("spends one subrequest on the whole write set, not one per row", async () => {
     const db = makeTestDb();
     seedAged(db, STALENESS_PASS_LIMIT);
-    const { env, prepared, execd } = countingEnv(db);
+    const { env, prepared, billed } = countingEnv(db);
 
     await runStalenessPass(env, {} as ExecutionContext);
 
-    // One candidate query plus one CAS write per entry — nothing per-row on the read side.
+    // One candidate query plus one batch carrying every CAS — nothing per-row on either
+    // side. The DDL is not counted here because it is memoised across the whole
+    // invocation; see test/unit/cron-subrequest-budget.test.ts, where the 50 actually binds.
     expect(prepared.filter(s => s.includes("COALESCE(updated_at, created_at) <"))).toHaveLength(1);
-    expect(prepared.filter(s => s.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")))
-      .toHaveLength(STALENESS_PASS_LIMIT);
-    // The pass's own cost: 1 candidate query + 25 CAS writes. The DDL is not counted
-    // here because it is memoised across the whole invocation — see the cron budget test
-    // in test/unit/cron-subrequest-budget.test.ts, which is where the 50 actually binds.
-    expect(prepared).toHaveLength(STALENESS_PASS_LIMIT + 1);
-    expect(execd.length).toBeLessThanOrEqual(SUBREQUEST_BUDGET);
+    expect(billed.batched).toEqual([STALENESS_PASS_LIMIT]);
+    expect(billed.run).toBe(0);
+    expect(billed.total).toBe(2);
+    expect(billed.total).toBeLessThanOrEqual(SUBREQUEST_BUDGET);
+    expect(db.entries.filter(e => e.staleness_checked_at != null)).toHaveLength(STALENESS_PASS_LIMIT);
+  });
+
+  // batch() is atomic on D1, so a losing CAS must not look like a failure: it comes back
+  // as changes: 0 with the rest of the batch committed (verified against workerd). What
+  // this pins is the code's half of that contract — that per-statement results are mapped
+  // back to the right rows, so only the loser is retried and the winners are left alone.
+  it("retries only the row whose CAS lost, not the batch", async () => {
+    const db = makeTestDb();
+    seedAged(db, 5);
+    const { env, prepared, billed } = countingEnv(db);
+    const original = db.prepare.bind(db);
+    let flipped = false;
+    (db as any).prepare = (sql: string) => {
+      if (!flipped && sql.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")) {
+        flipped = true; // only job-0's guard is invalidated
+        db.entries[0].tags = '["touched-by-someone-else"]';
+      }
+      return original(sql);
+    };
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    expect(prepared.filter(s => s.startsWith("SELECT id, tags, content FROM entries WHERE id IN"))).toHaveLength(1);
+    expect(billed.batched).toEqual([5, 1]); // the retry batch carries the loser alone
+    for (const row of db.entries) {
+      const tags: string[] = JSON.parse(row.tags);
+      expect(tags).toContain("stale:as-of");
+      expect(row.staleness_checked_at).toBeGreaterThan(0);
+    }
+    expect(JSON.parse(db.entries[0].tags)).toContain("touched-by-someone-else");
+  });
+
+  // A genuine SQL error rolls the whole batch back, so every row in it would keep a NULL
+  // cursor and camp the front of the next run's queue. Degrade to the per-row writes this
+  // replaced rather than lose the run.
+  it("falls back to per-row writes when the batch is rejected", async () => {
+    const db = makeTestDb();
+    seedAged(db, 3);
+    let batches = 0;
+    const { env, billed } = countingEnv(db, {
+      // Reject without applying anything, the way an atomic batch fails.
+      batch: (async () => { batches++; throw new Error("D1_ERROR: no such column"); }) as any,
+    });
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    expect(batches).toBe(1);
+    expect(billed.run).toBe(3); // one write per row, exactly as before the batching
+    for (const row of db.entries) {
+      expect(JSON.parse(row.tags)).toContain("stale:as-of");
+      expect(row.staleness_checked_at).toBeGreaterThan(0);
+    }
   });
 
   // The classification is derived from content, but the tag mutation is a no-op for an
@@ -397,10 +469,168 @@ describe("runStalenessPass D1 round-trip cost", () => {
     expect(db.entries[0].staleness_checked_at).toBeGreaterThan(0);
   });
 
+  // Nothing below strands a row: a row the pass could not settle still leaves the front of
+  // the queue, so a later run gets to it. The failure mode this guards against is a row
+  // that quietly holds one of the 25 slots forever.
+  it("advances the cursor for a row whose tags cannot be classified", async () => {
+    const db = makeTestDb();
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "corrupt",
+      content: "Alice works at Acme Corp",
+      tags: '"not-an-array"', // parses, but not into anything classify can walk
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    const { env } = countingEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    expect(db.entries[0].tags).toBe('"not-an-array"'); // untouched — no verdict was invented
+    expect(db.entries[0].staleness_checked_at).toBeGreaterThan(0);
+  });
+
+  it("advances the cursor when the retry re-read fails", async () => {
+    const db = makeTestDb();
+    seedAged(db, 1);
+    const { env } = countingEnv(db);
+    const original = db.prepare.bind(db);
+    let flipped = false;
+    (db as any).prepare = (sql: string) => {
+      if (sql.startsWith("SELECT id, tags, content FROM entries WHERE id IN")) {
+        return { bind: () => ({ all: async () => { throw new Error("D1_ERROR: connection lost"); } }) };
+      }
+      if (!flipped && sql.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")) {
+        flipped = true;
+        db.entries[0].tags = '["touched-by-someone-else"]';
+      }
+      return original(sql);
+    };
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    expect(db.entries[0].staleness_checked_at).toBeGreaterThan(0);
+  });
+
+  it("advances the cursor for a row whose write fails on the fallback path too", async () => {
+    const db = makeTestDb();
+    seedAged(db, 3);
+    const original = db.prepare.bind(db);
+    (db as any).prepare = (sql: string) => {
+      const stmt = original(sql);
+      const isCas = sql.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?");
+      const isCursor = sql.startsWith("UPDATE entries SET staleness_checked_at = ?");
+      if (!isCas && !isCursor) return stmt;
+      return {
+        bind: (...args: any[]) => {
+          const bound = stmt.bind(...args);
+          // The two statements bind the id in different positions — casWrite is
+          // (tags, now, id, …) and cursorWrite is (now, id) — so a single index would
+          // silently miss one of them and leave this test looking like coverage it is not.
+          const id = isCas ? args[2] : args[1];
+          // Only job-1's CAS ever fails. Its cursor write is deliberately left working,
+          // because the guarantee under test is that the cursor still lands when the
+          // verdict cannot; the test below covers a cursor write that fails.
+          if (!isCas || id !== "job-1") return bound;
+          return { ...bound, run: async () => { throw new Error("D1_ERROR: write failed"); } };
+        },
+      };
+    };
+    const { env } = countingEnv(db, {
+      batch: (async () => { throw new Error("D1_ERROR: batch rejected"); }) as any,
+    });
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const byId = (id: string) => db.entries.find(e => e.id === id)!;
+    expect(JSON.parse(byId("job-0").tags)).toContain("stale:as-of");
+    expect(JSON.parse(byId("job-2").tags)).toContain("stale:as-of");
+    expect(JSON.parse(byId("job-1").tags)).not.toContain("stale:as-of"); // never settled
+    for (const id of ["job-0", "job-1", "job-2"]) {
+      expect(byId(id).staleness_checked_at).toBeGreaterThan(0); // but not stranded either
+    }
+  });
+
+  // A row that short-circuits to a cursor advance — deprecated, or unparseable tags — has
+  // no CAS to lose, so it never enters the retry set. That makes the failure of its one
+  // write the only thing standing between it and a permanently NULL cursor, which would
+  // put it first in every future candidate query forever. One transient failure is enough
+  // to cause it: everything after the first batch here succeeds.
+  it("advances the cursor for a non-retryable row whose first write fails", async () => {
+    const db = makeTestDb();
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "corrupt",
+      content: "Alice works at Acme Corp",
+      tags: '"not-an-array"', // parses, but not into anything classify can walk
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    let writeAttempts = 0;
+    const original = db.prepare.bind(db);
+    (db as any).prepare = (sql: string) => {
+      const stmt = original(sql);
+      if (!sql.startsWith("UPDATE entries SET staleness_checked_at = ?")) return stmt;
+      return {
+        bind: (...args: any[]) => {
+          const bound = stmt.bind(...args);
+          return {
+            ...bound,
+            run: async () => {
+              if (writeAttempts++ === 0) throw new Error("D1_ERROR: transient");
+              return bound.run();
+            },
+          };
+        },
+      };
+    };
+    let batches = 0;
+    const { env } = countingEnv(db, {
+      batch: (async (stmts: any[]) => {
+        if (batches++ === 0) throw new Error("D1_ERROR: batch rejected");
+        return db.batch(stmts.map((s: any) => s.__inner ?? s));
+      }) as any,
+    });
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    expect(writeAttempts).toBeGreaterThan(1); // the failed cursor write was actually retried
+    expect(db.entries[0].staleness_checked_at).toBeGreaterThan(0);
+    expect(db.entries[0].tags).toBe('"not-an-array"'); // still no verdict invented
+  });
+
+  // Deprecated rows are excluded by the candidate query, so the only way one reaches the
+  // pass is by being deprecated after it was selected. It must not be classified: the
+  // cursor moves and nothing else.
+  it("short-circuits a row deprecated mid-pass to a cursor advance", async () => {
+    const db = makeTestDb();
+    seedAged(db, 1);
+    const { env } = countingEnv(db);
+    const original = db.prepare.bind(db);
+    let deprecated = false;
+    (db as any).prepare = (sql: string) => {
+      if (!deprecated && sql.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")) {
+        deprecated = true;
+        db.entries[0].tags = '["status:deprecated"]';
+      }
+      return original(sql);
+    };
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const tags: string[] = JSON.parse(db.entries[0].tags);
+    expect(tags).toEqual(["status:deprecated"]);
+    expect(db.entries[0].staleness_checked_at).toBeGreaterThan(0);
+  });
+
   it("still re-reads tags when a concurrent write makes the CAS lose", async () => {
     const db = makeTestDb();
     seedAged(db, 1);
-    const { env, prepared } = countingEnv(db);
+    const { env, prepared, billed } = countingEnv(db);
     // Flip the row's tags out from under the pass on the first CAS attempt, exactly as a
     // concurrent writer would. The retry must go back to the database for fresh tags.
     const original = db.prepare.bind(db);
@@ -415,7 +645,8 @@ describe("runStalenessPass D1 round-trip cost", () => {
 
     await runStalenessPass(env, {} as ExecutionContext);
 
-    expect(prepared.filter(s => s.startsWith("SELECT tags, content FROM entries WHERE id = ?"))).toHaveLength(1);
+    expect(prepared.filter(s => s.startsWith("SELECT id, tags, content FROM entries WHERE id IN"))).toHaveLength(1);
+    expect(billed.first).toBe(0); // the re-read is the batched one, not a per-row lookup
     const tags: string[] = JSON.parse(db.entries[0].tags);
     expect(tags).toContain("touched-by-someone-else"); // retry built on the fresh tags
     expect(tags).toContain("stale:as-of");


### PR DESCRIPTION
## Summary

All four nightly jobs share one `scheduled()` invocation and therefore one subrequest budget. The staleness pass spent one `UPDATE` per candidate row plus retries — measured at **43 in-cron**, because compression's `markSourcesRolledUp` runs concurrently and invalidates the CAS guards. Closes #278.

Each retry round is now one `batch()` write plus, on losses, one `IN (…)` re-read. A `batch()` is a single subrequest whatever it carries.

| | before | after |
|---|---|---|
| pass alone, 25 candidates | 26 | **2** |
| pass, every CAS losing | 151 | **7** |
| whole `scheduled()` @ 7/30/60 tags | 101 | **42** |
| same, staleness fully contended | 190 | **47** |
| convergence over four runs | `[25,50,60,60]` | unchanged |

Inside the 50-subrequest free-plan budget including the worst case. (42 rather than 41 because #281 added a sixth index to `initializeDatabase`; #282 will take that DDL from 8 statements to 1.)

## Guarantees preserved — re-proved on real workerd D1

Convergence past the first 25 across runs; the CAS guards **content** as well as tags, so a concurrent rewrite cannot commit a verdict about content that no longer exists; a lost CAS re-reads both fields fresh; and the cursor advances even when every attempt loses — **including when the cursor write itself failed**, which was a bug found in review: one transient failure left a row with a NULL cursor, sorting it first on every future run forever.

Verified on real D1 rather than assumed: a losing CAS is `changes: 0` and does **not** roll back siblings; an `UPDATE` writing identical values still reports `changes: 1`, so a null classification is distinguishable from a lost CAS; batch results are 1:1 and positional; a genuine SQL error rolls the whole batch back, and the per-row replay writes each row exactly once.

## The rollup bugs found while measuring

`volatility:` and `stale:as-of` were not excluded from compression candidates, so once the pass began tagging rows those pseudo-tags outranked real topics and ate slots — steady state digested **2 of 4** real topics.

**The bug made the cron look cheaper** — 29 subrequests versus 42 — because two slots did no work. A budget-only assertion would have rewarded it, so the test asserts real topics digested.

Reconciling the SQL fragment with the TS predicate exposed three more of the same class, each **reproduced destroying data on real SQLite** before being fixed:

- **Case.** `compressTag` selects sources with `tags LIKE`, which is case-insensitive, while the guard used `startsWith`. A mirrored `Kind:Semantic` tag conflated with `kind:semantic` and rolled up **9 unrelated `holiday-plans` memories**. Reconciled case-*insensitively*: over-excluding costs one un-digested tag, over-admitting costs up to 50 memories with content permanently mutated.
- **LIKE metacharacters.** The tag is interpolated into a pattern, so a `#q3_planning` hashtag matched `q3-planning` entries and rolled them up **with no user action**. `compressTag("%")` selected 18 unrelated entries.
- **`GET /digest?tag=`** passed an arbitrary string to `compressTag`, guarded only by `isReservedTag`, which by design ignores the bookkeeping tags — so `Duplicate-Candidate` rolled up every `duplicate-candidate` entry. That route had **no test file at all**.

The two read-only sites with the same unescaped pattern are escaped too. Blast radius there is over-broad results rather than mutation, but `?tag=%` silently defeats the filter entirely.

## Placement

`tagLikePattern` / `TAG_LIKE_ESCAPE` live in `src/memory/tag-sql.ts` — Pure, per `ARCHITECTURE.md`'s layer table — since how a tag is encoded and matched in the `tags` column is tag vocabulary, not compression's business. The old placement was legal (domain→domain-peer is permitted) but semantically wrong.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:coverage` — 1197 passing
- [x] `npx wrangler deploy --dry-run`
- [x] Three adversarial validation rounds, each of which found a real defect that is fixed here
- [x] Mutants after the module move: unescaping `search.ts` fails 1, `entry.ts` fails 3, the helper itself fails 8 across all three consumers

## Known, and deliberately out of scope

The row-level filters (`entries.tags NOT LIKE '%"synthesized"%'`, and `SYSTEM_TAG_EXCLUSIONS` in the pass) remain a third, non-derived encoding of "is this a system tag". They over-exclude, so the direction is safe — but that is the next place this class would surface.
