### PR TITLE
perf(db): probe the schema once instead of issuing thirteen blind statements (#282)

### DIFF
--- a/src/db/init.ts
+++ b/src/db/init.ts
@@ -1,10 +1,10 @@
 import type { Env } from "../env";
 
-// The schema work below is idempotent but not free — roughly a dozen D1 statements per
-// call. All four nightly jobs run inside a single scheduled() invocation and therefore
-// share one subrequest budget, and each of them awaits initializeDatabase, so without
-// memoisation the same CREATE/ALTER sequence is paid for three or four times per cron.
-// Memoise per isolate: the first caller does the work, everyone else awaits that promise.
+// The schema work below is idempotent but not free. All four nightly jobs run inside a
+// single scheduled() invocation and therefore share one subrequest budget, and each of
+// them awaits initializeDatabase, so without memoisation the same pass is paid for three
+// or four times per cron. Memoise per isolate: the first caller does the work, everyone
+// else awaits that promise.
 //
 // Deliberately not routed through ensureDbReady (src/runtime/state.ts) — that fires under
 // ctx.waitUntil *without* awaiting, and the nightly jobs must not begin querying before
@@ -35,29 +35,20 @@ export function resetDatabaseInit(): void {
 }
 
 /**
- * The one ALTER failure that is routine rather than a fault: the column was added by an
- * earlier run. Every other error means the schema is not in the shape the code expects.
+ * Tables and indexes, keyed by the name each occupies in sqlite_master. Declaration order
+ * is apply order: a table has to exist before the indexes over it.
  */
-function isDuplicateColumn(e: unknown): boolean {
-  return /duplicate column name/i.test(String((e as { message?: string })?.message ?? e));
-}
-
-// Rejects on any genuine failure. Nothing here may swallow errors: a resolved promise is
-// the signal initializeDatabase memoises, so swallowing would cache a schema that was
-// never applied. The installer creates the D1 database moments before the first request
-// reaches the Worker, so the very first run is exactly when a transient error is most
-// likely — and most damaging, since that run is the one that creates every table.
-async function applySchema(env: Env): Promise<void> {
-  await env.DB.exec(`CREATE TABLE IF NOT EXISTS entries (id TEXT PRIMARY KEY, content TEXT NOT NULL, tags TEXT NOT NULL DEFAULT '[]', source TEXT NOT NULL DEFAULT 'api', created_at INTEGER NOT NULL, vector_ids TEXT NOT NULL DEFAULT '[]')`);
-  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_entries_created_at ON entries(created_at DESC)`);
-  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_entries_source ON entries(source)`);
+const SCHEMA_OBJECTS: Record<string, string> = {
+  entries: `CREATE TABLE IF NOT EXISTS entries (id TEXT PRIMARY KEY, content TEXT NOT NULL, tags TEXT NOT NULL DEFAULT '[]', source TEXT NOT NULL DEFAULT 'api', created_at INTEGER NOT NULL, vector_ids TEXT NOT NULL DEFAULT '[]')`,
+  idx_entries_created_at: `CREATE INDEX IF NOT EXISTS idx_entries_created_at ON entries(created_at DESC)`,
+  idx_entries_source: `CREATE INDEX IF NOT EXISTS idx_entries_source ON entries(source)`,
   // Relationship graph (issue #16). One additive table — never touches existing
   // rows/queries, so old code ignores it and rollback is a no-op. Designed to never
   // need an ALTER: type/provenance are free TEXT validated in code, and metadata is
   // a JSON escape-hatch for any future per-edge attribute.
-  await env.DB.exec(`CREATE TABLE IF NOT EXISTS edges (id TEXT PRIMARY KEY, source_id TEXT NOT NULL, target_id TEXT NOT NULL, type TEXT NOT NULL DEFAULT 'relates_to', weight REAL NOT NULL DEFAULT 0.5, provenance TEXT NOT NULL DEFAULT 'inferred', metadata TEXT NOT NULL DEFAULT '{}', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, UNIQUE(source_id, target_id, type))`);
-  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id)`);
-  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_id)`);
+  edges: `CREATE TABLE IF NOT EXISTS edges (id TEXT PRIMARY KEY, source_id TEXT NOT NULL, target_id TEXT NOT NULL, type TEXT NOT NULL DEFAULT 'relates_to', weight REAL NOT NULL DEFAULT 0.5, provenance TEXT NOT NULL DEFAULT 'inferred', metadata TEXT NOT NULL DEFAULT '{}', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, UNIQUE(source_id, target_id, type))`,
+  idx_edges_source: `CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id)`,
+  idx_edges_target: `CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_id)`,
   // The graph view picks the strongest edges (ORDER BY weight DESC LIMIT n). Without an
   // ordered path to weight SQLite reads the whole table into a temp b-tree and applies the
   // LIMIT afterwards, so on workerd D1 that statement's rows_read is 2 x the edge count and
@@ -75,37 +66,153 @@ async function applySchema(env: Env): Promise<void> {
   // three orders of magnitude on any brain that is not capturing thousands of times a day.
   //
   // Building it on an existing brain costs one row written per edge, once: measured
-  // 200,001 rows written at 200k edges, and 0/0 on every run after that, since IF NOT
-  // EXISTS makes the repeat a genuine no-op. That one statement can exceed the 100k/day
-  // write cap on a brain that is already very large — the same hazard the updated_at note
-  // below describes. It is still the right call, because such a brain is precisely the one
-  // the missing index takes offline every day, and the cost here is paid once rather than
-  // on every /graph. If it ever needs to be avoided, the fix is to build the index out of
-  // band, not to leave the query unindexed.
+  // 200,001 rows written at 200k edges, and 0/0 on every run after that. Before #282 that
+  // no-op was a statement issued on every cold isolate and made free by IF NOT EXISTS;
+  // now the probe means it is not issued at all once the index exists, so the repeat costs
+  // nothing rather than costing a subrequest that does nothing. That one build can exceed
+  // the 100k/day write cap on a brain that is already very large — the same hazard the
+  // updated_at note below describes. It is still the right call, because such a brain is
+  // precisely the one the missing index takes offline every day, and the cost here is paid
+  // once rather than on every /graph. If it ever needs to be avoided, the fix is to build
+  // the index out of band, not to leave the query unindexed.
   //
   // DESC matches the query; SQLite would walk an ASC index backwards just as well, but
   // stating the direction keeps the index and its one caller obviously paired. Bonus: the
   // nightly prune's `weight < ?` becomes a range search, 200,000 rows read down to 60,000.
-  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_weight ON edges(weight DESC)`);
-  for (const alter of [
-    `ALTER TABLE entries ADD COLUMN recall_count INTEGER DEFAULT 0`,
-    `ALTER TABLE entries ADD COLUMN importance_score INTEGER DEFAULT 0`,
-    `ALTER TABLE entries ADD COLUMN contradiction_wins INTEGER DEFAULT 0`,
-    `ALTER TABLE entries ADD COLUMN contradiction_losses INTEGER DEFAULT 0`,
-    // updated_at and staleness_checked_at are deliberately nullable and deliberately NOT
-    // backfilled. Every reader coalesces them to a sensible default — updated_at to
-    // created_at (COALESCE in SQL, ?? in TS), staleness_checked_at to 0 — so on an
-    // existing row a NULL and a written value are indistinguishable downstream, and a
-    // backfill would be a pure no-op that still costs one row written per entry. That is
-    // not free: D1's plan limits row writes per day, and exceeding the cap fails every
-    // query account-wide until 00:00 UTC, so backfilling a large brain on the ordinary
-    // upgrade path is an availability risk that buys nothing. Please do not add one.
-    // test/unit/updated-at-coalesced.test.ts fails if any reader stops coalescing.
-    `ALTER TABLE entries ADD COLUMN updated_at INTEGER`,
-    `ALTER TABLE entries ADD COLUMN staleness_checked_at INTEGER`,
-  ]) {
+  idx_edges_weight: `CREATE INDEX IF NOT EXISTS idx_edges_weight ON edges(weight DESC)`,
+};
+
+/**
+ * Columns added to `entries` after the table shipped, keyed by column name. They arrived
+ * across several releases, so a real brain can hold any prefix of this list — the probe
+ * below is what decides which ones are still owed.
+ */
+const ENTRIES_COLUMNS: Record<string, string> = {
+  recall_count: `ALTER TABLE entries ADD COLUMN recall_count INTEGER DEFAULT 0`,
+  importance_score: `ALTER TABLE entries ADD COLUMN importance_score INTEGER DEFAULT 0`,
+  contradiction_wins: `ALTER TABLE entries ADD COLUMN contradiction_wins INTEGER DEFAULT 0`,
+  contradiction_losses: `ALTER TABLE entries ADD COLUMN contradiction_losses INTEGER DEFAULT 0`,
+  // updated_at and staleness_checked_at are deliberately nullable and deliberately NOT
+  // backfilled. Every reader coalesces them to a sensible default — updated_at to
+  // created_at (COALESCE in SQL, ?? in TS), staleness_checked_at to 0 — so on an
+  // existing row a NULL and a written value are indistinguishable downstream, and a
+  // backfill would be a pure no-op that still costs one row written per entry. That is
+  // not free: D1's plan limits row writes per day, and exceeding the cap fails every
+  // query account-wide until 00:00 UTC, so backfilling a large brain on the ordinary
+  // upgrade path is an availability risk that buys nothing. Please do not add one.
+  // test/unit/updated-at-coalesced.test.ts fails if any reader stops coalescing.
+  updated_at: `ALTER TABLE entries ADD COLUMN updated_at INTEGER`,
+  staleness_checked_at: `ALTER TABLE entries ADD COLUMN staleness_checked_at INTEGER`,
+};
+
+/**
+ * One statement that reports every schema object this file knows how to create: table and
+ * index names out of sqlite_master, and entries' columns out of the table-valued form of
+ * PRAGMA table_info (SQLite rewrites neither list lazily — an ALTER shows up immediately).
+ * `kind` is what stops a name that appears on both sides from being read as the wrong one.
+ *
+ * This exists because the thirteen statements it replaces cost thirteen subrequests to
+ * discover that a migrated brain — which is every brain after its first request — needs
+ * nothing done (#282). Free-plan invocations get 50 subrequests, ensureDbReady spends
+ * them inside the request that triggered it, and GET /graph was already close enough to
+ * the ceiling that a cold isolate pushed it over: 59 against a limit of 50, now 47.
+ *
+ * Cost is one subrequest and one row read per catalogue entry: rows_read = 23 on a fully
+ * migrated brain (our seven objects, plus D1's own bookkeeping table and SQLite's implicit
+ * autoindexes, plus twelve columns) and — the part worth checking rather than assuming —
+ * flat in the number of entries, because neither side of the UNION touches table data.
+ * Both figures measured on real D1 (workerd via Miniflare), not on the mock. It grows by
+ * one row per object added to SCHEMA_OBJECTS, which is the cheap direction: adding a
+ * statement above now costs one row here rather than one subrequest on every cold start.
+ */
+const PROBE_SQL =
+  `SELECT type AS kind, name FROM sqlite_master WHERE type IN ('table','index') ` +
+  `UNION ALL SELECT 'column' AS kind, name FROM pragma_table_info('entries')`;
+
+type ObjectKind = "table" | "index";
+/**
+ * `objects` maps name to kind rather than being a set of names, because SQLite puts tables
+ * and indexes in one namespace: a name can be taken by the wrong kind of thing. Skipping on
+ * the name alone would let a user table called `idx_entries_source` stand in for the index,
+ * which resolves init successfully and silently never creates it.
+ */
+type ExistingSchema = { objects: Map<string, ObjectKind>; columns: Set<string> };
+
+/** Which kind of object a CREATE statement makes, so the probe can be asked about it. */
+const kindOf = (ddl: string): ObjectKind => (ddl.startsWith("CREATE TABLE") ? "table" : "index");
+
+/**
+ * What the database already has, or null if that could not be established.
+ *
+ * The invariant, and the only one that matters here: this may report a thing PRESENT only
+ * if it actually saw it, as the kind it is looking for. Everything else — the probe
+ * throwing, a result shape it does not recognise, a row whose `kind` is not one of the
+ * three, a name that exists as the other kind — resolves towards "missing", so the worst a
+ * confused probe can do is make applySchema pay the old whole-schema cost against DDL
+ * that is idempotent anyway. The opposite error is the one that would hurt: a brand-new
+ * brain talked out of migrating would then serve every request against tables that do not
+ * exist.
+ *
+ * Returning null rather than throwing is not error-swallowing. It does not resolve
+ * initializeDatabase — applySchema still has to apply and still rejects if the DDL fails.
+ * It degrades this isolate to the pre-#282 cost, which is the behaviour that shipped for
+ * every release before this one, and it is what keeps an unsupported PRAGMA on some
+ * future D1 from bricking first-request migration for every new install.
+ */
+async function probeSchema(env: Env): Promise<ExistingSchema | null> {
+  let rows: unknown;
+  try {
+    rows = (await env.DB.prepare(PROBE_SQL).all<{ kind: string; name: string }>())?.results;
+  } catch (e) {
+    console.warn("Schema probe failed; applying the full schema instead:", e);
+    return null;
+  }
+  if (!Array.isArray(rows)) return null;
+
+  const objects = new Map<string, ObjectKind>();
+  const columns = new Set<string>();
+  for (const row of rows as { kind?: unknown; name?: unknown }[]) {
+    if (typeof row?.name !== "string") continue;
+    if (row.kind === "column") columns.add(row.name);
+    else if (row.kind === "table" || row.kind === "index") objects.set(row.name, row.kind);
+  }
+  return { objects, columns };
+}
+
+/**
+ * The one ALTER failure that is routine rather than a fault: the column was added between
+ * the probe and here. That window is small now but not closed — two isolates can cold-start
+ * on the same brain at once, and D1 has no transactional DDL to serialise them — so this
+ * stays as the backstop it was. Every other error means the schema is not in the shape the
+ * code expects.
+ */
+function isDuplicateColumn(e: unknown): boolean {
+  return /duplicate column name/i.test(String((e as { message?: string })?.message ?? e));
+}
+
+// Rejects on any genuine failure. Nothing here may swallow errors: a resolved promise is
+// the signal initializeDatabase memoises, so swallowing would cache a schema that was
+// never applied. The installer creates the D1 database moments before the first request
+// reaches the Worker, so the very first run is exactly when a transient error is most
+// likely — and most damaging, since that run is the one that creates every table.
+//
+// A fully migrated brain leaves here having issued the probe and nothing else. The DDL
+// keeps its IF NOT EXISTS: it costs nothing to keep and it is the same backstop as the
+// duplicate-column tolerance, for the same concurrent-cold-start race.
+async function applySchema(env: Env): Promise<void> {
+  const existing = await probeSchema(env);
+
+  for (const [name, ddl] of Object.entries(SCHEMA_OBJECTS)) {
+    // Kind as well as name: if something else has taken the name, this is not the object
+    // we need and the CREATE has to be issued so SQLite raises the collision, which is
+    // what it did before the probe existed.
+    if (existing?.objects.get(name) === kindOf(ddl)) continue;
+    await env.DB.exec(ddl);
+  }
+  for (const [column, ddl] of Object.entries(ENTRIES_COLUMNS)) {
+    if (existing?.columns.has(column)) continue;
     try {
-      await env.DB.exec(alter);
+      await env.DB.exec(ddl);
     } catch (e) {
       if (!isDuplicateColumn(e)) throw e; // column already exists — anything else is real
     }

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -1,5 +1,15 @@
 import { COMPRESSION_IMPORTANCE_THRESHOLD, COMPRESSION_MIN_RECALL } from "../../src/compression/eligibility";
 
+/** What src/db/init.ts's probe sees on a migrated brain — see the handler in all(). */
+const SCHEMA_PROBE_RESULTS = [
+  ...["entries", "edges"].map(name => ({ kind: "table", name })),
+  ...["idx_entries_created_at", "idx_entries_source", "idx_edges_source", "idx_edges_target",
+    "idx_edges_weight"].map(name => ({ kind: "index", name })),
+  ...["id", "content", "tags", "source", "created_at", "vector_ids", "recall_count",
+    "importance_score", "contradiction_wins", "contradiction_losses", "updated_at",
+    "staleness_checked_at"].map(name => ({ kind: "column", name })),
+];
+
 export class D1Mock {
   entries: any[] = [];
   edges: any[] = [];
@@ -247,6 +257,17 @@ export class D1Mock {
         return null;
       },
       async all() {
+        if (s.startsWith("SELECT type AS kind, name FROM sqlite_master")) {
+          // src/db/init.ts's schema probe. This mock stands in for a deployed brain, and
+          // a deployed brain is migrated — its rows carry every ALTER column below — so
+          // the honest answer is "all present", which is also what makes the mock report
+          // the real cold-start cost of a cold isolate rather than a fresh install's.
+          // The names are spelled out rather than imported from init.ts on purpose: a
+          // mock that derives its answer from the code under test can only ever agree
+          // with it. Fresh and partially-migrated brains are covered against real SQLite
+          // in test/unit/db-init.test.ts.
+          return { results: SCHEMA_PROBE_RESULTS };
+        }
         if (
           s === "SELECT id FROM entries WHERE tags LIKE ?" ||
           s === "SELECT id, vector_ids FROM entries WHERE tags LIKE ?" ||

--- a/test/helpers/sqlite-d1.ts
+++ b/test/helpers/sqlite-d1.ts
@@ -12,8 +12,16 @@
  * for real against the project's own `db/schema.sql`. A wrong comparison then
  * fails the test instead of passing a string match.
  *
+ * The schema migration in `src/db/init.ts` is the other case, and the sharper
+ * one: `d1-mock`'s `exec()` is a no-op, so it cannot express "that column is
+ * already there" or "that table is not" — the two facts the migration now reads
+ * before it writes. Against real SQLite a probe that misreports an empty
+ * database as migrated leaves the tables uncreated and the next statement fails,
+ * which is exactly the regression worth catching. Pass `{ schema: false }` for a
+ * database with nothing in it at all.
+ *
  * Only the surface the code under test uses is implemented — `prepare`, `bind`,
- * `all`, `first`, `run`. Reach for `d1-mock` for everything else.
+ * `all`, `first`, `run`, `exec`. Reach for `d1-mock` for everything else.
  */
 import { DatabaseSync } from "node:sqlite";
 import { readFileSync } from "node:fs";
@@ -51,6 +59,13 @@ class SqliteStatement {
 export interface SqliteD1 {
   /** Shaped like `env.DB`. */
   db: { prepare(sql: string): SqliteStatement; exec(sql: string): Promise<void> };
+  /**
+   * One entry per D1 call made through `db` — which is one entry per subrequest,
+   * since `prepare()` here is only ever followed by a single execution.
+   */
+  issued: string[];
+  /** Column names currently on `entries`, straight from SQLite. */
+  columns(): string[];
   /** Insert an entry directly, bypassing the capture pipeline. */
   seed(entry: {
     id: string;
@@ -72,11 +87,11 @@ export interface SqliteD1 {
  * column rename breaks these tests, which is the point — the migration's SQL
  * names columns.
  */
-export function makeSqliteD1(): SqliteD1 {
+export function makeSqliteD1({ schema: applySchema = true }: { schema?: boolean } = {}): SqliteD1 {
   const raw = new DatabaseSync(":memory:");
   // The schema uses D1-flavoured DDL; execute it statement by statement so one
   // unsupported pragma cannot take the whole file down silently.
-  const schema = readFileSync(SCHEMA, "utf8");
+  const schema = applySchema ? readFileSync(SCHEMA, "utf8") : "";
   for (const statement of schema.split(";")) {
     // Strip comment lines rather than skipping any chunk that starts with one:
     // splitting on ";" leaves the preceding comment attached to the statement
@@ -98,14 +113,27 @@ export function makeSqliteD1(): SqliteD1 {
     }
   }
 
+  const issued: string[] = [];
+
   return {
+    issued,
     db: {
-      prepare: (sql: string) => new SqliteStatement(raw, sql),
+      prepare: (sql: string) => {
+        issued.push(sql);
+        return new SqliteStatement(raw, sql);
+      },
       // Present so a whole-Worker request against this facade runs the real
       // initializeDatabase path rather than failing on a missing method. The
       // schema is already applied above; that DDL is idempotent, and the ALTERs
       // raise the same "duplicate column name" D1 does, which init.ts expects.
-      exec: async (sql: string) => { raw.exec(sql); },
+      exec: async (sql: string) => {
+        issued.push(sql);
+        raw.exec(sql);
+      },
+    },
+    columns() {
+      return (raw.prepare(`SELECT name FROM pragma_table_info('entries')`).all() as { name: string }[])
+        .map(r => r.name);
     },
     seed({ id, content, createdAt, tags = [], source = "api", vectorIds = [] }) {
       raw

--- a/test/unit/cron-subrequest-budget.test.ts
+++ b/test/unit/cron-subrequest-budget.test.ts
@@ -1,8 +1,13 @@
 /**
  * All four nightly jobs are fired from a single scheduled() invocation (src/index.ts),
  * so they share ONE subrequest budget — 50 on the free plan. Each of them awaits
- * initializeDatabase, so before it was memoised the same dozen DDL statements were paid
+ * initializeDatabase, so before it was memoised the same thirteen DDL statements were paid
  * for once per job, and the pass that runs last could find the budget already spent.
+ *
+ * Memoisation cut that to thirteen; #282 cut the thirteen to a single catalogue read
+ * on any brain that is already migrated, which every brain is after its first request.
+ * The D1 mock answers the probe as a migrated brain, which is what a nightly cron always
+ * runs against — a brain with no schema has no entries to compress.
  *
  * This measures the whole invocation rather than any one job, because per-job budget
  * assertions are not true in situ.
@@ -39,7 +44,7 @@ describe("nightly cron D1 subrequest cost", () => {
     vi.restoreAllMocks();
   });
 
-  it("pays for the schema DDL once per invocation, not once per job", async () => {
+  it("probes the schema once per invocation, not once per job, and issues no DDL", async () => {
     const db = makeTestDb();
     const old = Date.now() - STALENESS_AGE_MS - 86400000;
     for (let i = 0; i < 25; i++) {
@@ -53,8 +58,10 @@ describe("nightly cron D1 subrequest cost", () => {
     await runCron(env);
 
     // The signature statement of initializeDatabase, once for the whole cron.
-    const ddl = statements.filter(s => s.startsWith("CREATE TABLE IF NOT EXISTS entries"));
-    expect(ddl).toHaveLength(1);
+    expect(statements.filter(s => s.startsWith("SELECT type AS kind, name FROM sqlite_master"))).toHaveLength(1);
+    // #282: the schema is already there, and the whole point is that finding that out no
+    // longer costs a CREATE and an ALTER per object.
+    expect(statements.filter(s => /^(CREATE|ALTER)\b/.test(s))).toEqual([]);
   });
 
   it("keeps a whole nightly run inside the free-plan subrequest budget", async () => {

--- a/test/unit/db-init.test.ts
+++ b/test/unit/db-init.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { initializeDatabase, resetDatabaseInit } from "../../src/db/init";
 import { makeTestEnv } from "../helpers/make-env";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
 
 const MIGRATION: [column: string, alter: string][] = [
   ["recall_count", `ALTER TABLE entries ADD COLUMN recall_count INTEGER DEFAULT 0`],
@@ -11,17 +12,27 @@ const MIGRATION: [column: string, alter: string][] = [
   ["staleness_checked_at", `ALTER TABLE entries ADD COLUMN staleness_checked_at INTEGER`],
 ];
 const ALL_COLUMNS = MIGRATION.map(([column]) => column);
+const ALL_OBJECTS = ["entries", "idx_entries_created_at", "idx_entries_source", "edges", "idx_edges_source", "idx_edges_target", "idx_edges_weight"];
+const BASE_COLUMNS = ["id", "content", "tags", "source", "created_at", "vector_ids"];
+
+/** The catalogue read that opens every init. Spelled out so tests can exclude it by name. */
+const PROBE = /^SELECT type AS kind, name FROM sqlite_master\b/;
 
 type Row = { created_at: number; updated_at?: number | null };
 
 // D1Mock's exec() never throws, so it cannot express "this column already exists".
 // This stand-in models what the migration path turns on, verified against real workerd
-// D1 via Miniflare: D1 rejects an ALTER for a column the table already has, and a column
-// added to a populated table reads NULL on every pre-existing row. Every statement is
-// recorded so a test can assert what a cold start costs — ALTERs are recorded even when
-// they go on to throw.
-function makeMigrationDb(existingColumns: string[] = [], rows: Row[] = []) {
-  const columns = new Set(existingColumns);
+// D1 via Miniflare: D1 rejects an ALTER for a column the table already has, a column
+// added to a populated table reads NULL on every pre-existing row, and the probe reports
+// exactly the tables, indexes and columns that are there. Every statement is recorded so
+// a test can assert what a cold start costs — ALTERs are recorded even when they throw.
+//
+// `objects` defaults from the columns: a brain carrying migration columns necessarily has
+// the table they sit on, and a brain carrying none is the fresh case where nothing exists.
+// Pass it explicitly for anything in between.
+function makeMigrationDb(existingColumns: string[] = [], rows: Row[] = [], existingObjects?: string[]) {
+  const columns = new Set(existingColumns.length ? [...BASE_COLUMNS, ...existingColumns] : []);
+  const objects = new Set(existingObjects ?? (existingColumns.length ? ALL_OBJECTS : []));
   const execd: string[] = [];
   const prepared: string[] = [];
 
@@ -33,6 +44,12 @@ function makeMigrationDb(existingColumns: string[] = [], rows: Row[] = []) {
         if (columns.has(added[1])) throw new Error(`D1_EXEC_ERROR: duplicate column name: ${added[1]}`);
         columns.add(added[1]);
         if (added[1] === "updated_at") rows.forEach(r => { r.updated_at = null; });
+        return;
+      }
+      const created = sql.match(/CREATE (?:TABLE|INDEX) IF NOT EXISTS (\w+)/);
+      if (created) {
+        objects.add(created[1]);
+        if (created[1] === "entries") BASE_COLUMNS.forEach(c => columns.add(c));
       }
     },
     prepare(sql: string) {
@@ -40,7 +57,14 @@ function makeMigrationDb(existingColumns: string[] = [], rows: Row[] = []) {
       const make = (args: unknown[]) => ({
         bind: (...next: unknown[]) => make(next),
         first: async () => null,
-        all: async () => ({ results: [] }),
+        all: async () => ({
+          results: PROBE.test(sql)
+            ? [
+              ...[...objects].map(name => ({ kind: name.startsWith("idx_") ? "index" : "table", name })),
+              ...[...columns].map(name => ({ kind: "column", name })),
+            ]
+            : [],
+        }),
         run: async () => ({ meta: { changes: 0 } }),
       });
       return make([]);
@@ -51,8 +75,9 @@ function makeMigrationDb(existingColumns: string[] = [], rows: Row[] = []) {
 }
 
 const rowsAged = (n: number): Row[] => Array.from({ length: n }, (_, i) => ({ created_at: 1000 + i }));
+/** Statements that touch entry *rows*. The probe reads the catalogue, not the table. */
 const touchesEntries = (statements: string[]) =>
-  statements.filter(s => /\bentries\b/.test(s) && !/^(CREATE|ALTER)\b/.test(s));
+  statements.filter(s => /\bentries\b/.test(s) && !/^(CREATE|ALTER)\b/.test(s) && !PROBE.test(s));
 
 describe("initializeDatabase updated_at migration", () => {
   // initializeDatabase memoises per isolate, so each case needs a clean slate.
@@ -64,54 +89,82 @@ describe("initializeDatabase updated_at migration", () => {
   // unindexed column (D1 bills rows_read); a backfill would be one row written per entry
   // (D1 caps rows written per day) for a value no reader can distinguish from NULL.
 
-  it("issues no query at all on a fresh, unmigrated brain", async () => {
+  it("issues no entry-row query at all on a fresh, unmigrated brain", async () => {
     const { env, execd, prepared, rows } = makeMigrationDb([], rowsAged(3));
 
     await initializeDatabase(env);
 
-    expect(prepared).toEqual([]);
+    expect(prepared.filter(s => !PROBE.test(s))).toEqual([]);
     expect(touchesEntries(execd)).toEqual([]);
     // The rows are left NULL on purpose — readers coalesce updated_at to created_at.
     expect(rows.every(r => r.updated_at === null)).toBe(true);
   });
 
-  it("issues no query at all on an already-migrated brain", async () => {
+  it("issues no entry-row query at all on an already-migrated brain", async () => {
     const { env, execd, prepared } = makeMigrationDb(ALL_COLUMNS, [{ created_at: 1000, updated_at: 1000 }]);
 
     await initializeDatabase(env);
 
-    expect(prepared).toEqual([]);
+    expect(prepared.filter(s => !PROBE.test(s))).toEqual([]);
     expect(touchesEntries(execd)).toEqual([]);
   });
 
-  it("adds nothing on later cold starts", async () => {
-    const { env, execd, prepared } = makeMigrationDb([], rowsAged(1));
+  // #282. Twelve blind statements were spent per cold isolate discovering that a migrated
+  // brain — every brain after its first request — needed none of them, out of a 50-per-
+  // invocation free-plan budget that ensureDbReady spends inside the triggering request.
+  describe("cost on a migrated brain", () => {
+    it("costs one statement and issues no DDL when the schema is already complete", async () => {
+      const { env, execd, prepared } = makeMigrationDb(ALL_COLUMNS, rowsAged(1));
 
-    // Each reset stands in for a fresh isolate, which is what a cold start actually is.
-    await initializeDatabase(env);
-    const afterFirst = execd.length;
-    resetDatabaseInit();
-    await initializeDatabase(env);
-    resetDatabaseInit();
-    await initializeDatabase(env);
+      await initializeDatabase(env);
 
-    expect(prepared).toEqual([]);
-    expect(execd).toHaveLength(afterFirst * 3); // same DDL each time, nothing extra
-    expect(touchesEntries(execd)).toEqual([]);
+      expect(execd).toEqual([]);
+      expect(prepared).toHaveLength(1);
+      expect(prepared[0]).toMatch(PROBE);
+    });
+
+    it("costs one statement on every cold start after the first", async () => {
+      const { env, execd, prepared } = makeMigrationDb([], rowsAged(1));
+
+      // Each reset stands in for a fresh isolate, which is what a cold start actually is.
+      await initializeDatabase(env);
+      const migrated = execd.length;
+      resetDatabaseInit();
+      await initializeDatabase(env);
+      resetDatabaseInit();
+      await initializeDatabase(env);
+
+      expect(migrated).toBe(13); // the one-off cost of creating a brain: 7 objects + 6 columns
+      expect(execd).toHaveLength(migrated); // the two later cold starts added nothing
+      expect(prepared).toHaveLength(3); // one probe each, and nothing else
+      expect(touchesEntries(execd)).toEqual([]);
+    });
+
+    it("issues only the ALTERs a partially-migrated brain is missing", async () => {
+      const present = ["recall_count", "importance_score"];
+      const { env, execd, prepared } = makeMigrationDb(present, rowsAged(1));
+
+      await initializeDatabase(env);
+
+      const missing = MIGRATION.filter(([column]) => !present.includes(column));
+      expect(execd).toEqual(missing.map(([, alter]) => alter));
+      expect(prepared).toHaveLength(1);
+    });
   });
 
   // All four nightly jobs await initializeDatabase inside one scheduled() invocation,
-  // sharing a single subrequest budget. Without memoisation the DDL is paid for once per
+  // sharing a single subrequest budget. Without memoisation the work is paid for once per
   // job. Callers must still await real completion — ensureDbReady's waitUntil does not.
   describe("memoisation", () => {
     it("runs the schema work once per isolate no matter how many callers await it", async () => {
-      const { env, execd } = makeMigrationDb([], rowsAged(1));
+      const { env, execd, prepared } = makeMigrationDb([], rowsAged(1));
 
       await initializeDatabase(env);
       const once = execd.length;
       await Promise.all([initializeDatabase(env), initializeDatabase(env), initializeDatabase(env)]);
 
       expect(execd).toHaveLength(once);
+      expect(prepared).toHaveLength(1); // not even the probe is re-issued
     });
 
     it("shares one in-flight promise across concurrent callers", async () => {
@@ -125,14 +178,13 @@ describe("initializeDatabase updated_at migration", () => {
     it("resetDatabaseInit clears the memo so a later call redoes the work", async () => {
       // Named for what it actually exercises — the test seam, not the failure path. The
       // rejection tests below are the ones that cover failure.
-      const { env, execd } = makeMigrationDb([], rowsAged(1));
+      const { env, prepared } = makeMigrationDb([], rowsAged(1));
 
       await initializeDatabase(env);
-      const once = execd.length;
       resetDatabaseInit();
       await initializeDatabase(env);
 
-      expect(execd).toHaveLength(once * 2);
+      expect(prepared).toHaveLength(2); // the second call went back to the database
     });
   });
 
@@ -142,15 +194,19 @@ describe("initializeDatabase updated_at migration", () => {
   // failure is still retryable. Most likely trigger is a brand-new brain, where the very
   // first request must create every table against a D1 database made seconds earlier.
   describe("failure is not latched", () => {
-    /** DB whose exec fails until `failing` is cleared. */
+    beforeEach(() => { vi.spyOn(console, "warn").mockImplementation(() => {}); });
+    afterEach(() => { vi.restoreAllMocks(); });
+
+    /** DB whose statements all fail until `failing` is cleared. */
     function flakyDb() {
       const state = { failing: true, execd: [] as string[] };
+      const fail = () => { throw new Error("D1_ERROR: Network connection lost."); };
       const DB = {
         async exec(sql: string) {
-          if (state.failing) throw new Error("D1_ERROR: Network connection lost.");
+          if (state.failing) fail();
           state.execd.push(sql);
         },
-        prepare: () => { throw new Error("unexpected prepare"); },
+        prepare: () => ({ all: async () => (state.failing ? fail() : { results: [] }) }),
       } as unknown as D1Database;
       return { state, env: makeTestEnv(undefined, { DB }) };
     }
@@ -180,7 +236,7 @@ describe("initializeDatabase updated_at migration", () => {
           if (failEdges && sql.includes("CREATE TABLE IF NOT EXISTS edges")) throw new Error("D1_ERROR: Network connection lost.");
           execd.push(sql);
         },
-        prepare: () => { throw new Error("unexpected prepare"); },
+        prepare: () => ({ all: async () => ({ results: [] }) }),
       } as unknown as D1Database;
       const env = makeTestEnv(undefined, { DB });
 
@@ -193,9 +249,17 @@ describe("initializeDatabase updated_at migration", () => {
     });
 
     it("still swallows the routine duplicate-column ALTER error", async () => {
-      // The one expected failure: every run after the first. It must NOT reject.
-      const { env } = makeMigrationDb(ALL_COLUMNS, []);
-      await expect(initializeDatabase(env)).resolves.toBeUndefined();
+      // The probe closes the ordinary case, but not the race: two isolates can cold-start
+      // on the same brain at once, both read a schema without `updated_at`, and both try
+      // to add it. The loser must not reject.
+      const DB = {
+        async exec(sql: string) {
+          if (sql.startsWith("ALTER TABLE")) throw new Error("D1_EXEC_ERROR: duplicate column name: updated_at");
+        },
+        prepare: () => ({ all: async () => ({ results: [] }) }),
+      } as unknown as D1Database;
+
+      await expect(initializeDatabase(makeTestEnv(undefined, { DB }))).resolves.toBeUndefined();
     });
 
     it("rejects on an ALTER failure that is not duplicate-column", async () => {
@@ -205,7 +269,7 @@ describe("initializeDatabase updated_at migration", () => {
             throw new Error("D1_ERROR: database is locked");
           }
         },
-        prepare: () => { throw new Error("unexpected prepare"); },
+        prepare: () => ({ all: async () => ({ results: [] }) }),
       } as unknown as D1Database;
 
       await expect(initializeDatabase(makeTestEnv(undefined, { DB }))).rejects.toThrow(/database is locked/);
@@ -217,8 +281,11 @@ describe("initializeDatabase updated_at migration", () => {
 
     await initializeDatabase(env);
 
-    for (const [, alter] of MIGRATION) expect(execd).toContain(alter);
-    expect(prepared).toEqual([]);
+    for (const [column, alter] of MIGRATION) {
+      if (["recall_count", "importance_score"].includes(column)) continue;
+      expect(execd).toContain(alter);
+    }
+    expect(prepared.filter(s => !PROBE.test(s))).toEqual([]);
   });
 
   // The backfill this replaced wrote one row per entry. On a 50,000-entry brain that was
@@ -233,5 +300,219 @@ describe("initializeDatabase updated_at migration", () => {
     expect(all.filter(s => /UPDATE\s+entries/i.test(s))).toEqual([]);
     expect(all.filter(s => /updated_at IS NULL/i.test(s))).toEqual([]);
     expect(rows.filter(r => r.updated_at == null)).toHaveLength(50_000);
+  });
+});
+
+/**
+ * The probe against a real database.
+ *
+ * The failure that would actually hurt is a probe that reports a schema as PRESENT when
+ * it is not: the DDL is skipped, initializeDatabase resolves, and a brand-new brain
+ * serves every subsequent request against tables that were never created. No mock can
+ * catch that — d1-mock's exec() is a no-op and the stand-in above answers its own probe —
+ * so these run the real statements against real SQLite, which is what D1 is.
+ */
+describe("initializeDatabase against real SQLite", () => {
+  let d1: SqliteD1;
+  const envFor = (sqlite: SqliteD1) => makeTestEnv(undefined, { DB: sqlite.db as unknown as D1Database });
+
+  beforeEach(resetDatabaseInit);
+  afterEach(() => { d1?.close(); vi.restoreAllMocks(); });
+
+  async function objectNames(sqlite: SqliteD1): Promise<string[]> {
+    const { results } = await sqlite.db
+      .prepare(`SELECT name FROM sqlite_master WHERE type IN ('table','index')`)
+      .all() as { results: { name: string }[] };
+    return results.map(r => r.name);
+  }
+
+  it("migrates a genuinely empty database", async () => {
+    d1 = makeSqliteD1({ schema: false });
+    expect(await objectNames(d1)).toEqual([]); // nothing at all, the state a new brain is in
+
+    await initializeDatabase(envFor(d1));
+
+    for (const name of ALL_OBJECTS) expect(await objectNames(d1)).toContain(name);
+    expect(d1.columns()).toEqual([...BASE_COLUMNS, ...ALL_COLUMNS]);
+  });
+
+  it("leaves a migrated database usable, not merely present", async () => {
+    // The tables existing is not the claim worth making — the claim is that the columns
+    // every reader selects are really there. A missing ALTER passes an existence check
+    // and then fails at the first SELECT.
+    d1 = makeSqliteD1({ schema: false });
+    await initializeDatabase(envFor(d1));
+
+    await d1.db
+      .prepare(`INSERT INTO entries (id, content, tags, source, created_at, vector_ids) VALUES (?, ?, '[]', 'api', ?, '[]')`)
+      .bind("e1", "hello", 1000)
+      .run();
+    const { results } = await d1.db
+      .prepare(`SELECT id, COALESCE(updated_at, created_at) AS updated_at, staleness_checked_at, recall_count, importance_score, contradiction_wins, contradiction_losses FROM entries`)
+      .all() as { results: Record<string, unknown>[] };
+
+    expect(results).toEqual([{
+      id: "e1", updated_at: 1000, staleness_checked_at: null,
+      recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+    }]);
+  });
+
+  it("costs one statement on an already-migrated brain", async () => {
+    d1 = makeSqliteD1({ schema: false });
+    await initializeDatabase(envFor(d1));
+    const cold = d1.issued.length;
+    d1.issued.length = 0;
+
+    resetDatabaseInit(); // a second cold isolate against the brain the first one migrated
+    await initializeDatabase(envFor(d1));
+
+    expect(cold).toBe(14); // one probe, then the thirteen statements a new brain needs
+    expect(d1.issued).toHaveLength(1);
+    expect(d1.issued[0]).toMatch(PROBE);
+  });
+
+  it("adds only what a partially-migrated brain is missing", async () => {
+    // db/schema.sql is a real intermediate state: it ships entries with four of the six
+    // ALTER columns, so a brain installed from it is owed updated_at and
+    // staleness_checked_at and nothing else.
+    d1 = makeSqliteD1();
+    expect(d1.columns()).not.toContain("updated_at");
+
+    await initializeDatabase(envFor(d1));
+
+    expect(d1.issued.filter(s => /^ALTER/.test(s))).toEqual([
+      `ALTER TABLE entries ADD COLUMN updated_at INTEGER`,
+      `ALTER TABLE entries ADD COLUMN staleness_checked_at INTEGER`,
+    ]);
+    expect(d1.issued.filter(s => /^CREATE/.test(s))).toEqual([]);
+    expect(d1.columns()).toEqual([...BASE_COLUMNS, ...ALL_COLUMNS]);
+  });
+
+  it("adds only the weight index to a brain migrated before #281", async () => {
+    // The newest object, and the one most likely to be the only thing a brain is missing:
+    // every install that migrated before #281 has the complete schema apart from this.
+    d1 = makeSqliteD1({ schema: false });
+    await initializeDatabase(envFor(d1));
+    await d1.db.exec(`DROP INDEX idx_edges_weight`);
+    resetDatabaseInit();
+    d1.issued.length = 0;
+
+    await initializeDatabase(envFor(d1));
+
+    expect(d1.issued).toEqual([
+      expect.stringMatching(PROBE),
+      `CREATE INDEX IF NOT EXISTS idx_edges_weight ON edges(weight DESC)`,
+    ]);
+    expect(await objectNames(d1)).toContain("idx_edges_weight");
+  });
+
+  it("adds the edges table to a brain that predates it", async () => {
+    // The other real intermediate state (issue #16 added edges to brains that already had
+    // entries). Tables and indexes are probed independently of columns, so this is not
+    // the same path as the ALTERs above.
+    d1 = makeSqliteD1({ schema: false });
+    await d1.db.exec(`CREATE TABLE entries (id TEXT PRIMARY KEY, content TEXT NOT NULL, tags TEXT NOT NULL DEFAULT '[]', source TEXT NOT NULL DEFAULT 'api', created_at INTEGER NOT NULL, vector_ids TEXT NOT NULL DEFAULT '[]')`);
+    d1.issued.length = 0;
+
+    await initializeDatabase(envFor(d1));
+
+    expect(await objectNames(d1)).toContain("edges");
+    expect(d1.issued.filter(s => s.startsWith("CREATE TABLE IF NOT EXISTS entries"))).toEqual([]);
+    expect(d1.columns()).toEqual([...BASE_COLUMNS, ...ALL_COLUMNS]);
+  });
+
+  it("leaves existing rows untouched when it adds a column", async () => {
+    d1 = makeSqliteD1();
+    d1.seed({ id: "old", content: "written before the migration", createdAt: 1000 });
+
+    await initializeDatabase(envFor(d1));
+
+    // Not backfilled: readers coalesce updated_at to created_at, and writing it would
+    // cost one row written per entry for a value nothing downstream can distinguish.
+    expect(d1.rows()).toEqual([expect.objectContaining({
+      id: "old", content: "written before the migration", created_at: 1000,
+      updated_at: null, staleness_checked_at: null,
+    })]);
+  });
+
+  // Degrading to the pre-#282 cost is the acceptable failure; skipping the DDL is not.
+  // A probe may only report a thing PRESENT if it actually saw it, so every way of not
+  // seeing it has to end in the statement being issued. Each of these would otherwise
+  // leave a brand-new brain resolving initializeDatabase against tables that do not exist.
+  describe("a probe that cannot be trusted still migrates", () => {
+    /** Real SQLite for the DDL, `probe` for what the probe appears to return. */
+    function dbWhoseProbe(probe: () => unknown) {
+      return {
+        prepare: (sql: string) => (PROBE.test(sql) ? { all: async () => probe() } : d1.db.prepare(sql)),
+        exec: (sql: string) => d1.db.exec(sql),
+      } as unknown as D1Database;
+    }
+
+    async function expectFullyMigrated() {
+      for (const name of ALL_OBJECTS) expect(await objectNames(d1)).toContain(name);
+      expect(d1.columns()).toEqual([...BASE_COLUMNS, ...ALL_COLUMNS]);
+    }
+
+    beforeEach(() => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      d1 = makeSqliteD1({ schema: false });
+    });
+
+    it("applies the whole schema when the probe throws", async () => {
+      // The guard against the probe's one statement being unsupported on some future D1
+      // and taking first-request migration down with it.
+      await initializeDatabase(makeTestEnv(undefined, {
+        DB: dbWhoseProbe(() => { throw new Error("D1_ERROR: unsupported statement"); }),
+      }));
+
+      await expectFullyMigrated();
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("applies the whole schema when the probe returns a shape it cannot read", async () => {
+      await initializeDatabase(makeTestEnv(undefined, { DB: dbWhoseProbe(() => ({ success: true })) }));
+
+      await expectFullyMigrated();
+    });
+
+    it("does not accept a name held by the wrong kind of object", async () => {
+      // SQLite puts tables and indexes in one namespace. A user table that has taken an
+      // index's name is not that index, and matching on the name alone would resolve init
+      // having silently never created it. Issuing the CREATE gets SQLite's collision
+      // error instead — which is what happened before the probe existed.
+      await d1.db.exec(`CREATE TABLE idx_entries_source (id TEXT)`);
+
+      await expect(initializeDatabase(makeTestEnv(undefined, { DB: d1.db as unknown as D1Database })))
+        .rejects.toThrow(/already a table named idx_entries_source/);
+    });
+
+    it("treats a row it cannot classify as missing rather than present", async () => {
+      // `kind` is what separates a column from a table. A row that has lost it names
+      // something, but nothing that licenses skipping a statement.
+      await initializeDatabase(makeTestEnv(undefined, {
+        DB: dbWhoseProbe(() => ({
+          results: [
+            ...ALL_OBJECTS.map(name => ({ name })), // no kind
+            ...ALL_COLUMNS.map(name => ({ kind: "column", name: { toString: () => name } })), // not a string
+            { kind: "trigger", name: "entries" },
+          ],
+        })),
+      }));
+
+      await expectFullyMigrated();
+    });
+  });
+
+  it("survives two isolates migrating the same brain at once", async () => {
+    // Both probe an unmigrated brain, both decide every ALTER is owed, and the loser gets
+    // `duplicate column name` — the race the tolerance in applySchema exists for. D1 has
+    // no transactional DDL to serialise them.
+    d1 = makeSqliteD1({ schema: false });
+    const first = initializeDatabase(envFor(d1));
+    resetDatabaseInit(); // the second isolate has its own memo
+    const second = initializeDatabase(envFor(d1));
+
+    await expect(Promise.all([first, second])).resolves.toBeDefined();
+    expect(d1.columns()).toEqual([...BASE_COLUMNS, ...ALL_COLUMNS]);
   });
 });

--- a/test/unit/staleness-pass.test.ts
+++ b/test/unit/staleness-pass.test.ts
@@ -234,11 +234,19 @@ describe("runStalenessPass", () => {
 describe("runStalenessPass D1 round-trip cost", () => {
   const SUBREQUEST_BUDGET = 50;
 
+  /**
+   * `prepared` is the pass's own statements. initializeDatabase's schema probe is dropped
+   * because it is not per-row cost and it is memoised across the whole invocation, so
+   * counting it would make these assertions depend on whether some earlier test in the
+   * file happened to warm the memo first — which is exactly what it did before this
+   * filter existed. The cron budget test is where init's cost is measured.
+   */
   function countingEnv(db: D1Mock) {
     const prepared: string[] = [];
     const execd: string[] = [];
+    const isSchemaProbe = (sql: string) => sql.startsWith("SELECT type AS kind, name FROM sqlite_master");
     const DB = {
-      prepare(sql: string) { prepared.push(sql); return db.prepare(sql); },
+      prepare(sql: string) { if (!isSchemaProbe(sql)) prepared.push(sql); return db.prepare(sql); },
       exec(sql: string) { execd.push(sql); return db.exec(sql); },
       batch: (stmts: any[]) => db.batch(stmts),
     } as unknown as D1Database;
@@ -284,9 +292,10 @@ describe("runStalenessPass D1 round-trip cost", () => {
     expect(prepared.filter(s => s.includes("COALESCE(updated_at, created_at) <"))).toHaveLength(1);
     expect(prepared.filter(s => s.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")))
       .toHaveLength(STALENESS_PASS_LIMIT);
-    // The pass's own cost: 1 candidate query + 25 CAS writes. The DDL is not counted
-    // here because it is memoised across the whole invocation — see the cron budget test
-    // in test/unit/cron-subrequest-budget.test.ts, which is where the 50 actually binds.
+    // The pass's own cost: 1 candidate query + 25 CAS writes. Schema init is not counted
+    // here — countingEnv drops its probe and its DDL is memoised across the whole
+    // invocation. See the cron budget test in test/unit/cron-subrequest-budget.test.ts,
+    // which is where the 50 actually binds.
     expect(prepared).toHaveLength(STALENESS_PASS_LIMIT + 1);
     expect(execd.length).toBeLessThanOrEqual(SUBREQUEST_BUDGET);
   });


### PR DESCRIPTION
## Summary

`initializeDatabase` issued every `CREATE` and `ALTER` unconditionally on each cold isolate, with the `ALTER`s **expected** to fail with `duplicate column name` on any migrated brain. That spent **thirteen D1 subrequests to discover nothing needed doing** — and `ensureDbReady` fires it under `ctx.waitUntil`, the same invocation, so the first request on a fresh isolate started 26% of its 50-subrequest budget down. Closes #282.

One probe now reads what exists:

```sql
SELECT type AS kind, name FROM sqlite_master WHERE type IN ('table','index')
UNION ALL SELECT 'column' AS kind, name FROM pragma_table_info('entries')
```

and only missing objects are created.

| brain state | before | after |
|---|---|---|
| fresh | 13 | 14 (once per brain, ever) |
| **fully migrated** | 13 | **1** |
| migrated before #281 | 13 | **2** |
| partially migrated (`db/schema.sql`) | 13 | **3** |

| | before | after |
|---|---|---|
| nightly cron | 42 | **30** |
| cold `GET /graph` | 59 | **47** |

Cold `/graph` was **over** the 50-subrequest ceiling at every brain size (1,500 / 1,600 / 5,000 — it never depended on size once #277's node cap landed). It is now under it at every brain size, flat.

## The invariant

**The probe may report something present only if it actually saw it.** A throw, an unreadable result shape, or a row whose `kind` is not one of the three all resolve toward *missing* — so a confused probe costs the old thirteen statements against idempotent DDL rather than skipping work.

`UNION ALL` makes it a single statement, so the dangerous case — one half succeeding and being treated as authoritative — is structurally impossible: either side failing throws with zero partial results. Verified on real D1.

`IF NOT EXISTS` and the `duplicate column name` tolerance stay as the backstop for two isolates cold-starting on the same brain at once. Object names are keyed by **kind**, so a user table sharing a name with one of our indexes cannot satisfy the check for the index.

Probe cost is **23 rows read, flat** from 0 to 2,000 entries.

## Preserved

No backfill introduced — `updated_at` and `staleness_checked_at` stay nullable, and `updated-at-coalesced.test.ts` still fails any reader that stops coalescing. Rejection-on-genuine-failure, the memo keying on success rather than completion, and callers handling rejection are all unchanged and pinned by mutation.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:coverage` — 1158 passing, `init.ts` at 100% statements/lines
- [x] `npx wrangler deploy --dry-run`
- [x] Adversarially validated: **SHIP**. 21 cases on real workerd — a fresh brain plus **all 64 subsets** of the six ALTER columns and **all 12 legal object subsets**, each ending fully migrated with a row round-tripping through `COALESCE(updated_at, created_at)` and all four counters. 12 of 13 mutants killed.
- [x] All test files re-run individually in isolation — no order dependence.

## Known

A future index added to `db/schema.sql` but not to `SCHEMA_OBJECTS` would be created on fresh installs and silently never backfilled onto existing brains. That failure mode predates this change; the restructure makes the map the obvious single place to add one.
