### PR TITLE
fix(mcp): share one update path with POST /update instead of a private copy (#289)

### DIFF
--- a/src/capture/store.ts
+++ b/src/capture/store.ts
@@ -132,6 +132,9 @@ export async function updateEntryContent(
   const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
   const existingTags: string[] = JSON.parse(row.tags ?? "[]");
 
+  // Same treatment captureEntry gives every stored memory, which is the point — but note it
+  // flattens all whitespace, so a replacement does not preserve line breaks or code fences.
+  // `appendToEntry` deliberately does not flatten; prefer append when the shape matters.
   const { cleanContent, hashtags } = extractHashtags(newContent);
   // Content that is nothing but hashtags cleans down to "", which would blank the entry —
   // keep it as written in that case and let the tags be extracted anyway.

--- a/src/capture/store.ts
+++ b/src/capture/store.ts
@@ -5,6 +5,7 @@ import { embed } from "../lib/ai";
 import { inferEdgesOnWrite } from "../graph/edges";
 import { neighborsFromVectorQuery } from "../graph/traverse";
 import { chunkText } from "../text/chunk";
+import { extractHashtags } from "../text/hashtags";
 import { isVectorizeUnavailable } from "../vectorize/health";
 import { tagsAfterWrite } from "../memory/stale";
 
@@ -83,6 +84,94 @@ export async function reembedOrDegrade(env: Env, id: string, content: string, ta
     console.error("Vectorize unavailable — committing content without re-embedding:", e);
     return null;
   }
+}
+
+/**
+ * What `updateEntryContent` did, in the terms its callers have to answer in.
+ *
+ * `vectorIds: null` is the keyword-only degrade (#270) — the content committed but
+ * Vectorize was unreachable, so the entry still carries its previous embedding.
+ */
+export type UpdateEntryResult =
+  | { status: "not_found" }
+  | { status: "reembed_failed" }
+  | { status: "updated"; vectorIds: string[] | null };
+
+/**
+ * Replace an entry's content outright, keeping D1, the tags and the vector index in step.
+ *
+ * `POST /update` and the MCP `update` tool both land here. They used to be two
+ * implementations of the same thing, and the copy behind MCP — the one every assistant
+ * client actually calls — silently missed every hardening the route gained (#289): it
+ * committed content against stale vectors when an embed failed, never moved the entry's
+ * updated_at, never reset the staleness tags, and never extracted hashtags. Anything that
+ * decides what gets written lives in here now; the callers only shape the reply.
+ * (updated_at is named bare above on purpose — test/unit/updated-at-coalesced.test.ts reads
+ * every backtick-delimited span in src/ as SQL, comments included.)
+ *
+ * The one thing they still do for themselves is the managed-mirror guard, because
+ * `integrations/mirror.ts` imports this module and the dependency must not run both ways.
+ * That guard refuses before anything is written, so a drift there cannot corrupt a row —
+ * unlike everything below, which is why everything below moved.
+ */
+export async function updateEntryContent(
+  env: Env,
+  id: string,
+  newContent: string,
+  config: Readonly<Config> = DEFAULTS
+): Promise<UpdateEntryResult> {
+  // vector_ids has to be read before any mutation: storeEntry overwrites it, and the
+  // cleanup below needs to know which vectors the entry had on the way in.
+  const row = await env.DB.prepare(
+    `SELECT tags, source, vector_ids FROM entries WHERE id = ?`
+  ).bind(id).first() as Record<string, any> | null;
+
+  if (!row) return { status: "not_found" };
+
+  const source = row.source as string;
+  const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
+  const existingTags: string[] = JSON.parse(row.tags ?? "[]");
+
+  const { cleanContent, hashtags } = extractHashtags(newContent);
+  // Content that is nothing but hashtags cleans down to "", which would blank the entry —
+  // keep it as written in that case and let the tags be extracted anyway.
+  const finalContent = cleanContent || newContent;
+  const mergedTags = tagsAfterWrite([...new Set([...existingTags, ...hashtags])])
+    // `rolled-up` is a claim about content that no longer exists: the nightly digest wrote
+    // it in the same statement that appended a `[Digest: <id>]` marker to the body, and a
+    // full replacement destroys that marker. Left in place it costs the corrected memory a
+    // 0.4x recall penalty (recall/math.ts) and bars it from every future digest, burying
+    // the only copy of the new fact. The same reasoning tagsAfterWrite applies to the
+    // volatility/staleness verdicts, and the reason `append` must NOT strip it — an append
+    // keeps the digested original inside the entry, so the digest still covers it.
+    .filter(t => t !== "rolled-up");
+
+  // Re-embed FIRST (#212): if it fails, leave the entry's content and vectors untouched and
+  // surface an error, instead of committing new content and then deleting every vector —
+  // which would leave the entry silently unsearchable. null means Vectorize is unreachable
+  // (#270), not that this embed failed.
+  let newVectorIds: string[] | null;
+  try {
+    newVectorIds = await reembedOrDegrade(env, id, finalContent, mergedTags, source, config);
+  } catch (e) {
+    console.error("Re-embed failed — entry left unchanged:", e);
+    return { status: "reembed_failed" };
+  }
+
+  // Safe to commit: either the embed succeeded, or Vectorize is unavailable and the old
+  // vectors are kept below rather than retired.
+  await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
+    .bind(finalContent, JSON.stringify(mergedTags), Date.now(), id).run();
+
+  if (newVectorIds) {
+    try {
+      await deleteStaleVectors(env, oldVectorIds, newVectorIds);
+    } catch (e) {
+      console.error("Old vector cleanup failed (non-fatal):", e);
+    }
+  }
+
+  return { status: "updated", vectorIds: newVectorIds };
 }
 
 export async function appendToEntry(

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import type { Env } from "../env";
 import { VECTORIZE_FIX_HINT } from "../constants";
 import { buildEntryFilterQuery, captureEntry } from "../capture/entry";
-import { appendToEntry, deleteStaleVectors, storeEntry } from "../capture/store";
+import { appendToEntry, updateEntryContent } from "../capture/store";
 import { applyStatus, forgetEntry } from "../capture/lifecycle";
 import { createEdge, deleteEdge, edgeLabel } from "../graph/edges";
 import { EDGE_TYPES } from "../graph/types";
@@ -126,9 +126,9 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         return { content: [{ type: "text", text: "Content cannot be empty." }] };
       }
 
-      // Read current row upfront — need tags, source, AND old vector_ids before any mutation
+      // Refuse before anything is written — same guard, same read, as POST /update.
       const row = await env.DB.prepare(
-        `SELECT tags, source, vector_ids FROM entries WHERE id = ?`
+        `SELECT source FROM entries WHERE id = ?`
       ).bind(id).first() as Record<string, any> | null;
 
       if (!row) {
@@ -139,32 +139,32 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         return { content: [{ type: "text", text: mirrorEditError(row.source as string) }] };
       }
 
-      const tags: string[] = JSON.parse(row.tags ?? "[]").filter((t: string) => t !== "rolled-up");
-      const source = row.source as string;
-      const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
+      const result = await updateEntryContent(env, id, newContent, await resolveConfig(env));
 
-      // Step 1: Update D1 content and tags (strip rolled-up so updated entry ranks normally)
-      await env.DB.prepare(`UPDATE entries SET content = ?, tags = ? WHERE id = ?`)
-        .bind(newContent, JSON.stringify(tags), id).run();
-
-      // Step 2: Re-embed new content → inserts new vectors + updates vector_ids in D1
-      let newVectorIds: string[] = [];
-      try {
-        newVectorIds = await storeEntry(env, id, newContent, tags, source, Date.now(), await resolveConfig(env));
-      } catch (e) {
-        console.error("Vectorize re-embed failed (non-fatal):", e);
+      // Only reachable if the entry was deleted between the guard read and the write.
+      if (result.status === "not_found") {
+        return { content: [{ type: "text", text: `No entry found with ID: ${id}` }] };
       }
-      const newVectorCount = newVectorIds.length;
 
-      // Step 3: Delete only stale vectors — ids reused by the re-embed must survive
-      try {
-        await deleteStaleVectors(env, oldVectorIds, newVectorIds);
-      } catch (e) {
-        console.error("Old vector cleanup failed (non-fatal):", e);
+      // Fails closed (#212): nothing was written, so the reply must not claim otherwise.
+      // This tool used to report success here while leaving the index pointing at the old
+      // text, and no repair path could see it — /vectorize-pending and /stats both look for
+      // an empty vector_ids, which a mis-indexed entry does not have (#289).
+      if (result.status === "reembed_failed") {
+        return { content: [{ type: "text", text: `Couldn't update entry ${id}: search re-index failed. Your memory is unchanged — please try again.` }] };
+      }
+
+      if (!result.vectorIds) {
+        return {
+          content: [{
+            type: "text",
+            text: `Updated entry ${id}. Note: it was not re-indexed for semantic search because the Vectorize index is missing — the previous index is kept and it is still findable by keyword. Fix: ${VECTORIZE_FIX_HINT}.`,
+          }],
+        };
       }
 
       return {
-        content: [{ type: "text", text: `Updated entry ${id}. Re-embedded as ${newVectorCount} vector(s).` }],
+        content: [{ type: "text", text: `Updated entry ${id}. Re-embedded as ${result.vectorIds.length} vector(s).` }],
       };
     }
   );

--- a/src/routes/capture.ts
+++ b/src/routes/capture.ts
@@ -3,10 +3,8 @@ import { resolveConfig } from "../config";
 import { VECTORIZE_FIX_HINT } from "../constants";
 import { json, requireAuth } from "../lib/http";
 import { captureEntry } from "../capture/entry";
-import { appendToEntry, deleteStaleVectors, reembedOrDegrade } from "../capture/store";
+import { appendToEntry, updateEntryContent } from "../capture/store";
 import { isManagedMirror, mirrorEditError } from "../integrations/mirror";
-import { extractHashtags } from "../text/hashtags";
-import { tagsAfterWrite } from "../memory/stale";
 
 export async function handleCaptureRoutes(
   request: Request,
@@ -118,8 +116,11 @@ export async function handleCaptureRoutes(
     const id = body.id.trim();
     const newContent = body.content.trim();
 
+    // Refuse before anything is written. Only `source` is needed: updateEntryContent reads
+    // the rest for itself, and keeping the mirror guard out here is what stops
+    // capture/store.ts having to depend on the integrations registry (see #289).
     const row = await env.DB.prepare(
-      `SELECT tags, source, vector_ids FROM entries WHERE id = ?`
+      `SELECT source FROM entries WHERE id = ?`
     ).bind(id).first() as Record<string, any> | null;
 
     if (!row) return json({ ok: false, error: `No entry found with ID: ${id}` }, 404);
@@ -128,39 +129,18 @@ export async function handleCaptureRoutes(
       return json({ ok: false, error: mirrorEditError(row.source as string) }, 409);
     }
 
-    const tags: string[] = JSON.parse(row.tags ?? "[]");
-    const { cleanContent, hashtags: newHashtags } = extractHashtags(newContent);
-    const mergedTags = tagsAfterWrite([...new Set([...tags, ...newHashtags])]);
-    const source = row.source as string;
-    const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
-    const finalContent = cleanContent || newContent;
+    const result = await updateEntryContent(env, id, newContent, await resolveConfig(env));
 
-    // Re-embed FIRST (#212): if it fails, leave the entry's content and vectors
-    // untouched and surface an error, instead of committing new content and then
-    // deleting every vector — which would leave the entry silently unsearchable.
-    // null means Vectorize is unreachable (#270), not that this embed failed.
-    let newVectorIds: string[] | null;
-    try {
-      newVectorIds = await reembedOrDegrade(env, id, finalContent, mergedTags, source, await resolveConfig(env));
-    } catch (e) {
-      console.error("Re-embed failed — entry left unchanged:", e);
+    // Only reachable if the entry was deleted between the guard read and the write.
+    if (result.status === "not_found") {
+      return json({ ok: false, error: `No entry found with ID: ${id}` }, 404);
+    }
+
+    if (result.status === "reembed_failed") {
       return json({ ok: false, error: "Couldn't update: search re-index failed. Your memory is unchanged — please try again." }, 500);
     }
 
-    // Safe to commit: either the embed succeeded, or Vectorize is unavailable and
-    // the old vectors are kept below rather than retired.
-    await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
-      .bind(finalContent, JSON.stringify(mergedTags), Date.now(), id).run();
-
-    if (newVectorIds) {
-      try {
-        await deleteStaleVectors(env, oldVectorIds, newVectorIds);
-      } catch (e) {
-        console.error("Old vector cleanup failed (non-fatal):", e);
-      }
-    }
-
-    if (!newVectorIds) {
+    if (!result.vectorIds) {
       return json({
         ok: true,
         id,
@@ -170,7 +150,7 @@ export async function handleCaptureRoutes(
       });
     }
 
-    return json({ ok: true, id, vectors: newVectorIds.length });
+    return json({ ok: true, id, vectors: result.vectorIds.length });
   }
 
   return null;

--- a/test/integration/update-parity.test.ts
+++ b/test/integration/update-parity.test.ts
@@ -263,6 +263,26 @@ describe("POST /update and the MCP update tool write identical state (#289)", ()
       },
     },
     {
+      name: "(c) extraction flattens whitespace, including inside a fenced code block",
+      world: { seed: { content: "old runbook", tags: ["ops"] } },
+      content: "Runbook:\n\n1. drain\n2. deploy\n\n```sh\nnpm run deploy\n```\n\nTicket #4821",
+      expect: (s) => {
+        // Spelled out because it is destructive and, for the MCP path, new: the private copy
+        // stored content verbatim. extractHashtags collapses every whitespace run to one
+        // space and removes every #token unconditionally, so line breaks, list structure and
+        // code fences do not survive a replacement, and a bare issue reference becomes a tag.
+        // This is not a regression — captureEntry has always done it, so `remember` through
+        // this same transport produces a byte-identical row, and POST /update already did it.
+        // Divergence was the bug; this is what agreeing with the rest of the write path costs.
+        //
+        // `append` deliberately does NOT flatten: it embeds the addition verbatim after a
+        // "[Update <date>]: " separator (src/capture/store.ts), so newlines survive there.
+        // Reach for append, not update, when the text's shape matters.
+        expect(s.row!.content).toBe("Runbook: 1. drain 2. deploy ```sh npm run deploy ``` Ticket");
+        expect(tagsOf(s)).toEqual(["ops", "4821"]);
+      },
+    },
+    {
       name: "a hashtag already held as a tag is not duplicated",
       world: { seed: { content: "Berlin flat", tags: ["home"] } },
       content: "Lisbon flat #home",

--- a/test/integration/update-parity.test.ts
+++ b/test/integration/update-parity.test.ts
@@ -1,0 +1,437 @@
+/**
+ * POST /update and the MCP `update` tool must leave the database in the SAME state.
+ *
+ * They were two implementations of one operation, and the MCP copy — the path every
+ * assistant client actually calls — quietly drifted (#289): it committed content against
+ * stale vectors when an embed failed, never moved updated_at, never reset the staleness
+ * tags, and never extracted hashtags. Every one of those is invisible from the
+ * MCP side alone; each only reads as a bug next to what the route does with the same
+ * input. Nothing compared them, so nothing failed.
+ *
+ * So this suite does not assert what update *should* write. It runs each scenario through
+ * both callers against the same starting row and asserts the resulting rows and vectors are
+ * identical — then, separately, pins the handful of facts that both must satisfy so a
+ * change that breaks them in both places is still caught. Add a scenario to CASES and both
+ * callers are covered by construction.
+ *
+ * Real workerd D1 through Miniflare, not test/helpers/d1-mock. The mock matches query
+ * strings, so it cannot tell a row that was written from one that was not — which is
+ * exactly the distinction the fail-closed path turns on — and it has diverged from
+ * production in this repo before, in both directions.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { Miniflare } from "miniflare";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import worker from "../../src/index";
+import { buildMcpServer } from "../../src/mcp/server";
+import { initializeDatabase, resetDatabaseInit } from "../../src/db/init";
+import { makeAIMock, makeMemoryKV, makeVectorizeMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+
+const ctx = { waitUntil: (_: Promise<unknown>) => {} } as unknown as ExecutionContext;
+
+const ENTRY_ID = "x1";
+/** Fixed, so the two runs of a scenario are byte-identical everywhere the code does not write. */
+const SEEDED_AT = Date.parse("2024-01-17T00:00:00Z");
+
+// ── The world both callers run against ──────────────────────────────────────────────────
+
+/** Vectorize with real insert/upsert/delete semantics, so "what is indexed" is observable. */
+function makeStatefulVectorize(seed: { id: string; content: string }[], overrides: Partial<VectorizeIndex> = {}) {
+  const store = new Map<string, any>();
+  for (const v of seed) store.set(v.id, { id: v.id, values: [], metadata: { content: v.content } });
+  const index = makeVectorizeMock({
+    insert: vi.fn(async (vectors: any[]): Promise<any> => {
+      for (const v of vectors) if (!store.has(v.id)) store.set(v.id, v);
+      return { mutationId: "m" };
+    }),
+    upsert: vi.fn(async (vectors: any[]): Promise<any> => {
+      for (const v of vectors) store.set(v.id, v);
+      return { mutationId: "m" };
+    }),
+    deleteByIds: vi.fn(async (ids: string[]): Promise<any> => {
+      for (const id of ids) store.delete(id);
+      return { mutationId: "m" };
+    }),
+    ...overrides,
+  });
+  return { store, index };
+}
+
+/** Workers AI that embeds normally, or refuses — a transient embed failure is one of these. */
+function makeAI({ embedFails }: { embedFails: boolean }): Ai {
+  if (!embedFails) return makeAIMock();
+  return {
+    run: vi.fn(async () => { throw new Error("AI binding overloaded"); }),
+  } as unknown as Ai;
+}
+
+type World = {
+  /** The entry as it exists before the update. */
+  seed: {
+    content: string;
+    tags: string[];
+    source?: string;
+    vectorIds?: string[];
+    createdAt?: number;
+    updatedAt?: number | null;
+  };
+  /** What is in Vectorize before the update, keyed by vector id. */
+  vectors?: { id: string; content: string }[];
+  /** A single embed call fails, with the index itself healthy — #212's transient case. */
+  embedFails?: boolean;
+  /** describe() throws: Vectorize is not reachable at all — #270's keyword-only deployment. */
+  vectorizeDown?: boolean;
+  /** Retiring the orphaned vectors fails. Non-fatal: the content is already committed. */
+  deleteFails?: boolean;
+  /** A connected integration owns entries with this source, making them read-only. */
+  connectedIntegration?: string;
+};
+
+// ── State capture ───────────────────────────────────────────────────────────────────────
+
+type Snapshot = {
+  row: Record<string, unknown> | null;
+  vectors: { id: string; content: unknown }[];
+};
+
+/**
+ * updated_at is Date.now(), so the two runs cannot produce the same number. Collapsing it
+ * to a marker keeps the comparison meaningful while still failing when one caller writes it
+ * and the other leaves it NULL — which is divergence (b), and the whole reason it is here.
+ * Freshness is asserted separately, against the clock.
+ */
+function normalize(snapshot: Snapshot): Snapshot {
+  if (!snapshot.row) return snapshot;
+  const row = { ...snapshot.row };
+  if (typeof row.updated_at === "number") row.updated_at = "<written>";
+  return { ...snapshot, row };
+}
+
+describe("POST /update and the MCP update tool write identical state (#289)", () => {
+  let mf: Miniflare;
+  let d1: D1Database;
+
+  beforeAll(async () => {
+    mf = new Miniflare({
+      modules: true,
+      script: "export default { fetch() { return new Response('ok'); } };",
+      d1Databases: { DB: "update-parity" },
+    });
+    d1 = (await mf.getD1Database("DB")) as unknown as D1Database;
+    // The real migration, so the columns under test are the ones production has —
+    // updated_at in particular is a runtime ALTER that db/schema.sql does not carry.
+    resetDatabaseInit();
+    await initializeDatabase({ DB: d1 } as Env);
+  }, 30_000);
+
+  afterAll(async () => {
+    await mf?.dispose();
+  });
+
+  function makeEnv(world: World) {
+    const { store, index } = makeStatefulVectorize(world.vectors ?? [], {
+      ...(world.vectorizeDown ? { describe: vi.fn(async () => { throw new Error("no such index"); }) } : {}),
+      ...(world.deleteFails ? { deleteByIds: vi.fn(async () => { throw new Error("delete failed"); }) } : {}),
+    });
+    const OAUTH_KV = makeMemoryKV();
+    const env = {
+      DB: d1,
+      VECTORIZE: index,
+      AI: makeAI({ embedFails: world.embedFails ?? world.vectorizeDown ?? false }),
+      AUTH_TOKEN: "test-token",
+      OAUTH_KV,
+    } as unknown as Env;
+    return { env, store, OAUTH_KV };
+  }
+
+  /**
+   * A world, from scratch. Called once per caller, so the second run starts from exactly
+   * the row the first one did rather than from what the first one left behind.
+   */
+  async function setUp(world: World) {
+    await d1.prepare(`DELETE FROM entries`).run();
+    const { env, store, OAUTH_KV } = makeEnv(world);
+    if (world.connectedIntegration) {
+      await OAUTH_KV.put(
+        `integrations:${world.connectedIntegration}`,
+        JSON.stringify({ provider: world.connectedIntegration, status: "connected", itemMap: {} }),
+      );
+    }
+    const s = world.seed;
+    await d1.prepare(
+      `INSERT INTO entries (id, content, tags, source, created_at, updated_at, vector_ids, recall_count, importance_score)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 0, 3)`,
+    ).bind(
+      ENTRY_ID,
+      s.content,
+      JSON.stringify(s.tags),
+      s.source ?? "claude",
+      s.createdAt ?? SEEDED_AT,
+      s.updatedAt ?? null,
+      JSON.stringify(s.vectorIds ?? [ENTRY_ID]),
+    ).run();
+    return { env, store };
+  }
+
+  async function capture(store: Map<string, any>): Promise<Snapshot> {
+    const row = await d1.prepare(`SELECT * FROM entries WHERE id = ?`).bind(ENTRY_ID).first();
+    return {
+      row: (row as Record<string, unknown> | null) ?? null,
+      vectors: [...store.values()]
+        .map(v => ({ id: v.id as string, content: v.metadata?.content }))
+        .sort((a, b) => a.id.localeCompare(b.id)),
+    };
+  }
+
+  /** POST /update, through the whole Worker. */
+  async function viaHttp(world: World, content: string) {
+    const { env, store } = await setUp(world);
+    const res = await worker.fetch(req("POST", "/update", { body: { id: ENTRY_ID, content } }), env, ctx);
+    const body = await res.json() as any;
+    return { snapshot: await capture(store), status: res.status, reply: body.message ?? body.error ?? "" };
+  }
+
+  /** The MCP `update` tool, through a real MCP client and transport. */
+  async function viaMcp(world: World, content: string) {
+    const { env, store } = await setUp(world);
+    const server = buildMcpServer(env, ctx);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "parity-client", version: "1.0.0" });
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+    try {
+      const result = await client.callTool({ name: "update", arguments: { id: ENTRY_ID, content } });
+      const reply = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+      return { snapshot: await capture(store), reply };
+    } finally {
+      await client.close();
+    }
+  }
+
+  // ── The scenarios ─────────────────────────────────────────────────────────────────────
+
+  type Case = {
+    name: string;
+    world: World;
+    content: string;
+    /** Facts both callers must satisfy. Parity alone would pass if both were wrong. */
+    expect: (snapshot: Snapshot) => void;
+  };
+
+  const tagsOf = (snapshot: Snapshot) => JSON.parse((snapshot.row!.tags as string) ?? "[]") as string[];
+
+  const CASES: Case[] = [
+    {
+      name: "healthy re-index",
+      world: { seed: { content: "I live in Berlin", tags: ["home"] }, vectors: [{ id: ENTRY_ID, content: "I live in Berlin" }] },
+      content: "I live in Lisbon",
+      expect: (s) => {
+        expect(s.row!.content).toBe("I live in Lisbon");
+        // The vector the entry is keyed by holds the new text, not the old.
+        expect(s.vectors).toEqual([{ id: ENTRY_ID, content: "I live in Lisbon" }]);
+        expect(JSON.parse(s.row!.vector_ids as string)).toEqual([ENTRY_ID]);
+      },
+    },
+    {
+      name: "(b) staleness verdicts are cleared and updated_at moves",
+      world: {
+        seed: {
+          content: "I live in Berlin",
+          tags: ["home", "volatility:state", "stale:as-of"],
+          updatedAt: SEEDED_AT,
+        },
+      },
+      content: "I live in Lisbon",
+      expect: (s) => {
+        // The verdicts described the content that was just replaced. Left behind, recall
+        // reports a seconds-old correction as years stale and hedges the answer built on it.
+        expect(tagsOf(s)).toEqual(["home"]);
+        // And a stationary updated_at leaves the row a permanent staleness-pass candidate,
+        // so the tag comes straight back on the next nightly run.
+        expect(s.row!.updated_at as number).toBeGreaterThan(Date.parse("2025-01-01T00:00:00Z"));
+      },
+    },
+    {
+      name: "(c) hashtags are extracted from the new content",
+      world: { seed: { content: "I live in Berlin", tags: ["home"] } },
+      content: "Moving to Lisbon #relocation",
+      expect: (s) => {
+        expect(s.row!.content).toBe("Moving to Lisbon");
+        expect(tagsOf(s)).toEqual(["home", "relocation"]);
+      },
+    },
+    {
+      name: "a hashtag already held as a tag is not duplicated",
+      world: { seed: { content: "Berlin flat", tags: ["home"] } },
+      content: "Lisbon flat #home",
+      expect: (s) => expect(tagsOf(s)).toEqual(["home"]),
+    },
+    {
+      name: "content that is nothing but hashtags is kept verbatim",
+      world: { seed: { content: "Berlin flat", tags: ["home"] } },
+      content: "#lisbon",
+      expect: (s) => {
+        expect(s.row!.content).toBe("#lisbon");
+        expect(tagsOf(s)).toEqual(["home", "lisbon"]);
+      },
+    },
+    {
+      name: "rolled-up is dropped: the digest marker it annotated is gone with the old content",
+      world: { seed: { content: "Berlin flat\n\n[Digest: d9]", tags: ["home", "rolled-up"] } },
+      content: "Lisbon flat",
+      expect: (s) => {
+        expect(tagsOf(s)).toEqual(["home"]);
+        expect(s.row!.content).toBe("Lisbon flat");
+      },
+    },
+    {
+      name: "(a) a transient embed failure against a healthy index fails closed",
+      world: {
+        seed: { content: "I live in Berlin", tags: ["home"] },
+        vectors: [{ id: ENTRY_ID, content: "I live in Berlin" }],
+        embedFails: true,
+      },
+      content: "I live in Lisbon",
+      expect: (s) => {
+        // Committing here would leave D1 saying Lisbon and Vectorize saying Berlin, with a
+        // non-empty vector_ids — so /vectorize-pending and /stats.unvectorized, which both
+        // select vector_ids = '[]', would never see it and recall would answer Berlin forever.
+        expect(s.row!.content).toBe("I live in Berlin");
+        expect(s.row!.updated_at).toBeNull();
+        expect(s.vectors).toEqual([{ id: ENTRY_ID, content: "I live in Berlin" }]);
+      },
+    },
+    {
+      name: "Vectorize unreachable commits keyword-only and keeps the old index",
+      world: {
+        seed: { content: "I live in Berlin", tags: ["home"] },
+        vectors: [{ id: ENTRY_ID, content: "I live in Berlin" }],
+        vectorizeDown: true,
+      },
+      content: "I live in Lisbon",
+      expect: (s) => {
+        // Keyword search reads entries.content, so the correction is still findable.
+        expect(s.row!.content).toBe("I live in Lisbon");
+        // The old vectors are the entry's only remaining semantic index — retiring them
+        // would make it unsearchable rather than merely stale.
+        expect(JSON.parse(s.row!.vector_ids as string)).toEqual([ENTRY_ID]);
+        expect(s.vectors).toEqual([{ id: ENTRY_ID, content: "I live in Berlin" }]);
+      },
+    },
+    {
+      name: "a multi-chunk entry shrinking to one chunk retires only the orphan",
+      world: {
+        seed: { content: "long original", tags: ["work"], vectorIds: [ENTRY_ID, `${ENTRY_ID}-chunk-1`] },
+        vectors: [
+          { id: ENTRY_ID, content: "long original" },
+          { id: `${ENTRY_ID}-chunk-1`, content: "long original tail" },
+        ],
+      },
+      content: "short replacement",
+      expect: (s) => {
+        // The re-embed reuses the entry id, so that vector must survive its own cleanup.
+        expect(s.vectors).toEqual([{ id: ENTRY_ID, content: "short replacement" }]);
+        expect(JSON.parse(s.row!.vector_ids as string)).toEqual([ENTRY_ID]);
+      },
+    },
+    {
+      name: "a failed retirement of the orphaned vector does not undo the update",
+      world: {
+        seed: { content: "long original", tags: ["work"], vectorIds: [ENTRY_ID, `${ENTRY_ID}-chunk-1`] },
+        vectors: [
+          { id: ENTRY_ID, content: "long original" },
+          { id: `${ENTRY_ID}-chunk-1`, content: "long original tail" },
+        ],
+        deleteFails: true,
+      },
+      content: "short replacement",
+      expect: (s) => {
+        // The new vectors are already in place, so the leftover orphan is a tidiness
+        // problem, not a correctness one — rolling the content back would be worse.
+        expect(s.row!.content).toBe("short replacement");
+        expect(JSON.parse(s.row!.vector_ids as string)).toEqual([ENTRY_ID]);
+      },
+    },
+    {
+      name: "an entry owned by a connected integration is refused before anything is written",
+      world: { seed: { content: "Synced page", tags: ["notion"], source: "notion" }, connectedIntegration: "notion" },
+      content: "Hand-edited",
+      expect: (s) => {
+        expect(s.row!.content).toBe("Synced page");
+        expect(s.row!.updated_at).toBeNull();
+      },
+    },
+  ];
+
+  it.each(CASES)("$name — both callers agree", async ({ world, content, expect: assertFacts }) => {
+    const http = await viaHttp(world, content);
+    const mcp = await viaMcp(world, content);
+
+    expect(normalize(mcp.snapshot)).toEqual(normalize(http.snapshot));
+    assertFacts(http.snapshot);
+    assertFacts(mcp.snapshot);
+  });
+
+  it("a missing entry leaves both callers with nothing to write", async () => {
+    const world: World = { seed: { content: "present", tags: [] } };
+
+    const { env: httpEnv, store: httpStore } = await setUp(world);
+    const res = await worker.fetch(req("POST", "/update", { body: { id: "nope", content: "x" } }), httpEnv, ctx);
+    expect(res.status).toBe(404);
+    const httpSnapshot = await capture(httpStore);
+
+    const { env: mcpEnv, store: mcpStore } = await setUp(world);
+    const server = buildMcpServer(mcpEnv, ctx);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "parity-client", version: "1.0.0" });
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+    let reply = "";
+    try {
+      const result = await client.callTool({ name: "update", arguments: { id: "nope", content: "x" } });
+      reply = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+    } finally {
+      await client.close();
+    }
+
+    expect(reply).toMatch(/No entry found with ID: nope/);
+    expect(normalize(await capture(mcpStore))).toEqual(normalize(httpSnapshot));
+  });
+
+  // ── The replies, which are the one thing that legitimately differs ─────────────────────
+
+  it("the MCP tool reports a failed re-index as a failure, not as a success", async () => {
+    // It used to answer "Updated entry x1. Re-embedded as 0 vector(s)." on this path, which
+    // reads as success and is what let a mis-indexed entry go unnoticed. The route already
+    // 500s here; the tool now says the same thing in its own voice.
+    const world: World = {
+      seed: { content: "I live in Berlin", tags: ["home"] },
+      vectors: [{ id: ENTRY_ID, content: "I live in Berlin" }],
+      embedFails: true,
+    };
+
+    const http = await viaHttp(world, "I live in Lisbon");
+    expect(http.status).toBe(500);
+    expect(http.reply).toMatch(/Your memory is unchanged/);
+
+    const mcp = await viaMcp(world, "I live in Lisbon");
+    expect(mcp.reply).not.toMatch(/^Updated entry/);
+    expect(mcp.reply).toMatch(/Your memory is unchanged/);
+  });
+
+  it("the MCP tool flags the keyword-only degrade instead of claiming a re-index", async () => {
+    const mcp = await viaMcp(
+      { seed: { content: "I live in Berlin", tags: ["home"] }, vectorizeDown: true },
+      "I live in Lisbon",
+    );
+    expect(mcp.reply).toMatch(/Updated entry x1/);
+    expect(mcp.reply).toMatch(/not re-indexed for semantic search/);
+    expect(mcp.reply).toMatch(/wrangler vectorize create/);
+  });
+
+  it("the MCP tool still reports the vector count on the healthy path", async () => {
+    const mcp = await viaMcp({ seed: { content: "I live in Berlin", tags: ["home"] } }, "I live in Lisbon");
+    expect(mcp.reply).toBe("Updated entry x1. Re-embedded as 1 vector(s).");
+  });
+});


### PR DESCRIPTION
## Summary

The MCP `update` tool had its own inline implementation and never received the hardening `POST /update` did. MCP is the path assistant clients actually call, so these were live for every assistant-driven edit. Closes #289.

Three divergences, each reproduced against **real workerd D1** with a stateful Vectorize:

| | before (MCP) | after (MCP) | HTTP |
|---|---|---|---|
| **(a)** embed fails, index healthy | `Updated entry x1. Re-embedded as 0 vector(s).` · D1 `"Lisbon"` · Vectorize `"Berlin"` | `Couldn't update… Your memory is unchanged` · D1 `"Berlin"` · Vectorize `"Berlin"` | 500, unchanged |
| **(b)** healthy path | tags `["home","volatility:state","stale:as-of"]` · `updated_at NULL` | tags `["home"]` · `updated_at` written | same |
| **(c)** `"Moving to Lisbon #relocation"` | content keeps the hashtag, tags `["home"]` | content `"Moving to Lisbon"`, tags `["home","relocation"]` | same |

**(a) was permanent.** `vector_ids` stayed non-empty, and both `/vectorize-pending` and `/stats.unvectorized` select `vector_ids = '[]'` — so no repair path could ever see it. Recall kept returning the old text while `/stats` reported nothing wrong.

**(b) fired on the healthy path, every time.** A memory corrected seconds earlier came back from recall carrying `stale:as-of` and *"true as of \<two years ago\>, verify before asserting"*, under a compound-staleness banner — the exact "hedge on every memory-backed answer" failure the staleness work exists to avoid. And since `updated_at` never moved, the nightly pass re-applied the tag after every correction.

## The fix

Extracted the route body into `updateEntryContent` in `src/capture/store.ts`, beside `appendToEntry`, and called from both. `remember` and `append` already shared `captureEntry` / `appendToEntry` with their routes; `update` was the only tool holding a private copy.

The MCP tool now **fails closed** on a re-embed failure, so its reply changes from a false success to an error. That is the fix, not a regression.

## `rolled-up`: MCP was right, HTTP was not — both now strip it

`markSourcesRolledUp` writes the tag *and* appends a `[Digest: <id>]` marker in one statement. A full replacement destroys the marker, leaving the tag annotating text that no longer exists — while costing a 0.4× recall penalty and barring the entry from every future digest, with the existing digest summarising content that is gone.

`append` deliberately keeps it: an append leaves the digested original inside the entry, so the digest still covers it.

## The test that should have existed

`test/integration/update-parity.test.ts` runs each scenario through the whole Worker **and** through a real MCP client over `InMemoryTransport`, against the same seeded row in real workerd D1, then asserts the resulting D1 rows and Vectorize contents are deep-equal — plus per-case assertions, so parity alone cannot pass with both callers wrong.

**Against the shipped MCP tool it fails 12 of 15. With the fix, 15/15.**

Adding a scenario now covers both callers by construction. Nothing was passing *because* of the bug: no test anywhere asserted on that tool's behaviour, only that it appeared in the tool list — which is why it drifted.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:coverage` — 1231 passing (1216 → 1231, no existing test modified)
- [x] `npx wrangler deploy --dry-run`
- [x] Divergences demonstrated before/after on a real engine, not the mock

## Known and out of scope

`makeMirrorStore.updateEntry` is a third copy with divergence (a) — it commits content, then re-embeds in a swallowing `try/catch`. It is not user-triggered (the mirror owns those rows and re-syncs them, so a stale embed self-heals), so it does not meet the bar for this release, but it is the same shape.

`src/mcp/server.ts` is at 32% coverage overall. Most tools still have no behavioural tests — the condition that produced this bug.
