### PR TITLE
perf(recall): cache the tag vocabulary instead of scanning for it every call (#288)

### DIFF
--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -25,6 +25,7 @@ Incremental split of the former monolithic `index.ts`. Entry point remains `src/
 | initializeDatabase | `db/init.ts` |
 | status/kind tags | `memory/status.ts`, `memory/kind.ts` |
 | tag LIKE pattern + escaping | `memory/tag-sql.ts` |
+| tag vocabulary cache | `tags/vocabulary.ts` |
 | compression eligibility | `compression/eligibility.ts` |
 | chunk, hashtags, temporal, tokenize | `text/*` |
 | cosineSim, rerank, mmr | `recall/math.ts` |

--- a/src/capture/entry.ts
+++ b/src/capture/entry.ts
@@ -9,6 +9,7 @@ import { deprecateEntry } from "./lifecycle";
 import { deleteStaleVectors, reembedOrThrow, storeEntry } from "./store";
 import { tagsAfterWrite } from "../memory/stale";
 import { TAG_LIKE_ESCAPE, tagLikePattern } from "../memory/tag-sql";
+import { rememberTags } from "../tags/vocabulary";
 
 export function buildEntryFilterQuery(params: {
   n: number;
@@ -122,6 +123,11 @@ export async function captureEntry(
     storeEntry(env, id, c, finalTags, source, now, cfg)
       .catch(e => console.error("Vectorize insert failed (non-fatal):", e))
   );
+
+  // Capture is where a tag string nobody wrote into the source first exists, so it
+  // is where the cached vocabulary has to learn one (#288). Deferred: the row is
+  // already committed, and the next recall reads KV, not this promise.
+  ctx.waitUntil(rememberTags(env, finalTags));
 
   scheduleClassifyAndTag(id, c, env, ctx, cfg);
 

--- a/src/capture/entry.ts
+++ b/src/capture/entry.ts
@@ -124,9 +124,11 @@ export async function captureEntry(
       .catch(e => console.error("Vectorize insert failed (non-fatal):", e))
   );
 
-  // Capture is where a tag string nobody wrote into the source first exists, so it
-  // is where the cached vocabulary has to learn one (#288). Deferred: the row is
-  // already committed, and the next recall reads KV, not this promise.
+  // Capture is where a tag string nobody wrote into the source first exists, so it is
+  // one of the two places the cached vocabulary has to learn one (#288). Deferred, so
+  // the capture does not wait on KV — which means the tag is admitted once this
+  // settles rather than by the time the response lands, and a `GET /tags` fired
+  // straight off the back of the save can miss it by one refresh.
   ctx.waitUntil(rememberTags(env, finalTags));
 
   scheduleClassifyAndTag(id, c, env, ctx, cfg);

--- a/src/integrations/mirror.ts
+++ b/src/integrations/mirror.ts
@@ -41,11 +41,15 @@ export function makeMirrorStore(env: Env): MirrorStore {
       await env.DB.prepare(
         `INSERT INTO entries (id, content, tags, source, created_at, updated_at, vector_ids, importance_score) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
       ).bind(id, content, JSON.stringify(finalTags), source, now, now, "[]", importance).run();
-      // Third and last of the unknown-tag entry points (#288). Awaited rather than
-      // deferred because the scheduled sync has no ExecutionContext to hand this to,
-      // and it costs one KV read — a put only on the first item of a newly connected
-      // provider, so a steady-state sync pays nothing. Without it a freshly connected
-      // integration is missing from the dashboard's tag filter until the next rebuild.
+      // Promptness, not correctness (#288). Every tag inserted here is a compile-time
+      // constant — a provider id from the registry in integrations/index.ts, plus
+      // whatever kind:/status: the classifier added — so the vocabulary's age limit
+      // would admit them on its own. This just means a freshly connected integration
+      // shows up in the dashboard's tag filter today rather than tomorrow.
+      //
+      // Awaited because the scheduled sync has no ExecutionContext to defer to. Costs
+      // one KV get per created entry; the put fires only on the first item of a newly
+      // connected provider.
       await rememberTags(env, finalTags);
       try {
         await storeEntry(env, id, content, finalTags, source, now, cfg);

--- a/src/integrations/mirror.ts
+++ b/src/integrations/mirror.ts
@@ -14,6 +14,7 @@ import { classifyEntry } from "../capture/classify";
 import { withKind } from "../memory/kind";
 import { withStatus } from "../memory/status";
 import { tagsAfterWrite } from "../memory/stale";
+import { rememberTags } from "../tags/vocabulary";
 
 export function makeMirrorStore(env: Env): MirrorStore {
   return {
@@ -40,6 +41,12 @@ export function makeMirrorStore(env: Env): MirrorStore {
       await env.DB.prepare(
         `INSERT INTO entries (id, content, tags, source, created_at, updated_at, vector_ids, importance_score) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
       ).bind(id, content, JSON.stringify(finalTags), source, now, now, "[]", importance).run();
+      // Third and last of the unknown-tag entry points (#288). Awaited rather than
+      // deferred because the scheduled sync has no ExecutionContext to hand this to,
+      // and it costs one KV read — a put only on the first item of a newly connected
+      // provider, so a steady-state sync pays nothing. Without it a freshly connected
+      // integration is missing from the dashboard's tag filter until the next rebuild.
+      await rememberTags(env, finalTags);
       try {
         await storeEntry(env, id, content, finalTags, source, now, cfg);
       } catch (e) {

--- a/src/recall/distill.ts
+++ b/src/recall/distill.ts
@@ -9,15 +9,32 @@ import {
 } from "../constants";
 import { readStreamText } from "../lib/ai";
 import { extractHashtags } from "../text/hashtags";
+import { isTopicTag } from "../compression/eligibility";
+import { getTagVocabulary } from "../tags/vocabulary";
 
-export async function inferQueryTags(query: string, env: Env, config: Readonly<Config> = DEFAULTS): Promise<string[]> {
+/**
+ * `ctx` is optional only so this stays callable from tests and any future internal
+ * caller; pass it wherever there is one, or an aged-out vocabulary is rebuilt on the
+ * request's own critical path instead of behind it.
+ */
+export async function inferQueryTags(query: string, env: Env, config: Readonly<Config> = DEFAULTS, ctx?: ExecutionContext): Promise<string[]> {
   const { hashtags } = extractHashtags(query);
   if (hashtags.length) return hashtags;
 
-  const { results: tagRows } = await env.DB.prepare(
-    `SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value`
-  ).all();
-  const knownTags = (tagRows as { value: string }[]).map(r => r.value);
+  // Cached (#288): this used to be a full table scan expanded per tag per row, on
+  // every recall, and it was 82% of a recall's read cost.
+  //
+  // System tags are dropped rather than matched against. They say what the system
+  // did to an entry, not what it is about, and the only thing a query tag does is
+  // boost entries whose subject overlaps the question. Two of them — `auto-pattern`
+  // and `status:deprecated` — name entries that recall's hydration filter removes
+  // outright, so a boost they win is spent on rows that are then discarded. They are
+  // also applied in bulk (the staleness pass alone writes `volatility:` and
+  // `stale:as-of` across up to 25 entries a night), which makes them the highest-
+  // count tags in a mature brain and exactly the ones that would crowd real topics
+  // out of the 50 the LLM below is shown. The same predicate #278 used to keep them
+  // out of digest candidates, so the two agree by construction.
+  const knownTags = (await getTagVocabulary(env, ctx)).filter(isTopicTag);
 
   const lowerQuery = query.toLowerCase();
   const keywordMatches = knownTags.filter(t =>

--- a/src/recall/search.ts
+++ b/src/recall/search.ts
@@ -133,7 +133,7 @@ export async function recallEntries(
   const tokens = tokenizeQuery(embedQuery);
   const [values, queryTags] = await Promise.all([
     embed(embedQuery, env, cfg),
-    inferQueryTags(embedQuery, env, cfg),
+    inferQueryTags(embedQuery, env, cfg, ctx),
   ]);
 
   let keywordRows: KeywordRow[] = [];

--- a/src/routes/capture.ts
+++ b/src/routes/capture.ts
@@ -154,7 +154,7 @@ export async function handleCaptureRoutes(
       .bind(finalContent, JSON.stringify(mergedTags), Date.now(), id).run();
 
     // The rewritten content can carry hashtags the brain has never seen, which makes
-    // this the second of the three places an unknown tag enters the corpus (#288).
+    // this the second of the two places an unknown tag enters the corpus (#288).
     ctx.waitUntil(rememberTags(env, mergedTags));
 
     if (newVectorIds) {

--- a/src/routes/capture.ts
+++ b/src/routes/capture.ts
@@ -7,6 +7,7 @@ import { appendToEntry, deleteStaleVectors, reembedOrDegrade } from "../capture/
 import { isManagedMirror, mirrorEditError } from "../integrations/mirror";
 import { extractHashtags } from "../text/hashtags";
 import { tagsAfterWrite } from "../memory/stale";
+import { rememberTags } from "../tags/vocabulary";
 
 export async function handleCaptureRoutes(
   request: Request,
@@ -151,6 +152,10 @@ export async function handleCaptureRoutes(
     // the old vectors are kept below rather than retired.
     await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
       .bind(finalContent, JSON.stringify(mergedTags), Date.now(), id).run();
+
+    // The rewritten content can carry hashtags the brain has never seen, which makes
+    // this the second of the three places an unknown tag enters the corpus (#288).
+    ctx.waitUntil(rememberTags(env, mergedTags));
 
     if (newVectorIds) {
       try {

--- a/src/routes/entries.ts
+++ b/src/routes/entries.ts
@@ -3,12 +3,13 @@ import { json, requireAuth } from "../lib/http";
 import { forgetEntry } from "../capture/lifecycle";
 import { applyStatus } from "../capture/lifecycle";
 import { STATUS_VALUES, type MemoryStatus } from "../memory/status";
+import { getTagVocabulary } from "../tags/vocabulary";
 
 export async function handleEntriesRoutes(
   request: Request,
   url: URL,
   env: Env,
-  _ctx: ExecutionContext,
+  ctx: ExecutionContext,
 ): Promise<Response | null> {
   // GET /count
   if (url.pathname === "/count" && request.method === "GET") {
@@ -18,14 +19,15 @@ export async function handleEntriesRoutes(
     return json({ count: (row?.count as number) ?? 0 });
   }
 
-  // GET /tags
+  // GET /tags — the dashboard's filter dropdown, refetched on every page load.
+  // Reads the same cache recall does (#288): the scan behind it costs 180,000 rows
+  // on a 20,000-entry brain, and nothing here is worth that per navigation. Unlike
+  // recall this route has no useful degraded answer, so a cold cache is scanned
+  // inline rather than answered empty — see getTagVocabulary.
   if (url.pathname === "/tags" && request.method === "GET") {
     const authErr = requireAuth(request, env);
     if (authErr) return authErr;
-    const { results } = await env.DB.prepare(
-      `SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value`
-    ).all();
-    return json((results as any[]).map(r => r.value as string));
+    return json(await getTagVocabulary(env, ctx));
   }
 
   // GET /export — complete backup: every entry plus the edges table. Single

--- a/src/tags/vocabulary.ts
+++ b/src/tags/vocabulary.ts
@@ -1,0 +1,213 @@
+/**
+ * The brain's tag vocabulary, cached in KV (#288).
+ *
+ * `SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value` is
+ * the only way to ask SQLite which tags exist, and it is a full table scan expanded
+ * once per tag per row. Measured on workerd D1 at four tags an entry: 9,000 rows
+ * read at 1,000 entries, 45,000 at 5,000, 180,000 at 20,000. `inferQueryTags` ran
+ * it on every recall — 82% of a recall's read cost — which put a 5,000-memory brain
+ * at 90 recalls before D1's free 5M rows/day, and once that is spent every D1 query
+ * on the account fails until 00:00 UTC. The MCP clients this project ships
+ * instructions for recall at the start of every conversation and every few messages
+ * after, so 90 is an ordinary day rather than a stress test.
+ *
+ * Nothing makes that SQL cheaper. DISTINCT with ORDER BY cannot know its first row
+ * until it has visited the last one. Checked on real SQLite at 5,000 entries: with
+ * ORDER BY, without it, as a GROUP BY, and with a LIMIT 50 on either — and with an
+ * index on `tags` present — every variant plans identically, `SCAN entries` then
+ * `SCAN json_each` into a temp b-tree. The only saving available is not running it.
+ *
+ * WHY ITS OWN KEY, rather than riding along in `config:overrides`, which recall
+ * already reads through `resolveConfig`:
+ *
+ *  - `writeOverrides` serialises the whole blob from `readOverrides`, and
+ *    `readOverrides` drops every key that is not a known setting. A vocabulary
+ *    parked in that blob would be deleted the first time the user saved a setting,
+ *    and keeping it would mean teaching the settings write path to preserve data it
+ *    does not own.
+ *  - The KV read is not an extra one anyway. `inferQueryTags` already spent exactly
+ *    one subrequest on the scan; a KV get in its place is subrequest-neutral, and it
+ *    moves the cost off the budget this issue is about — D1 rows read, metered and
+ *    account-fatal — onto KV reads, which are a separate quota, edge-cached, and
+ *    constant in the size of the brain.
+ *  - Capture writes this key; the settings UI writes that one. One blob with two
+ *    independent writers is a lost update waiting to happen.
+ *
+ * WHY IT IS ONLY EVER STALE, NEVER WRONG. Both consumers degrade rather than
+ * mislead. `inferQueryTags` feeds a ranking boost (`TAG_BOOST_STEP`, applied in
+ * rerankWithTimeDecay), so a tag missing from the vocabulary costs one call a nudge
+ * in its ordering, and a tag that no longer exists boosts nothing because no entry
+ * carries it. `GET /tags` fills the dashboard's filter dropdown. Neither can return
+ * a wrong memory, and neither may fail: every path below falls back to the last good
+ * value, and finally to no vocabulary at all — which is the pre-cache behaviour of
+ * an empty brain, not an error.
+ */
+import type { Env } from "../env";
+
+// Prefixed to coexist with workers-oauth-provider's token:/grant:/client: keys,
+// config:overrides, and the integrations: blobs in the same namespace.
+export const TAG_VOCABULARY_KEY = "tags:vocabulary";
+
+/**
+ * How long a scanned vocabulary is trusted before it is rebuilt.
+ *
+ * The rebuild *is* the scan this cache exists to avoid, so its frequency is the
+ * residual cost: once a day is 180,000 rows on a 20,000-entry brain — 3.6% of the
+ * free daily budget, against 22 recalls' worth of budget before. An hour would be
+ * 4.3M rows a day and would have solved nothing.
+ *
+ * A day is affordable because nothing time-critical depends on it. Write-through
+ * (`rememberTags`) admits a newly captured tag immediately, so the age limit only
+ * has to cover the two things write-through cannot: pruning a tag whose last entry
+ * was deleted, and admitting the tags background jobs write — `status:`, `kind:`,
+ * `volatility:`, `stale:as-of`, `synthesized`, `rolled-up`, `auto-pattern`. Those
+ * are a closed set fixed at compile time, query inference excludes them on purpose
+ * (see `inferQueryTags`), and the only place they surface is a dropdown.
+ */
+export const TAG_VOCABULARY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * `rebuiltAt` is when the vocabulary was last reconciled against D1 — not when it
+ * was last written. `rememberTags` deliberately leaves it alone; see there.
+ */
+interface CachedVocabulary {
+  tags: string[];
+  rebuiltAt: number;
+}
+
+/** Any failure reads as "nothing cached", which costs a scan rather than a request. */
+async function readCache(env: Env): Promise<CachedVocabulary | null> {
+  try {
+    const raw = await env.OAUTH_KV.get(TAG_VOCABULARY_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const { tags, rebuiltAt } = parsed as Record<string, unknown>;
+    if (!Array.isArray(tags)) return null;
+    return {
+      tags: tags.filter((t): t is string => typeof t === "string"),
+      // A missing or unusable timestamp reads as "never reconciled", so the value
+      // is still served and a rebuild is still scheduled.
+      rebuiltAt: typeof rebuiltAt === "number" && Number.isFinite(rebuiltAt) ? rebuiltAt : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The scan, kept verbatim from the two call sites it replaces so that what is
+ * cached is exactly what `GET /tags` has always returned.
+ */
+async function scanTagVocabulary(env: Env): Promise<string[]> {
+  const { results } = await env.DB.prepare(
+    `SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value`
+  ).all();
+  return (results as { value: unknown }[]).map(r => r.value).filter((v): v is string => typeof v === "string");
+}
+
+/**
+ * Scan and store. Throws only if the scan does — a KV write failure still returns
+ * the fresh vocabulary, because the caller asked what the tags are, not where they
+ * are kept.
+ */
+async function rebuildTagVocabulary(env: Env): Promise<string[]> {
+  const tags = await scanTagVocabulary(env);
+  try {
+    await env.OAUTH_KV.put(TAG_VOCABULARY_KEY, JSON.stringify({ tags, rebuiltAt: Date.now() } satisfies CachedVocabulary));
+  } catch (e) {
+    console.error("Tag vocabulary cache write failed (non-fatal):", e);
+  }
+  return tags;
+}
+
+/**
+ * The read path. One KV get in the steady state and no D1 rows at all.
+ *
+ * Pass `ctx` wherever there is one. It decides what happens to an aged-out
+ * vocabulary: with a ctx the stale list is served and the rebuild runs behind the
+ * response, which is the whole point of the cache; without one there is nowhere to
+ * hang the work, so it runs inline.
+ *
+ * With nothing cached at all — a brain's first request, or KV having lost the key —
+ * the scan runs inline whoever is asking. That is once per brain rather than once
+ * per recall, it is bounded by what every recall used to cost, and it keeps the two
+ * consumers honest: an empty answer from `GET /tags` is not a degraded answer, it is
+ * a wrong one. If the scan fails too, the last good value is used, and failing that
+ * an empty vocabulary — a boost not applied and a dropdown short of options, never a
+ * failed request.
+ *
+ * If KV is unavailable entirely, every call lands here with nothing cached and
+ * rebuilds: the pre-cache cost, exactly, and not a byte worse.
+ *
+ * Not single-flighted. Two requests that both find the vocabulary aged out before
+ * either refresh lands will each scan. The window is one scan wide and opens once a
+ * day, against a brain that recalls a few hundred times a day — so the collision is
+ * rare and its cost is one extra scan, which is what every recall used to cost. Add
+ * an isolate-scoped guard if that ever shows up in a bill, not before.
+ */
+export async function getTagVocabulary(env: Env, ctx?: ExecutionContext): Promise<string[]> {
+  const cached = await readCache(env);
+
+  if (cached && Date.now() - cached.rebuiltAt < TAG_VOCABULARY_MAX_AGE_MS) return cached.tags;
+
+  if (cached && ctx) {
+    ctx.waitUntil(
+      rebuildTagVocabulary(env).catch(e => console.error("Tag vocabulary rebuild failed (non-fatal):", e))
+    );
+    return cached.tags;
+  }
+
+  try {
+    return await rebuildTagVocabulary(env);
+  } catch (e) {
+    console.error("Tag vocabulary rebuild failed (non-fatal):", e);
+    return cached?.tags ?? [];
+  }
+}
+
+/**
+ * Write-through: union tags that have just been written into the cached vocabulary,
+ * so a tag is inferable on the next recall rather than on the next rebuild.
+ *
+ * Called from the three places a tag string not known at compile time can enter the
+ * corpus — `captureEntry`, `POST /update`'s hashtag merge, and the integrations
+ * mirror. Every other writer of `entries.tags` (classification, `POST /status`, the
+ * compression pass, the staleness pass, the admin backfills) emits from a closed set
+ * of system tags, which query inference filters out anyway and which the age limit
+ * admits to the dropdown. That boundary is why this is three call sites rather than
+ * sixteen, each of which would be a chance to forget one.
+ *
+ * Costs one KV get, and a put only when a tag is genuinely new — so an established
+ * brain pays nothing to capture into a tag it already has. Does nothing when there
+ * is no cache yet: the entry row is already committed by the time this runs, so the
+ * scan that builds the first cache will find the tag by itself.
+ *
+ * Never throws, and never advances `rebuiltAt`: that field records the last
+ * reconciliation against D1, and moving it here would let an actively used brain
+ * postpone its rebuild forever, so a deleted tag would never be pruned.
+ *
+ * A rebuild running concurrently can overwrite an addition made here — it scanned
+ * before the insert and writes after it. The cost is one tag missing its boost until
+ * the next capture or rebuild, which is the same degradation as every other path.
+ */
+export async function rememberTags(env: Env, tags: string[]): Promise<void> {
+  try {
+    const cached = await readCache(env);
+    if (!cached) return;
+
+    const merged = new Set(cached.tags);
+    const before = merged.size;
+    for (const tag of tags) if (typeof tag === "string" && tag) merged.add(tag);
+    if (merged.size === before) return;
+
+    // Sorted to match the scan's ORDER BY, so /tags stays ordered however the
+    // vocabulary was last written.
+    await env.OAUTH_KV.put(
+      TAG_VOCABULARY_KEY,
+      JSON.stringify({ tags: [...merged].sort(), rebuiltAt: cached.rebuiltAt } satisfies CachedVocabulary)
+    );
+  } catch (e) {
+    console.error("Tag vocabulary write-through failed (non-fatal):", e);
+  }
+}

--- a/src/tags/vocabulary.ts
+++ b/src/tags/vocabulary.ts
@@ -11,11 +11,16 @@
  * instructions for recall at the start of every conversation and every few messages
  * after, so 90 is an ordinary day rather than a stress test.
  *
- * Nothing makes that SQL cheaper. DISTINCT with ORDER BY cannot know its first row
- * until it has visited the last one. Checked on real SQLite at 5,000 entries: with
- * ORDER BY, without it, as a GROUP BY, and with a LIMIT 50 on either — and with an
- * index on `tags` present — every variant plans identically, `SCAN entries` then
- * `SCAN json_each` into a temp b-tree. The only saving available is not running it.
+ * No rewrite of that SQL makes it sub-linear. It has to visit every row before it can
+ * know the first one, and on real SQLite every variant plans identically — with
+ * ORDER BY, without it, as a GROUP BY, with a LIMIT, and with an index on `tags`
+ * present: `SCAN entries`, `SCAN json_each`, temp b-tree, every time. So the fix is
+ * not running it per recall.
+ *
+ * Identical plans are not identical costs, though, and `scanTagVocabulary` takes the
+ * one saving that is available: dropping `ORDER BY value` is 44% off the rows read,
+ * because DISTINCT already builds a temp b-tree and ordering makes SQLite walk it
+ * back out. See there.
  *
  * WHY ITS OWN KEY, rather than riding along in `config:overrides`, which recall
  * already reads through `resolveConfig`:
@@ -52,17 +57,18 @@ export const TAG_VOCABULARY_KEY = "tags:vocabulary";
  * How long a scanned vocabulary is trusted before it is rebuilt.
  *
  * The rebuild *is* the scan this cache exists to avoid, so its frequency is the
- * residual cost: once a day is 180,000 rows on a 20,000-entry brain — 3.6% of the
- * free daily budget, against 22 recalls' worth of budget before. An hour would be
- * 4.3M rows a day and would have solved nothing.
+ * residual cost: once a day is 100,000 rows on a 20,000-entry brain — 2% of the free
+ * daily budget, against 22 recalls' worth of budget before. An hour would be 2.4M
+ * rows a day and would have solved nothing.
  *
  * A day is affordable because nothing time-critical depends on it. Write-through
- * (`rememberTags`) admits a newly captured tag immediately, so the age limit only
- * has to cover the two things write-through cannot: pruning a tag whose last entry
- * was deleted, and admitting the tags background jobs write — `status:`, `kind:`,
- * `volatility:`, `stale:as-of`, `synthesized`, `rolled-up`, `auto-pattern`. Those
- * are a closed set fixed at compile time, query inference excludes them on purpose
- * (see `inferQueryTags`), and the only place they surface is a dropdown.
+ * (`rememberTags`) admits a newly captured tag once its deferred write settles, so
+ * the age limit only has to cover the three things write-through cannot: pruning a
+ * tag whose last entry was deleted, admitting the tags background jobs write —
+ * `status:`, `kind:`, `volatility:`, `stale:as-of`, `synthesized`, `rolled-up`,
+ * `auto-pattern` — and repairing an addition a concurrent rebuild overwrote. The
+ * system tags are a closed set fixed at compile time, query inference excludes them
+ * on purpose (see `inferQueryTags`), and the only place they surface is a dropdown.
  */
 export const TAG_VOCABULARY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
@@ -86,9 +92,27 @@ async function readCache(env: Env): Promise<CachedVocabulary | null> {
     if (!Array.isArray(tags)) return null;
     return {
       tags: tags.filter((t): t is string => typeof t === "string"),
-      // A missing or unusable timestamp reads as "never reconciled", so the value
-      // is still served and a rebuild is still scheduled.
-      rebuiltAt: typeof rebuiltAt === "number" && Number.isFinite(rebuiltAt) ? rebuiltAt : 0,
+      // A missing or unusable timestamp reads as "never reconciled" — 0 — so the value
+      // is still served and a rebuild is still scheduled. A timestamp in the future is
+      // unusable in exactly that sense: nothing can have been reconciled at a moment
+      // that has not happened.
+      //
+      // It has to be rejected rather than clamped to now, which is the tempting
+      // one-liner and does not work. The freshness test is `now - rebuiltAt < MAX_AGE`,
+      // so every future timestamp passes it; clamping to `Date.now()` re-anchors on
+      // each read, so the value passes again a day later, and again — a blob dated next
+      // year, or carrying Number.MAX_SAFE_INTEGER, is served forever. No rebuild is
+      // ever scheduled, so nothing can correct it, and a tag deleted from the brain
+      // stays in the dropdown for good. Clock skew between the writing isolate and the
+      // reading one can produce one; a hand-edited value certainly can.
+      //
+      // Rejecting costs at most one scan and then converges: the rebuild writes the
+      // *reading* isolate's clock, so the slowest clock involved wins and every later
+      // read sees a past timestamp. There is no oscillation to trade off against.
+      rebuiltAt:
+        typeof rebuiltAt === "number" && Number.isFinite(rebuiltAt) && rebuiltAt <= Date.now()
+          ? rebuiltAt
+          : 0,
     };
   } catch {
     return null;
@@ -96,14 +120,32 @@ async function readCache(env: Env): Promise<CachedVocabulary | null> {
 }
 
 /**
- * The scan, kept verbatim from the two call sites it replaces so that what is
- * cached is exactly what `GET /tags` has always returned.
+ * The scan. This is now the whole residual D1 cost of the cache, paid once a day and
+ * on every cold read, so the `ORDER BY value` the two replaced call sites carried is
+ * gone — sorted in JS instead.
+ *
+ * That is not a plan improvement; every variant of this query plans identically
+ * (`SCAN entries`, `SCAN json_each`, temp b-tree, with or without ORDER BY, as a
+ * GROUP BY, with a LIMIT, with an index on `tags`). It is a rows-read improvement,
+ * and the plan is why the two are not the same thing: DISTINCT already needs a temp
+ * b-tree, and asking for it ordered as well makes SQLite walk that b-tree back out.
+ * Measured on workerd D1: 45,000 rows against 25,000 at 5,000 entries, 180,000
+ * against 100,000 at 20,000 — 44% off, for identical results.
+ *
+ * Free because the sort had to happen in JS anyway: `rememberTags` re-sorts whatever
+ * it writes back, so SQLite's ordering never survived a write-through in the first
+ * place. One caveat, unchanged by this: SQLite's BINARY collation orders UTF-8 bytes
+ * and JS orders UTF-16 code units, which differ only for astral-plane characters. A
+ * tag containing one could sit in a different dropdown position than it used to.
  */
 async function scanTagVocabulary(env: Env): Promise<string[]> {
   const { results } = await env.DB.prepare(
-    `SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value`
+    `SELECT DISTINCT value FROM entries, json_each(entries.tags)`
   ).all();
-  return (results as { value: unknown }[]).map(r => r.value).filter((v): v is string => typeof v === "string");
+  return (results as { value: unknown }[])
+    .map(r => r.value)
+    .filter((v): v is string => typeof v === "string")
+    .sort();
 }
 
 /**
@@ -168,44 +210,68 @@ export async function getTagVocabulary(env: Env, ctx?: ExecutionContext): Promis
 
 /**
  * Write-through: union tags that have just been written into the cached vocabulary,
- * so a tag is inferable on the next recall rather than on the next rebuild.
+ * so a new tag is admitted on the next read after this settles rather than having to
+ * wait for the next rebuild.
  *
- * Called from the three places a tag string not known at compile time can enter the
- * corpus — `captureEntry`, `POST /update`'s hashtag merge, and the integrations
- * mirror. Every other writer of `entries.tags` (classification, `POST /status`, the
- * compression pass, the staleness pass, the admin backfills) emits from a closed set
- * of system tags, which query inference filters out anyway and which the age limit
- * admits to the dropdown. That boundary is why this is three call sites rather than
- * sixteen, each of which would be a chance to forget one.
+ * "After this settles" is the honest bound, not "immediately". Both request-path
+ * callers defer it to `ctx.waitUntil`, which runs after the response, and KV needs a
+ * moment to propagate on top of that — so a dashboard that captures and then reloads
+ * `GET /tags` (`public/js/memory-crud.js`, and four other `loadTags()` call sites)
+ * can miss a hashtag it just saved and pick it up on the next load. Before this cache
+ * that route read D1 and always saw the committed row. The window is a dropdown
+ * option arriving one refresh late; it closes by itself.
  *
- * Costs one KV get, and a put only when a tag is genuinely new — so an established
- * brain pays nothing to capture into a tag it already has. Does nothing when there
- * is no cache yet: the entry row is already committed by the time this runs, so the
- * scan that builds the first cache will find the tag by itself.
+ * `captureEntry` and `POST /update`'s hashtag merge are the only two writers of
+ * `entries.tags` that can introduce a string not known at compile time. Every other
+ * one — classification, `POST /status`, the compression pass, the staleness pass, the
+ * admin backfills, and the integrations mirror, whose tags are provider ids from a
+ * compile-time registry — emits from a closed set, which query inference filters out
+ * anyway and which the age limit admits to the dropdown by itself. The mirror calls
+ * this too, but for promptness rather than correctness: without it a freshly
+ * connected integration is missing from the tag filter until the next rebuild.
  *
- * Never throws, and never advances `rebuiltAt`: that field records the last
- * reconciliation against D1, and moving it here would let an actively used brain
- * postpone its rebuild forever, so a deleted tag would never be pruned.
+ * Costs one KV get; the put and a second get happen only when a tag is genuinely new,
+ * so an established brain pays one get to capture into a tag it already has. Does
+ * nothing when there is no cache yet: the entry row is already committed by the time
+ * this runs, so the scan that builds the first cache will find the tag by itself.
  *
- * A rebuild running concurrently can overwrite an addition made here — it scanned
- * before the insert and writes after it. The cost is one tag missing its boost until
- * the next capture or rebuild, which is the same degradation as every other path.
+ * Never throws, and never advances `rebuiltAt` past what it read: that field records
+ * the last reconciliation against D1, and moving it forward here would let an
+ * actively used brain postpone its rebuild forever, so a deleted tag would never be
+ * pruned.
  */
 export async function rememberTags(env: Env, tags: string[]): Promise<void> {
   try {
     const cached = await readCache(env);
     if (!cached) return;
 
-    const merged = new Set(cached.tags);
-    const before = merged.size;
-    for (const tag of tags) if (typeof tag === "string" && tag) merged.add(tag);
-    if (merged.size === before) return;
+    const known = new Set(cached.tags);
+    const additions = tags.filter(t => typeof t === "string" && t && !known.has(t));
+    if (!additions.length) return;
 
-    // Sorted to match the scan's ORDER BY, so /tags stays ordered however the
-    // vocabulary was last written.
+    // Re-read immediately before writing, and merge onto whatever is there now.
+    //
+    // This races a rebuild in both directions. A rebuild that scanned before the row
+    // was committed and puts after this one wins, and the addition is lost until the
+    // next capture — that is the documented degradation, a tag missing its boost.
+    // The other direction is the one worth spending a KV get on: if a rebuild landed
+    // between the read above and this put, writing back the *older* `rebuiltAt` would
+    // age the cache out again and buy a second full scan, and writing back the older
+    // tag list would resurrect tags that rebuild had just pruned. Reading again
+    // narrows both windows to the put itself — KV has no compare-and-set, so they
+    // cannot be closed, and the residual cost is one scan, which is what every recall
+    // used to cost.
+    const latest = (await readCache(env)) ?? cached;
+    const merged = new Set(latest.tags);
+    for (const tag of additions) merged.add(tag);
+    if (merged.size === latest.tags.length) return;
+
     await env.OAUTH_KV.put(
       TAG_VOCABULARY_KEY,
-      JSON.stringify({ tags: [...merged].sort(), rebuiltAt: cached.rebuiltAt } satisfies CachedVocabulary)
+      JSON.stringify({
+        tags: [...merged].sort(),
+        rebuiltAt: Math.max(cached.rebuiltAt, latest.rebuiltAt),
+      } satisfies CachedVocabulary)
     );
   } catch (e) {
     console.error("Tag vocabulary write-through failed (non-fatal):", e);

--- a/test/integration/tag-vocabulary-cache.test.ts
+++ b/test/integration/tag-vocabulary-cache.test.ts
@@ -18,12 +18,17 @@
  * conversation and every few messages after — so 90 a day on a 5,000-memory brain
  * was ordinary use, not a stress test.
  *
- * Making the SQL cheaper is not available: DISTINCT with ORDER BY cannot know its
- * first row until it has visited the last, and on real SQLite the plan is identical
- * with ORDER BY, without it, as a GROUP BY, with a LIMIT, and with an index on
- * `tags` — `SCAN entries`, `SCAN json_each`, temp b-tree, every time. So the tests
- * below are about the query *not running*, and about every way it can fail to run
- * costing a boost rather than a result.
+ * No rewrite makes that query sub-linear — every variant plans identically on real
+ * SQLite (`SCAN entries`, `SCAN json_each`, temp b-tree, with or without ORDER BY, as
+ * a GROUP BY, with a LIMIT, with an index on `tags`) — so the tests below are about
+ * the query *not running*, and about every way it can fail to run costing a boost
+ * rather than a result.
+ *
+ * The rebuild that remains does drop `ORDER BY value` and sort in JS, which is 44%
+ * off its rows read for identical output (5,000 entries: 45,000 → 25,000; 20,000:
+ * 180,000 → 100,000). Identical plans, different costs: the DISTINCT b-tree has to be
+ * walked back out to emit in order. `orders the vocabulary identically to the SQL it
+ * replaced` below is what keeps that honest.
  *
  * Driven against real SQLite (`test/helpers/sqlite-d1.ts`) with every statement
  * recorded, because what is under test is which statements are issued.
@@ -156,6 +161,53 @@ describe("the tag vocabulary is scanned once, not per recall", () => {
     expect(stored.rebuiltAt).toBeGreaterThan(0);
   });
 
+  it("orders the vocabulary identically to the SQL it replaced", async () => {
+    // The rebuild drops `ORDER BY value` and sorts in JS instead, for 44% off its
+    // rows read. That is only free if the order is the same, and this asserts it
+    // against SQLite's own answer rather than against a hand-written expectation —
+    // a JS sort that disagreed with BINARY collation would reorder the dashboard's
+    // dropdown and pass a literal list quite happily.
+    const h = harness(CORPUS);
+    const { results } = await h.env.DB.prepare(
+      `SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value`
+    ).all();
+    const fromSql = (results as { value: string }[]).map(r => r.value);
+
+    expect(await getTagVocabulary(h.env)).toEqual(fromSql);
+  });
+
+  it("never freezes on a timestamp from the future, however far ahead", async () => {
+    // `now - rebuiltAt < MAX_AGE` is satisfied by every future timestamp, so one that
+    // is merely clamped to `Date.now()` re-anchors on each read and passes forever:
+    // no rebuild is ever scheduled, so nothing can correct it, and a tag deleted from
+    // the brain stays in the dropdown for good. Clock skew between the writing isolate
+    // and the reading one can produce one; a hand-edited blob certainly can.
+    for (const rebuiltAt of [Date.now() + 365 * 86400000, Number.MAX_SAFE_INTEGER]) {
+      const h = harness(CORPUS);
+      await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({ tags: ["frozen"], rebuiltAt }));
+
+      expect(await getTagVocabulary(h.env)).toEqual(ALL_TAGS);
+      expect(h.scans()).toHaveLength(1);
+      sqlite?.close();
+      sqlite = null;
+    }
+  });
+
+  it("serves the future-dated list meanwhile rather than answering empty", async () => {
+    // Rejecting the timestamp must not reject the vocabulary with it: this is the
+    // same degradation as any other aged-out copy, so the caller gets something and
+    // the correction happens behind the response.
+    const h = harness(CORPUS);
+    await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({
+      tags: ["frozen"],
+      rebuiltAt: Date.now() + 365 * 86400000,
+    }));
+
+    expect(await getTagVocabulary(h.env, h.ctx)).toEqual(["frozen"]);
+    await h.ctx.settle();
+    expect(await getTagVocabulary(h.env, h.ctx)).toEqual(ALL_TAGS);
+  });
+
   it("rebuilds behind the response once the cached copy ages out", async () => {
     const h = harness(CORPUS);
     await getTagVocabulary(h.env);
@@ -216,6 +268,37 @@ describe("a tag captured just now is inferable on the next recall", () => {
     expect(tags).toContain("lakehouse");
     // The whole point: no second scan bought that.
     expect(h.scans()).toHaveLength(1);
+  });
+
+  it("does not revert a rebuild that landed while it was working", async () => {
+    // Write-through reads, merges, and writes. A rebuild that puts between that read
+    // and that write would be undone by it: the older `rebuiltAt` goes back, aging
+    // the cache out and buying a second full scan, and the older tag list resurrects
+    // whatever the rebuild had just pruned. Re-reading before the put narrows both.
+    const h = harness(CORPUS);
+    await getTagVocabulary(h.env);
+    const aged = Date.now() - TAG_VOCABULARY_MAX_AGE_MS - 1;
+    await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({ tags: ["gone", "work"], rebuiltAt: aged }));
+
+    // A rebuild lands in the middle of the write-through: after its read, before its put.
+    // Bound before the spy replaces the property, or the double would call itself.
+    // `get` is overloaded (single key vs bulk), so it is installed untyped.
+    const realGet = (h.kv.get as (k: string) => Promise<string | null>).bind(h.kv);
+    let interleaved = false;
+    vi.spyOn(h.kv, "get").mockImplementation((async (key: string) => {
+      const value = await realGet(key);
+      if (!interleaved) {
+        interleaved = true;
+        await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({ tags: ["work"], rebuiltAt: Date.now() }));
+      }
+      return value;
+    }) as never);
+
+    await rememberTags(h.env, ["lakehouse"]);
+
+    const after = JSON.parse((await realGet(TAG_VOCABULARY_KEY))!);
+    expect(after.tags).toEqual(["lakehouse", "work"]);   // the pruned tag stays pruned
+    expect(after.rebuiltAt).toBeGreaterThan(aged);        // and the cache is still fresh
   });
 
   it("does not postpone the rebuild by touching rebuiltAt", async () => {

--- a/test/integration/tag-vocabulary-cache.test.ts
+++ b/test/integration/tag-vocabulary-cache.test.ts
@@ -1,0 +1,389 @@
+/**
+ * #288 — recall must not scan the tag table on every call.
+ *
+ * `SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value` is a
+ * full table scan expanded once per tag per row, and `inferQueryTags` ran it on
+ * every recall. Measured on workerd D1 through Miniflare (`meta.rows_read`), one
+ * `recallEntries({ query, topK: 5 })` at four tags an entry:
+ *
+ *   entries   tag scan   whole recall   whole recall    GET /tags   recalls/day
+ *                            (before)        (after)   before→after   before→after
+ *   1,000        9,000         11,000          2,000     9,000 → 0     454 → 2,500
+ *   5,000       45,000         55,000         10,000    45,000 → 0      90 →   500
+ *   20,000     180,000        220,000         40,000   180,000 → 0      22 →   125
+ *
+ * D1's free plan allows 5M rows read per day and fails every query on the account
+ * until 00:00 UTC once that is spent. The scan was 82% of a recall, and the MCP
+ * clients this project ships instructions for recall at the start of every
+ * conversation and every few messages after — so 90 a day on a 5,000-memory brain
+ * was ordinary use, not a stress test.
+ *
+ * Making the SQL cheaper is not available: DISTINCT with ORDER BY cannot know its
+ * first row until it has visited the last, and on real SQLite the plan is identical
+ * with ORDER BY, without it, as a GROUP BY, with a LIMIT, and with an index on
+ * `tags` — `SCAN entries`, `SCAN json_each`, temp b-tree, every time. So the tests
+ * below are about the query *not running*, and about every way it can fail to run
+ * costing a boost rather than a result.
+ *
+ * Driven against real SQLite (`test/helpers/sqlite-d1.ts`) with every statement
+ * recorded, because what is under test is which statements are issued.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { recallEntries } from "../../src/recall/search";
+import { inferQueryTags } from "../../src/recall/distill";
+import { captureEntry } from "../../src/capture/entry";
+import { handleEntriesRoutes } from "../../src/routes/entries";
+import {
+  getTagVocabulary,
+  rememberTags,
+  TAG_VOCABULARY_KEY,
+  TAG_VOCABULARY_MAX_AGE_MS,
+} from "../../src/tags/vocabulary";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestEnv, makeMemoryKV, makeKVMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+
+/** The one statement this issue is about. */
+const TAG_SCAN = /SELECT DISTINCT value FROM entries, json_each/;
+
+let sqlite: SqliteD1 | null = null;
+afterEach(() => { sqlite?.close(); sqlite = null; });
+
+/** Collects deferred work so a test can await what the Worker would run after responding. */
+function makeCtx(): ExecutionContext & { settle: () => Promise<void> } {
+  const pending: Promise<unknown>[] = [];
+  return {
+    waitUntil: (p: Promise<unknown>) => { pending.push(p); },
+    passThroughOnException: () => {},
+    props: {},
+    settle: async () => { await Promise.allSettled(pending.splice(0)); },
+  } as unknown as ExecutionContext & { settle: () => Promise<void> };
+}
+
+interface Harness {
+  env: Env;
+  issued: string[];
+  ctx: ExecutionContext & { settle: () => Promise<void> };
+  kv: KVNamespace;
+  scans: () => string[];
+}
+
+/**
+ * A brain with `tags` on every entry, real SQL underneath, and a KV that remembers
+ * what was written to it. `failScan` makes the tag scan — and only the tag scan —
+ * fail, which is how the degraded paths are reached without breaking recall itself.
+ */
+function harness(
+  entries: { id: string; content: string; tags: string[] }[],
+  opts: { failScan?: boolean; kv?: KVNamespace } = {},
+): Harness {
+  sqlite = makeSqliteD1();
+  // `updated_at` is added by ALTER in src/db/init.ts rather than in schema.sql, and
+  // that path goes through `exec`, which this facade does not run. Capture writes it
+  // and recall's hydration selects it.
+  sqlite.db.prepare(`ALTER TABLE entries ADD COLUMN updated_at INTEGER`).run();
+  entries.forEach((e, i) => sqlite!.seed({ ...e, createdAt: 1_700_000_000_000 + i }));
+
+  const issued: string[] = [];
+  const inner = sqlite.db;
+  const DB = {
+    prepare(sql: string) {
+      issued.push(sql.replace(/\s+/g, " ").trim());
+      if (opts.failScan && TAG_SCAN.test(sql)) {
+        const boom = () => Promise.reject(new Error("D1_ERROR: network error: SQLITE_ERROR"));
+        return { bind: () => ({ all: boom, first: boom, run: boom }), all: boom, first: boom, run: boom };
+      }
+      return inner.prepare(sql);
+    },
+    exec: (sql: string) => inner.exec(sql),
+  } as unknown as D1Database;
+
+  const kv = opts.kv ?? makeMemoryKV();
+  return {
+    env: makeTestEnv(undefined, { DB, OAUTH_KV: kv }),
+    issued,
+    ctx: makeCtx(),
+    kv,
+    scans: () => issued.filter(s => TAG_SCAN.test(s)),
+  };
+}
+
+/**
+ * Ten entries rather than three: `distillToRareTerms` drops any term occurring in
+ * more than QUERY_SATURATION_FRACTION of the corpus, and on a three-row brain a term
+ * in one row is already saturated — the query would be distilled to nothing and the
+ * recall assertions below would pass on an empty result set.
+ */
+const CORPUS = [
+  { id: "e1", content: "Signed the office lease renewal for the Dublin site", tags: ["work", "legal", "kind:semantic"] },
+  { id: "e2", content: "Quarterly planning session moved to Thursday", tags: ["work", "planning", "status:canonical"] },
+  { id: "e3", content: "Booked the dentist for next month", tags: ["health", "personal"] },
+  { id: "e4", content: "Ran five kilometres before breakfast", tags: ["health"] },
+  { id: "e5", content: "Drafted the supplier contract amendment", tags: ["legal"] },
+  { id: "e6", content: "Reviewed the hiring pipeline with the team", tags: ["work"] },
+  { id: "e7", content: "Bought a bicycle at the weekend", tags: ["personal"] },
+  { id: "e8", content: "Trip to the coast in autumn", tags: ["planning", "personal"] },
+  { id: "e9", content: "Filed the annual accounts", tags: ["legal", "work"] },
+  { id: "e10", content: "Renewed the gym membership", tags: ["health", "personal"] },
+];
+
+const ALL_TAGS = ["health", "kind:semantic", "legal", "personal", "planning", "status:canonical", "work"];
+
+describe("the tag vocabulary is scanned once, not per recall", () => {
+  it("scans on the first recall and never again while the cache is warm", async () => {
+    const h = harness(CORPUS);
+
+    await recallEntries({ query: "what did I decide about the office lease", topK: 5 }, h.env, h.ctx);
+    await h.ctx.settle();
+    expect(h.scans()).toHaveLength(1);
+
+    for (let i = 0; i < 5; i++) {
+      await recallEntries({ query: `notes on the quarterly planning session ${i}`, topK: 5 }, h.env, h.ctx);
+      await h.ctx.settle();
+    }
+    expect(h.scans()).toHaveLength(1);
+  });
+
+  it("caches what the scan found, under its own key", async () => {
+    const h = harness(CORPUS);
+    await getTagVocabulary(h.env);
+
+    const raw = await h.kv.get(TAG_VOCABULARY_KEY);
+    expect(raw).toBeTruthy();
+    const stored = JSON.parse(raw!);
+    expect(stored.tags).toEqual(ALL_TAGS);
+    expect(stored.rebuiltAt).toBeGreaterThan(0);
+  });
+
+  it("rebuilds behind the response once the cached copy ages out", async () => {
+    const h = harness(CORPUS);
+    await getTagVocabulary(h.env);
+    expect(h.scans()).toHaveLength(1);
+
+    await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({
+      tags: ["stale-only"],
+      rebuiltAt: Date.now() - TAG_VOCABULARY_MAX_AGE_MS - 1,
+    }));
+
+    // The aged copy is what the caller gets — it is handed back before the rebuild
+    // this call scheduled can have finished, which is the whole point of deferring it.
+    expect(await getTagVocabulary(h.env, h.ctx)).toEqual(["stale-only"]);
+
+    await h.ctx.settle();
+    expect(h.scans()).toHaveLength(2);
+    expect(await getTagVocabulary(h.env, h.ctx)).toContain("work");
+  });
+});
+
+describe("recall results are unchanged — only their cost", () => {
+  it("infers the same tags warm as it did cold", async () => {
+    const h = harness(CORPUS);
+
+    const cold = await inferQueryTags("notes about legal work", h.env);
+    expect(h.scans()).toHaveLength(1);
+
+    const warm = await inferQueryTags("notes about legal work", h.env);
+    expect(h.scans()).toHaveLength(1);
+    expect(warm).toEqual(cold);
+    expect(warm).toEqual(expect.arrayContaining(["legal", "work"]));
+  });
+
+  it("returns the same ordered matches warm as cold", async () => {
+    const h = harness(CORPUS);
+    const ids = async () => (await recallEntries({ query: "office lease renewal", topK: 5 }, h.env, h.ctx)).matches.map(m => m.id);
+
+    const cold = await ids();
+    await h.ctx.settle();
+    const warm = await ids();
+
+    expect(cold.length).toBeGreaterThan(0);
+    expect(warm).toEqual(cold);
+  });
+});
+
+describe("a tag captured just now is inferable on the next recall", () => {
+  it("write-through admits it without waiting for a rebuild", async () => {
+    const h = harness(CORPUS);
+    await getTagVocabulary(h.env); // the brain has been used before
+    expect(h.scans()).toHaveLength(1);
+
+    const result = await captureEntry("Moving the warehouse to #lakehouse next spring", [], "api", h.env, h.ctx);
+    expect(result.status).toBe("stored");
+    await h.ctx.settle();
+
+    const tags = await inferQueryTags("what is happening with lakehouse", h.env);
+    expect(tags).toContain("lakehouse");
+    // The whole point: no second scan bought that.
+    expect(h.scans()).toHaveLength(1);
+  });
+
+  it("does not postpone the rebuild by touching rebuiltAt", async () => {
+    // Advancing it on every capture would let an actively used brain never
+    // reconcile, so a deleted tag's last mention would never be pruned.
+    const h = harness(CORPUS);
+    await getTagVocabulary(h.env);
+    const before = JSON.parse((await h.kv.get(TAG_VOCABULARY_KEY))!).rebuiltAt;
+
+    await rememberTags(h.env, ["freshly-invented"]);
+
+    const after = JSON.parse((await h.kv.get(TAG_VOCABULARY_KEY))!);
+    expect(after.tags).toContain("freshly-invented");
+    expect(after.rebuiltAt).toBe(before);
+  });
+
+  it("leaves the cache alone when there is nothing cached yet", async () => {
+    // The row is already committed by then, so the scan that builds the first
+    // cache finds the tag by itself — writing a partial vocabulary would only
+    // invent a second source of truth.
+    const h = harness(CORPUS);
+    await rememberTags(h.env, ["lakehouse"]);
+    expect(await h.kv.get(TAG_VOCABULARY_KEY)).toBeNull();
+  });
+});
+
+describe("every way the cache can fail degrades, and none of them fails a request", () => {
+  it("answers recall when the scan itself is broken and nothing is cached", async () => {
+    const h = harness(CORPUS, { failScan: true });
+
+    const { matches } = await recallEntries({ query: "office lease renewal", topK: 5 }, h.env, h.ctx);
+
+    // Results, just without the tag boost that vocabulary would have fed.
+    expect(matches.length).toBeGreaterThan(0);
+    expect(await inferQueryTags("notes about legal work", h.env)).toEqual([]);
+  });
+
+  it("answers GET /tags with an empty list rather than a 500", async () => {
+    const h = harness(CORPUS, { failScan: true });
+
+    const res = await handleEntriesRoutes(req("GET", "/tags"), new URL("http://localhost/tags"), h.env, h.ctx);
+
+    expect(res!.status).toBe(200);
+    expect(await res!.json()).toEqual([]);
+  });
+
+  it("serves the last good vocabulary when a later scan breaks", async () => {
+    const h = harness(CORPUS);
+    await getTagVocabulary(h.env);
+
+    await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({
+      tags: ["work", "legal"],
+      rebuiltAt: Date.now() - TAG_VOCABULARY_MAX_AGE_MS - 1,
+    }));
+    const broken = harness([], { kv: h.kv, failScan: true });
+
+    expect(await getTagVocabulary(broken.env)).toEqual(["work", "legal"]);
+  });
+
+  it("falls back to scanning when KV is unavailable, which is exactly the old cost", async () => {
+    // makeKVMock reads null and swallows writes — the shape of a KV outage.
+    const h = harness(CORPUS, { kv: makeKVMock() });
+
+    expect(await inferQueryTags("notes about legal work", h.env)).toEqual(expect.arrayContaining(["legal", "work"]));
+    expect(await inferQueryTags("notes about legal work", h.env)).toEqual(expect.arrayContaining(["legal", "work"]));
+    expect(h.scans()).toHaveLength(2);
+  });
+
+  it("rebuilds rather than trusting a blob it cannot read", async () => {
+    for (const blob of ["not json at all", '{"tags":"work"}', "null", '{"rebuiltAt":123}']) {
+      const h = harness(CORPUS);
+      await h.kv.put(TAG_VOCABULARY_KEY, blob);
+      expect(await getTagVocabulary(h.env)).toContain("work");
+      expect(h.scans()).toHaveLength(1);
+      sqlite?.close();
+      sqlite = null;
+    }
+  });
+
+  it("serves a blob whose timestamp is unusable, and reconciles it", async () => {
+    const h = harness(CORPUS);
+    await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({ tags: ["kept"], rebuiltAt: "yesterday" }));
+
+    expect(await getTagVocabulary(h.env, h.ctx)).toEqual(["kept"]);
+    await h.ctx.settle();
+    expect(await getTagVocabulary(h.env, h.ctx)).toContain("work");
+  });
+
+  it("still answers when the cache write fails", async () => {
+    const kv = makeMemoryKV();
+    vi.spyOn(kv, "put").mockRejectedValue(new Error("KV unavailable"));
+    const h = harness(CORPUS, { kv });
+
+    expect(await getTagVocabulary(h.env)).toContain("work");
+  });
+
+  it("keeps serving the aged copy when the rebuild behind the response fails", async () => {
+    // A rejection inside waitUntil is not a failed request, but it is an unhandled
+    // rejection unless it is caught — and the vocabulary it was refreshing has to
+    // survive the attempt rather than be cleared by it.
+    const kv = makeMemoryKV();
+    await kv.put(TAG_VOCABULARY_KEY, JSON.stringify({
+      tags: ["work", "legal"],
+      rebuiltAt: Date.now() - TAG_VOCABULARY_MAX_AGE_MS - 1,
+    }));
+    const h = harness(CORPUS, { kv, failScan: true });
+
+    expect(await getTagVocabulary(h.env, h.ctx)).toEqual(["work", "legal"]);
+    await expect(h.ctx.settle()).resolves.toBeUndefined();
+    expect(await getTagVocabulary(h.env, h.ctx)).toEqual(["work", "legal"]);
+  });
+
+  it("swallows a failed write-through rather than failing the capture behind it", async () => {
+    const kv = makeMemoryKV();
+    const h = harness(CORPUS, { kv });
+    await getTagVocabulary(h.env);
+    vi.spyOn(kv, "put").mockRejectedValue(new Error("KV unavailable"));
+
+    await expect(rememberTags(h.env, ["lakehouse"])).resolves.toBeUndefined();
+  });
+});
+
+describe("system tags", () => {
+  const SYSTEM = [
+    { id: "s1", content: "A rolled-up digest of several older memories", tags: ["synthesized", "rolled-up", "work"] },
+    { id: "s2", content: "A memory the staleness pass has looked at", tags: ["volatility:state", "stale:as-of", "work"] },
+  ];
+
+  it("are not part of the vocabulary query inference matches against", async () => {
+    // They say what the system did to an entry, not what it is about, and the only
+    // thing a query tag does is boost entries whose subject overlaps the question.
+    const h = harness(SYSTEM);
+
+    const tags = await inferQueryTags("show me the synthesized rolled-up notes", h.env);
+
+    expect(tags).not.toContain("synthesized");
+    expect(tags).not.toContain("rolled-up");
+  });
+
+  it("still reach GET /tags, which is a browse affordance rather than a ranking input", async () => {
+    const h = harness(SYSTEM);
+
+    const res = await handleEntriesRoutes(req("GET", "/tags"), new URL("http://localhost/tags"), h.env, h.ctx);
+
+    expect(await res!.json()).toEqual(["rolled-up", "stale:as-of", "synthesized", "volatility:state", "work"]);
+  });
+});
+
+describe("GET /tags", () => {
+  it("reads the vocabulary a recall warmed, and scans nothing of its own", async () => {
+    const h = harness(CORPUS);
+    await recallEntries({ query: "office lease renewal", topK: 5 }, h.env, h.ctx);
+    await h.ctx.settle();
+    expect(h.scans()).toHaveLength(1);
+
+    const res = await handleEntriesRoutes(req("GET", "/tags"), new URL("http://localhost/tags"), h.env, h.ctx);
+
+    expect(await res!.json()).toEqual(ALL_TAGS);
+    expect(h.scans()).toHaveLength(1);
+  });
+
+  it("warms the same vocabulary recall then reads", async () => {
+    const h = harness(CORPUS);
+    await handleEntriesRoutes(req("GET", "/tags"), new URL("http://localhost/tags"), h.env, h.ctx);
+    expect(h.scans()).toHaveLength(1);
+
+    await inferQueryTags("notes about legal work", h.env);
+
+    expect(h.scans()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

`inferQueryTags` ran a full table scan on **every** recall:

```sql
SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value
```

expanded per tag per row. It short-circuited only when the query contained a literal `#hashtag`, so ordinary natural-language queries always paid it — 82% of a recall's read cost. `GET /tags` issued the same statement on every dashboard load. Closes #288.

## Measured on real workerd D1 (`meta.rows_read`), four tags per entry

| entries | recall before | after | `GET /tags` before | after | recalls/day @ 5M |
|---|---|---|---|---|---|
| 1,000 | 11,000 | **2,000** | 9,000 | **0** | 454 → **2,500** |
| 5,000 | 55,000 | **10,000** | 45,000 | **0** | 90 → **500** |
| 20,000 | 220,000 | **40,000** | 180,000 | **0** | 22 → **125** |

The project's own guidance tells clients to recall at the start of every conversation and every few messages, so ninety a day on a 5,000-memory brain was ordinary use — and exceeding the daily read budget returns errors for **every** D1 query on the account until 00:00 UTC, not just recall.

A cold-cache recall still costs exactly the old price, once per brain and then once per 24h. At 20,000 entries that daily rebuild is 3.6% of the free budget.

## Why its own KV key, not `config:overrides`

`writeOverrides` reserialises from `readOverrides` and drops every key not in `DEFAULTS` — a vocabulary parked there would be **deleted the first time a user saved a setting**. It would also make capture and the settings UI two independent writers of one blob.

The KV read is subrequest-neutral: it replaces a D1 query that cost exactly one, moving the cost off the account-fatal D1 budget onto a separate quota that is constant in brain size.

## Invalidation — both mechanisms, split by what each can cover

**Write-through** unions new tags in at the three places a tag string not known at compile time enters the corpus. It deliberately does **not** advance `rebuiltAt`, or an actively used brain would postpone reconciliation forever and a deleted tag would never be pruned.

**A 24h age limit** covers what write-through cannot: pruning dead tags, and admitting tags written by background jobs. All sixteen other `tags` write statements — classification, `POST /status`, the compression and staleness passes, the admin backfills, the provider ids — emit from closed compile-time sets, which is why this is three call sites rather than sixteen.

The nightly cron deliberately does *not* rebuild: an unconditional 180,000-row scan every night costs more than on-demand expiry, which only fires if someone actually recalls.

**Everything degrades.** Stale + a ctx → serve stale, rebuild under `waitUntil`. Nothing cached → scan inline once. Scan fails → last good value, then `[]`. KV down entirely → every call rebuilds, i.e. exactly the pre-fix cost and not a byte worse.

## One intentional result change

Reserved tags are excluded from query **inference** but kept in `GET /tags`. They describe what the system did to an entry rather than its subject; two of them (`auto-pattern`, `status:deprecated`) name rows the hydration filter discards anyway, so any boost is spent on rows then thrown away; and being applied in bulk they are the highest-count tags in a mature brain, exactly the ones that would crowd real topics out.

So a query that literally spells `synthesized` or `rolled-up` no longer boosts those entries. Exclusion reuses `isTopicTag`, so it agrees with digest candidacy by construction.

`GET /tags` keeps them — it is a browse affordance, and dropping `status:deprecated` from the dashboard filter would be a real regression.

## Placement

`src/tags/vocabulary.ts`, not `src/memory/`. `ARCHITECTURE.md` declares `memory/` a Pure layer that may import `constants.ts` only, and this touches `env.DB` and `env.OAUTH_KV` — so it follows the `vectorize/health.ts` precedent instead.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:coverage` — 1237 passing; all 1216 pre-existing unchanged, plus 21 new
- [x] `npx wrangler deploy --dry-run`
- [x] Results verified unchanged: `inferQueryTags` returns identical tags warm vs cold, and `recallEntries` returns identical ordered matches warm vs cold
- [x] Confirmed on real SQLite that no SQL variant helps — with/without `ORDER BY`, as `GROUP BY`, with `LIMIT 50`, and with an index on `tags`, every plan is `SCAN entries | SCAN json_each | USE TEMP B-TREE`

## Known, and the next thing on this budget

**Recall still costs ~2× the entry count** — 40,000 rows at 20,000 entries. `distillToRareTerms`'s `SUM(CASE WHEN content LIKE ?)` aggregate is a full scan, and the keyword arm is another. Both still scale linearly, so 125 recalls/day at 20,000 entries is better but not bounded. That needs FTS5 or a real inverted index, not a cache — filed separately.

`GET /export` is also unbounded, on the same budget.
