### PR TITLE
perf(integrations): give sync its own trigger and bound the recurrence walk (#290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Prefer to run it yourself? Use the one-click **[Deploy to Cloudflare](https://de
 
 * **Memory graph.** Memories now connect to each other — automatically as you save, or explicitly with the new `link` and `connections` tools. Recall can follow those connections (the `hops` option) to surface related context that a plain search would miss, and the dashboard has a new **Graph** tab to explore your memory visually.
 
-* **Notion sync.** Connect your Notion workspace from **Settings → Integrations** in the dashboard. Pages you share with the connection sync into memory, stay updated as they change in Notion, and surface in recall alongside everything else. Nightly automatic sync, or on demand with **Sync now**.
+* **Notion sync.** Connect your Notion workspace from **Settings → Integrations** in the dashboard. Pages you share with the connection sync into memory, stay updated as they change in Notion, and surface in recall alongside everything else. Automatic hourly sync, or on demand with **Sync now**.
 
 * **Graceful degradation.** If the Vectorize index is missing, the whole brain keeps working keyword-only: recall falls back to keyword search with a clear notice, and captures, appends and updates are still committed rather than rejected. A `/health` endpoint reports index status, and the dashboard shows a banner with the exact fix.
 
@@ -92,9 +92,9 @@ Memory is most useful when capturing information is easy. Second Brain connects 
   npm install -g second-brain-cf-cli
   ```
 
-* **Notion:** Connect your Notion workspace from **Settings → Integrations** in the web dashboard. Create an internal **connection** in the [Notion developer portal](https://app.notion.com/developers/connections) (a connection, not a personal access token — only connections appear in a page's Connections menu), share the pages you want remembered with it, and paste its secret — shared pages sync into memory automatically (nightly, or on demand with **Sync now**) and stay updated as they change in Notion.
+* **Notion:** Connect your Notion workspace from **Settings → Integrations** in the web dashboard. Create an internal **connection** in the [Notion developer portal](https://app.notion.com/developers/connections) (a connection, not a personal access token — only connections appear in a page's Connections menu), share the pages you want remembered with it, and paste its secret — shared pages sync into memory automatically (hourly, or on demand with **Sync now**) and stay updated as they change in Notion.
 
-* **Calendar:** Connect Google, Outlook, or iCloud from **Settings → Integrations** and paste your calendar's private **iCal (`.ics`) link** (Google: *your calendar → Integrate calendar → "Secret address in iCal format"*; Outlook: *Calendar → Shared calendars → Publish*; iCloud: *Share Calendar → Public Calendar*). Read-only — upcoming events sync into memory automatically (nightly, or on demand with **Sync now**), and past events are kept as a bounded history.
+* **Calendar:** Connect Google, Outlook, or iCloud from **Settings → Integrations** and paste your calendar's private **iCal (`.ics`) link** (Google: *your calendar → Integrate calendar → "Secret address in iCal format"*; Outlook: *Calendar → Shared calendars → Publish*; iCloud: *Share Calendar → Public Calendar*). Read-only — upcoming events sync into memory automatically (hourly, or on demand with **Sync now**), and past events are kept as a bounded history.
 
 * **Email:** Connect Gmail or iCloud from **Settings → Integrations** with an **app password** (Google: *Account → Security → App passwords*; iCloud: *appleid.apple.com → App-Specific Passwords*). Read-only — meaningful messages are captured into memory, while newsletters, marketing, receipts, and other automated mail are filtered out.
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -225,7 +225,7 @@ Everything the installer ever calls, for auditability:
 | `POST /accounts/{a}/workers/scripts/second-brain/assets-upload-session` | start the dashboard asset upload |
 | `POST /accounts/{a}/workers/assets/upload?base64=true` | upload dashboard files |
 | `PUT /accounts/{a}/workers/scripts/second-brain` | deploy the Worker (multipart: module + metadata with D1/Vectorize/KV/AI bindings, `VECTORIZE_GRACE_MS` var, `AUTH_TOKEN` secret, assets) |
-| `PUT /accounts/{a}/workers/scripts/second-brain/schedules` | nightly maintenance cron (`0 1 * * *`) |
+| `PUT /accounts/{a}/workers/scripts/second-brain/schedules` | nightly maintenance (`0 1 * * *`) and hourly integration sync (`30 * * * *`) crons |
 | `POST /accounts/{a}/workers/scripts/second-brain/subdomain` | turn on the `workers.dev` URL |
 | `GET {worker}/health`, `POST {worker}/capture` | post-deploy smoke tests against the user's own Worker |
 

--- a/installer/src-tauri/src/cf/provision.rs
+++ b/installer/src-tauri/src/cf/provision.rs
@@ -620,7 +620,10 @@ mod tests {
             "compatibilityDate": "2026-06-17",
             "compatibilityFlags": ["nodejs_compat"],
             "vars": { "VECTORIZE_GRACE_MS": "300000" },
-            "cron": ["0 1 * * *"],
+            // Both schedules: nightly maintenance and the hourly integration sync,
+            // which runs on its own budget (#290). The app has to register every
+            // entry, not just the first.
+            "cron": ["0 1 * * *", "30 * * * *"],
             "d1Binding": "DB",
             "d1Name": "second-brain-db",
             "vectorizeBinding": "VECTORIZE",
@@ -817,7 +820,7 @@ mod tests {
         assert!(log.contains(&"create_vectorize:second-brain-vectors:384:cosine".to_string()));
         // 5 fixed bindings + 1 var
         assert!(log.contains(&"deploy:second-brain:6".to_string()));
-        assert!(log.contains(&"set_cron:0 1 * * *".to_string()));
+        assert!(log.contains(&"set_cron:0 1 * * *,30 * * * *".to_string()));
         assert!(log.contains(&"health_ok".to_string()));
         assert!(log.contains(&"capture_ok".to_string()));
     }
@@ -1050,6 +1053,14 @@ mod tests {
         let bindings = meta["bindings"].as_array().unwrap();
         let vectorize = bindings.iter().find(|b| b["type"] == "vectorize").unwrap();
         assert_eq!(vectorize["index_name"], "second-brain-vectors-768");
+
+        // Updating an existing install has to re-register the whole schedule set.
+        // A user who installed before the integration sync got its own trigger
+        // only picks it up here, and only if every entry is sent.
+        assert!(
+            log.contains(&"set_cron:0 1 * * *,30 * * * *".to_string()),
+            "update must set every schedule the manifest carries: {log:?}"
+        );
     }
 
     /// A routine update must keep binding what the build ships with, or every

--- a/installer/src-tauri/src/worker_bundle.rs
+++ b/installer/src-tauri/src/worker_bundle.rs
@@ -147,7 +147,11 @@ mod tests {
         assert_eq!(m.kv_binding, "OAUTH_KV");
         assert_eq!(m.ai_binding, "AI");
         assert!(m.compatibility_flags.contains(&"nodejs_compat".to_string()));
-        assert_eq!(m.cron, vec!["0 1 * * *"]);
+        // Two schedules, and the app has to provision BOTH: nightly maintenance, and
+        // the hourly integration sync that runs on its own budget (#290). An install
+        // that registered only the first would leave mirrors never syncing on their
+        // own. Order follows wrangler.jsonc, which is what set_cron receives.
+        assert_eq!(m.cron, vec!["0 1 * * *", "30 * * * *"]);
     }
 
     #[test]

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
 import type { Env } from "./env";
 import { runNightlyCompression } from "./compression/nightly";
 import { runGraphPass } from "./graph/pass";
-import { runScheduledIntegrationSync } from "./integrations/mirror";
+import { INTEGRATION_SYNC_CRON, runScheduledIntegrationSync } from "./integrations/mirror";
 import { runStalenessPass } from "./staleness/pass";
 import { apiHandler } from "./mcp/handler";
 import { augmentOAuthRegistrationRequest } from "./oauth/register";
@@ -40,15 +40,30 @@ export default {
     }
     return oauthProvider.fetch(req, env as any, ctx);
   },
-  scheduled: async (_event: ScheduledEvent, env: Env, ctx: ExecutionContext) => {
+  scheduled: async (event: ScheduledEvent, env: Env, ctx: ExecutionContext) => {
     // The jobs are independent, and each begins by awaiting the shared schema init. One
     // of them failing — including on that init — must not take the others down or surface
     // as an unhandled rejection inside waitUntil.
     const job = (name: string, run: Promise<void>) =>
       ctx.waitUntil(run.catch((e) => console.error(`${name} failed (non-fatal):`, e)));
+
+    // Two schedules, two budgets (#290). A Worker invocation gets 50 D1 queries and 10 ms
+    // of CPU on the free plan; the maintenance jobs below already spend 30 of those
+    // queries, so the mirror sync gets its own invocation rather than the remainder of
+    // this one. Routing on the cron string is what makes that real — without the branch
+    // both triggers would run everything and the split would cost budget instead of
+    // buying it.
+    if (event.cron === INTEGRATION_SYNC_CRON) {
+      job("integration sync", runScheduledIntegrationSync(env));
+      return;
+    }
+
+    // Anything else runs maintenance: the nightly cron, and any invocation whose cron we
+    // do not recognise (a hand-fired trigger, or a schedule added to wrangler.jsonc and
+    // not yet routed here). Maintenance is the safe default — skipping it degrades recall
+    // quality silently, whereas a skipped mirror sync is picked up on the next hour.
     job("nightly compression", runNightlyCompression(env, ctx));
     job("graph pass", runGraphPass(env, ctx));
-    job("integration sync", runScheduledIntegrationSync(env));
     job("staleness pass", runStalenessPass(env, ctx));
   },
 };

--- a/src/integrations/calendar.ts
+++ b/src/integrations/calendar.ts
@@ -29,7 +29,16 @@ export const RETENTION_MS = 180 * DAY_MS;    // hard bound on kept history
 // past, so they don't accumulate as low-value memories; one-off past events still
 // keep the full RETENTION_MS as historical memory.
 export const RECURRING_RETENTION_MS: number | null = 0;
-export const SYNC_EVENT_BATCH = 10;          // create/update ceiling per batch (subrequest budget)
+// Create/update ceiling per batch. The budget that binds here is D1's — 50
+// queries per Worker invocation on the free plan — not the one outbound fetch
+// per sync this used to be justified by, which is how the real cost went
+// unnoticed (#290). Each mirrored occurrence costs the mirror store two D1
+// queries to create (insert, then vector_ids) and three to update (read, content
+// write, vector_ids), on top of its classify, embed and Vectorize calls. So ten
+// items is 20–30 D1 queries: comfortable in an HTTP sync, which owns its whole
+// invocation, and the most the nightly cron can afford in the one it shares with
+// three other jobs (see CRON_SYNC_MAX_BATCHES in mirror.ts).
+export const SYNC_EVENT_BATCH = 10;
 export const MAX_OCCURRENCES_PER_EVENT = 200;
 const MAX_ITER = 100_000;                     // guards pathological RRULEs. Note: ev.iterator() walks from DTSTART, so this budget is also spent reaching the window; 100k covers realistic old/frequent series (e.g. hourly for ~10y, daily for centuries). Sub-hourly rules running many years may exhaust it and yield no occurrences — acceptable.
 const MAX_DESCRIPTION_CHARS = 4000;
@@ -86,7 +95,33 @@ function pushSingle(ev: any, startMs: number, endMs: number, out: Occurrence[]):
   });
 }
 
-function expandRecurring(ev: any, startMs: number, endMs: number, out: Occurrence[]): void {
+/**
+ * The furthest past its nominal start that an occurrence of this series can
+ * still be running — its longest possible (end − recurrence time).
+ *
+ * This is what lets the walk below reject a spent occurrence from the iterator's
+ * own time, without building the occurrence first. It has to bound overrides as
+ * well as the master, because a RECURRENCE-ID instance can be both moved later
+ * and made longer; `end − recurrence-id` covers those two in one number. An
+ * override we cannot read returns Infinity, which disables the shortcut for this
+ * series rather than risking a wrong skip.
+ */
+function seriesReachMs(ev: any, exceptions: any[]): number {
+  let reach = ev.endDate.toJSDate().getTime() - ev.startDate.toJSDate().getTime();
+  for (const ex of exceptions) {
+    try {
+      const rid = ex.getFirstPropertyValue("recurrence-id");
+      if (!rid) continue;
+      const end = new ICAL.Event(ex).endDate.toJSDate().getTime();
+      reach = Math.max(reach, end - rid.toJSDate().getTime());
+    } catch {
+      return Infinity;
+    }
+  }
+  return Math.max(reach, 0);
+}
+
+function expandRecurring(ev: any, startMs: number, endMs: number, out: Occurrence[], reachMs: number): void {
   if (!ev.uid) return;
   const it = ev.iterator();
   let next: any;
@@ -96,6 +131,14 @@ function expandRecurring(ev: any, startMs: number, endMs: number, out: Occurrenc
     if (++iter > MAX_ITER) break;
     const occStartMs = next.toJSDate().getTime();
     if (occStartMs > endMs) break; // iterator is chronological — nothing further is in-window
+    // Cheap rejection before the expensive one. ev.iterator() walks from DTSTART,
+    // so on a series that has been running for a year the great majority of the
+    // occurrences visited here ended long before the window opens — measured at
+    // 91% for weekly series a year old, and getOccurrenceDetails is where
+    // essentially all of the expansion's CPU goes (#290). Deciding it from the
+    // iterator's own time skips building the occurrence at all. The reach bound
+    // is what keeps this exact for events still running when the window opens.
+    if (occStartMs + reachMs < startMs) continue;
     const details = ev.getOccurrenceDetails(next);
     const e = details.endDate.toJSDate().getTime();
     if (e < startMs) continue;                 // occurrence already ended before window
@@ -153,8 +196,9 @@ export function parseAndExpand(icsText: string, windowStartMs: number, windowEnd
     try {
       if (g.master) {
         const ev = new ICAL.Event(g.master, { exceptions: g.exceptions });
-        if (ev.isRecurring()) expandRecurring(ev, windowStartMs, windowEndMs, out);
-        else pushSingle(ev, windowStartMs, windowEndMs, out);
+        if (ev.isRecurring()) {
+          expandRecurring(ev, windowStartMs, windowEndMs, out, seriesReachMs(ev, g.exceptions));
+        } else pushSingle(ev, windowStartMs, windowEndMs, out);
       } else {
         // No master in the feed (e.g. Google exports only the modified instances
         // of a series whose master is out of range): emit each override as a

--- a/src/integrations/calendar.ts
+++ b/src/integrations/calendar.ts
@@ -96,8 +96,33 @@ function pushSingle(ev: any, startMs: number, endMs: number, out: Occurrence[]):
 }
 
 /**
+ * Slack added to every reach bound, to cover UTC-offset changes.
+ *
+ * The bound below is measured in absolute milliseconds, but ical.js builds an
+ * occurrence by adding the master's WALL-CLOCK duration in the occurrence's own
+ * timezone. Those two disagree across a DST transition, in both directions:
+ *
+ *  - A two-hour event whose end lands in a repeated hour takes THREE absolute
+ *    hours, so a bound measured off a master that spans no transition is short
+ *    by the offset change.
+ *  - A master whose own DTSTART/DTEND straddles a spring-forward gap measures
+ *    ONE absolute hour while being two on the wall — and since the master is
+ *    what the bound is derived from, that under-measurement would poison every
+ *    occurrence of the series forever, including ones nowhere near a transition.
+ *
+ * Reproducing ical.js's timezone arithmetic per occurrence would mean building
+ * the occurrence, which is the exact work the bound exists to avoid. A day of
+ * slack sidesteps it: every transition in current tzdata is an hour or less
+ * (Lord Howe's is thirty minutes), so this is not a close call. It costs almost
+ * nothing, because the bound is compared against a window that opens two days
+ * back — a year-old weekly series still rejects 51 of its 52 occurrences.
+ */
+const REACH_DST_SLACK_MS = DAY_MS;
+
+/**
  * The furthest past its nominal start that an occurrence of this series can
- * still be running — its longest possible (end − recurrence time).
+ * still be running — its longest possible (end − recurrence time), plus the
+ * slack above.
  *
  * This is what lets the walk below reject a spent occurrence from the iterator's
  * own time, without building the occurrence first. It has to bound overrides as
@@ -118,7 +143,7 @@ function seriesReachMs(ev: any, exceptions: any[]): number {
       return Infinity;
     }
   }
-  return Math.max(reach, 0);
+  return Math.max(reach, 0) + REACH_DST_SLACK_MS;
 }
 
 function expandRecurring(ev: any, startMs: number, endMs: number, out: Occurrence[], reachMs: number): void {
@@ -137,7 +162,8 @@ function expandRecurring(ev: any, startMs: number, endMs: number, out: Occurrenc
     // 91% for weekly series a year old, and getOccurrenceDetails is where
     // essentially all of the expansion's CPU goes (#290). Deciding it from the
     // iterator's own time skips building the occurrence at all. The reach bound
-    // is what keeps this exact for events still running when the window opens.
+    // is what keeps this exact for events still running when the window opens,
+    // including across a DST transition — see seriesReachMs.
     if (occStartMs + reachMs < startMs) continue;
     const details = ev.getOccurrenceDetails(next);
     const e = details.endDate.toJSDate().getTime();

--- a/src/integrations/mirror.ts
+++ b/src/integrations/mirror.ts
@@ -4,6 +4,7 @@ import {
   INTEGRATION_PROVIDERS,
   getProvider,
   loadIntegration,
+  saveIntegration,
   deleteIntegration,
 } from "../integrations";
 import type { IntegrationProvider, MirrorStore } from "./framework";
@@ -143,12 +144,15 @@ const CRON_SYNC_MAX_BATCHES = 1;
  * multiplier is the provider count. Rotating keeps the cost of a run flat in the
  * number of connections; the hourly schedule is what keeps each one fresh.
  *
- * The rotation key is `updatedAt`, not `lastSyncedAt`. Every provider writes
+ * The rotation key is `updatedAt`, not `lastSyncedAt`. Providers write
  * `updatedAt` on every sync ATTEMPT but `lastSyncedAt` only on success, so
  * ordering by the latter would park the rotation on a provider whose token has
  * expired — it would be picked every hour, forever, and starve the ones that
- * still work. `updatedAt` always advances, so a failing provider takes its turn
- * and yields.
+ * still work.
+ *
+ * Advancing that key is this function's job, not the provider's — see
+ * advanceRotationCursor. Under rotation a provider that never advances is not a
+ * slow provider, it is a stuck queue.
  */
 export async function runScheduledIntegrationSync(env: Env): Promise<void> {
   let due: IntegrationProvider | null = null;
@@ -168,8 +172,47 @@ export async function runScheduledIntegrationSync(env: Env): Promise<void> {
 
   await initializeDatabase(env);
   const store = makeMirrorStore(env);
-  for (let i = 0; i < CRON_SYNC_MAX_BATCHES; i++) {
-    const result = await due.sync(env, store);
-    if (!result.ok || result.remaining === 0) break;
+  try {
+    for (let i = 0; i < CRON_SYNC_MAX_BATCHES; i++) {
+      const result = await due.sync(env, store);
+      if (!result.ok || result.remaining === 0) break;
+    }
+  } finally {
+    await advanceRotationCursor(env, due.id);
+  }
+}
+
+/**
+ * Move the rotation past the provider that just had its turn, whatever happened
+ * during it.
+ *
+ * Providers persist `updatedAt` themselves on success and on the errors their own
+ * handlers catch, but a throw that escapes those handlers persists nothing.
+ * `job()` in src/index.ts swallows it, the record keeps its old `updatedAt`, and
+ * the selection above picks the same provider again — every hour, forever, while
+ * every other connection waits. Its item map did not persist either, so each of
+ * those runs re-mirrors the same batch under fresh ids: new memories and new D1
+ * writes every hour for work already done. The old shape visited every provider
+ * per run, so a throw cost the providers after it in registry order one turn;
+ * under rotation it costs all of them every turn, which is why this is the
+ * caller's responsibility now rather than a detail each provider gets right.
+ *
+ * Best effort by design. If this write is the thing failing there is nothing
+ * further to try, and it must not replace the sync error that brought us here —
+ * hence the catch, in a `finally` block.
+ *
+ * One case it deliberately cannot fix: a KV outage broad enough to fail this put
+ * would have failed the provider's own save too. The cursor lives in KV, so
+ * nothing in-process can advance it. What this does cover is the far likelier
+ * shape — a provider throwing past its handlers while KV is perfectly healthy.
+ */
+async function advanceRotationCursor(env: Env, providerId: string): Promise<void> {
+  try {
+    const record = await loadIntegration(env, providerId);
+    if (!record) return; // disconnected mid-run — nothing to advance
+    record.updatedAt = Date.now();
+    await saveIntegration(env, record);
+  } catch (e) {
+    console.error(`Integration rotation cursor did not advance for ${providerId} (non-fatal):`, e);
   }
 }

--- a/src/integrations/mirror.ts
+++ b/src/integrations/mirror.ts
@@ -1,12 +1,12 @@
 import type { Env } from "../env";
-import { resolveConfig } from "../config";
+import { resolveConfig, type Config } from "../config";
 import {
   INTEGRATION_PROVIDERS,
   getProvider,
   loadIntegration,
   deleteIntegration,
 } from "../integrations";
-import type { MirrorStore } from "./framework";
+import type { IntegrationProvider, MirrorStore } from "./framework";
 import { initializeDatabase } from "../db/init";
 import { forgetEntry } from "../capture/lifecycle";
 import { deleteStaleVectors, storeEntry } from "../capture/store";
@@ -16,6 +16,20 @@ import { withStatus } from "../memory/status";
 import { tagsAfterWrite } from "../memory/stale";
 
 export function makeMirrorStore(env: Env): MirrorStore {
+  // One config read per store, not one per mirrored item. A store is built once
+  // per sync batch, so this is still the per-request scope every other caller
+  // resolves at (src/config.ts) — but the batch writes up to SYNC_EVENT_BATCH
+  // items, and resolving inside the write paths made each of those cost its own
+  // KV read on top of its D1, Workers AI and Vectorize calls (#290).
+  //
+  // Lazy rather than eager so makeMirrorStore stays synchronous for its callers
+  // and a sync with nothing to write still costs nothing. Memoising the promise
+  // rather than the value is what makes concurrent writes share one read;
+  // resolveConfig degrades to the defaults instead of rejecting, so there is no
+  // failure to latch.
+  let pending: Promise<Readonly<Config>> | null = null;
+  const config = () => (pending ??= resolveConfig(env));
+
   return {
     async createEntry(content, tags, source) {
       const id = crypto.randomUUID();
@@ -25,10 +39,10 @@ export function makeMirrorStore(env: Env): MirrorStore {
       // bucket. Non-fatal — a failure just leaves it for the backfill to pick up.
       let finalTags = tags;
       let importance = 0;
-      // Resolved once and used for both the classify and the embed below: they
-      // must agree on the model, and this function previously resolved config
-      // for the embed while classifying with the shipped default.
-      const cfg = await resolveConfig(env);
+      // Used for both the classify and the embed below: they must agree on the
+      // model, and this function once resolved config for the embed while
+      // classifying with the shipped default.
+      const cfg = await config();
       try {
         const c = await classifyEntry(content, env, cfg);
         importance = c.importance;
@@ -61,9 +75,10 @@ export function makeMirrorStore(env: Env): MirrorStore {
 
       await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
         .bind(content, JSON.stringify(refreshedTags), now, id).run();
+      const cfg = await config();
       let newVectorIds: string[] = [];
       try {
-        newVectorIds = await storeEntry(env, id, content, refreshedTags, row.source as string, now, await resolveConfig(env));
+        newVectorIds = await storeEntry(env, id, content, refreshedTags, row.source as string, now, cfg);
       } catch (e) {
         console.error("Vectorize re-embed failed (non-fatal):", e);
       }
@@ -89,20 +104,72 @@ export function mirrorEditError(source: string): string {
   return `This memory is synced from ${name}. Edit it in ${name} (the change syncs automatically), or disconnect the ${name} integration to make it editable.`;
 }
 
-const CRON_SYNC_MAX_BATCHES = 5;
+/**
+ * The schedule this job owns, and the reason it has one.
+ *
+ * A Worker invocation gets 50 D1 queries and 10 ms of CPU on the free plan. The
+ * nightly maintenance pass already spends 30 of those queries, which left a
+ * mirror sync sharing that invocation with room for nothing useful: five batches
+ * cost 100 D1 queries on their own, and even one batch put the shared invocation
+ * exactly at the cap — over it as soon as the batch was updates rather than
+ * creates, or a second provider was connected (#290).
+ *
+ * So the sync runs on its own trigger with its own allowance. Must match the
+ * second entry in wrangler.jsonc's `triggers.crons` exactly — scheduled() in
+ * src/index.ts routes on it, and a mismatch would silently send this job's work
+ * to the nightly invocation, which is the problem it exists to avoid.
+ * test/unit/cron-triggers.test.ts fails if the two drift apart.
+ */
+export const INTEGRATION_SYNC_CRON = "30 * * * *";
 
+/**
+ * Batches per run.
+ *
+ * One. The caller has always been the thing that loops: every sync returns
+ * `remaining`, and the dashboard's "Sync now" drains a backlog on demand. The
+ * cron only has to make progress, and one batch an hour does, on a cursor the
+ * next run resumes from. Raising this spends a budget that is now sized for one
+ * batch — and it would spend the CPU cap too, since each batch re-fetches and
+ * re-expands the whole feed.
+ */
+const CRON_SYNC_MAX_BATCHES = 1;
+
+/**
+ * Sync ONE provider per run, least-recently-attempted first.
+ *
+ * Syncing every connected provider in a single invocation multiplies the cost by
+ * however many the user has connected — two calendars measured 70 D1 queries
+ * against a cap of 50 — and no per-provider batch size can fix that, because the
+ * multiplier is the provider count. Rotating keeps the cost of a run flat in the
+ * number of connections; the hourly schedule is what keeps each one fresh.
+ *
+ * The rotation key is `updatedAt`, not `lastSyncedAt`. Every provider writes
+ * `updatedAt` on every sync ATTEMPT but `lastSyncedAt` only on success, so
+ * ordering by the latter would park the rotation on a provider whose token has
+ * expired — it would be picked every hour, forever, and starve the ones that
+ * still work. `updatedAt` always advances, so a failing provider takes its turn
+ * and yields.
+ */
 export async function runScheduledIntegrationSync(env: Env): Promise<void> {
-  let initialized = false;
+  let due: IntegrationProvider | null = null;
+  let dueSince = Infinity;
   for (const provider of Object.values(INTEGRATION_PROVIDERS)) {
-    if (!(await loadIntegration(env, provider.id))) continue;
-    if (!initialized) {
-      await initializeDatabase(env);
-      initialized = true;
+    const record = await loadIntegration(env, provider.id);
+    if (!record) continue;
+    // Strict <, so registry order breaks ties deterministically — which is what
+    // orders the first run after two providers are connected together.
+    const touchedAt = record.updatedAt ?? 0;
+    if (touchedAt < dueSince) {
+      due = provider;
+      dueSince = touchedAt;
     }
-    const store = makeMirrorStore(env);
-    for (let i = 0; i < CRON_SYNC_MAX_BATCHES; i++) {
-      const result = await provider.sync(env, store);
-      if (!result.ok || result.remaining === 0) break;
-    }
+  }
+  if (!due) return;
+
+  await initializeDatabase(env);
+  const store = makeMirrorStore(env);
+  for (let i = 0; i < CRON_SYNC_MAX_BATCHES; i++) {
+    const result = await due.sync(env, store);
+    if (!result.ok || result.remaining === 0) break;
   }
 }

--- a/test/integration/integrations.test.ts
+++ b/test/integration/integrations.test.ts
@@ -226,6 +226,27 @@ describe("integrations routes", () => {
       expect(db.entries).toHaveLength(7);
     });
 
+    // #290: the mirror store resolved config inside createEntry, so every item in
+    // a batch paid its own KV read for a value that cannot change mid-batch — on
+    // top of the D1, Workers AI and Vectorize calls the item already costs. The
+    // store is built once per sync, which is the scope the read belongs at.
+    it("resolves config once per sync batch, not once per mirrored item", async () => {
+      fixture.pages = Array.from({ length: 5 }, (_, i) =>
+        notionPage(`p${i}`, `Note ${i}`, `2026-01-0${i + 1}T00:00:00.000Z`)
+      );
+      for (let i = 0; i < 5; i++) fixture.blocks[`p${i}`] = [paragraph(`body ${i}`)];
+      await connect();
+
+      const reads: string[] = [];
+      const kv = env.OAUTH_KV;
+      env.OAUTH_KV = { ...kv, get: (key: string) => { reads.push(key); return kv.get(key); } } as any;
+
+      const result = await (await sync()).json() as any;
+
+      expect(result).toMatchObject({ created: 5 });
+      expect(reads.filter(k => k === "config:overrides")).toHaveLength(1);
+    });
+
     it("records the error and returns 502 when the Notion API fails", async () => {
       fixture.pages = [notionPage("p1", "Note", "2026-01-01T00:00:00.000Z")];
       fixture.blocks["p1"] = [paragraph("test")];

--- a/test/unit/calendar.test.ts
+++ b/test/unit/calendar.test.ts
@@ -209,6 +209,58 @@ describe("parseAndExpand", () => {
     const occs = parseAndExpand(ics, ms("2026-07-01T00:00:00Z"), ms("2026-07-31T00:00:00Z"));
     expect(occs).toEqual([]);
   });
+
+  // ── The reach bound (#290) ──────────────────────────────────────────────
+  // The walk rejects spent occurrences from the iterator's own time so it does
+  // not have to build them, which is where the expansion's CPU went. These are
+  // the two cases where an occurrence whose recurrence time is BEFORE the
+  // window is nonetheless in it — i.e. exactly what a naive start-time skip
+  // would silently drop.
+
+  it("keeps a long-running instance that began before the window and is still running", () => {
+    const ics = calendar(
+      vevent([
+        "UID:long-run@test",
+        "DTSTAMP:20260101T000000Z",
+        // Weekly nine-day event: the instance starting 2026-06-29 runs to 07-08,
+        // so it overlaps a window that opens on 07-01 despite starting before it.
+        "DTSTART:20260105T090000Z",
+        "DTEND:20260114T170000Z",
+        "RRULE:FREQ=WEEKLY",
+        "SUMMARY:Long Conference",
+      ]),
+    );
+    const occs = parseAndExpand(ics, ms("2026-07-01T00:00:00Z"), ms("2026-07-02T00:00:00Z"));
+    expect(occs.length).toBeGreaterThan(0);
+    expect(occs.every(o => o.summary === "Long Conference")).toBe(true);
+    // At least one of them started before the window opened.
+    expect(occs.some(o => o.start < ms("2026-07-01T00:00:00Z"))).toBe(true);
+  });
+
+  it("keeps an instance an override moved forward into the window", () => {
+    const ics = calendar(
+      vevent([
+        "UID:moved@test",
+        "DTSTAMP:20260101T000000Z",
+        "DTSTART:20260601T090000Z",
+        "DTEND:20260601T100000Z",
+        "RRULE:FREQ=WEEKLY",
+        "SUMMARY:Standup",
+      ]),
+      vevent([
+        "UID:moved@test",
+        // Nominally 2026-06-22, three weeks before the window — but pushed out
+        // to 2026-07-10, which is inside it.
+        "RECURRENCE-ID:20260622T090000Z",
+        "DTSTAMP:20260101T000000Z",
+        "DTSTART:20260710T090000Z",
+        "DTEND:20260710T100000Z",
+        "SUMMARY:Standup (moved)",
+      ]),
+    );
+    const occs = parseAndExpand(ics, ms("2026-07-09T00:00:00Z"), ms("2026-07-11T00:00:00Z"));
+    expect(occs.map(o => o.summary)).toContain("Standup (moved)");
+  });
 });
 
 describe("computeCalendarPlan", () => {

--- a/test/unit/calendar.test.ts
+++ b/test/unit/calendar.test.ts
@@ -237,6 +237,97 @@ describe("parseAndExpand", () => {
     expect(occs.some(o => o.start < ms("2026-07-01T00:00:00Z"))).toBe(true);
   });
 
+  // The bound is measured in absolute milliseconds; ical.js builds occurrences by
+  // adding a WALL-CLOCK duration in the event's own zone. These two cases are
+  // where those disagree. Both need a constructed calendar — a fuzz run over
+  // random windows practically never lands in the affected band.
+  const NEW_YORK_VTIMEZONE = [
+    "BEGIN:VTIMEZONE",
+    "TZID:America/New_York",
+    "BEGIN:DAYLIGHT",
+    "TZOFFSETFROM:-0500",
+    "TZOFFSETTO:-0400",
+    "TZNAME:EDT",
+    "DTSTART:19700308T020000",
+    "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU",
+    "END:DAYLIGHT",
+    "BEGIN:STANDARD",
+    "TZOFFSETFROM:-0400",
+    "TZOFFSETTO:-0500",
+    "TZNAME:EST",
+    "DTSTART:19701101T020000",
+    "RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU",
+    "END:STANDARD",
+    "END:VTIMEZONE",
+  ].join("\r\n");
+
+  it("keeps an instance that runs long because it spans a fall-back transition", () => {
+    // Weekly Sat 23:00–01:00 New York: two hours on the wall. The instance
+    // starting 2024-11-02 23:00 EDT ends at an 01:00 that happens twice, so it
+    // runs THREE absolute hours — an hour past where a wall-clock bound lands.
+    const ics = calendar(
+      NEW_YORK_VTIMEZONE,
+      vevent([
+        "UID:fallback@test",
+        "DTSTAMP:20240101T000000Z",
+        "DTSTART;TZID=America/New_York:20241005T230000",
+        "DTEND;TZID=America/New_York:20241006T010000",
+        "RRULE:FREQ=WEEKLY",
+        "SUMMARY:Late Show",
+      ]),
+    );
+    // Window opens 2.5h into that occurrence — inside the hour it is still
+    // running but a two-hour bound has already written off.
+    const occs = parseAndExpand(ics, ms("2024-11-03T05:30:00Z"), ms("2024-11-03T12:00:00Z"));
+    expect(occs.map(o => o.start)).toContain(ms("2024-11-03T03:00:00Z"));
+  });
+
+  // The single case above is one point inside one band. This sweeps the whole
+  // transition weekend against a reference expansion that cannot skip anything
+  // (its window opens a month earlier), which is the property that actually
+  // matters: the skip must never change the result, whatever minute the window
+  // happens to open on. A bound short by any amount fails here.
+  it("stays exact minute by minute across a DST transition", () => {
+    const ics = calendar(
+      NEW_YORK_VTIMEZONE,
+      vevent([
+        "UID:evening@test", "DTSTAMP:20240101T000000Z",
+        "DTSTART;TZID=America/New_York:20240106T230000",
+        "DTEND;TZID=America/New_York:20240107T010000",
+        "RRULE:FREQ=WEEKLY", "SUMMARY:Late Show",
+      ]),
+      // Master straddling the spring-forward gap: two hours on the wall, one
+      // absolute, so the whole series is bounded off that shorter measurement.
+      vevent([
+        "UID:gap-master@test", "DTSTAMP:20240101T000000Z",
+        "DTSTART;TZID=America/New_York:20240310T013000",
+        "DTEND;TZID=America/New_York:20240310T033000",
+        "RRULE:FREQ=WEEKLY", "SUMMARY:Sunday Session",
+      ]),
+      // An hour that lands inside the repeated hour itself.
+      vevent([
+        "UID:repeated-hour@test", "DTSTAMP:20240101T000000Z",
+        "DTSTART;TZID=America/New_York:20240107T013000",
+        "DTEND;TZID=America/New_York:20240107T023000",
+        "RRULE:FREQ=WEEKLY", "SUMMARY:Small Hours",
+      ]),
+    );
+    const windowEnd = ms("2024-11-10T00:00:00Z");
+    const reference = parseAndExpand(ics, ms("2024-10-01T00:00:00Z"), windowEnd);
+    expect(reference.length).toBeGreaterThan(0);
+
+    // Two-minute steps either side of the 06:00Z transition. The error this
+    // guards against is an offset change, so it is never finer than the
+    // half-hour Lord Howe shifts by, let alone the hour everywhere else.
+    for (let t = ms("2024-11-03T02:00:00Z"); t <= ms("2024-11-03T08:00:00Z"); t += 120_000) {
+      // parseAndExpand keeps an occurrence when it has not yet ended at the
+      // window's start, so the reference filtered by that rule is the answer.
+      const expected = reference.filter(o => o.end >= t).map(o => o.key).sort();
+      const actual = parseAndExpand(ics, t, windowEnd).map(o => o.key).sort();
+      expect(actual, `window opening ${new Date(t).toISOString()}`).toEqual(expected);
+    }
+  });
+
   it("keeps an instance an override moved forward into the window", () => {
     const ics = calendar(
       vevent([

--- a/test/unit/cron-subrequest-budget.test.ts
+++ b/test/unit/cron-subrequest-budget.test.ts
@@ -21,6 +21,7 @@ import { makeTestDb, makeTestEnv, makeVectorizeMock, makeMemoryKV } from "../hel
 import { D1Mock } from "../helpers/d1-mock";
 import type { Env } from "../../src/env";
 import { INTEGRATION_SYNC_CRON } from "../../src/integrations/mirror";
+import { INTEGRATION_PROVIDERS } from "../../src/integrations";
 
 const FREE_PLAN_SUBREQUESTS = 50;
 const MAINTENANCE_CRON = "0 1 * * *";
@@ -113,6 +114,16 @@ async function connectCalendar(
   const fetchMock = vi.fn(async () => ({ ok: true, status: 200, text: async () => ics }) as any);
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
+}
+
+// Consecutive runs in a test land in the same millisecond, which the real
+// schedule never does — and the rotation cursor is a timestamp, so equal
+// timestamps tie and registry order wins every time. Step a fake clock by an
+// hour per run so a multi-run test models the schedule it is describing.
+function hourlyClock(): (run: number) => void {
+  const base = Date.now();
+  const spy = vi.spyOn(Date, "now");
+  return (run: number) => spy.mockReturnValue(base + run * 3600_000);
 }
 
 // `cron` selects which invocation is being measured — the two schedules are two
@@ -289,7 +300,9 @@ describe("nightly cron D1 subrequest cost", () => {
         return { ok: true, status: 200, text: async () => ics } as any;
       }));
 
+      const tick = hourlyClock();
       for (let run = 0; run < 4; run++) {
+        tick(run);
         resetDatabaseInit();
         await runCron(env, INTEGRATION_SYNC_CRON);
       }
@@ -300,6 +313,36 @@ describe("nightly cron D1 subrequest cost", () => {
       // four runs, so two of them were its.
       expect(db.entries.filter(e => e.source === "calendar-outlook"))
         .toHaveLength(2 * SYNC_EVENT_BATCH);
+    });
+
+    // The case above is an error the provider's own handler catches, so the
+    // provider persists updatedAt itself. This is the one where it does not:
+    // a throw escaping the handler is swallowed by job() in src/index.ts, and
+    // nothing about the record was written. If the rotation trusted providers to
+    // advance their own cursor, this provider would be re-selected every run
+    // forever — and, because its item map did not persist either, would re-mirror
+    // the same batch under fresh ids each time.
+    it("advances past a provider whose sync throws past its own handler", async () => {
+      const db = makeTestDb();
+      const kv = makeMemoryKV();
+      await connectCalendar(kv, 120, ["calendar-google", "calendar-outlook"]);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+      vi.spyOn(INTEGRATION_PROVIDERS["calendar-google"], "sync")
+        .mockRejectedValue(new Error("KV write failed inside saveIntegration"));
+
+      const tick = hourlyClock();
+      for (let run = 0; run < 4; run++) {
+        tick(run);
+        resetDatabaseInit();
+        await runCron(env, INTEGRATION_SYNC_CRON);
+      }
+
+      // Two of the four runs went to the provider that works.
+      expect(db.entries.filter(e => e.source === "calendar-outlook"))
+        .toHaveLength(2 * SYNC_EVENT_BATCH);
+      // And the thrower never mirrored anything, so there are no duplicate
+      // re-creations to find.
+      expect(db.entries.filter(e => e.source === "calendar-google")).toHaveLength(0);
     });
   });
 

--- a/test/unit/cron-subrequest-budget.test.ts
+++ b/test/unit/cron-subrequest-budget.test.ts
@@ -12,20 +12,24 @@
  * This measures the whole invocation rather than any one job, because per-job budget
  * assertions are not true in situ.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import worker from "../../src/index";
 import { resetDatabaseInit } from "../../src/db/init";
+import { SYNC_EVENT_BATCH } from "../../src/integrations/calendar";
 import { STALENESS_AGE_MS } from "../../src/staleness/pass";
-import { makeTestDb, makeTestEnv, makeVectorizeMock } from "../helpers/make-env";
+import { makeTestDb, makeTestEnv, makeVectorizeMock, makeMemoryKV } from "../helpers/make-env";
 import { D1Mock } from "../helpers/d1-mock";
+import type { Env } from "../../src/env";
+import { INTEGRATION_SYNC_CRON } from "../../src/integrations/mirror";
 
 const FREE_PLAN_SUBREQUESTS = 50;
+const MAINTENANCE_CRON = "0 1 * * *";
 
 // D1 bills EXECUTIONS: run/first/all/exec spend one each, and a batch() spends one however
 // many statements it carries. Counting prepares instead would price the batched writes in
 // the compression and staleness passes as if they were still one round trip per row —
 // which is exactly the cost this budget is meant to track.
-function countingEnv(db: D1Mock) {
+function countingEnv(db: D1Mock, overrides: Partial<Env> = {}) {
   const statements: string[] = [];
   const bill = (sql: string) => statements.push(sql.replace(/\s+/g, " ").trim());
   const wrap = (stmt: any, sql: string): any => ({
@@ -41,7 +45,7 @@ function countingEnv(db: D1Mock) {
     exec(sql: string) { bill(sql); return db.exec(sql); },
     batch: (stmts: any[]) => { bill("BATCH"); return db.batch(stmts.map((s: any) => s.__inner ?? s)); },
   } as unknown as D1Database;
-  return { env: makeTestEnv(db, { DB, VECTORIZE: makeVectorizeMock() }), statements, prepared };
+  return { env: makeTestEnv(db, { DB, VECTORIZE: makeVectorizeMock(), ...overrides }), statements, prepared };
 }
 
 // Each tag gets more than the ten eligible entries a digest needs, so nightly compression
@@ -59,10 +63,64 @@ function seedCompressibleTags(db: D1Mock, tagCount: number) {
   }
 }
 
-async function runCron(env: any) {
+// ─── Integration fixture ──────────────────────────────────────────────────────
+// A connected calendar with a backlog far larger than one batch, so the cron is
+// measured with the integration job doing as much work as it is ever allowed to.
+
+function icsUtc(ms: number): string {
+  return new Date(ms).toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+}
+
+function icsWithUpcomingEvents(count: number): string {
+  const now = Date.now();
+  const lines = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//Test//EN"];
+  for (let i = 0; i < count; i++) {
+    const start = now + (i + 1) * 3600_000; // hourly, inside the 30-day window
+    lines.push(
+      "BEGIN:VEVENT", `UID:evt-${i}@test`, `DTSTAMP:${icsUtc(now)}`,
+      `DTSTART:${icsUtc(start)}`, `DTEND:${icsUtc(start + 1800_000)}`,
+      `SUMMARY:Event ${i}`, "END:VEVENT",
+    );
+  }
+  lines.push("END:VCALENDAR");
+  return lines.join("\r\n");
+}
+
+// The feed URL carries the provider id so a stubbed fetch can tell the
+// connections apart when more than one is wired up.
+async function connectCalendar(
+  kv: KVNamespace,
+  eventCount: number,
+  providers: string[] = ["calendar-google"],
+): Promise<ReturnType<typeof vi.fn>> {
+  for (const [i, id] of providers.entries()) {
+    await kv.put(`integrations:${id}`, JSON.stringify({
+      provider: id,
+      authKind: "token",
+      credentials: { token: `https://cal.example/${id}/feed.ics` },
+      config: {},
+      status: "connected",
+      workspaceName: id,
+      lastSyncedAt: null,
+      lastSyncError: null,
+      itemMap: {},
+      createdAt: 0,
+      // Distinct so the rotation has a defined starting order.
+      updatedAt: i,
+    }));
+  }
+  const ics = icsWithUpcomingEvents(eventCount);
+  const fetchMock = vi.fn(async () => ({ ok: true, status: 200, text: async () => ics }) as any);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+// `cron` selects which invocation is being measured — the two schedules are two
+// separate budgets, so a run has to name the one it means (#290).
+async function runCron(env: any, cron = MAINTENANCE_CRON) {
   const pending: Promise<any>[] = [];
   const ctx = { waitUntil: (p: Promise<any>) => pending.push(p) } as any;
-  await (worker as any).scheduled({} as any, env, ctx);
+  await (worker as any).scheduled({ cron } as any, env, ctx);
   await Promise.allSettled(pending);
 }
 
@@ -137,5 +195,168 @@ describe("nightly cron D1 subrequest cost", () => {
 
     const tags: string[] = JSON.parse(db.entries.find(e => e.id === "job")!.tags);
     expect(tags).toContain("stale:as-of");
+  });
+
+  // ─── The integration sync's own invocation (#290) ──────────────────────────
+  // The mirror sync used to be the fourth job on this invocation, sized against
+  // an accounting that counted only the ONE outbound fetch a sync makes. What a
+  // batch actually costs is the bindings each mirrored item touches — two D1
+  // queries per created entry, three per updated one — so its five batches were
+  // 100 D1 queries in an invocation that allows 50 in total. Even one batch only
+  // fitted while the batch was creates and exactly one provider was connected.
+  // It now runs on its own schedule, so these are two budgets to keep, not one.
+
+  describe("the integration schedule", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("runs one batch, and records the cursor the next run resumes from", async () => {
+      const db = makeTestDb();
+      const kv = makeMemoryKV();
+      const fetchMock = await connectCalendar(kv, 120);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, INTEGRATION_SYNC_CRON);
+
+      // One batch is one feed fetch and one expansion of it — the expansion is
+      // the CPU half of #290, so paying it once per run is the point.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(db.entries.filter(e => e.source === "calendar-google")).toHaveLength(SYNC_EVENT_BATCH);
+
+      const saved = JSON.parse((await kv.get("integrations:calendar-google")) as string);
+      expect(Object.keys(saved.itemMap)).toHaveLength(SYNC_EVENT_BATCH);
+      expect(saved.lastSyncedAt).not.toBeNull();
+    });
+
+    it("keeps its own invocation inside the D1 budget", async () => {
+      const db = makeTestDb();
+      seedCompressibleTags(db, 7); // a big brain must not make the sync cost more
+      const kv = makeMemoryKV();
+      await connectCalendar(kv, 120);
+      const { env, statements } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, INTEGRATION_SYNC_CRON);
+
+      expect(db.entries.filter(e => e.source === "calendar-google")).toHaveLength(SYNC_EVENT_BATCH);
+      expect(statements.length).toBeLessThanOrEqual(FREE_PLAN_SUBREQUESTS);
+    });
+
+    // The multiplier the rotation exists to remove: syncing every connected
+    // provider in one invocation measured 70 D1 queries with two calendars.
+    it("syncs one provider per run however many are connected", async () => {
+      const db = makeTestDb();
+      seedCompressibleTags(db, 7);
+      const kv = makeMemoryKV();
+      const fetchMock = await connectCalendar(kv, 120, ["calendar-google", "calendar-outlook", "calendar-icloud"]);
+      const { env, statements } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, INTEGRATION_SYNC_CRON);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(db.entries.filter(e => e.source.startsWith("calendar-"))).toHaveLength(SYNC_EVENT_BATCH);
+      expect(statements.length).toBeLessThanOrEqual(FREE_PLAN_SUBREQUESTS);
+    });
+
+    it("rotates to the least recently attempted provider on the next run", async () => {
+      const db = makeTestDb();
+      const kv = makeMemoryKV();
+      await connectCalendar(kv, 120, ["calendar-google", "calendar-outlook"]);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, INTEGRATION_SYNC_CRON);
+      resetDatabaseInit();
+      await runCron(env, INTEGRATION_SYNC_CRON);
+
+      // Each got exactly one batch — the second run did not repeat the first's
+      // provider, which is what stops one connection starving the others.
+      expect(db.entries.filter(e => e.source === "calendar-google")).toHaveLength(SYNC_EVENT_BATCH);
+      expect(db.entries.filter(e => e.source === "calendar-outlook")).toHaveLength(SYNC_EVENT_BATCH);
+    });
+
+    // A provider whose token has expired writes updatedAt but never lastSyncedAt.
+    // Ordering the rotation by lastSyncedAt would therefore pick it every single
+    // run, forever, and the working connection would never sync again.
+    it("does not let a permanently failing provider starve a working one", async () => {
+      const db = makeTestDb();
+      const kv = makeMemoryKV();
+      await connectCalendar(kv, 120, ["calendar-google", "calendar-outlook"]);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+      const ics = icsWithUpcomingEvents(120);
+      // calendar-google's feed is broken; calendar-outlook's is fine.
+      vi.stubGlobal("fetch", vi.fn(async (url: any) => {
+        if (String(url).includes("calendar-google")) throw new Error("401 Unauthorized");
+        return { ok: true, status: 200, text: async () => ics } as any;
+      }));
+
+      for (let run = 0; run < 4; run++) {
+        resetDatabaseInit();
+        await runCron(env, INTEGRATION_SYNC_CRON);
+      }
+
+      const failing = JSON.parse((await kv.get("integrations:calendar-google")) as string);
+      expect(failing.status).toBe("error");
+      // The working provider kept getting turns rather than being locked out —
+      // four runs, so two of them were its.
+      expect(db.entries.filter(e => e.source === "calendar-outlook"))
+        .toHaveLength(2 * SYNC_EVENT_BATCH);
+    });
+  });
+
+  // ─── Routing (#290) ────────────────────────────────────────────────────────
+  // The split only buys anything if scheduled() actually branches. A handler
+  // that ignored event.cron would run every job on BOTH triggers, which is
+  // strictly worse than before: the same shared cost, now paid hourly.
+
+  describe("cron routing", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("does not run the mirror sync on the maintenance schedule", async () => {
+      const db = makeTestDb();
+      const kv = makeMemoryKV();
+      const fetchMock = await connectCalendar(kv, 120);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, MAINTENANCE_CRON);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(db.entries.filter(e => e.source === "calendar-google")).toHaveLength(0);
+    });
+
+    it("does not run the maintenance jobs on the integration schedule", async () => {
+      const db = makeTestDb();
+      const old = Date.now() - STALENESS_AGE_MS - 86400000;
+      db.entries.push({
+        id: "job", content: "Bob works at Example Inc", tags: "[]",
+        source: "api", created_at: old, updated_at: old, vector_ids: "[]",
+      });
+      const kv = makeMemoryKV();
+      await connectCalendar(kv, 1);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, INTEGRATION_SYNC_CRON);
+
+      // The staleness pass is the cheapest maintenance job to detect: on the
+      // maintenance schedule this same entry comes back tagged.
+      const tags: string[] = JSON.parse(db.entries.find(e => e.id === "job")!.tags);
+      expect(tags).not.toContain("stale:as-of");
+    });
+
+    it("falls back to maintenance for an unrecognised schedule", async () => {
+      const db = makeTestDb();
+      const old = Date.now() - STALENESS_AGE_MS - 86400000;
+      db.entries.push({
+        id: "job", content: "Bob works at Example Inc", tags: "[]",
+        source: "api", created_at: old, updated_at: old, vector_ids: "[]",
+      });
+      const { env } = countingEnv(db);
+
+      await runCron(env, "*/5 * * * *");
+
+      const tags: string[] = JSON.parse(db.entries.find(e => e.id === "job")!.tags);
+      expect(tags).toContain("stale:as-of");
+    });
   });
 });

--- a/test/unit/cron-triggers.test.ts
+++ b/test/unit/cron-triggers.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The cron strings in wrangler.jsonc and the one scheduled() routes on are the
+ * same fact written in two places, and nothing at build or deploy time checks
+ * they agree (#290).
+ *
+ * Drift is silent and it is expensive in one direction: if INTEGRATION_SYNC_CRON
+ * stops matching a configured schedule, every invocation falls through to the
+ * maintenance branch, the mirror sync never runs at all, and the only symptom is
+ * integrations quietly going stale. If a schedule is configured that nothing
+ * routes, it costs an invocation an hour to run maintenance again.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { INTEGRATION_SYNC_CRON } from "../../src/integrations/mirror";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+
+function configuredCrons(): string[] {
+  const raw = readFileSync(resolve(ROOT, "wrangler.jsonc"), "utf8");
+  // Strip // comments (wrangler.jsonc uses them) before parsing. Deliberately
+  // not a full JSONC parser: the file has no block comments and no strings
+  // containing "//" outside the URLs in comments, which this removes anyway.
+  const stripped = raw.replace(/^\s*\/\/.*$/gm, "");
+  const config = JSON.parse(stripped);
+  return config.triggers?.crons ?? [];
+}
+
+describe("cron triggers", () => {
+  it("configures the integration schedule the worker routes on", () => {
+    expect(configuredCrons()).toContain(INTEGRATION_SYNC_CRON);
+  });
+
+  it("configures a maintenance schedule distinct from the integration one", () => {
+    const crons = configuredCrons();
+    const maintenance = crons.filter(c => c !== INTEGRATION_SYNC_CRON);
+    expect(maintenance.length).toBeGreaterThan(0);
+  });
+
+  it("stays inside the free plan's five triggers", () => {
+    expect(configuredCrons().length).toBeLessThanOrEqual(5);
+  });
+
+  // The two schedules must not be able to fire in the same minute: that would
+  // put both invocations' work on the same wall clock, which is the contention
+  // the split exists to avoid.
+  it("does not schedule the two on a colliding minute", () => {
+    const minuteOf = (cron: string) => cron.trim().split(/\s+/)[0];
+    const integrationMinute = minuteOf(INTEGRATION_SYNC_CRON);
+    for (const cron of configuredCrons()) {
+      if (cron === INTEGRATION_SYNC_CRON) continue;
+      expect(minuteOf(cron), `${cron} shares a minute with ${INTEGRATION_SYNC_CRON}`)
+        .not.toBe(integrationMinute);
+    }
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -35,9 +35,23 @@
 	"assets": {
 		"directory": "./public"
 	},
+	// Two schedules, because they are two budgets. A Worker invocation gets 50 D1
+	// queries and 10 ms of CPU on the free plan, and the nightly maintenance pass
+	// already spends 30 of those queries — leaving too little for a mirror sync to
+	// do useful work without pushing the whole invocation over (#290). Splitting
+	// them gives the integration sync its own allowance. scheduled() in
+	// src/index.ts routes on the cron string; INTEGRATION_SYNC_CRON in
+	// src/integrations/mirror.ts must match the second entry exactly, and
+	// test/unit/cron-triggers.test.ts fails if it drifts.
 	"triggers": {
 		"crons": [
-			"0 1 * * *"
+			// Nightly maintenance: compression, graph pass, staleness pass.
+			"0 1 * * *",
+			// Integrations. Hourly, because one provider syncs per run (see
+			// runScheduledIntegrationSync) — a nightly rotation would leave a user
+			// with several connections waiting days between syncs. Offset to :30 so
+			// it never fires in the same minute as the nightly job.
+			"30 * * * *"
 		]
 	}
 }


### PR DESCRIPTION
## Summary

Integration sync shared the nightly invocation with the three maintenance jobs and ran five batches per connected provider inside it. Measured by binding, one calendar with 120 events cost **105 D1 queries against the free plan's documented 50 per invocation**, and re-expanded the whole ICS five times. Closes #290.

## Measured, by binding

| scenario | before | now |
|---|---|---|
| HTTP sync, 40 events | D1 20, total 64 | D1 20, total **55** |
| maintenance cron, busy brain + calendar | D1 **130**, total 437 | D1 **30**, total 116 |
| integration cron, creates | — | D1 **21**, total 61 |
| integration cron, update steady state | D1 **180** | D1 **31** |
| integration cron, **six** providers | — | D1 **21** |

Every invocation is inside 50 D1, and the integration cost is now **flat in provider count** — 1, 2 and 6 all measure 21.

## Three changes

**`resolveConfig` hoisted out of the per-item write paths.** `updateEntry` had the same per-item read as `createEntry`, so fixing only the create path would have left updates paying it.

**Sync gets its own hourly trigger and handles one provider per run.** The rotation orders by `updatedAt`, **not** `lastSyncedAt` as originally specified: all three providers write `updatedAt` on every *attempt* but `lastSyncedAt` only on *success*, so ordering by the latter parks the rotation permanently on a connection whose token has expired — it wins every hour forever while the working connection never syncs again. There is a test for that starvation case.

**The recurrence walk skips occurrences that ended before the window**, from inside the iterator. Profiling put **1040 of 1140** iterations at 20 weekly series on occurrences already over; `ICAL.parse` itself is 0.1ms. `seriesReachMs` keeps it exact — an occurrence can still be running when the window opens, and an override can move an instance later — so the bound is the largest `end − recurrence-time` the series can produce. Verified against the original algorithm across **800 expansions and 62,329 occurrences, byte-identical**.

## CPU: reduced, not solved — and I want this stated plainly

| | before | now |
|---|---|---|
| 20 weekly series | 12.4 ms | **7.9 ms** ✅ |
| 60 weekly series | 35.5 ms | **21.2 ms** ❌ |
| 20 series, DTSTART 3 years ago | 31.9 ms | **17.8 ms** ❌ |

A mid-size calendar now fits under the 10 ms limit. Heavy ones do not. The residual is ical.js's iterator walking from `DTSTART` — inherent to its API; removing it means re-implementing RRULE.

Two things that make this degradation rather than a hard stop: the same 10 ms applies to **HTTP requests**, so "Sync now" was always equally exposed and this predates the trigger split; and the overrun happens **before any write**, so it costs progress, never consistency.

**Alternatives rejected on measurement**, not preference:
- *Narrower window* — 30d → 7d saves 0.7 ms of 7.1. The cost is the walk *to* the window, not its width.
- *ETag / `Last-Modified` caching* — misses exactly when it matters: draining a 120-item backlog re-expands an unchanged feed 12 times by necessity. And a server wrongly serving 304 silently freezes mirroring.
- *Per-run series cap* — unsafe: a partial occurrence set makes `computeCalendarPlan` treat unexpanded upcoming occurrences as vanished and **delete their mirrors**.

## The installer would have broken

`installer/src-tauri/src/worker_bundle.rs` asserted the manifest carried exactly `["0 1 * * *"]`, and the installer **provisions crons from that manifest** — so a second schedule the app didn't register would mean installer-based deployments never sync. Assertion updated, bundler output confirmed, and the full Rust suite run: **243 passed, 0 failed**.

`test/unit/cron-triggers.test.ts` fails if the constant drifts from `wrangler.jsonc`, if the two schedules share a minute, or if the count exceeds the free plan's five.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:coverage` — 1231 passing
- [x] `npx wrangler deploy --dry-run`
- [x] `cargo test` — 243 passed
- [x] Trigger routing verified by mutation: removing the branch fails two tests
- [x] Non-regression: `remaining` still 30 of 40 after one press so the dashboard loop terminates; a provider erroring mid-batch leaves the item map un-advanced and the record saved

## Known

**Rotation latency:** six connections means each syncs every 6 hours, so a 120-item backlog takes ~3 days to drain unattended. "Sync now" still drains on demand and connect auto-syncs, so this affects unattended catch-up only.

**CPU above ~20 long-running series**, as above. The honest fix is incremental expansion or a paid plan.
