### PR TITLE
v2.2.2: eight free-plan and data-integrity fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Prefer to run it yourself? Use the one-click **[Deploy to Cloudflare](https://de
 
 * **Memory graph.** Memories now connect to each other — automatically as you save, or explicitly with the new `link` and `connections` tools. Recall can follow those connections (the `hops` option) to surface related context that a plain search would miss, and the dashboard has a new **Graph** tab to explore your memory visually.
 
-* **Notion sync.** Connect your Notion workspace from **Settings → Integrations** in the dashboard. Pages you share with the connection sync into memory, stay updated as they change in Notion, and surface in recall alongside everything else. Nightly automatic sync, or on demand with **Sync now**.
+* **Notion sync.** Connect your Notion workspace from **Settings → Integrations** in the dashboard. Pages you share with the connection sync into memory, stay updated as they change in Notion, and surface in recall alongside everything else. Automatic hourly sync, or on demand with **Sync now**.
 
 * **Graceful degradation.** If the Vectorize index is missing, the whole brain keeps working keyword-only: recall falls back to keyword search with a clear notice, and captures, appends and updates are still committed rather than rejected. A `/health` endpoint reports index status, and the dashboard shows a banner with the exact fix.
 
@@ -92,9 +92,9 @@ Memory is most useful when capturing information is easy. Second Brain connects 
   npm install -g second-brain-cf-cli
   ```
 
-* **Notion:** Connect your Notion workspace from **Settings → Integrations** in the web dashboard. Create an internal **connection** in the [Notion developer portal](https://app.notion.com/developers/connections) (a connection, not a personal access token — only connections appear in a page's Connections menu), share the pages you want remembered with it, and paste its secret — shared pages sync into memory automatically (nightly, or on demand with **Sync now**) and stay updated as they change in Notion.
+* **Notion:** Connect your Notion workspace from **Settings → Integrations** in the web dashboard. Create an internal **connection** in the [Notion developer portal](https://app.notion.com/developers/connections) (a connection, not a personal access token — only connections appear in a page's Connections menu), share the pages you want remembered with it, and paste its secret — shared pages sync into memory automatically (hourly, or on demand with **Sync now**) and stay updated as they change in Notion.
 
-* **Calendar:** Connect Google, Outlook, or iCloud from **Settings → Integrations** and paste your calendar's private **iCal (`.ics`) link** (Google: *your calendar → Integrate calendar → "Secret address in iCal format"*; Outlook: *Calendar → Shared calendars → Publish*; iCloud: *Share Calendar → Public Calendar*). Read-only — upcoming events sync into memory automatically (nightly, or on demand with **Sync now**), and past events are kept as a bounded history.
+* **Calendar:** Connect Google, Outlook, or iCloud from **Settings → Integrations** and paste your calendar's private **iCal (`.ics`) link** (Google: *your calendar → Integrate calendar → "Secret address in iCal format"*; Outlook: *Calendar → Shared calendars → Publish*; iCloud: *Share Calendar → Public Calendar*). Read-only — upcoming events sync into memory automatically (hourly, or on demand with **Sync now**), and past events are kept as a bounded history.
 
 * **Email:** Connect Gmail or iCloud from **Settings → Integrations** with an **app password** (Google: *Account → Security → App passwords*; iCloud: *appleid.apple.com → App-Specific Passwords*). Read-only — meaningful messages are captured into memory, while newsletters, marketing, receipts, and other automated mail are filtered out.
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -36,3 +36,11 @@ CREATE TABLE IF NOT EXISTS edges (
 
 CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id);
 CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_id);
+-- The graph view reads the strongest edges (ORDER BY weight DESC LIMIT n). Without an
+-- ordered path to weight, SQLite scans every edge into a temp b-tree before the LIMIT
+-- applies — measured rows_read is 2 x the edge count whether or not a LIMIT is present,
+-- which at 500k edges is 1M rows read per request against D1's 5M/day free cap. Costs one
+-- extra index write per edge (5 -> 6 rows written per insert), which the far larger read
+-- saving pays for many times over. Must stay in step with src/db/init.ts, which creates
+-- the same index at runtime for brains that were migrated before it existed.
+CREATE INDEX IF NOT EXISTS idx_edges_weight ON edges(weight DESC);

--- a/installer/README.md
+++ b/installer/README.md
@@ -225,7 +225,7 @@ Everything the installer ever calls, for auditability:
 | `POST /accounts/{a}/workers/scripts/second-brain/assets-upload-session` | start the dashboard asset upload |
 | `POST /accounts/{a}/workers/assets/upload?base64=true` | upload dashboard files |
 | `PUT /accounts/{a}/workers/scripts/second-brain` | deploy the Worker (multipart: module + metadata with D1/Vectorize/KV/AI bindings, `VECTORIZE_GRACE_MS` var, `AUTH_TOKEN` secret, assets) |
-| `PUT /accounts/{a}/workers/scripts/second-brain/schedules` | nightly maintenance cron (`0 1 * * *`) |
+| `PUT /accounts/{a}/workers/scripts/second-brain/schedules` | nightly maintenance (`0 1 * * *`) and hourly integration sync (`30 * * * *`) crons |
 | `POST /accounts/{a}/workers/scripts/second-brain/subdomain` | turn on the `workers.dev` URL |
 | `GET {worker}/health`, `POST {worker}/capture` | post-deploy smoke tests against the user's own Worker |
 

--- a/installer/src-tauri/src/cf/provision.rs
+++ b/installer/src-tauri/src/cf/provision.rs
@@ -620,7 +620,10 @@ mod tests {
             "compatibilityDate": "2026-06-17",
             "compatibilityFlags": ["nodejs_compat"],
             "vars": { "VECTORIZE_GRACE_MS": "300000" },
-            "cron": ["0 1 * * *"],
+            // Both schedules: nightly maintenance and the hourly integration sync,
+            // which runs on its own budget (#290). The app has to register every
+            // entry, not just the first.
+            "cron": ["0 1 * * *", "30 * * * *"],
             "d1Binding": "DB",
             "d1Name": "second-brain-db",
             "vectorizeBinding": "VECTORIZE",
@@ -817,7 +820,7 @@ mod tests {
         assert!(log.contains(&"create_vectorize:second-brain-vectors:384:cosine".to_string()));
         // 5 fixed bindings + 1 var
         assert!(log.contains(&"deploy:second-brain:6".to_string()));
-        assert!(log.contains(&"set_cron:0 1 * * *".to_string()));
+        assert!(log.contains(&"set_cron:0 1 * * *,30 * * * *".to_string()));
         assert!(log.contains(&"health_ok".to_string()));
         assert!(log.contains(&"capture_ok".to_string()));
     }
@@ -1050,6 +1053,14 @@ mod tests {
         let bindings = meta["bindings"].as_array().unwrap();
         let vectorize = bindings.iter().find(|b| b["type"] == "vectorize").unwrap();
         assert_eq!(vectorize["index_name"], "second-brain-vectors-768");
+
+        // Updating an existing install has to re-register the whole schedule set.
+        // A user who installed before the integration sync got its own trigger
+        // only picks it up here, and only if every entry is sent.
+        assert!(
+            log.contains(&"set_cron:0 1 * * *,30 * * * *".to_string()),
+            "update must set every schedule the manifest carries: {log:?}"
+        );
     }
 
     /// A routine update must keep binding what the build ships with, or every

--- a/installer/src-tauri/src/worker_bundle.rs
+++ b/installer/src-tauri/src/worker_bundle.rs
@@ -147,7 +147,11 @@ mod tests {
         assert_eq!(m.kv_binding, "OAUTH_KV");
         assert_eq!(m.ai_binding, "AI");
         assert!(m.compatibility_flags.contains(&"nodejs_compat".to_string()));
-        assert_eq!(m.cron, vec!["0 1 * * *"]);
+        // Two schedules, and the app has to provision BOTH: nightly maintenance, and
+        // the hourly integration sync that runs on its own budget (#290). An install
+        // that registered only the first would leave mirrors never syncing on their
+        // own. Order follows wrangler.jsonc, which is what set_cron receives.
+        assert_eq!(m.cron, vec!["0 1 * * *", "30 * * * *"]);
     }
 
     #[test]

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -24,6 +24,7 @@ Incremental split of the former monolithic `index.ts`. Entry point remains `src/
 | embed, readStreamText, graceMs | `lib/ai.ts` |
 | initializeDatabase | `db/init.ts` |
 | status/kind tags | `memory/status.ts`, `memory/kind.ts` |
+| tag LIKE pattern + escaping | `memory/tag-sql.ts` |
 | compression eligibility | `compression/eligibility.ts` |
 | chunk, hashtags, temporal, tokenize | `text/*` |
 | cosineSim, rerank, mmr | `recall/math.ts` |

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -25,6 +25,7 @@ Incremental split of the former monolithic `index.ts`. Entry point remains `src/
 | initializeDatabase | `db/init.ts` |
 | status/kind tags | `memory/status.ts`, `memory/kind.ts` |
 | tag LIKE pattern + escaping | `memory/tag-sql.ts` |
+| tag vocabulary cache | `tags/vocabulary.ts` |
 | compression eligibility | `compression/eligibility.ts` |
 | chunk, hashtags, temporal, tokenize | `text/*` |
 | cosineSim, rerank, mmr | `recall/math.ts` |

--- a/src/capture/entry.ts
+++ b/src/capture/entry.ts
@@ -8,6 +8,7 @@ import { checkDuplicateAndContradiction } from "./duplicate";
 import { deprecateEntry } from "./lifecycle";
 import { deleteStaleVectors, reembedOrThrow, storeEntry } from "./store";
 import { tagsAfterWrite } from "../memory/stale";
+import { TAG_LIKE_ESCAPE, tagLikePattern } from "../memory/tag-sql";
 
 export function buildEntryFilterQuery(params: {
   n: number;
@@ -17,7 +18,11 @@ export function buildEntryFilterQuery(params: {
 }): { sql: string; bindings: (string | number)[] } {
   const conds: string[] = [];
   const bindings: (string | number)[] = [];
-  if (params.tag) { conds.push(`tags LIKE ?`); bindings.push(`%"${params.tag}"%`); }
+  // Escaped for the same reason as the recall path: `_` and `%` in a tag are LIKE
+  // wildcards, so `#q3_planning` would also list `q3-planning` entries and `?tag=%` would
+  // list everything. A read, so over-broad rather than destructive — but a filter that
+  // silently stops filtering is worse than one that returns nothing.
+  if (params.tag) { conds.push(`tags LIKE ? ${TAG_LIKE_ESCAPE}`); bindings.push(tagLikePattern(params.tag)); }
   if (params.after !== undefined) { conds.push(`created_at >= ?`); bindings.push(params.after); }
   if (params.before !== undefined) { conds.push(`created_at <= ?`); bindings.push(params.before); }
 

--- a/src/capture/entry.ts
+++ b/src/capture/entry.ts
@@ -9,6 +9,7 @@ import { deprecateEntry } from "./lifecycle";
 import { deleteStaleVectors, reembedOrThrow, storeEntry } from "./store";
 import { tagsAfterWrite } from "../memory/stale";
 import { TAG_LIKE_ESCAPE, tagLikePattern } from "../memory/tag-sql";
+import { rememberTags } from "../tags/vocabulary";
 
 export function buildEntryFilterQuery(params: {
   n: number;
@@ -122,6 +123,13 @@ export async function captureEntry(
     storeEntry(env, id, c, finalTags, source, now, cfg)
       .catch(e => console.error("Vectorize insert failed (non-fatal):", e))
   );
+
+  // Capture is where a tag string nobody wrote into the source first exists, so it is
+  // one of the two places the cached vocabulary has to learn one (#288). Deferred, so
+  // the capture does not wait on KV — which means the tag is admitted once this
+  // settles rather than by the time the response lands, and a `GET /tags` fired
+  // straight off the back of the save can miss it by one refresh.
+  ctx.waitUntil(rememberTags(env, finalTags));
 
   scheduleClassifyAndTag(id, c, env, ctx, cfg);
 

--- a/src/capture/store.ts
+++ b/src/capture/store.ts
@@ -5,6 +5,7 @@ import { embed } from "../lib/ai";
 import { inferEdgesOnWrite } from "../graph/edges";
 import { neighborsFromVectorQuery } from "../graph/traverse";
 import { chunkText } from "../text/chunk";
+import { rememberTags } from "../tags/vocabulary";
 import { extractHashtags } from "../text/hashtags";
 import { isVectorizeUnavailable } from "../vectorize/health";
 import { tagsAfterWrite } from "../memory/stale";
@@ -165,6 +166,12 @@ export async function updateEntryContent(
   // vectors are kept below rather than retired.
   await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
     .bind(finalContent, JSON.stringify(mergedTags), Date.now(), id).run();
+
+  // Rewritten content can carry hashtags the brain has never seen, so this is one of the
+  // two places an unknown tag enters the corpus (#288). It sits here rather than in the
+  // route because #289 made this the single update path — putting it in the caller would
+  // have left the MCP tool introducing tags the cache never learned about.
+  await rememberTags(env, mergedTags);
 
   if (newVectorIds) {
     try {

--- a/src/capture/store.ts
+++ b/src/capture/store.ts
@@ -5,6 +5,7 @@ import { embed } from "../lib/ai";
 import { inferEdgesOnWrite } from "../graph/edges";
 import { neighborsFromVectorQuery } from "../graph/traverse";
 import { chunkText } from "../text/chunk";
+import { extractHashtags } from "../text/hashtags";
 import { isVectorizeUnavailable } from "../vectorize/health";
 import { tagsAfterWrite } from "../memory/stale";
 
@@ -83,6 +84,97 @@ export async function reembedOrDegrade(env: Env, id: string, content: string, ta
     console.error("Vectorize unavailable — committing content without re-embedding:", e);
     return null;
   }
+}
+
+/**
+ * What `updateEntryContent` did, in the terms its callers have to answer in.
+ *
+ * `vectorIds: null` is the keyword-only degrade (#270) — the content committed but
+ * Vectorize was unreachable, so the entry still carries its previous embedding.
+ */
+export type UpdateEntryResult =
+  | { status: "not_found" }
+  | { status: "reembed_failed" }
+  | { status: "updated"; vectorIds: string[] | null };
+
+/**
+ * Replace an entry's content outright, keeping D1, the tags and the vector index in step.
+ *
+ * `POST /update` and the MCP `update` tool both land here. They used to be two
+ * implementations of the same thing, and the copy behind MCP — the one every assistant
+ * client actually calls — silently missed every hardening the route gained (#289): it
+ * committed content against stale vectors when an embed failed, never moved the entry's
+ * updated_at, never reset the staleness tags, and never extracted hashtags. Anything that
+ * decides what gets written lives in here now; the callers only shape the reply.
+ * (updated_at is named bare above on purpose — test/unit/updated-at-coalesced.test.ts reads
+ * every backtick-delimited span in src/ as SQL, comments included.)
+ *
+ * The one thing they still do for themselves is the managed-mirror guard, because
+ * `integrations/mirror.ts` imports this module and the dependency must not run both ways.
+ * That guard refuses before anything is written, so a drift there cannot corrupt a row —
+ * unlike everything below, which is why everything below moved.
+ */
+export async function updateEntryContent(
+  env: Env,
+  id: string,
+  newContent: string,
+  config: Readonly<Config> = DEFAULTS
+): Promise<UpdateEntryResult> {
+  // vector_ids has to be read before any mutation: storeEntry overwrites it, and the
+  // cleanup below needs to know which vectors the entry had on the way in.
+  const row = await env.DB.prepare(
+    `SELECT tags, source, vector_ids FROM entries WHERE id = ?`
+  ).bind(id).first() as Record<string, any> | null;
+
+  if (!row) return { status: "not_found" };
+
+  const source = row.source as string;
+  const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
+  const existingTags: string[] = JSON.parse(row.tags ?? "[]");
+
+  // Same treatment captureEntry gives every stored memory, which is the point — but note it
+  // flattens all whitespace, so a replacement does not preserve line breaks or code fences.
+  // `appendToEntry` deliberately does not flatten; prefer append when the shape matters.
+  const { cleanContent, hashtags } = extractHashtags(newContent);
+  // Content that is nothing but hashtags cleans down to "", which would blank the entry —
+  // keep it as written in that case and let the tags be extracted anyway.
+  const finalContent = cleanContent || newContent;
+  const mergedTags = tagsAfterWrite([...new Set([...existingTags, ...hashtags])])
+    // `rolled-up` is a claim about content that no longer exists: the nightly digest wrote
+    // it in the same statement that appended a `[Digest: <id>]` marker to the body, and a
+    // full replacement destroys that marker. Left in place it costs the corrected memory a
+    // 0.4x recall penalty (recall/math.ts) and bars it from every future digest, burying
+    // the only copy of the new fact. The same reasoning tagsAfterWrite applies to the
+    // volatility/staleness verdicts, and the reason `append` must NOT strip it — an append
+    // keeps the digested original inside the entry, so the digest still covers it.
+    .filter(t => t !== "rolled-up");
+
+  // Re-embed FIRST (#212): if it fails, leave the entry's content and vectors untouched and
+  // surface an error, instead of committing new content and then deleting every vector —
+  // which would leave the entry silently unsearchable. null means Vectorize is unreachable
+  // (#270), not that this embed failed.
+  let newVectorIds: string[] | null;
+  try {
+    newVectorIds = await reembedOrDegrade(env, id, finalContent, mergedTags, source, config);
+  } catch (e) {
+    console.error("Re-embed failed — entry left unchanged:", e);
+    return { status: "reembed_failed" };
+  }
+
+  // Safe to commit: either the embed succeeded, or Vectorize is unavailable and the old
+  // vectors are kept below rather than retired.
+  await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
+    .bind(finalContent, JSON.stringify(mergedTags), Date.now(), id).run();
+
+  if (newVectorIds) {
+    try {
+      await deleteStaleVectors(env, oldVectorIds, newVectorIds);
+    } catch (e) {
+      console.error("Old vector cleanup failed (non-fatal):", e);
+    }
+  }
+
+  return { status: "updated", vectorIds: newVectorIds };
 }
 
 export async function appendToEntry(

--- a/src/compression/digest.ts
+++ b/src/compression/digest.ts
@@ -3,12 +3,10 @@ import { DEFAULTS, resolveConfig, type Config } from "../config";
 import { captureEntry } from "../capture/entry";
 import { DIGEST_MAX_TOKENS, LLM_MODEL } from "../constants";
 import { readStreamText } from "../lib/ai";
-import { KIND_PREFIX } from "../memory/kind";
-import { STATUS_PREFIX } from "../memory/status";
-import { VOLATILITY_PREFIX } from "../memory/volatility";
-import { STALE_AS_OF } from "../memory/stale";
+import { TAG_LIKE_ESCAPE, tagLikePattern } from "../memory/tag-sql";
 import {
   compressionEligibilitySql,
+  isTopicTag,
 } from "./eligibility";
 
 export async function synthesizeDigest(
@@ -86,8 +84,12 @@ export async function compressTag(
   ctx: ExecutionContext
 ): Promise<{ synthesizedId: string | null; entriesUsed: number; text: string }> {
   // Guard before resolveConfig: that is a KV read, and a system tag never compresses, so
-  // paying for it first is a wasted subrequest per skipped tag per night.
-  if (tag.startsWith(STATUS_PREFIX) || tag.startsWith(KIND_PREFIX) || tag.startsWith(VOLATILITY_PREFIX) || tag === STALE_AS_OF) {
+  // paying for it first is a wasted subrequest per skipped tag per night. The candidate
+  // query excludes these already; this is the backstop for a tag arriving another way, and
+  // GET /digest?tag= hands this function an arbitrary user string. isTopicTag rather than
+  // isReservedTag, because the bookkeeping tags are not "reserved" but are just as
+  // destructive to compress: `duplicate-candidate` has no row-level exclusion either.
+  if (!isTopicTag(tag)) {
     return { synthesizedId: null, entriesUsed: 0, text: "" };
   }
   const cfg = await resolveConfig(env);
@@ -95,10 +97,10 @@ export async function compressTag(
   const recentSynth = await env.DB.prepare(`
     SELECT id FROM entries
     WHERE tags LIKE '%"synthesized"%'
-      AND tags LIKE ?
+      AND tags LIKE ? ${TAG_LIKE_ESCAPE}
       AND created_at > ?
     LIMIT 1
-  `).bind(`%"${tag}"%`, Date.now() - 86400000).first();
+  `).bind(tagLikePattern(tag), Date.now() - 86400000).first();
 
   if (recentSynth) {
     return { synthesizedId: null, entriesUsed: 0, text: "" };
@@ -106,14 +108,14 @@ export async function compressTag(
 
   const { results: rawEntries } = await env.DB.prepare(`
     SELECT id, content FROM entries
-    WHERE tags LIKE ?
+    WHERE tags LIKE ? ${TAG_LIKE_ESCAPE}
       AND tags NOT LIKE '%"synthesized"%'
       AND tags NOT LIKE '%"auto-pattern"%'
       AND tags NOT LIKE '%"rolled-up"%'
       AND ${compressionEligibilitySql("", cfg)}
     ORDER BY created_at DESC
     LIMIT 50
-  `).bind(`%"${tag}"%`, Date.now() - cfg.COMPRESSION_MIN_AGE_MS).all();
+  `).bind(tagLikePattern(tag), Date.now() - cfg.COMPRESSION_MIN_AGE_MS).all();
 
   if (rawEntries.length < 10) {
     return { synthesizedId: null, entriesUsed: 0, text: "" };

--- a/src/compression/eligibility.ts
+++ b/src/compression/eligibility.ts
@@ -2,10 +2,78 @@
 // not proven-useful by recall, and not a contradiction survivor. Strictly more
 // protective than the old `importance_score < 4` filter — it can only exempt MORE.
 import { DEFAULTS, type Config } from "../config";
+import { STATUS_PREFIX } from "../memory/status";
+import { KIND_PREFIX } from "../memory/kind";
+import { VOLATILITY_PREFIX } from "../memory/volatility";
+import { STALE_AS_OF } from "../memory/stale";
 
 export const COMPRESSION_IMPORTANCE_THRESHOLD = 4;   // importance >= this → protected
 export const COMPRESSION_MIN_RECALL = 2;             // recalled >= this many times → protected
 export const COMPRESSION_MIN_AGE_MS = 60 * 86400000; // entries with fewer than COMPRESSION_MIN_RECALL recalls protected until this old (60 days)
+
+/**
+ * Tags the system writes ABOUT an entry, as opposed to tags describing what it is about.
+ *
+ * They are never digest candidates, and getting that wrong is not merely a wasted check:
+ * a nightly run compresses at most COMPRESSION_MAX_TAGS_PER_RUN tags, chosen by descending
+ * entry count, so a reserved tag in the candidate list takes a slot a real topic would have
+ * had. These tags are applied in bulk — the staleness pass alone writes volatility: and
+ * stale:as-of across up to 25 entries a night — so they outrank ordinary topics easily, and
+ * the symptom is compression appearing to stop working with nothing in the logs to say why.
+ *
+ * Derived from the prefixes themselves so the SQL below, the guard in compressTag, and the
+ * test double all agree by construction rather than by three copies staying in step.
+ *
+ * MATCHING IS CASE-INSENSITIVE, deliberately, and this is the dangerous half to get wrong.
+ * compressTag selects the entries it will roll up with `tags LIKE '%"<tag>"%'`, and SQLite's
+ * LIKE ignores ASCII case — so a candidate tag `Kind:Semantic` does not select the entries
+ * carrying `Kind:Semantic`, it selects every entry carrying `kind:semantic` in any case.
+ * Admitting one mixed-case reserved tag therefore does not cost a digest slot, it rolls up
+ * whatever unrelated entries happen to share the lowercase system tag: content permanently
+ * appended to, recall penalised, and the entries dropped from staleness, future compression
+ * and /stats. Nothing lowercases the tags src/integrations/mirror.ts inserts, so this is
+ * reachable, and it was reproduced: 9 entries tagged `holiday-plans` rolled up by a
+ * candidate tag they never carried.
+ *
+ * The two directions are not symmetric. Wrongly reserving a user's `Status:Active` costs one
+ * tag that never gets a digest. Wrongly admitting it costs up to 50 memories, irreversibly.
+ */
+const RESERVED_TAG_PREFIXES = [STATUS_PREFIX, KIND_PREFIX, VOLATILITY_PREFIX];
+const RESERVED_TAGS = [STALE_AS_OF];
+
+/** Bookkeeping tags that mark an entry's role in compression rather than its subject. */
+const NON_TOPIC_TAGS = ["synthesized", "auto-pattern", "duplicate-candidate", "contradiction-resolved", "rolled-up"];
+
+export function isReservedTag(tag: string): boolean {
+  const t = tag.toLowerCase();
+  return RESERVED_TAG_PREFIXES.some(prefix => t.startsWith(prefix)) || RESERVED_TAGS.includes(t);
+}
+
+export function isTopicTag(tag: string): boolean {
+  return !isReservedTag(tag) && !NON_TOPIC_TAGS.includes(tag.toLowerCase());
+}
+
+/**
+ * SQL boolean fragment for isTopicTag, applied to a json_each() tag value. No placeholders.
+ *
+ * Every clause is case-insensitive, matching the predicate above: LIKE ignores ASCII case,
+ * and the set membership is compared through lower(). The constants are all lowercase, and
+ * none may contain a LIKE metacharacter (% or _) — LIKE would read it as a wildcard. That
+ * is an invariant now, not an observation, and test/unit/compression-eligibility.test.ts
+ * enforces it.
+ *
+ * Note lower() is ASCII-only in SQLite while JavaScript's toLowerCase is Unicode-aware, so
+ * for a non-ASCII tag the predicate can reserve something the SQL admits. That direction is
+ * harmless: the candidate query offers the tag, compressTag's backstop declines it, and the
+ * cost is a spent slot rather than a wrong rollup.
+ */
+export function isTopicTagSql(column = "value"): string {
+  return [
+    `lower(${column}) NOT IN (${NON_TOPIC_TAGS.map(t => `'${t}'`).join(", ")})`,
+    ...RESERVED_TAG_PREFIXES.map(prefix => `${column} NOT LIKE '${prefix}%'`),
+    ...RESERVED_TAGS.map(t => `${column} NOT LIKE '${t}'`),
+  ].join("\n      AND ");
+}
 
 // Returns a SQL boolean fragment for "this entry is eligible for compression".
 // Contains exactly one `?` placeholder — bind `Date.now() - COMPRESSION_MIN_AGE_MS`.

--- a/src/compression/nightly.ts
+++ b/src/compression/nightly.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../env";
 import { resolveConfig } from "../config";
 import { initializeDatabase } from "../db/init";
-import { COMPRESSION_MIN_AGE_MS, compressionEligibilitySql } from "./eligibility";
+import { COMPRESSION_MIN_AGE_MS, compressionEligibilitySql, isTopicTagSql } from "./eligibility";
 import { compressTag } from "./digest";
 
 /**
@@ -66,9 +66,7 @@ export async function runNightlyCompression(env: Env, ctx: ExecutionContext): Pr
   const { results } = await env.DB.prepare(`
     SELECT value as tag, COUNT(*) as count
     FROM entries, json_each(entries.tags)
-    WHERE value NOT IN ('synthesized', 'auto-pattern', 'duplicate-candidate', 'contradiction-resolved', 'rolled-up')
-      AND value NOT LIKE 'status:%'
-      AND value NOT LIKE 'kind:%'
+    WHERE ${isTopicTagSql()}
       AND entries.tags NOT LIKE '%"rolled-up"%'
       AND entries.tags NOT LIKE '%"synthesized"%'
       AND entries.tags NOT LIKE '%"auto-pattern"%'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -51,6 +51,20 @@ export const KEYWORD_CANDIDATE_LIMIT = 500;
 // genuine word-boundary matches.
 export const SUBSTRING_MATCH_WEIGHT = 0.25;
 export const KEYWORD_MIN_TOKEN_LEN = 2;
+// The most LIKE terms this codebase will put into a single D1 statement: the
+// frequency scan's SUM columns (distill.ts) and the keyword arm's OR chain
+// (search.ts). The keyword arm needs the ceiling because distillToRareTerms
+// normally hands it MAX_QUERY_TERMS but two of its exits return the query
+// whole, and one of those needs nothing worse than an empty corpus to fire — so
+// a fresh install's first long query built a clause D1 rejected outright
+// (#276). Both of D1's limits bind at 99 terms: one parameter per term plus the
+// row limit against a budget of D1_MAX_BOUND_PARAMS, and an OR chain one
+// expression node deep per term against a tree-depth ceiling of 100 (measured:
+// 99 terms accepted, 100 rejected on depth first). 16 leaves 6x margin for a
+// future predicate, and keeps the two call sites agreeing by construction — the
+// widest set the scan ranks is the widest set the clause can carry, so no query
+// distillation can rank is ever truncated by the backstop.
+export const KEYWORD_MAX_TOKENS = 16;
 export const QUERY_SATURATION_FRACTION = 0.3;
 export const MAX_QUERY_TERMS = 3;
 export const KEYWORD_STOPWORDS = new Set([

--- a/src/db/init.ts
+++ b/src/db/init.ts
@@ -1,10 +1,10 @@
 import type { Env } from "../env";
 
-// The schema work below is idempotent but not free — roughly a dozen D1 statements per
-// call. All four nightly jobs run inside a single scheduled() invocation and therefore
-// share one subrequest budget, and each of them awaits initializeDatabase, so without
-// memoisation the same CREATE/ALTER sequence is paid for three or four times per cron.
-// Memoise per isolate: the first caller does the work, everyone else awaits that promise.
+// The schema work below is idempotent but not free. All four nightly jobs run inside a
+// single scheduled() invocation and therefore share one subrequest budget, and each of
+// them awaits initializeDatabase, so without memoisation the same pass is paid for three
+// or four times per cron. Memoise per isolate: the first caller does the work, everyone
+// else awaits that promise.
 //
 // Deliberately not routed through ensureDbReady (src/runtime/state.ts) — that fires under
 // ctx.waitUntil *without* awaiting, and the nightly jobs must not begin querying before
@@ -35,29 +35,20 @@ export function resetDatabaseInit(): void {
 }
 
 /**
- * The one ALTER failure that is routine rather than a fault: the column was added by an
- * earlier run. Every other error means the schema is not in the shape the code expects.
+ * Tables and indexes, keyed by the name each occupies in sqlite_master. Declaration order
+ * is apply order: a table has to exist before the indexes over it.
  */
-function isDuplicateColumn(e: unknown): boolean {
-  return /duplicate column name/i.test(String((e as { message?: string })?.message ?? e));
-}
-
-// Rejects on any genuine failure. Nothing here may swallow errors: a resolved promise is
-// the signal initializeDatabase memoises, so swallowing would cache a schema that was
-// never applied. The installer creates the D1 database moments before the first request
-// reaches the Worker, so the very first run is exactly when a transient error is most
-// likely — and most damaging, since that run is the one that creates every table.
-async function applySchema(env: Env): Promise<void> {
-  await env.DB.exec(`CREATE TABLE IF NOT EXISTS entries (id TEXT PRIMARY KEY, content TEXT NOT NULL, tags TEXT NOT NULL DEFAULT '[]', source TEXT NOT NULL DEFAULT 'api', created_at INTEGER NOT NULL, vector_ids TEXT NOT NULL DEFAULT '[]')`);
-  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_entries_created_at ON entries(created_at DESC)`);
-  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_entries_source ON entries(source)`);
+const SCHEMA_OBJECTS: Record<string, string> = {
+  entries: `CREATE TABLE IF NOT EXISTS entries (id TEXT PRIMARY KEY, content TEXT NOT NULL, tags TEXT NOT NULL DEFAULT '[]', source TEXT NOT NULL DEFAULT 'api', created_at INTEGER NOT NULL, vector_ids TEXT NOT NULL DEFAULT '[]')`,
+  idx_entries_created_at: `CREATE INDEX IF NOT EXISTS idx_entries_created_at ON entries(created_at DESC)`,
+  idx_entries_source: `CREATE INDEX IF NOT EXISTS idx_entries_source ON entries(source)`,
   // Relationship graph (issue #16). One additive table — never touches existing
   // rows/queries, so old code ignores it and rollback is a no-op. Designed to never
   // need an ALTER: type/provenance are free TEXT validated in code, and metadata is
   // a JSON escape-hatch for any future per-edge attribute.
-  await env.DB.exec(`CREATE TABLE IF NOT EXISTS edges (id TEXT PRIMARY KEY, source_id TEXT NOT NULL, target_id TEXT NOT NULL, type TEXT NOT NULL DEFAULT 'relates_to', weight REAL NOT NULL DEFAULT 0.5, provenance TEXT NOT NULL DEFAULT 'inferred', metadata TEXT NOT NULL DEFAULT '{}', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, UNIQUE(source_id, target_id, type))`);
-  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id)`);
-  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_id)`);
+  edges: `CREATE TABLE IF NOT EXISTS edges (id TEXT PRIMARY KEY, source_id TEXT NOT NULL, target_id TEXT NOT NULL, type TEXT NOT NULL DEFAULT 'relates_to', weight REAL NOT NULL DEFAULT 0.5, provenance TEXT NOT NULL DEFAULT 'inferred', metadata TEXT NOT NULL DEFAULT '{}', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, UNIQUE(source_id, target_id, type))`,
+  idx_edges_source: `CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id)`,
+  idx_edges_target: `CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_id)`,
   // The graph view picks the strongest edges (ORDER BY weight DESC LIMIT n). Without an
   // ordered path to weight SQLite reads the whole table into a temp b-tree and applies the
   // LIMIT afterwards, so on workerd D1 that statement's rows_read is 2 x the edge count and
@@ -75,37 +66,153 @@ async function applySchema(env: Env): Promise<void> {
   // three orders of magnitude on any brain that is not capturing thousands of times a day.
   //
   // Building it on an existing brain costs one row written per edge, once: measured
-  // 200,001 rows written at 200k edges, and 0/0 on every run after that, since IF NOT
-  // EXISTS makes the repeat a genuine no-op. That one statement can exceed the 100k/day
-  // write cap on a brain that is already very large — the same hazard the updated_at note
-  // below describes. It is still the right call, because such a brain is precisely the one
-  // the missing index takes offline every day, and the cost here is paid once rather than
-  // on every /graph. If it ever needs to be avoided, the fix is to build the index out of
-  // band, not to leave the query unindexed.
+  // 200,001 rows written at 200k edges, and 0/0 on every run after that. Before #282 that
+  // no-op was a statement issued on every cold isolate and made free by IF NOT EXISTS;
+  // now the probe means it is not issued at all once the index exists, so the repeat costs
+  // nothing rather than costing a subrequest that does nothing. That one build can exceed
+  // the 100k/day write cap on a brain that is already very large — the same hazard the
+  // updated_at note below describes. It is still the right call, because such a brain is
+  // precisely the one the missing index takes offline every day, and the cost here is paid
+  // once rather than on every /graph. If it ever needs to be avoided, the fix is to build
+  // the index out of band, not to leave the query unindexed.
   //
   // DESC matches the query; SQLite would walk an ASC index backwards just as well, but
   // stating the direction keeps the index and its one caller obviously paired. Bonus: the
   // nightly prune's `weight < ?` becomes a range search, 200,000 rows read down to 60,000.
-  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_weight ON edges(weight DESC)`);
-  for (const alter of [
-    `ALTER TABLE entries ADD COLUMN recall_count INTEGER DEFAULT 0`,
-    `ALTER TABLE entries ADD COLUMN importance_score INTEGER DEFAULT 0`,
-    `ALTER TABLE entries ADD COLUMN contradiction_wins INTEGER DEFAULT 0`,
-    `ALTER TABLE entries ADD COLUMN contradiction_losses INTEGER DEFAULT 0`,
-    // updated_at and staleness_checked_at are deliberately nullable and deliberately NOT
-    // backfilled. Every reader coalesces them to a sensible default — updated_at to
-    // created_at (COALESCE in SQL, ?? in TS), staleness_checked_at to 0 — so on an
-    // existing row a NULL and a written value are indistinguishable downstream, and a
-    // backfill would be a pure no-op that still costs one row written per entry. That is
-    // not free: D1's plan limits row writes per day, and exceeding the cap fails every
-    // query account-wide until 00:00 UTC, so backfilling a large brain on the ordinary
-    // upgrade path is an availability risk that buys nothing. Please do not add one.
-    // test/unit/updated-at-coalesced.test.ts fails if any reader stops coalescing.
-    `ALTER TABLE entries ADD COLUMN updated_at INTEGER`,
-    `ALTER TABLE entries ADD COLUMN staleness_checked_at INTEGER`,
-  ]) {
+  idx_edges_weight: `CREATE INDEX IF NOT EXISTS idx_edges_weight ON edges(weight DESC)`,
+};
+
+/**
+ * Columns added to `entries` after the table shipped, keyed by column name. They arrived
+ * across several releases, so a real brain can hold any prefix of this list — the probe
+ * below is what decides which ones are still owed.
+ */
+const ENTRIES_COLUMNS: Record<string, string> = {
+  recall_count: `ALTER TABLE entries ADD COLUMN recall_count INTEGER DEFAULT 0`,
+  importance_score: `ALTER TABLE entries ADD COLUMN importance_score INTEGER DEFAULT 0`,
+  contradiction_wins: `ALTER TABLE entries ADD COLUMN contradiction_wins INTEGER DEFAULT 0`,
+  contradiction_losses: `ALTER TABLE entries ADD COLUMN contradiction_losses INTEGER DEFAULT 0`,
+  // updated_at and staleness_checked_at are deliberately nullable and deliberately NOT
+  // backfilled. Every reader coalesces them to a sensible default — updated_at to
+  // created_at (COALESCE in SQL, ?? in TS), staleness_checked_at to 0 — so on an
+  // existing row a NULL and a written value are indistinguishable downstream, and a
+  // backfill would be a pure no-op that still costs one row written per entry. That is
+  // not free: D1's plan limits row writes per day, and exceeding the cap fails every
+  // query account-wide until 00:00 UTC, so backfilling a large brain on the ordinary
+  // upgrade path is an availability risk that buys nothing. Please do not add one.
+  // test/unit/updated-at-coalesced.test.ts fails if any reader stops coalescing.
+  updated_at: `ALTER TABLE entries ADD COLUMN updated_at INTEGER`,
+  staleness_checked_at: `ALTER TABLE entries ADD COLUMN staleness_checked_at INTEGER`,
+};
+
+/**
+ * One statement that reports every schema object this file knows how to create: table and
+ * index names out of sqlite_master, and entries' columns out of the table-valued form of
+ * PRAGMA table_info (SQLite rewrites neither list lazily — an ALTER shows up immediately).
+ * `kind` is what stops a name that appears on both sides from being read as the wrong one.
+ *
+ * This exists because the thirteen statements it replaces cost thirteen subrequests to
+ * discover that a migrated brain — which is every brain after its first request — needs
+ * nothing done (#282). Free-plan invocations get 50 subrequests, ensureDbReady spends
+ * them inside the request that triggered it, and GET /graph was already close enough to
+ * the ceiling that a cold isolate pushed it over: 59 against a limit of 50, now 47.
+ *
+ * Cost is one subrequest and one row read per catalogue entry: rows_read = 23 on a fully
+ * migrated brain (our seven objects, plus D1's own bookkeeping table and SQLite's implicit
+ * autoindexes, plus twelve columns) and — the part worth checking rather than assuming —
+ * flat in the number of entries, because neither side of the UNION touches table data.
+ * Both figures measured on real D1 (workerd via Miniflare), not on the mock. It grows by
+ * one row per object added to SCHEMA_OBJECTS, which is the cheap direction: adding a
+ * statement above now costs one row here rather than one subrequest on every cold start.
+ */
+const PROBE_SQL =
+  `SELECT type AS kind, name FROM sqlite_master WHERE type IN ('table','index') ` +
+  `UNION ALL SELECT 'column' AS kind, name FROM pragma_table_info('entries')`;
+
+type ObjectKind = "table" | "index";
+/**
+ * `objects` maps name to kind rather than being a set of names, because SQLite puts tables
+ * and indexes in one namespace: a name can be taken by the wrong kind of thing. Skipping on
+ * the name alone would let a user table called `idx_entries_source` stand in for the index,
+ * which resolves init successfully and silently never creates it.
+ */
+type ExistingSchema = { objects: Map<string, ObjectKind>; columns: Set<string> };
+
+/** Which kind of object a CREATE statement makes, so the probe can be asked about it. */
+const kindOf = (ddl: string): ObjectKind => (ddl.startsWith("CREATE TABLE") ? "table" : "index");
+
+/**
+ * What the database already has, or null if that could not be established.
+ *
+ * The invariant, and the only one that matters here: this may report a thing PRESENT only
+ * if it actually saw it, as the kind it is looking for. Everything else — the probe
+ * throwing, a result shape it does not recognise, a row whose `kind` is not one of the
+ * three, a name that exists as the other kind — resolves towards "missing", so the worst a
+ * confused probe can do is make applySchema pay the old whole-schema cost against DDL
+ * that is idempotent anyway. The opposite error is the one that would hurt: a brand-new
+ * brain talked out of migrating would then serve every request against tables that do not
+ * exist.
+ *
+ * Returning null rather than throwing is not error-swallowing. It does not resolve
+ * initializeDatabase — applySchema still has to apply and still rejects if the DDL fails.
+ * It degrades this isolate to the pre-#282 cost, which is the behaviour that shipped for
+ * every release before this one, and it is what keeps an unsupported PRAGMA on some
+ * future D1 from bricking first-request migration for every new install.
+ */
+async function probeSchema(env: Env): Promise<ExistingSchema | null> {
+  let rows: unknown;
+  try {
+    rows = (await env.DB.prepare(PROBE_SQL).all<{ kind: string; name: string }>())?.results;
+  } catch (e) {
+    console.warn("Schema probe failed; applying the full schema instead:", e);
+    return null;
+  }
+  if (!Array.isArray(rows)) return null;
+
+  const objects = new Map<string, ObjectKind>();
+  const columns = new Set<string>();
+  for (const row of rows as { kind?: unknown; name?: unknown }[]) {
+    if (typeof row?.name !== "string") continue;
+    if (row.kind === "column") columns.add(row.name);
+    else if (row.kind === "table" || row.kind === "index") objects.set(row.name, row.kind);
+  }
+  return { objects, columns };
+}
+
+/**
+ * The one ALTER failure that is routine rather than a fault: the column was added between
+ * the probe and here. That window is small now but not closed — two isolates can cold-start
+ * on the same brain at once, and D1 has no transactional DDL to serialise them — so this
+ * stays as the backstop it was. Every other error means the schema is not in the shape the
+ * code expects.
+ */
+function isDuplicateColumn(e: unknown): boolean {
+  return /duplicate column name/i.test(String((e as { message?: string })?.message ?? e));
+}
+
+// Rejects on any genuine failure. Nothing here may swallow errors: a resolved promise is
+// the signal initializeDatabase memoises, so swallowing would cache a schema that was
+// never applied. The installer creates the D1 database moments before the first request
+// reaches the Worker, so the very first run is exactly when a transient error is most
+// likely — and most damaging, since that run is the one that creates every table.
+//
+// A fully migrated brain leaves here having issued the probe and nothing else. The DDL
+// keeps its IF NOT EXISTS: it costs nothing to keep and it is the same backstop as the
+// duplicate-column tolerance, for the same concurrent-cold-start race.
+async function applySchema(env: Env): Promise<void> {
+  const existing = await probeSchema(env);
+
+  for (const [name, ddl] of Object.entries(SCHEMA_OBJECTS)) {
+    // Kind as well as name: if something else has taken the name, this is not the object
+    // we need and the CREATE has to be issued so SQLite raises the collision, which is
+    // what it did before the probe existed.
+    if (existing?.objects.get(name) === kindOf(ddl)) continue;
+    await env.DB.exec(ddl);
+  }
+  for (const [column, ddl] of Object.entries(ENTRIES_COLUMNS)) {
+    if (existing?.columns.has(column)) continue;
     try {
-      await env.DB.exec(alter);
+      await env.DB.exec(ddl);
     } catch (e) {
       if (!isDuplicateColumn(e)) throw e; // column already exists — anything else is real
     }

--- a/src/db/init.ts
+++ b/src/db/init.ts
@@ -58,6 +58,35 @@ async function applySchema(env: Env): Promise<void> {
   await env.DB.exec(`CREATE TABLE IF NOT EXISTS edges (id TEXT PRIMARY KEY, source_id TEXT NOT NULL, target_id TEXT NOT NULL, type TEXT NOT NULL DEFAULT 'relates_to', weight REAL NOT NULL DEFAULT 0.5, provenance TEXT NOT NULL DEFAULT 'inferred', metadata TEXT NOT NULL DEFAULT '{}', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, UNIQUE(source_id, target_id, type))`);
   await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id)`);
   await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_id)`);
+  // The graph view picks the strongest edges (ORDER BY weight DESC LIMIT n). Without an
+  // ordered path to weight SQLite reads the whole table into a temp b-tree and applies the
+  // LIMIT afterwards, so on workerd D1 that statement's rows_read is 2 x the edge count and
+  // is *identical* with and without the LIMIT: 400,000 at 200k edges, 6,000 with this
+  // index. D1's free plan allows 5M rows read/day and fails every query account-wide until
+  // 00:00 UTC once that is spent, so an authenticated caller could take the brain offline
+  // in a handful of /graph requests.
+  //
+  // This is the fifth index on a table written on the capture hot path, so it is a real
+  // trade rather than a free win. Measured, one whole capture (entry insert, vector_ids
+  // and classifier updates, plus inferEdgesOnWrite's worst case of 3 edges) costs 22 rows
+  // written before and 25 after — 4,545 captures/day against the 100k/day budget, down to
+  // 4,000. The same brain went from 3 /graph requests/day to 129 (and, unlike the write
+  // cost, that ceiling no longer falls as the brain grows). The read budget binds first by
+  // three orders of magnitude on any brain that is not capturing thousands of times a day.
+  //
+  // Building it on an existing brain costs one row written per edge, once: measured
+  // 200,001 rows written at 200k edges, and 0/0 on every run after that, since IF NOT
+  // EXISTS makes the repeat a genuine no-op. That one statement can exceed the 100k/day
+  // write cap on a brain that is already very large — the same hazard the updated_at note
+  // below describes. It is still the right call, because such a brain is precisely the one
+  // the missing index takes offline every day, and the cost here is paid once rather than
+  // on every /graph. If it ever needs to be avoided, the fix is to build the index out of
+  // band, not to leave the query unindexed.
+  //
+  // DESC matches the query; SQLite would walk an ASC index backwards just as well, but
+  // stating the direction keeps the index and its one caller obviously paired. Bonus: the
+  // nightly prune's `weight < ?` becomes a range search, 200,000 rows read down to 60,000.
+  await env.DB.exec(`CREATE INDEX IF NOT EXISTS idx_edges_weight ON edges(weight DESC)`);
   for (const alter of [
     `ALTER TABLE entries ADD COLUMN recall_count INTEGER DEFAULT 0`,
     `ALTER TABLE entries ADD COLUMN importance_score INTEGER DEFAULT 0`,

--- a/src/env.ts
+++ b/src/env.ts
@@ -8,4 +8,4 @@ export interface Env extends Omit<Cloudflare.Env, "VECTORIZE_GRACE_MS"> {
 // Worker version, echoed by GET /health. The desktop app compares this against
 // the version it bundles to offer a one-click "update your Second Brain".
 // Bump (semver) when the Worker changes; see installer/README "Worker versioning".
-export const SB_VERSION = "2.2.1";
+export const SB_VERSION = "2.2.2";

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -9,6 +9,35 @@ import type { Connection, EdgeProvenance, GraphNeighbor, GraphView } from "./typ
 export const GRAPH_MAX_HOPS = 3;
 const GRAPH_FANOUT_CAP = 8;
 const GRAPH_MAX_NODES = 50;
+// Ceiling on the /graph view's node set, applied even when the caller asks for
+// no cap. The binding constraint is the Workers free-plan limit of 50
+// subrequests per invocation, not row reads. buildGraph costs
+//
+//   1 (edge scan) + ceil(N/D1_MAX_BOUND_PARAMS) (node hydration)
+//                 + ceil(N/EDGE_QUERY_BATCH)    (edge hydration)
+//
+// D1 queries for N nodes, plus one KV read for the config. At N=1500 that is
+// 1 + 15 + 30 = 46, or 47 with the KV read. N=1600 lands on exactly 50 with
+// nothing spare, and anything from 1634 up exceeds it outright — which would be
+// a deterministically dead graph tab for every free-plan brain that large, and
+// runGraphPass backfills edges nightly, so a brain arrives there on its own.
+//
+// 47 is the WARM figure. On a cold isolate the budget is shared with
+// initializeDatabase, which fires under waitUntil and spends about 12 more on
+// its DDL, so the first request against a fresh isolate costs ~59 and is over
+// the limit — 1500 buys margin on the warm path, it does not clear the cold one.
+// That is #282 (probe sqlite_master once instead of issuing twelve blind
+// statements, taking cold /graph from 59 to 48), not something a lower cap here
+// can fix: the tax is fixed, so it eats any N.
+//
+// Recompute the formula above before raising this, and count the cold case as
+// well as the warm one. D1's 5M rows/day cap is the secondary bound and is
+// nowhere near binding here; sizing against it is what produced a number that
+// broke the free plan.
+//
+// It is a legibility limit too: the packed-cluster canvas is unreadable well
+// before 1500 nodes.
+export const GRAPH_VIEW_MAX_NODES = 1500;
 export const GRAPH_HOP_DECAY = 0.6;
 const EDGE_QUERY_BATCH = Math.floor(D1_MAX_BOUND_PARAMS / 2);
 
@@ -128,18 +157,29 @@ export async function getConnections(id: string, type: string | undefined, env: 
 }
 
 export async function buildGraph(opts: { seed?: string; limit?: number }, env: Env, config: Readonly<Config> = DEFAULTS): Promise<GraphView> {
-  const limit = opts.limit && opts.limit > 0 ? opts.limit : Infinity;
+  // "No cap" resolves to GRAPH_VIEW_MAX_NODES, never to Infinity. Anything that
+  // is not a positive finite number — absent, 0, negative, NaN — takes that
+  // branch, so a caller who reaches here past the route's own validation still
+  // cannot ask for an unbounded result set. Keeping `limit` a finite integer is
+  // also what makes it safe to interpolate into the SQL below.
+  //
+  // The LIMIT bounds rows *returned*, not rows read: `weight` has no index, so
+  // SQLite full-scans and sorts `edges` either way and rows_read is unchanged.
+  // Bounding the result is still the point — it is what caps the node set, and
+  // the node set is what drives the query count above.
+  const asked = Number.isFinite(opts.limit) && (opts.limit as number) > 0
+    ? Math.floor(opts.limit as number)
+    : GRAPH_VIEW_MAX_NODES;
+  const limit = Math.min(asked, GRAPH_VIEW_MAX_NODES);
 
   let nodeIds: string[];
   if (opts.seed) {
     const neighbors = await expandGraph([opts.seed], { hops: 2, maxNodes: limit, includeDeprecated: true }, env, config);
     nodeIds = [opts.seed, ...neighbors.map(n => n.id)].slice(0, limit);
   } else {
-    const sql = Number.isFinite(limit)
-      ? `SELECT source_id, target_id FROM edges ORDER BY weight DESC LIMIT ${limit * 4}`
-      : `SELECT source_id, target_id FROM edges ORDER BY weight DESC`;
-    const { results } = await env.DB.prepare(sql)
-      .all() as { results: { source_id: string; target_id: string }[] };
+    const { results } = await env.DB.prepare(
+      `SELECT source_id, target_id FROM edges ORDER BY weight DESC LIMIT ${limit * 4}`
+    ).all() as { results: { source_id: string; target_id: string }[] };
     const ids: string[] = [];
     const seenIds = new Set<string>();
     for (const r of results) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
 import type { Env } from "./env";
 import { runNightlyCompression } from "./compression/nightly";
 import { runGraphPass } from "./graph/pass";
-import { runScheduledIntegrationSync } from "./integrations/mirror";
+import { INTEGRATION_SYNC_CRON, runScheduledIntegrationSync } from "./integrations/mirror";
 import { runStalenessPass } from "./staleness/pass";
 import { apiHandler } from "./mcp/handler";
 import { augmentOAuthRegistrationRequest } from "./oauth/register";
@@ -40,15 +40,30 @@ export default {
     }
     return oauthProvider.fetch(req, env as any, ctx);
   },
-  scheduled: async (_event: ScheduledEvent, env: Env, ctx: ExecutionContext) => {
+  scheduled: async (event: ScheduledEvent, env: Env, ctx: ExecutionContext) => {
     // The jobs are independent, and each begins by awaiting the shared schema init. One
     // of them failing — including on that init — must not take the others down or surface
     // as an unhandled rejection inside waitUntil.
     const job = (name: string, run: Promise<void>) =>
       ctx.waitUntil(run.catch((e) => console.error(`${name} failed (non-fatal):`, e)));
+
+    // Two schedules, two budgets (#290). A Worker invocation gets 50 D1 queries and 10 ms
+    // of CPU on the free plan; the maintenance jobs below already spend 30 of those
+    // queries, so the mirror sync gets its own invocation rather than the remainder of
+    // this one. Routing on the cron string is what makes that real — without the branch
+    // both triggers would run everything and the split would cost budget instead of
+    // buying it.
+    if (event.cron === INTEGRATION_SYNC_CRON) {
+      job("integration sync", runScheduledIntegrationSync(env));
+      return;
+    }
+
+    // Anything else runs maintenance: the nightly cron, and any invocation whose cron we
+    // do not recognise (a hand-fired trigger, or a schedule added to wrangler.jsonc and
+    // not yet routed here). Maintenance is the safe default — skipping it degrades recall
+    // quality silently, whereas a skipped mirror sync is picked up on the next hour.
     job("nightly compression", runNightlyCompression(env, ctx));
     job("graph pass", runGraphPass(env, ctx));
-    job("integration sync", runScheduledIntegrationSync(env));
     job("staleness pass", runStalenessPass(env, ctx));
   },
 };

--- a/src/integrations/calendar.ts
+++ b/src/integrations/calendar.ts
@@ -29,7 +29,16 @@ export const RETENTION_MS = 180 * DAY_MS;    // hard bound on kept history
 // past, so they don't accumulate as low-value memories; one-off past events still
 // keep the full RETENTION_MS as historical memory.
 export const RECURRING_RETENTION_MS: number | null = 0;
-export const SYNC_EVENT_BATCH = 10;          // create/update ceiling per batch (subrequest budget)
+// Create/update ceiling per batch. The budget that binds here is D1's — 50
+// queries per Worker invocation on the free plan — not the one outbound fetch
+// per sync this used to be justified by, which is how the real cost went
+// unnoticed (#290). Each mirrored occurrence costs the mirror store two D1
+// queries to create (insert, then vector_ids) and three to update (read, content
+// write, vector_ids), on top of its classify, embed and Vectorize calls. So ten
+// items is 20–30 D1 queries: comfortable in an HTTP sync, which owns its whole
+// invocation, and the most the nightly cron can afford in the one it shares with
+// three other jobs (see CRON_SYNC_MAX_BATCHES in mirror.ts).
+export const SYNC_EVENT_BATCH = 10;
 export const MAX_OCCURRENCES_PER_EVENT = 200;
 const MAX_ITER = 100_000;                     // guards pathological RRULEs. Note: ev.iterator() walks from DTSTART, so this budget is also spent reaching the window; 100k covers realistic old/frequent series (e.g. hourly for ~10y, daily for centuries). Sub-hourly rules running many years may exhaust it and yield no occurrences — acceptable.
 const MAX_DESCRIPTION_CHARS = 4000;
@@ -86,7 +95,58 @@ function pushSingle(ev: any, startMs: number, endMs: number, out: Occurrence[]):
   });
 }
 
-function expandRecurring(ev: any, startMs: number, endMs: number, out: Occurrence[]): void {
+/**
+ * Slack added to every reach bound, to cover UTC-offset changes.
+ *
+ * The bound below is measured in absolute milliseconds, but ical.js builds an
+ * occurrence by adding the master's WALL-CLOCK duration in the occurrence's own
+ * timezone. Those two disagree across a DST transition, in both directions:
+ *
+ *  - A two-hour event whose end lands in a repeated hour takes THREE absolute
+ *    hours, so a bound measured off a master that spans no transition is short
+ *    by the offset change.
+ *  - A master whose own DTSTART/DTEND straddles a spring-forward gap measures
+ *    ONE absolute hour while being two on the wall — and since the master is
+ *    what the bound is derived from, that under-measurement would poison every
+ *    occurrence of the series forever, including ones nowhere near a transition.
+ *
+ * Reproducing ical.js's timezone arithmetic per occurrence would mean building
+ * the occurrence, which is the exact work the bound exists to avoid. A day of
+ * slack sidesteps it: every transition in current tzdata is an hour or less
+ * (Lord Howe's is thirty minutes), so this is not a close call. It costs almost
+ * nothing, because the bound is compared against a window that opens two days
+ * back — a year-old weekly series still rejects 51 of its 52 occurrences.
+ */
+const REACH_DST_SLACK_MS = DAY_MS;
+
+/**
+ * The furthest past its nominal start that an occurrence of this series can
+ * still be running — its longest possible (end − recurrence time), plus the
+ * slack above.
+ *
+ * This is what lets the walk below reject a spent occurrence from the iterator's
+ * own time, without building the occurrence first. It has to bound overrides as
+ * well as the master, because a RECURRENCE-ID instance can be both moved later
+ * and made longer; `end − recurrence-id` covers those two in one number. An
+ * override we cannot read returns Infinity, which disables the shortcut for this
+ * series rather than risking a wrong skip.
+ */
+function seriesReachMs(ev: any, exceptions: any[]): number {
+  let reach = ev.endDate.toJSDate().getTime() - ev.startDate.toJSDate().getTime();
+  for (const ex of exceptions) {
+    try {
+      const rid = ex.getFirstPropertyValue("recurrence-id");
+      if (!rid) continue;
+      const end = new ICAL.Event(ex).endDate.toJSDate().getTime();
+      reach = Math.max(reach, end - rid.toJSDate().getTime());
+    } catch {
+      return Infinity;
+    }
+  }
+  return Math.max(reach, 0) + REACH_DST_SLACK_MS;
+}
+
+function expandRecurring(ev: any, startMs: number, endMs: number, out: Occurrence[], reachMs: number): void {
   if (!ev.uid) return;
   const it = ev.iterator();
   let next: any;
@@ -96,6 +156,15 @@ function expandRecurring(ev: any, startMs: number, endMs: number, out: Occurrenc
     if (++iter > MAX_ITER) break;
     const occStartMs = next.toJSDate().getTime();
     if (occStartMs > endMs) break; // iterator is chronological — nothing further is in-window
+    // Cheap rejection before the expensive one. ev.iterator() walks from DTSTART,
+    // so on a series that has been running for a year the great majority of the
+    // occurrences visited here ended long before the window opens — measured at
+    // 91% for weekly series a year old, and getOccurrenceDetails is where
+    // essentially all of the expansion's CPU goes (#290). Deciding it from the
+    // iterator's own time skips building the occurrence at all. The reach bound
+    // is what keeps this exact for events still running when the window opens,
+    // including across a DST transition — see seriesReachMs.
+    if (occStartMs + reachMs < startMs) continue;
     const details = ev.getOccurrenceDetails(next);
     const e = details.endDate.toJSDate().getTime();
     if (e < startMs) continue;                 // occurrence already ended before window
@@ -153,8 +222,9 @@ export function parseAndExpand(icsText: string, windowStartMs: number, windowEnd
     try {
       if (g.master) {
         const ev = new ICAL.Event(g.master, { exceptions: g.exceptions });
-        if (ev.isRecurring()) expandRecurring(ev, windowStartMs, windowEndMs, out);
-        else pushSingle(ev, windowStartMs, windowEndMs, out);
+        if (ev.isRecurring()) {
+          expandRecurring(ev, windowStartMs, windowEndMs, out, seriesReachMs(ev, g.exceptions));
+        } else pushSingle(ev, windowStartMs, windowEndMs, out);
       } else {
         // No master in the feed (e.g. Google exports only the modified instances
         // of a series whose master is out of range): emit each override as a

--- a/src/integrations/mirror.ts
+++ b/src/integrations/mirror.ts
@@ -1,12 +1,13 @@
 import type { Env } from "../env";
-import { resolveConfig } from "../config";
+import { resolveConfig, type Config } from "../config";
 import {
   INTEGRATION_PROVIDERS,
   getProvider,
   loadIntegration,
+  saveIntegration,
   deleteIntegration,
 } from "../integrations";
-import type { MirrorStore } from "./framework";
+import type { IntegrationProvider, MirrorStore } from "./framework";
 import { initializeDatabase } from "../db/init";
 import { forgetEntry } from "../capture/lifecycle";
 import { deleteStaleVectors, storeEntry } from "../capture/store";
@@ -17,6 +18,20 @@ import { tagsAfterWrite } from "../memory/stale";
 import { rememberTags } from "../tags/vocabulary";
 
 export function makeMirrorStore(env: Env): MirrorStore {
+  // One config read per store, not one per mirrored item. A store is built once
+  // per sync batch, so this is still the per-request scope every other caller
+  // resolves at (src/config.ts) — but the batch writes up to SYNC_EVENT_BATCH
+  // items, and resolving inside the write paths made each of those cost its own
+  // KV read on top of its D1, Workers AI and Vectorize calls (#290).
+  //
+  // Lazy rather than eager so makeMirrorStore stays synchronous for its callers
+  // and a sync with nothing to write still costs nothing. Memoising the promise
+  // rather than the value is what makes concurrent writes share one read;
+  // resolveConfig degrades to the defaults instead of rejecting, so there is no
+  // failure to latch.
+  let pending: Promise<Readonly<Config>> | null = null;
+  const config = () => (pending ??= resolveConfig(env));
+
   return {
     async createEntry(content, tags, source) {
       const id = crypto.randomUUID();
@@ -26,10 +41,10 @@ export function makeMirrorStore(env: Env): MirrorStore {
       // bucket. Non-fatal — a failure just leaves it for the backfill to pick up.
       let finalTags = tags;
       let importance = 0;
-      // Resolved once and used for both the classify and the embed below: they
-      // must agree on the model, and this function previously resolved config
-      // for the embed while classifying with the shipped default.
-      const cfg = await resolveConfig(env);
+      // Used for both the classify and the embed below: they must agree on the
+      // model, and this function once resolved config for the embed while
+      // classifying with the shipped default.
+      const cfg = await config();
       try {
         const c = await classifyEntry(content, env, cfg);
         importance = c.importance;
@@ -72,9 +87,10 @@ export function makeMirrorStore(env: Env): MirrorStore {
 
       await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
         .bind(content, JSON.stringify(refreshedTags), now, id).run();
+      const cfg = await config();
       let newVectorIds: string[] = [];
       try {
-        newVectorIds = await storeEntry(env, id, content, refreshedTags, row.source as string, now, await resolveConfig(env));
+        newVectorIds = await storeEntry(env, id, content, refreshedTags, row.source as string, now, cfg);
       } catch (e) {
         console.error("Vectorize re-embed failed (non-fatal):", e);
       }
@@ -100,20 +116,114 @@ export function mirrorEditError(source: string): string {
   return `This memory is synced from ${name}. Edit it in ${name} (the change syncs automatically), or disconnect the ${name} integration to make it editable.`;
 }
 
-const CRON_SYNC_MAX_BATCHES = 5;
+/**
+ * The schedule this job owns, and the reason it has one.
+ *
+ * A Worker invocation gets 50 D1 queries and 10 ms of CPU on the free plan. The
+ * nightly maintenance pass already spends 30 of those queries, which left a
+ * mirror sync sharing that invocation with room for nothing useful: five batches
+ * cost 100 D1 queries on their own, and even one batch put the shared invocation
+ * exactly at the cap — over it as soon as the batch was updates rather than
+ * creates, or a second provider was connected (#290).
+ *
+ * So the sync runs on its own trigger with its own allowance. Must match the
+ * second entry in wrangler.jsonc's `triggers.crons` exactly — scheduled() in
+ * src/index.ts routes on it, and a mismatch would silently send this job's work
+ * to the nightly invocation, which is the problem it exists to avoid.
+ * test/unit/cron-triggers.test.ts fails if the two drift apart.
+ */
+export const INTEGRATION_SYNC_CRON = "30 * * * *";
 
+/**
+ * Batches per run.
+ *
+ * One. The caller has always been the thing that loops: every sync returns
+ * `remaining`, and the dashboard's "Sync now" drains a backlog on demand. The
+ * cron only has to make progress, and one batch an hour does, on a cursor the
+ * next run resumes from. Raising this spends a budget that is now sized for one
+ * batch — and it would spend the CPU cap too, since each batch re-fetches and
+ * re-expands the whole feed.
+ */
+const CRON_SYNC_MAX_BATCHES = 1;
+
+/**
+ * Sync ONE provider per run, least-recently-attempted first.
+ *
+ * Syncing every connected provider in a single invocation multiplies the cost by
+ * however many the user has connected — two calendars measured 70 D1 queries
+ * against a cap of 50 — and no per-provider batch size can fix that, because the
+ * multiplier is the provider count. Rotating keeps the cost of a run flat in the
+ * number of connections; the hourly schedule is what keeps each one fresh.
+ *
+ * The rotation key is `updatedAt`, not `lastSyncedAt`. Providers write
+ * `updatedAt` on every sync ATTEMPT but `lastSyncedAt` only on success, so
+ * ordering by the latter would park the rotation on a provider whose token has
+ * expired — it would be picked every hour, forever, and starve the ones that
+ * still work.
+ *
+ * Advancing that key is this function's job, not the provider's — see
+ * advanceRotationCursor. Under rotation a provider that never advances is not a
+ * slow provider, it is a stuck queue.
+ */
 export async function runScheduledIntegrationSync(env: Env): Promise<void> {
-  let initialized = false;
+  let due: IntegrationProvider | null = null;
+  let dueSince = Infinity;
   for (const provider of Object.values(INTEGRATION_PROVIDERS)) {
-    if (!(await loadIntegration(env, provider.id))) continue;
-    if (!initialized) {
-      await initializeDatabase(env);
-      initialized = true;
+    const record = await loadIntegration(env, provider.id);
+    if (!record) continue;
+    // Strict <, so registry order breaks ties deterministically — which is what
+    // orders the first run after two providers are connected together.
+    const touchedAt = record.updatedAt ?? 0;
+    if (touchedAt < dueSince) {
+      due = provider;
+      dueSince = touchedAt;
     }
-    const store = makeMirrorStore(env);
+  }
+  if (!due) return;
+
+  await initializeDatabase(env);
+  const store = makeMirrorStore(env);
+  try {
     for (let i = 0; i < CRON_SYNC_MAX_BATCHES; i++) {
-      const result = await provider.sync(env, store);
+      const result = await due.sync(env, store);
       if (!result.ok || result.remaining === 0) break;
     }
+  } finally {
+    await advanceRotationCursor(env, due.id);
+  }
+}
+
+/**
+ * Move the rotation past the provider that just had its turn, whatever happened
+ * during it.
+ *
+ * Providers persist `updatedAt` themselves on success and on the errors their own
+ * handlers catch, but a throw that escapes those handlers persists nothing.
+ * `job()` in src/index.ts swallows it, the record keeps its old `updatedAt`, and
+ * the selection above picks the same provider again — every hour, forever, while
+ * every other connection waits. Its item map did not persist either, so each of
+ * those runs re-mirrors the same batch under fresh ids: new memories and new D1
+ * writes every hour for work already done. The old shape visited every provider
+ * per run, so a throw cost the providers after it in registry order one turn;
+ * under rotation it costs all of them every turn, which is why this is the
+ * caller's responsibility now rather than a detail each provider gets right.
+ *
+ * Best effort by design. If this write is the thing failing there is nothing
+ * further to try, and it must not replace the sync error that brought us here —
+ * hence the catch, in a `finally` block.
+ *
+ * One case it deliberately cannot fix: a KV outage broad enough to fail this put
+ * would have failed the provider's own save too. The cursor lives in KV, so
+ * nothing in-process can advance it. What this does cover is the far likelier
+ * shape — a provider throwing past its handlers while KV is perfectly healthy.
+ */
+async function advanceRotationCursor(env: Env, providerId: string): Promise<void> {
+  try {
+    const record = await loadIntegration(env, providerId);
+    if (!record) return; // disconnected mid-run — nothing to advance
+    record.updatedAt = Date.now();
+    await saveIntegration(env, record);
+  } catch (e) {
+    console.error(`Integration rotation cursor did not advance for ${providerId} (non-fatal):`, e);
   }
 }

--- a/src/integrations/mirror.ts
+++ b/src/integrations/mirror.ts
@@ -14,6 +14,7 @@ import { classifyEntry } from "../capture/classify";
 import { withKind } from "../memory/kind";
 import { withStatus } from "../memory/status";
 import { tagsAfterWrite } from "../memory/stale";
+import { rememberTags } from "../tags/vocabulary";
 
 export function makeMirrorStore(env: Env): MirrorStore {
   return {
@@ -40,6 +41,16 @@ export function makeMirrorStore(env: Env): MirrorStore {
       await env.DB.prepare(
         `INSERT INTO entries (id, content, tags, source, created_at, updated_at, vector_ids, importance_score) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
       ).bind(id, content, JSON.stringify(finalTags), source, now, now, "[]", importance).run();
+      // Promptness, not correctness (#288). Every tag inserted here is a compile-time
+      // constant — a provider id from the registry in integrations/index.ts, plus
+      // whatever kind:/status: the classifier added — so the vocabulary's age limit
+      // would admit them on its own. This just means a freshly connected integration
+      // shows up in the dashboard's tag filter today rather than tomorrow.
+      //
+      // Awaited because the scheduled sync has no ExecutionContext to defer to. Costs
+      // one KV get per created entry; the put fires only on the first item of a newly
+      // connected provider.
+      await rememberTags(env, finalTags);
       try {
         await storeEntry(env, id, content, finalTags, source, now, cfg);
       } catch (e) {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -24,3 +24,60 @@ export function requireAuth(request: Request, env: Env): Response | null {
   if (isAuthorized(request, env)) return null;
   return json({ ok: false, error: "Unauthorized" }, 401);
 }
+
+// Anchored so the whole value has to be an integer. parseInt stops at the first
+// character it cannot use, which is how "7abc" became 7, "1e3" became 1 and
+// "0x10" became 0 — each of them a value the caller never wrote, accepted
+// silently. Whatever it could not salvage became NaN, and NaN survives every
+// Math.min/Math.max clamp, so the bad value reached the database: bound as a
+// LIMIT it is a D1 SQLITE_MISMATCH (an HTTP 500), and compared against
+// created_at it matches nothing, so a malformed date filter reads to the caller
+// as an empty brain rather than a bad request.
+const INTEGER = /^[+-]?\d+$/;
+
+/**
+ * Reads an integer query parameter, or returns the 400 to send back.
+ *
+ * Malformed is rejected rather than defaulted, which is how every other bad
+ * value on this surface is already treated (an unknown `type`, `status` or
+ * `action` is a 400, as is any bad value on the config write path) and how the
+ * MCP twins of these routes behave, since zod rejects a non-integer outright.
+ * `after` and `before` have no default to fall back to either — defaulting them
+ * would drop the filter and answer with more rows than were asked for, which is
+ * wrong data wearing a 200, the one failure a caller cannot detect.
+ *
+ * Out of range is still clamped, not rejected: `?n=200` means "as many as
+ * you'll give me" and has always been answered with 100.
+ *
+ * Only an absent parameter gets the default. A present one must parse, and that
+ * includes the empty forms `?after=` and `?after` — for the same reason as
+ * above, since defaulting them drops the filter. It also means `?n=$UNSET` from
+ * a shell says so instead of quietly becoming 20. This is a deliberate
+ * divergence from the string parameters beside these, where `?tag=` reads as
+ * absent: an empty tag filter has one obvious meaning, an empty timestamp does
+ * not.
+ *
+ * Used as `const n = intParam(url, "n", …); if (n instanceof Response) return n;`
+ * — the same early-return shape as requireAuth above.
+ */
+export function intParam(url: URL, name: string, opts: { fallback: number; min?: number; max?: number }): number | Response;
+export function intParam(url: URL, name: string, opts?: { min?: number; max?: number }): number | undefined | Response;
+export function intParam(
+  url: URL,
+  name: string,
+  opts: { fallback?: number; min?: number; max?: number } = {},
+): number | undefined | Response {
+  const raw = url.searchParams.get(name);
+  if (raw === null) return opts.fallback;
+
+  // An empty value falls through to the check below and is rejected: it is
+  // present, so it has to parse.
+  const text = raw.trim();
+  const value = Number(text);
+  if (!INTEGER.test(text) || !Number.isSafeInteger(value)) {
+    return json({ ok: false, error: `${name} must be an integer` }, 400);
+  }
+
+  const floored = opts.min === undefined ? value : Math.max(opts.min, value);
+  return opts.max === undefined ? floored : Math.min(opts.max, floored);
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import type { Env } from "../env";
 import { VECTORIZE_FIX_HINT } from "../constants";
 import { buildEntryFilterQuery, captureEntry } from "../capture/entry";
-import { appendToEntry, deleteStaleVectors, storeEntry } from "../capture/store";
+import { appendToEntry, updateEntryContent } from "../capture/store";
 import { applyStatus, forgetEntry } from "../capture/lifecycle";
 import { createEdge, deleteEdge, edgeLabel } from "../graph/edges";
 import { EDGE_TYPES } from "../graph/types";
@@ -126,9 +126,9 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         return { content: [{ type: "text", text: "Content cannot be empty." }] };
       }
 
-      // Read current row upfront — need tags, source, AND old vector_ids before any mutation
+      // Refuse before anything is written — same guard, same read, as POST /update.
       const row = await env.DB.prepare(
-        `SELECT tags, source, vector_ids FROM entries WHERE id = ?`
+        `SELECT source FROM entries WHERE id = ?`
       ).bind(id).first() as Record<string, any> | null;
 
       if (!row) {
@@ -139,32 +139,32 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         return { content: [{ type: "text", text: mirrorEditError(row.source as string) }] };
       }
 
-      const tags: string[] = JSON.parse(row.tags ?? "[]").filter((t: string) => t !== "rolled-up");
-      const source = row.source as string;
-      const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
+      const result = await updateEntryContent(env, id, newContent, await resolveConfig(env));
 
-      // Step 1: Update D1 content and tags (strip rolled-up so updated entry ranks normally)
-      await env.DB.prepare(`UPDATE entries SET content = ?, tags = ? WHERE id = ?`)
-        .bind(newContent, JSON.stringify(tags), id).run();
-
-      // Step 2: Re-embed new content → inserts new vectors + updates vector_ids in D1
-      let newVectorIds: string[] = [];
-      try {
-        newVectorIds = await storeEntry(env, id, newContent, tags, source, Date.now(), await resolveConfig(env));
-      } catch (e) {
-        console.error("Vectorize re-embed failed (non-fatal):", e);
+      // Only reachable if the entry was deleted between the guard read and the write.
+      if (result.status === "not_found") {
+        return { content: [{ type: "text", text: `No entry found with ID: ${id}` }] };
       }
-      const newVectorCount = newVectorIds.length;
 
-      // Step 3: Delete only stale vectors — ids reused by the re-embed must survive
-      try {
-        await deleteStaleVectors(env, oldVectorIds, newVectorIds);
-      } catch (e) {
-        console.error("Old vector cleanup failed (non-fatal):", e);
+      // Fails closed (#212): nothing was written, so the reply must not claim otherwise.
+      // This tool used to report success here while leaving the index pointing at the old
+      // text, and no repair path could see it — /vectorize-pending and /stats both look for
+      // an empty vector_ids, which a mis-indexed entry does not have (#289).
+      if (result.status === "reembed_failed") {
+        return { content: [{ type: "text", text: `Couldn't update entry ${id}: search re-index failed. Your memory is unchanged — please try again.` }] };
+      }
+
+      if (!result.vectorIds) {
+        return {
+          content: [{
+            type: "text",
+            text: `Updated entry ${id}. Note: it was not re-indexed for semantic search because the Vectorize index is missing — the previous index is kept and it is still findable by keyword. Fix: ${VECTORIZE_FIX_HINT}.`,
+          }],
+        };
       }
 
       return {
-        content: [{ type: "text", text: `Updated entry ${id}. Re-embedded as ${newVectorCount} vector(s).` }],
+        content: [{ type: "text", text: `Updated entry ${id}. Re-embedded as ${result.vectorIds.length} vector(s).` }],
       };
     }
   );

--- a/src/memory/tag-sql.ts
+++ b/src/memory/tag-sql.ts
@@ -1,0 +1,43 @@
+/**
+ * Matching a single tag inside the JSON `tags` column.
+ *
+ * Tags are stored as a JSON array, so every reader finds one with `tags LIKE '%"<tag>"%'`.
+ * That makes the tag part of a LIKE pattern, where `_` matches any character and `%`
+ * matches everything — and a tag is user data. Interpolated raw, the pattern does not
+ * select the entries carrying the tag: `q3_planning` also selects `q3-planning`, and `%`
+ * selects the whole table.
+ *
+ * Neither character is exotic. src/text/hashtags.ts matches \w, so writing `#q3_planning`
+ * in a memory creates the tag `q3_planning`; the API's tags[] array and the integrations
+ * mirror accept any string at all.
+ *
+ * On read paths the cost is over-broad results. On the compression path it is permanent:
+ * compressTag rolls up every row its selector returns, appending to their content and
+ * marking them `rolled-up`.
+ *
+ * Known and deliberately not handled: `tags` is JSON, so a tag containing `"` or `\` is
+ * stored escaped (`a"b` as `a\"b`) and this pattern will not match it. The unescaped form
+ * did not match it either — it just failed differently — and neither character can arrive
+ * through a hashtag, since src/text/hashtags.ts matches \w. Escaping for LIKE and escaping
+ * for JSON are two different transforms; doing the second properly means building the
+ * pattern from the JSON encoding of the tag, not from the tag. Failing closed is the right
+ * side to be wrong on for a selector that decides what gets rolled up.
+ *
+ * Lives here rather than with any one caller because four modules across three concerns
+ * need it, and it is the tag vocabulary's own business how a tag is encoded and matched.
+ * Pure by the rules in src/ARCHITECTURE.md — it imports nothing.
+ */
+
+/**
+ * The `tags LIKE` pattern that matches exactly the given tag.
+ *
+ * Must be paired with TAG_LIKE_ESCAPE on the clause. Without it the backslashes are
+ * literal and the pattern matches nothing instead of too much — wrong in the safe
+ * direction, but still wrong, which is why the two are exported together.
+ */
+export function tagLikePattern(tag: string): string {
+  return `%"${tag.replace(/([%_\\])/g, "\\$1")}"%`;
+}
+
+/** Goes immediately after any `LIKE ?` whose parameter came from tagLikePattern. */
+export const TAG_LIKE_ESCAPE = `ESCAPE '\\'`;

--- a/src/recall/distill.ts
+++ b/src/recall/distill.ts
@@ -9,15 +9,32 @@ import {
 } from "../constants";
 import { readStreamText } from "../lib/ai";
 import { extractHashtags } from "../text/hashtags";
+import { isTopicTag } from "../compression/eligibility";
+import { getTagVocabulary } from "../tags/vocabulary";
 
-export async function inferQueryTags(query: string, env: Env, config: Readonly<Config> = DEFAULTS): Promise<string[]> {
+/**
+ * `ctx` is optional only so this stays callable from tests and any future internal
+ * caller; pass it wherever there is one, or an aged-out vocabulary is rebuilt on the
+ * request's own critical path instead of behind it.
+ */
+export async function inferQueryTags(query: string, env: Env, config: Readonly<Config> = DEFAULTS, ctx?: ExecutionContext): Promise<string[]> {
   const { hashtags } = extractHashtags(query);
   if (hashtags.length) return hashtags;
 
-  const { results: tagRows } = await env.DB.prepare(
-    `SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value`
-  ).all();
-  const knownTags = (tagRows as { value: string }[]).map(r => r.value);
+  // Cached (#288): this used to be a full table scan expanded per tag per row, on
+  // every recall, and it was 82% of a recall's read cost.
+  //
+  // System tags are dropped rather than matched against. They say what the system
+  // did to an entry, not what it is about, and the only thing a query tag does is
+  // boost entries whose subject overlaps the question. Two of them — `auto-pattern`
+  // and `status:deprecated` — name entries that recall's hydration filter removes
+  // outright, so a boost they win is spent on rows that are then discarded. They are
+  // also applied in bulk (the staleness pass alone writes `volatility:` and
+  // `stale:as-of` across up to 25 entries a night), which makes them the highest-
+  // count tags in a mature brain and exactly the ones that would crowd real topics
+  // out of the 50 the LLM below is shown. The same predicate #278 used to keep them
+  // out of digest candidates, so the two agree by construction.
+  const knownTags = (await getTagVocabulary(env, ctx)).filter(isTopicTag);
 
   const lowerQuery = query.toLowerCase();
   const keywordMatches = knownTags.filter(t =>

--- a/src/recall/distill.ts
+++ b/src/recall/distill.ts
@@ -1,6 +1,7 @@
 import type { Env } from "../env";
 import { DEFAULTS, type Config } from "../config";
 import {
+  KEYWORD_MAX_TOKENS,
   KEYWORD_MIN_TOKEN_LEN,
   KEYWORD_STOPWORDS,
   MAX_QUERY_TERMS,
@@ -69,7 +70,11 @@ export async function distillToRareTerms(query: string, env: Env, config: Readon
     return { query: content.length ? content.join(" ") : query, df: null, total: null };
   }
 
-  const uniq = [...new Set(content.map(norm))].slice(0, 16);
+  // One bound parameter and one SUM column per term, so this scan is bounded by
+  // the same ceiling as the keyword clause it feeds. Sharing the constant is
+  // what makes that true rather than coincidental: the widest set ranked here
+  // is the widest set search.ts can carry, in either direction.
+  const uniq = [...new Set(content.map(norm))].slice(0, KEYWORD_MAX_TOKENS);
   try {
     const sums = uniq.map((_, i) => `SUM(CASE WHEN content LIKE ? THEN 1 ELSE 0 END) AS d${i}`).join(", ");
     const row = await env.DB.prepare(`SELECT COUNT(*) AS total, ${sums} FROM entries`)

--- a/src/recall/search.ts
+++ b/src/recall/search.ts
@@ -20,6 +20,7 @@ import { cosineSim, mmrRerank, rerankWithTimeDecay, type VectorizeMatch } from "
 import { rrfFuse } from "./rrf";
 import { computeCompoundStale } from "./compound-stale";
 import type { KeywordRow, RecallMatch, RecallSearchResult } from "./types";
+import { TAG_LIKE_ESCAPE, tagLikePattern } from "../memory/tag-sql";
 
 async function keywordSearch(tokens: string[], env: Env, limit: number): Promise<KeywordRow[]> {
   if (!tokens.length) return [];
@@ -138,9 +139,13 @@ export async function recallEntries(
   let keywordRows: KeywordRow[] = [];
   let results: { matches: VectorizeMatch[] };
   if (tag) {
+    // Escaped: a tag is user data and LIKE reads _ and % as wildcards. This is a read, so
+    // the failure is over-broad results rather than the permanent rollup the same bug
+    // caused in compressTag — but `?tag=%` silently defeats the filter entirely and
+    // returns the whole brain, which is not a recoverable-looking answer either.
     const { results: tagRows } = await env.DB.prepare(
-      `SELECT id, vector_ids, content, tags, source, created_at FROM entries WHERE tags LIKE ?`
-    ).bind(`%"${tag}"%`).all();
+      `SELECT id, vector_ids, content, tags, source, created_at FROM entries WHERE tags LIKE ? ${TAG_LIKE_ESCAPE}`
+    ).bind(tagLikePattern(tag)).all();
     if (!tagRows.length) return { matches: [], insight: "", semanticUnavailable };
     keywordRows = tagRows as unknown as KeywordRow[];
 

--- a/src/recall/search.ts
+++ b/src/recall/search.ts
@@ -133,7 +133,7 @@ export async function recallEntries(
   const tokens = tokenizeQuery(embedQuery);
   const [values, queryTags] = await Promise.all([
     embed(embedQuery, env, cfg),
-    inferQueryTags(embedQuery, env, cfg),
+    inferQueryTags(embedQuery, env, cfg, ctx),
   ]);
 
   let keywordRows: KeywordRow[] = [];

--- a/src/recall/search.ts
+++ b/src/recall/search.ts
@@ -1,6 +1,7 @@
 import type { Env } from "../env";
 import {
   D1_MAX_BOUND_PARAMS,
+  KEYWORD_MAX_TOKENS,
   VECTORIZE_GET_BY_IDS_BATCH,
   VECTORIZE_TOP_K_MULTIPLIER,
 } from "../constants";
@@ -22,10 +23,16 @@ import type { KeywordRow, RecallMatch, RecallSearchResult } from "./types";
 
 async function keywordSearch(tokens: string[], env: Env, limit: number): Promise<KeywordRow[]> {
   if (!tokens.length) return [];
-  const where = tokens.map(() => "content LIKE ?").join(" OR ");
+  // Capped here rather than at distillation's uncapped exits because this is
+  // the only place a token count becomes SQL, and there are two such exits —
+  // one of which needs nothing worse than an empty corpus to fire (#276). Query
+  // order is the only ordering available on those paths: they are exactly the
+  // paths where the frequencies that would rank the terms are missing.
+  const terms = tokens.slice(0, KEYWORD_MAX_TOKENS);
+  const where = terms.map(() => "content LIKE ?").join(" OR ");
   const { results } = await env.DB.prepare(
     `SELECT id, content, tags, source, created_at FROM entries WHERE ${where} ORDER BY created_at DESC LIMIT ?`
-  ).bind(...tokens.map(t => `%${t}%`), limit).all();
+  ).bind(...terms.map(t => `%${t}%`), limit).all();
   return results as unknown as KeywordRow[];
 }
 
@@ -236,16 +243,31 @@ export async function recallEntries(
     }));
   }
 
+  // Chunked like the recall-count fetch above. This id list is the seeds plus
+  // whatever the graph expansion returned, so its length is the sum of two caps
+  // this query does not own — topK and GRAPH_MAX_NODES. They sum to 70 today,
+  // which fits one statement; the loop is what makes raising either of them a
+  // tuning change here rather than a query D1 rejects. One consequence if a
+  // second batch ever runs: d1Rows is then batch order, not one result set's
+  // order, which derivePattern's rows.slice(0, 20) below samples from.
   const allParentIds = [...seedParentIds, ...expandedScored.map(e => e.parentId)];
-  const placeholders = allParentIds.map(() => "?").join(", ");
-  const d1Bindings: (string | number)[] = [...allParentIds];
-  let d1Sql = `SELECT id, content, tags, source, created_at, updated_at FROM entries WHERE id IN (${placeholders}) AND tags NOT LIKE '%"auto-pattern"%' AND tags NOT LIKE '%"status:deprecated"%'`;
+  let d1Filters = ` AND tags NOT LIKE '%"auto-pattern"%' AND tags NOT LIKE '%"status:deprecated"%'`;
+  const filterBindings: number[] = [];
   if (kind && (KIND_VALUES as readonly string[]).includes(kind)) {
-    d1Sql += ` AND tags LIKE '%"kind:${kind}"%'`;
+    d1Filters += ` AND tags LIKE '%"kind:${kind}"%'`;
   }
-  if (after !== undefined) { d1Sql += ` AND created_at >= ?`; d1Bindings.push(after); }
-  if (before !== undefined) { d1Sql += ` AND created_at <= ?`; d1Bindings.push(before); }
-  const { results: d1Rows } = await env.DB.prepare(d1Sql).bind(...d1Bindings).all() as { results: Record<string, any>[] };
+  if (after !== undefined) { d1Filters += ` AND created_at >= ?`; filterBindings.push(after); }
+  if (before !== undefined) { d1Filters += ` AND created_at <= ?`; filterBindings.push(before); }
+  const d1Rows: Record<string, any>[] = [];
+  const idBatchSize = D1_MAX_BOUND_PARAMS - filterBindings.length;
+  for (let i = 0; i < allParentIds.length; i += idBatchSize) {
+    const batch = allParentIds.slice(i, i + idBatchSize);
+    const placeholders = batch.map(() => "?").join(", ");
+    const { results } = await env.DB.prepare(
+      `SELECT id, content, tags, source, created_at, updated_at FROM entries WHERE id IN (${placeholders})${d1Filters}`
+    ).bind(...batch, ...filterBindings).all() as { results: Record<string, any>[] };
+    d1Rows.push(...results);
+  }
 
   const d1Map = new Map(d1Rows.map((r) => [r.id as string, r]));
 

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../env";
 import { resolveConfig } from "../config";
 import { SB_VERSION } from "../env";
-import { COMPRESSION_MIN_AGE_MS, compressionEligibilitySql } from "../compression/eligibility";
+import { COMPRESSION_MIN_AGE_MS, compressionEligibilitySql, isTopicTagSql } from "../compression/eligibility";
 import { json, requireAuth } from "../lib/http";
 import { graceMs } from "../lib/ai";
 import { classifyEntry } from "../capture/classify";
@@ -10,6 +10,7 @@ import { deprecateEntry } from "../capture/lifecycle";
 import { getStatus, withStatus } from "../memory/status";
 import { withKind } from "../memory/kind";
 import { checkVectorizeHealth } from "../vectorize/health";
+import { TAG_LIKE_ESCAPE, tagLikePattern } from "../memory/tag-sql";
 
 export async function handleAdminRoutes(
   request: Request,
@@ -34,9 +35,7 @@ export async function handleAdminRoutes(
       env.DB.prepare(`
         SELECT value as tag, COUNT(*) as count
         FROM entries, json_each(entries.tags)
-        WHERE value NOT IN ('synthesized', 'auto-pattern', 'duplicate-candidate', 'contradiction-resolved', 'rolled-up')
-          AND value NOT LIKE 'status:%'
-          AND value NOT LIKE 'kind:%'
+        WHERE ${isTopicTagSql()}
           AND entries.tags NOT LIKE '%"rolled-up"%'
           AND entries.tags NOT LIKE '%"synthesized"%'
           AND entries.tags NOT LIKE '%"auto-pattern"%'
@@ -52,8 +51,8 @@ export async function handleAdminRoutes(
     const digestCandidates: { tag: string; count: number }[] = [];
     for (const row of candidateRows.results as any[]) {
       const existing = await env.DB.prepare(
-        `SELECT id FROM entries WHERE tags LIKE '%"synthesized"%' AND tags LIKE ? AND created_at > ? LIMIT 1`
-      ).bind(`%"${row.tag}"%`, cutoff).first();
+        `SELECT id FROM entries WHERE tags LIKE '%"synthesized"%' AND tags LIKE ? ${TAG_LIKE_ESCAPE} AND created_at > ? LIMIT 1`
+      ).bind(tagLikePattern(row.tag as string), cutoff).first();
       if (!existing) digestCandidates.push({ tag: row.tag as string, count: row.count as number });
     }
 

--- a/src/routes/capture.ts
+++ b/src/routes/capture.ts
@@ -3,10 +3,8 @@ import { resolveConfig } from "../config";
 import { VECTORIZE_FIX_HINT } from "../constants";
 import { json, requireAuth } from "../lib/http";
 import { captureEntry } from "../capture/entry";
-import { appendToEntry, deleteStaleVectors, reembedOrDegrade } from "../capture/store";
+import { appendToEntry, updateEntryContent } from "../capture/store";
 import { isManagedMirror, mirrorEditError } from "../integrations/mirror";
-import { extractHashtags } from "../text/hashtags";
-import { tagsAfterWrite } from "../memory/stale";
 
 export async function handleCaptureRoutes(
   request: Request,
@@ -118,8 +116,11 @@ export async function handleCaptureRoutes(
     const id = body.id.trim();
     const newContent = body.content.trim();
 
+    // Refuse before anything is written. Only `source` is needed: updateEntryContent reads
+    // the rest for itself, and keeping the mirror guard out here is what stops
+    // capture/store.ts having to depend on the integrations registry (see #289).
     const row = await env.DB.prepare(
-      `SELECT tags, source, vector_ids FROM entries WHERE id = ?`
+      `SELECT source FROM entries WHERE id = ?`
     ).bind(id).first() as Record<string, any> | null;
 
     if (!row) return json({ ok: false, error: `No entry found with ID: ${id}` }, 404);
@@ -128,39 +129,18 @@ export async function handleCaptureRoutes(
       return json({ ok: false, error: mirrorEditError(row.source as string) }, 409);
     }
 
-    const tags: string[] = JSON.parse(row.tags ?? "[]");
-    const { cleanContent, hashtags: newHashtags } = extractHashtags(newContent);
-    const mergedTags = tagsAfterWrite([...new Set([...tags, ...newHashtags])]);
-    const source = row.source as string;
-    const oldVectorIds: string[] = JSON.parse(row.vector_ids ?? "[]");
-    const finalContent = cleanContent || newContent;
+    const result = await updateEntryContent(env, id, newContent, await resolveConfig(env));
 
-    // Re-embed FIRST (#212): if it fails, leave the entry's content and vectors
-    // untouched and surface an error, instead of committing new content and then
-    // deleting every vector — which would leave the entry silently unsearchable.
-    // null means Vectorize is unreachable (#270), not that this embed failed.
-    let newVectorIds: string[] | null;
-    try {
-      newVectorIds = await reembedOrDegrade(env, id, finalContent, mergedTags, source, await resolveConfig(env));
-    } catch (e) {
-      console.error("Re-embed failed — entry left unchanged:", e);
+    // Only reachable if the entry was deleted between the guard read and the write.
+    if (result.status === "not_found") {
+      return json({ ok: false, error: `No entry found with ID: ${id}` }, 404);
+    }
+
+    if (result.status === "reembed_failed") {
       return json({ ok: false, error: "Couldn't update: search re-index failed. Your memory is unchanged — please try again." }, 500);
     }
 
-    // Safe to commit: either the embed succeeded, or Vectorize is unavailable and
-    // the old vectors are kept below rather than retired.
-    await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
-      .bind(finalContent, JSON.stringify(mergedTags), Date.now(), id).run();
-
-    if (newVectorIds) {
-      try {
-        await deleteStaleVectors(env, oldVectorIds, newVectorIds);
-      } catch (e) {
-        console.error("Old vector cleanup failed (non-fatal):", e);
-      }
-    }
-
-    if (!newVectorIds) {
+    if (!result.vectorIds) {
       return json({
         ok: true,
         id,
@@ -170,7 +150,7 @@ export async function handleCaptureRoutes(
       });
     }
 
-    return json({ ok: true, id, vectors: newVectorIds.length });
+    return json({ ok: true, id, vectors: result.vectorIds.length });
   }
 
   return null;

--- a/src/routes/entries.ts
+++ b/src/routes/entries.ts
@@ -3,12 +3,13 @@ import { json, requireAuth } from "../lib/http";
 import { forgetEntry } from "../capture/lifecycle";
 import { applyStatus } from "../capture/lifecycle";
 import { STATUS_VALUES, type MemoryStatus } from "../memory/status";
+import { getTagVocabulary } from "../tags/vocabulary";
 
 export async function handleEntriesRoutes(
   request: Request,
   url: URL,
   env: Env,
-  _ctx: ExecutionContext,
+  ctx: ExecutionContext,
 ): Promise<Response | null> {
   // GET /count
   if (url.pathname === "/count" && request.method === "GET") {
@@ -18,14 +19,15 @@ export async function handleEntriesRoutes(
     return json({ count: (row?.count as number) ?? 0 });
   }
 
-  // GET /tags
+  // GET /tags — the dashboard's filter dropdown, refetched on every page load.
+  // Reads the same cache recall does (#288): the scan behind it costs 180,000 rows
+  // on a 20,000-entry brain, and nothing here is worth that per navigation. Unlike
+  // recall this route has no useful degraded answer, so a cold cache is scanned
+  // inline rather than answered empty — see getTagVocabulary.
   if (url.pathname === "/tags" && request.method === "GET") {
     const authErr = requireAuth(request, env);
     if (authErr) return authErr;
-    const { results } = await env.DB.prepare(
-      `SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value`
-    ).all();
-    return json((results as any[]).map(r => r.value as string));
+    return json(await getTagVocabulary(env, ctx));
   }
 
   // GET /export — complete backup: every entry plus the edges table. Single

--- a/src/routes/graph.ts
+++ b/src/routes/graph.ts
@@ -1,5 +1,5 @@
 import type { Env } from "../env";
-import { json, requireAuth } from "../lib/http";
+import { intParam, json, requireAuth } from "../lib/http";
 import { createEdge, deleteEdge, isValidEdgeType } from "../graph/edges";
 import { EDGE_TYPES } from "../graph/types";
 import { buildGraph, getConnections } from "../graph/traverse";
@@ -72,8 +72,10 @@ export async function handleGraphRoutes(
     if (authErr) return authErr;
 
     const seed = url.searchParams.get("seed")?.trim() || undefined;
-    const limitParam = url.searchParams.get("limit");
-    const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+    // Omitted still means the whole graph, up to buildGraph's own ceiling. The
+    // floor of 1 is what stops `?limit=0` and `?limit=-1` from meaning that too.
+    const limit = intParam(url, "limit", { min: 1 });
+    if (limit instanceof Response) return limit;
 
     const { nodes, edges } = await buildGraph({ seed, limit }, env, await resolveConfig(env));
     return json({ ok: true, nodes, edges });

--- a/src/routes/recall.ts
+++ b/src/routes/recall.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../env";
 import { resolveConfig } from "../config";
 import { LLM_MODEL, VECTORIZE_FIX_HINT } from "../constants";
-import { CORS_HEADERS, json, requireAuth } from "../lib/http";
+import { CORS_HEADERS, intParam, json, requireAuth } from "../lib/http";
 import { buildEntryFilterQuery } from "../capture/entry";
 import { compressTag } from "../compression/digest";
 import { KIND_VALUES, type MemoryKind } from "../memory/kind";
@@ -18,10 +18,15 @@ export async function handleRecallRoutes(
   if (url.pathname === "/list" && request.method === "GET") {
     const authErr = requireAuth(request, env);
     if (authErr) return authErr;
-    const n = Math.min(parseInt(url.searchParams.get("n") ?? "20", 10), 100);
+    // Floor of 0 as well as the cap: SQLite reads a negative LIMIT as no limit
+    // at all, so `?n=-1` used to return the whole entries table.
+    const n = intParam(url, "n", { fallback: 20, min: 0, max: 100 });
+    if (n instanceof Response) return n;
     const tag = url.searchParams.get("tag")?.trim() || undefined;
-    const after = url.searchParams.has("after") ? parseInt(url.searchParams.get("after")!, 10) : undefined;
-    const before = url.searchParams.has("before") ? parseInt(url.searchParams.get("before")!, 10) : undefined;
+    const after = intParam(url, "after");
+    if (after instanceof Response) return after;
+    const before = intParam(url, "before");
+    if (before instanceof Response) return before;
 
     const { sql, bindings } = buildEntryFilterQuery({ n, tag, after, before });
     const { results } = await env.DB.prepare(sql).bind(...bindings).all();
@@ -36,13 +41,17 @@ export async function handleRecallRoutes(
     const query = url.searchParams.get("query")?.trim();
     if (!query) return json({ ok: false, error: "query is required" }, 400);
 
-    const topK = Math.min(Math.max(parseInt(url.searchParams.get("topK") ?? "5", 10), 1), 20);
+    const topK = intParam(url, "topK", { fallback: 5, min: 1, max: 20 });
+    if (topK instanceof Response) return topK;
     const tag = url.searchParams.get("tag")?.trim() || undefined;
-    const after = url.searchParams.has("after") ? parseInt(url.searchParams.get("after")!, 10) : undefined;
-    const before = url.searchParams.has("before") ? parseInt(url.searchParams.get("before")!, 10) : undefined;
+    const after = intParam(url, "after");
+    if (after instanceof Response) return after;
+    const before = intParam(url, "before");
+    if (before instanceof Response) return before;
     const kindParam = url.searchParams.get("kind")?.trim();
     const kind = kindParam && (KIND_VALUES as readonly string[]).includes(kindParam) ? kindParam as MemoryKind : undefined;
-    const hops = Math.min(Math.max(parseInt(url.searchParams.get("hops") ?? "0", 10), 0), 3);
+    const hops = intParam(url, "hops", { fallback: 0, min: 0, max: 3 });
+    if (hops instanceof Response) return hops;
     // Long memories are shortened by default so API/CLI consumers get a bounded
     // payload. Renderers that show the whole memory (the dashboard) pass full=1.
     const full = ["1", "true", "yes"].includes((url.searchParams.get("full") ?? "").toLowerCase());

--- a/src/staleness/pass.ts
+++ b/src/staleness/pass.ts
@@ -6,7 +6,21 @@ import { hasStaleAsOf, withStaleAsOf, withoutStaleAsOf } from "../memory/stale";
 import { classifyVolatility, shouldFlagStale } from "./heuristic";
 
 export const STALENESS_AGE_MS = 90 * 24 * 60 * 60 * 1000;
+
+/**
+ * How many candidates one pass inspects.
+ *
+ * Raising this past 100 breaks the retry re-read: rereadSnapshots binds one parameter per
+ * unsettled row into a single `WHERE id IN (…)`, and D1 allows at most 100 bound parameters
+ * per query. It fails only under contention, which is the hard case to notice. Chunk that
+ * read before raising this.
+ */
 export const STALENESS_PASS_LIMIT = 25;
+
+// Unchanged from when every row retried on its own. What changed is the price: a whole
+// round of retries now costs one re-read plus one batch, not one of each per row, so the
+// depth is bounded by correctness rather than by budget.
+const STALENESS_CAS_ATTEMPTS = 3;
 
 const SYSTEM_TAG_EXCLUSIONS = [
   `tags NOT LIKE '%"status:deprecated"%'`,
@@ -15,45 +29,137 @@ const SYSTEM_TAG_EXCLUSIONS = [
   `tags NOT LIKE '%"rolled-up"%'`,
 ].join(" AND ");
 
-// `known` lets the caller spend the row it already selected on the first attempt instead
-// of re-reading it; a lost CAS drops back to a fresh read for the retry.
-//
+/** The row as the pass last saw it — the CAS guard is built from exactly these values. */
+type Snapshot = { id: string; tags: string; content: string };
+
+/** `retryable` marks a CAS, whose result decides whether the row needs another attempt. */
+type Write = { id: string; stmt: D1PreparedStatement; retryable: boolean };
+
+function classify(tags: string[], content: string): string[] {
+  const classified = classifyVolatility(content, tags);
+  const existing = getVolatility(tags);
+
+  if (classified && !existing) {
+    tags = withVolatility(tags, classified);
+  }
+
+  const volatility = getVolatility(tags);
+
+  if (shouldFlagStale(volatility)) {
+    if (!hasStaleAsOf(tags)) tags = withStaleAsOf(tags);
+  } else if (volatility === "durable") {
+    tags = withoutStaleAsOf(tags);
+  }
+
+  return tags;
+}
+
 // The guard covers content as well as tags because the classification is derived from
 // content. Guarding tags alone is not enough: for an entry carrying neither a volatility:
 // nor a stale:as-of tag — the common case — the mutation is a no-op on tags, so a
 // concurrent rewrite would leave the guard satisfied and the CAS would commit a verdict
 // about content that no longer exists. That misfire does not self-correct either, since
 // the concurrent write also bumps updated_at past the staleness cutoff.
-async function casUpdateEntry(
-  env: Env,
-  id: string,
-  mutate: (row: { tags: string[]; content: string }) => { tags: string[] },
-  extraSets: Record<string, unknown> = {},
-  known?: { tags: string; content: string },
-): Promise<boolean> {
-  let current = known;
-  for (let attempt = 0; attempt < 3; attempt++) {
-    if (current === undefined) {
-      const row = await env.DB.prepare(`SELECT tags, content FROM entries WHERE id = ?`).bind(id).first() as { tags: string; content: string } | null;
-      if (!row) return false;
-      current = { tags: row.tags ?? "[]", content: row.content };
+//
+// Binding content per row means a batch of these carries every candidate's body at once.
+// D1 applies its per-statement limits to each statement inside a batch, not to the batch,
+// and the ones that could bite are comfortable: the SQL text is a fixed ~110 bytes because
+// content and tags are bound rather than interpolated, and 5 bound parameters is far under
+// the 100 allowed. Size is bounded too — D1 caps a row at 2 MB, so 25 statements carrying
+// content plus tags twice cannot approach the 100 MB request ceiling in any arrangement
+// that a 128 MB isolate could have built. The candidate query already materialises all 25
+// bodies in one response, so the write side is not the first place this would break;
+// STALENESS_PASS_LIMIT is the knob if it ever does.
+function casWrite(env: Env, snap: Snapshot, now: number): D1PreparedStatement {
+  const nextTags = JSON.stringify(classify(JSON.parse(snap.tags), snap.content));
+  return env.DB.prepare(
+    `UPDATE entries SET tags = ?, staleness_checked_at = ? WHERE id = ? AND tags = ? AND content = ?`,
+  ).bind(nextTags, now, snap.id, snap.tags, snap.content);
+}
+
+// The candidate query orders by COALESCE(staleness_checked_at, 0) ASC, so a row left NULL
+// sorts first on every future pass and camps one of the 25 slots indefinitely. Any row the
+// pass inspects must have its cursor moved, verdict or no verdict.
+function cursorWrite(env: Env, id: string, now: number): D1PreparedStatement {
+  return env.DB.prepare(`UPDATE entries SET staleness_checked_at = ? WHERE id = ?`).bind(now, id);
+}
+
+function planWrite(env: Env, snap: Snapshot, now: number): Write {
+  try {
+    // A deprecated row is never classified; it only needs to stop being a candidate.
+    if (getStatus(JSON.parse(snap.tags)) === "deprecated") {
+      return { id: snap.id, stmt: cursorWrite(env, snap.id, now), retryable: false };
     }
-    const next = mutate({ tags: JSON.parse(current.tags), content: current.content });
-    const nextTagsJson = JSON.stringify(next.tags);
-    const setClauses = ["tags = ?"];
-    const bindings: unknown[] = [nextTagsJson];
-    for (const [col, val] of Object.entries(extraSets)) {
-      setClauses.push(`${col} = ?`);
-      bindings.push(val);
-    }
-    bindings.push(id, current.tags, current.content);
-    const result = await env.DB.prepare(
-      `UPDATE entries SET ${setClauses.join(", ")} WHERE id = ? AND tags = ? AND content = ?`,
-    ).bind(...bindings).run();
-    if ((result.meta.changes ?? 0) > 0) return true;
-    current = undefined; // CAS lost (or the row is gone) — retry against a fresh read
+    return { id: snap.id, stmt: casWrite(env, snap, now), retryable: true };
+  } catch (e) {
+    // Tags that will not parse cannot be classified on this attempt or any other, so there
+    // is nothing to retry — but the cursor still has to move, or the row parks at the front
+    // of the queue forever.
+    console.error(`Staleness pass failed for ${snap.id} (non-fatal):`, e);
+    return { id: snap.id, stmt: cursorWrite(env, snap.id, now), retryable: false };
   }
-  return false;
+}
+
+/**
+ * One round of writes as a single subrequest, keeping the per-row path as a fallback.
+ *
+ * All four nightly jobs fire from one scheduled() invocation and share its budget (#278),
+ * and at one UPDATE per candidate — plus retries, plus cursor advances — this pass was the
+ * largest consumer of it. A batch costs one subrequest whatever it carries.
+ *
+ * batch() is atomic, and the two ways a statement can come back have to be told apart. A
+ * CAS that loses reports changes: 0 and does not roll the batch back (verified against
+ * workerd, not assumed), so contention is free here. A genuine SQL error does roll back
+ * everything, which would leave up to 25 inspected rows with a NULL cursor sitting at the
+ * front of the next run's queue — so a rejected batch replays per row: the behaviour this
+ * replaced, at the cost it used to pay, on the path that used to be the only path.
+ *
+ * That fallback is deliberately not free. If every batch is rejected AND every per-row
+ * replay also fails, the pass degenerates to about 107 subrequests — 1 candidate query,
+ * then a rejected batch plus 25 replays on each of three attempts and again on the cursor
+ * advance. That is well over the free plan's 50, but it only happens when D1 is refusing
+ * writes outright, and a pass that spends the budget failing is strictly better than one
+ * that abandons 25 rows with NULL cursors for every later run to trip over.
+ */
+async function runWrites(env: Env, writes: Write[]): Promise<number[]> {
+  if (!writes.length) return [];
+  try {
+    const results = await env.DB.batch(writes.map(w => w.stmt));
+    return results.map(r => r.meta.changes ?? 0);
+  } catch (e) {
+    console.error("Batched staleness writes failed; retrying per row (non-fatal):", e);
+    const changes: number[] = [];
+    for (const w of writes) {
+      try {
+        const result = await w.stmt.run();
+        changes.push(result.meta.changes ?? 0);
+      } catch (err) {
+        console.error(`Staleness pass failed for ${w.id} (non-fatal):`, err);
+        // Indistinguishable from a lost CAS from here, and treated as one: retried, and
+        // cursor-advanced if it never lands. No row is left owed a write it never gets.
+        changes.push(0);
+      }
+    }
+    return changes;
+  }
+}
+
+/**
+ * Fresh tags AND content for every loser, in one read rather than one read each.
+ *
+ * One bound parameter per id, against D1's limit of 100 per query — safe only because
+ * STALENESS_PASS_LIMIT caps the caller at 25. See the note on that constant.
+ */
+async function rereadSnapshots(env: Env, ids: string[]): Promise<Snapshot[] | null> {
+  try {
+    const { results } = await env.DB.prepare(
+      `SELECT id, tags, content FROM entries WHERE id IN (${ids.map(() => "?").join(", ")})`,
+    ).bind(...ids).all() as { results: { id: string; tags: string; content: string }[] };
+    return results.map(r => ({ id: r.id, tags: r.tags ?? "[]", content: r.content }));
+  } catch (e) {
+    console.error("Staleness retry re-read failed (non-fatal):", e);
+    return null;
+  }
 }
 
 export async function runStalenessPass(env: Env, _ctx: ExecutionContext): Promise<void> {
@@ -61,7 +167,7 @@ export async function runStalenessPass(env: Env, _ctx: ExecutionContext): Promis
 
   const cutoff = Date.now() - STALENESS_AGE_MS;
   const now = Date.now();
-  let candidates: { id: string; content: string; tags: string }[] = [];
+  let candidates: Snapshot[] = [];
 
   try {
     const { results } = await env.DB.prepare(
@@ -71,47 +177,48 @@ export async function runStalenessPass(env: Env, _ctx: ExecutionContext): Promis
        ORDER BY COALESCE(staleness_checked_at, 0) ASC
        LIMIT ${STALENESS_PASS_LIMIT}`,
     ).bind(cutoff).all() as { results: { id: string; content: string; tags: string }[] };
-    candidates = results;
+    candidates = results.map(r => ({ id: r.id, tags: r.tags ?? "[]", content: r.content }));
   } catch (e) {
     console.error("Staleness pass query failed (non-fatal):", e);
     return;
   }
 
-  for (const row of candidates) {
-    try {
-      if (getStatus(JSON.parse(row.tags ?? "[]")) === "deprecated") {
-        await env.DB.prepare(`UPDATE entries SET staleness_checked_at = ? WHERE id = ?`).bind(now, row.id).run();
-        continue;
-      }
+  // Rows still owed a write. A row leaves this list only by landing its CAS, by being
+  // deleted underneath the pass, or — below the loop — by having its cursor advanced.
+  let unsettled = candidates;
+  // Rows whose cursor write itself failed. There is no verdict left to retry for these, but
+  // the cursor is still owed: a row that keeps a NULL cursor sorts first on every future
+  // pass forever, so dropping it here would be exactly the camping bug the cursor prevents.
+  const cursorFailed: string[] = [];
 
-      const settled = await casUpdateEntry(env, row.id, ({ tags, content }) => {
-        const classified = classifyVolatility(content, tags);
-        const existing = getVolatility(tags);
-
-        if (classified && !existing) {
-          tags = withVolatility(tags, classified);
-        }
-
-        const volatility = getVolatility(tags);
-
-        if (shouldFlagStale(volatility)) {
-          if (!hasStaleAsOf(tags)) tags = withStaleAsOf(tags);
-        } else if (volatility === "durable") {
-          tags = withoutStaleAsOf(tags);
-        }
-
-        return { tags };
-      }, { staleness_checked_at: now }, { tags: row.tags ?? "[]", content: row.content });
-
-      if (!settled) {
-        // Every CAS attempt lost, or the row is gone. Advance the cursor anyway: the
-        // candidate query orders by COALESCE(staleness_checked_at, 0) ASC, so leaving it
-        // NULL would put this row first on every future pass, camping one of the 25 slots
-        // indefinitely. The next pass will pick it up again on its merits.
-        await env.DB.prepare(`UPDATE entries SET staleness_checked_at = ? WHERE id = ?`).bind(now, row.id).run();
-      }
-    } catch (e) {
-      console.error(`Staleness pass failed for ${row.id} (non-fatal):`, e);
+  for (let attempt = 0; attempt < STALENESS_CAS_ATTEMPTS && unsettled.length; attempt++) {
+    if (attempt > 0) {
+      // A lost CAS means someone else wrote the row, so the retry re-classifies from the
+      // fresh tags and content rather than from the snapshot that just lost. Ids that do
+      // not come back were deleted mid-pass: no verdict and no cursor to write.
+      const fresh = await rereadSnapshots(env, unsettled.map(r => r.id));
+      if (!fresh) break; // read failed — stop retrying, but still advance the cursors below
+      unsettled = fresh;
     }
+
+    const writes = unsettled.map(snap => planWrite(env, snap, now));
+    const changes = await runWrites(env, writes);
+    const lost = new Set<string>();
+    writes.forEach((w, i) => {
+      if (changes[i] !== 0) return;
+      // A CAS reporting no change usually lost a race and is worth re-reading. A cursor
+      // write reporting none only ever means the write failed — the row is not a candidate
+      // for reclassification, it just still needs its cursor moved.
+      if (w.retryable) lost.add(w.id); else cursorFailed.push(w.id);
+    });
+    unsettled = unsettled.filter(snap => lost.has(snap.id));
+  }
+
+  // Everything still owed a cursor: rows whose every CAS attempt lost, and rows whose
+  // cursor write failed earlier. One more batch is the last attempt either gets — a cursor
+  // UPDATE on a row deleted meanwhile is a harmless no-op, so nothing needs excluding.
+  const owed = [...unsettled.map(snap => snap.id), ...cursorFailed];
+  if (owed.length) {
+    await runWrites(env, owed.map(id => ({ id, stmt: cursorWrite(env, id, now), retryable: false })));
   }
 }

--- a/src/tags/vocabulary.ts
+++ b/src/tags/vocabulary.ts
@@ -1,0 +1,279 @@
+/**
+ * The brain's tag vocabulary, cached in KV (#288).
+ *
+ * `SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value` is
+ * the only way to ask SQLite which tags exist, and it is a full table scan expanded
+ * once per tag per row. Measured on workerd D1 at four tags an entry: 9,000 rows
+ * read at 1,000 entries, 45,000 at 5,000, 180,000 at 20,000. `inferQueryTags` ran
+ * it on every recall — 82% of a recall's read cost — which put a 5,000-memory brain
+ * at 90 recalls before D1's free 5M rows/day, and once that is spent every D1 query
+ * on the account fails until 00:00 UTC. The MCP clients this project ships
+ * instructions for recall at the start of every conversation and every few messages
+ * after, so 90 is an ordinary day rather than a stress test.
+ *
+ * No rewrite of that SQL makes it sub-linear. It has to visit every row before it can
+ * know the first one, and on real SQLite every variant plans identically — with
+ * ORDER BY, without it, as a GROUP BY, with a LIMIT, and with an index on `tags`
+ * present: `SCAN entries`, `SCAN json_each`, temp b-tree, every time. So the fix is
+ * not running it per recall.
+ *
+ * Identical plans are not identical costs, though, and `scanTagVocabulary` takes the
+ * one saving that is available: dropping `ORDER BY value` is 44% off the rows read,
+ * because DISTINCT already builds a temp b-tree and ordering makes SQLite walk it
+ * back out. See there.
+ *
+ * WHY ITS OWN KEY, rather than riding along in `config:overrides`, which recall
+ * already reads through `resolveConfig`:
+ *
+ *  - `writeOverrides` serialises the whole blob from `readOverrides`, and
+ *    `readOverrides` drops every key that is not a known setting. A vocabulary
+ *    parked in that blob would be deleted the first time the user saved a setting,
+ *    and keeping it would mean teaching the settings write path to preserve data it
+ *    does not own.
+ *  - The KV read is not an extra one anyway. `inferQueryTags` already spent exactly
+ *    one subrequest on the scan; a KV get in its place is subrequest-neutral, and it
+ *    moves the cost off the budget this issue is about — D1 rows read, metered and
+ *    account-fatal — onto KV reads, which are a separate quota, edge-cached, and
+ *    constant in the size of the brain.
+ *  - Capture writes this key; the settings UI writes that one. One blob with two
+ *    independent writers is a lost update waiting to happen.
+ *
+ * WHY IT IS ONLY EVER STALE, NEVER WRONG. Both consumers degrade rather than
+ * mislead. `inferQueryTags` feeds a ranking boost (`TAG_BOOST_STEP`, applied in
+ * rerankWithTimeDecay), so a tag missing from the vocabulary costs one call a nudge
+ * in its ordering, and a tag that no longer exists boosts nothing because no entry
+ * carries it. `GET /tags` fills the dashboard's filter dropdown. Neither can return
+ * a wrong memory, and neither may fail: every path below falls back to the last good
+ * value, and finally to no vocabulary at all — which is the pre-cache behaviour of
+ * an empty brain, not an error.
+ */
+import type { Env } from "../env";
+
+// Prefixed to coexist with workers-oauth-provider's token:/grant:/client: keys,
+// config:overrides, and the integrations: blobs in the same namespace.
+export const TAG_VOCABULARY_KEY = "tags:vocabulary";
+
+/**
+ * How long a scanned vocabulary is trusted before it is rebuilt.
+ *
+ * The rebuild *is* the scan this cache exists to avoid, so its frequency is the
+ * residual cost: once a day is 100,000 rows on a 20,000-entry brain — 2% of the free
+ * daily budget, against 22 recalls' worth of budget before. An hour would be 2.4M
+ * rows a day and would have solved nothing.
+ *
+ * A day is affordable because nothing time-critical depends on it. Write-through
+ * (`rememberTags`) admits a newly captured tag once its deferred write settles, so
+ * the age limit only has to cover the three things write-through cannot: pruning a
+ * tag whose last entry was deleted, admitting the tags background jobs write —
+ * `status:`, `kind:`, `volatility:`, `stale:as-of`, `synthesized`, `rolled-up`,
+ * `auto-pattern` — and repairing an addition a concurrent rebuild overwrote. The
+ * system tags are a closed set fixed at compile time, query inference excludes them
+ * on purpose (see `inferQueryTags`), and the only place they surface is a dropdown.
+ */
+export const TAG_VOCABULARY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * `rebuiltAt` is when the vocabulary was last reconciled against D1 — not when it
+ * was last written. `rememberTags` deliberately leaves it alone; see there.
+ */
+interface CachedVocabulary {
+  tags: string[];
+  rebuiltAt: number;
+}
+
+/** Any failure reads as "nothing cached", which costs a scan rather than a request. */
+async function readCache(env: Env): Promise<CachedVocabulary | null> {
+  try {
+    const raw = await env.OAUTH_KV.get(TAG_VOCABULARY_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const { tags, rebuiltAt } = parsed as Record<string, unknown>;
+    if (!Array.isArray(tags)) return null;
+    return {
+      tags: tags.filter((t): t is string => typeof t === "string"),
+      // A missing or unusable timestamp reads as "never reconciled" — 0 — so the value
+      // is still served and a rebuild is still scheduled. A timestamp in the future is
+      // unusable in exactly that sense: nothing can have been reconciled at a moment
+      // that has not happened.
+      //
+      // It has to be rejected rather than clamped to now, which is the tempting
+      // one-liner and does not work. The freshness test is `now - rebuiltAt < MAX_AGE`,
+      // so every future timestamp passes it; clamping to `Date.now()` re-anchors on
+      // each read, so the value passes again a day later, and again — a blob dated next
+      // year, or carrying Number.MAX_SAFE_INTEGER, is served forever. No rebuild is
+      // ever scheduled, so nothing can correct it, and a tag deleted from the brain
+      // stays in the dropdown for good. Clock skew between the writing isolate and the
+      // reading one can produce one; a hand-edited value certainly can.
+      //
+      // Rejecting costs at most one scan and then converges: the rebuild writes the
+      // *reading* isolate's clock, so the slowest clock involved wins and every later
+      // read sees a past timestamp. There is no oscillation to trade off against.
+      rebuiltAt:
+        typeof rebuiltAt === "number" && Number.isFinite(rebuiltAt) && rebuiltAt <= Date.now()
+          ? rebuiltAt
+          : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The scan. This is now the whole residual D1 cost of the cache, paid once a day and
+ * on every cold read, so the `ORDER BY value` the two replaced call sites carried is
+ * gone — sorted in JS instead.
+ *
+ * That is not a plan improvement; every variant of this query plans identically
+ * (`SCAN entries`, `SCAN json_each`, temp b-tree, with or without ORDER BY, as a
+ * GROUP BY, with a LIMIT, with an index on `tags`). It is a rows-read improvement,
+ * and the plan is why the two are not the same thing: DISTINCT already needs a temp
+ * b-tree, and asking for it ordered as well makes SQLite walk that b-tree back out.
+ * Measured on workerd D1: 45,000 rows against 25,000 at 5,000 entries, 180,000
+ * against 100,000 at 20,000 — 44% off, for identical results.
+ *
+ * Free because the sort had to happen in JS anyway: `rememberTags` re-sorts whatever
+ * it writes back, so SQLite's ordering never survived a write-through in the first
+ * place. One caveat, unchanged by this: SQLite's BINARY collation orders UTF-8 bytes
+ * and JS orders UTF-16 code units, which differ only for astral-plane characters. A
+ * tag containing one could sit in a different dropdown position than it used to.
+ */
+async function scanTagVocabulary(env: Env): Promise<string[]> {
+  const { results } = await env.DB.prepare(
+    `SELECT DISTINCT value FROM entries, json_each(entries.tags)`
+  ).all();
+  return (results as { value: unknown }[])
+    .map(r => r.value)
+    .filter((v): v is string => typeof v === "string")
+    .sort();
+}
+
+/**
+ * Scan and store. Throws only if the scan does — a KV write failure still returns
+ * the fresh vocabulary, because the caller asked what the tags are, not where they
+ * are kept.
+ */
+async function rebuildTagVocabulary(env: Env): Promise<string[]> {
+  const tags = await scanTagVocabulary(env);
+  try {
+    await env.OAUTH_KV.put(TAG_VOCABULARY_KEY, JSON.stringify({ tags, rebuiltAt: Date.now() } satisfies CachedVocabulary));
+  } catch (e) {
+    console.error("Tag vocabulary cache write failed (non-fatal):", e);
+  }
+  return tags;
+}
+
+/**
+ * The read path. One KV get in the steady state and no D1 rows at all.
+ *
+ * Pass `ctx` wherever there is one. It decides what happens to an aged-out
+ * vocabulary: with a ctx the stale list is served and the rebuild runs behind the
+ * response, which is the whole point of the cache; without one there is nowhere to
+ * hang the work, so it runs inline.
+ *
+ * With nothing cached at all — a brain's first request, or KV having lost the key —
+ * the scan runs inline whoever is asking. That is once per brain rather than once
+ * per recall, it is bounded by what every recall used to cost, and it keeps the two
+ * consumers honest: an empty answer from `GET /tags` is not a degraded answer, it is
+ * a wrong one. If the scan fails too, the last good value is used, and failing that
+ * an empty vocabulary — a boost not applied and a dropdown short of options, never a
+ * failed request.
+ *
+ * If KV is unavailable entirely, every call lands here with nothing cached and
+ * rebuilds: the pre-cache cost, exactly, and not a byte worse.
+ *
+ * Not single-flighted. Two requests that both find the vocabulary aged out before
+ * either refresh lands will each scan. The window is one scan wide and opens once a
+ * day, against a brain that recalls a few hundred times a day — so the collision is
+ * rare and its cost is one extra scan, which is what every recall used to cost. Add
+ * an isolate-scoped guard if that ever shows up in a bill, not before.
+ */
+export async function getTagVocabulary(env: Env, ctx?: ExecutionContext): Promise<string[]> {
+  const cached = await readCache(env);
+
+  if (cached && Date.now() - cached.rebuiltAt < TAG_VOCABULARY_MAX_AGE_MS) return cached.tags;
+
+  if (cached && ctx) {
+    ctx.waitUntil(
+      rebuildTagVocabulary(env).catch(e => console.error("Tag vocabulary rebuild failed (non-fatal):", e))
+    );
+    return cached.tags;
+  }
+
+  try {
+    return await rebuildTagVocabulary(env);
+  } catch (e) {
+    console.error("Tag vocabulary rebuild failed (non-fatal):", e);
+    return cached?.tags ?? [];
+  }
+}
+
+/**
+ * Write-through: union tags that have just been written into the cached vocabulary,
+ * so a new tag is admitted on the next read after this settles rather than having to
+ * wait for the next rebuild.
+ *
+ * "After this settles" is the honest bound, not "immediately". Both request-path
+ * callers defer it to `ctx.waitUntil`, which runs after the response, and KV needs a
+ * moment to propagate on top of that — so a dashboard that captures and then reloads
+ * `GET /tags` (`public/js/memory-crud.js`, and four other `loadTags()` call sites)
+ * can miss a hashtag it just saved and pick it up on the next load. Before this cache
+ * that route read D1 and always saw the committed row. The window is a dropdown
+ * option arriving one refresh late; it closes by itself.
+ *
+ * `captureEntry` and `POST /update`'s hashtag merge are the only two writers of
+ * `entries.tags` that can introduce a string not known at compile time. Every other
+ * one — classification, `POST /status`, the compression pass, the staleness pass, the
+ * admin backfills, and the integrations mirror, whose tags are provider ids from a
+ * compile-time registry — emits from a closed set, which query inference filters out
+ * anyway and which the age limit admits to the dropdown by itself. The mirror calls
+ * this too, but for promptness rather than correctness: without it a freshly
+ * connected integration is missing from the tag filter until the next rebuild.
+ *
+ * Costs one KV get; the put and a second get happen only when a tag is genuinely new,
+ * so an established brain pays one get to capture into a tag it already has. Does
+ * nothing when there is no cache yet: the entry row is already committed by the time
+ * this runs, so the scan that builds the first cache will find the tag by itself.
+ *
+ * Never throws, and never advances `rebuiltAt` past what it read: that field records
+ * the last reconciliation against D1, and moving it forward here would let an
+ * actively used brain postpone its rebuild forever, so a deleted tag would never be
+ * pruned.
+ */
+export async function rememberTags(env: Env, tags: string[]): Promise<void> {
+  try {
+    const cached = await readCache(env);
+    if (!cached) return;
+
+    const known = new Set(cached.tags);
+    const additions = tags.filter(t => typeof t === "string" && t && !known.has(t));
+    if (!additions.length) return;
+
+    // Re-read immediately before writing, and merge onto whatever is there now.
+    //
+    // This races a rebuild in both directions. A rebuild that scanned before the row
+    // was committed and puts after this one wins, and the addition is lost until the
+    // next capture — that is the documented degradation, a tag missing its boost.
+    // The other direction is the one worth spending a KV get on: if a rebuild landed
+    // between the read above and this put, writing back the *older* `rebuiltAt` would
+    // age the cache out again and buy a second full scan, and writing back the older
+    // tag list would resurrect tags that rebuild had just pruned. Reading again
+    // narrows both windows to the put itself — KV has no compare-and-set, so they
+    // cannot be closed, and the residual cost is one scan, which is what every recall
+    // used to cost.
+    const latest = (await readCache(env)) ?? cached;
+    const merged = new Set(latest.tags);
+    for (const tag of additions) merged.add(tag);
+    if (merged.size === latest.tags.length) return;
+
+    await env.OAUTH_KV.put(
+      TAG_VOCABULARY_KEY,
+      JSON.stringify({
+        tags: [...merged].sort(),
+        rebuiltAt: Math.max(cached.rebuiltAt, latest.rebuiltAt),
+      } satisfies CachedVocabulary)
+    );
+  } catch (e) {
+    console.error("Tag vocabulary write-through failed (non-fatal):", e);
+  }
+}

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -32,6 +32,16 @@ const tagFromLikePattern = (pattern: string) =>
 const tagMatchesLike = (tags: string[], tag: string) =>
   tags.some(t => t.toLowerCase() === tag.toLowerCase());
 
+/** What src/db/init.ts's probe sees on a migrated brain — see the handler in all(). */
+const SCHEMA_PROBE_RESULTS = [
+  ...["entries", "edges"].map(name => ({ kind: "table", name })),
+  ...["idx_entries_created_at", "idx_entries_source", "idx_edges_source", "idx_edges_target",
+    "idx_edges_weight"].map(name => ({ kind: "index", name })),
+  ...["id", "content", "tags", "source", "created_at", "vector_ids", "recall_count",
+    "importance_score", "contradiction_wins", "contradiction_losses", "updated_at",
+    "staleness_checked_at"].map(name => ({ kind: "column", name })),
+];
+
 export class D1Mock {
   entries: any[] = [];
   edges: any[] = [];
@@ -288,6 +298,17 @@ export class D1Mock {
         return null;
       },
       async all() {
+        if (s.startsWith("SELECT type AS kind, name FROM sqlite_master")) {
+          // src/db/init.ts's schema probe. This mock stands in for a deployed brain, and
+          // a deployed brain is migrated — its rows carry every ALTER column below — so
+          // the honest answer is "all present", which is also what makes the mock report
+          // the real cold-start cost of a cold isolate rather than a fresh install's.
+          // The names are spelled out rather than imported from init.ts on purpose: a
+          // mock that derives its answer from the code under test can only ever agree
+          // with it. Fresh and partially-migrated brains are covered against real SQLite
+          // in test/unit/db-init.test.ts.
+          return { results: SCHEMA_PROBE_RESULTS };
+        }
         if (
           sBare === "SELECT id FROM entries WHERE tags LIKE ?" ||
           sBare === "SELECT id, vector_ids FROM entries WHERE tags LIKE ?" ||

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -1,4 +1,36 @@
-import { COMPRESSION_IMPORTANCE_THRESHOLD, COMPRESSION_MIN_RECALL } from "../../src/compression/eligibility";
+import { COMPRESSION_IMPORTANCE_THRESHOLD, COMPRESSION_MIN_RECALL, isTopicTag } from "../../src/compression/eligibility";
+
+/**
+ * Decode a `%"tag"%` bind parameter back to the tag, undoing tagLikePattern's escaping.
+ *
+ * Production escapes % and _ in the tag and pairs the clause with ESCAPE '\\', so a tag
+ * `q3_planning` arrives here as `%"q3\\_planning"%`. Without this the double would look for
+ * a tag spelled with a backslash and silently match nothing.
+ */
+const tagFromLikePattern = (pattern: string) =>
+  pattern.replace(/%"/g, "").replace(/"%/g, "").replace(/\\([%_\\])/g, "$1");
+
+/**
+ * Does this tag array satisfy `tags LIKE '%"<tag>"%'`?
+ *
+ * MODELS: ASCII case-insensitivity. SQLite's LIKE matches `Work` for `%"work"%`, and
+ * comparing case-sensitively here would make the double disagree with production on exactly
+ * the inputs behind #278's rollup bug, where the candidate `Kind:Semantic` selected — and
+ * rolled up — every entry carrying `kind:semantic`. test/unit/d1-mock-fidelity.test.ts pins
+ * this; do not "simplify" it back to Array.includes.
+ *
+ * DOES NOT MODEL, so a green test here is NOT coverage of any of these:
+ *   - LIKE wildcards in the tag. Real `%"q3_planning"%` also matches `q3-planning`, and
+ *     `%"%"%` matches every row; this matches exactly one tag either way. That is why P1's
+ *     escaping bug is covered against real SQLite in test/integration/, not here.
+ *   - JSON escaping. A tag containing a quote is stored as \\" so real LIKE misses it;
+ *     this compares the decoded strings and matches.
+ *   - Unicode case folding. SQLite's LIKE is ASCII-only; toLowerCase is not, so this
+ *     matches `Σ`/`σ` where real LIKE does not.
+ * Anything whose subject is the pattern rather than the tag belongs in a real-SQLite test.
+ */
+const tagMatchesLike = (tags: string[], tag: string) =>
+  tags.some(t => t.toLowerCase() === tag.toLowerCase());
 
 export class D1Mock {
   entries: any[] = [];
@@ -6,6 +38,10 @@ export class D1Mock {
 
   prepare(sql: string) {
     const s = sql.replace(/\s+/g, " ").trim();
+    // Production pairs every tag LIKE clause with `ESCAPE '\\'` (see tagLikePattern). The
+    // escape clause never changes which query a statement IS, so branches that identify a
+    // query by its exact text compare against this form rather than each growing a suffix.
+    const sBare = s.replace(/ ESCAPE '\\'/g, "");
     const db = this;
 
     const makeStmt = (args: any[]) => ({
@@ -199,6 +235,11 @@ export class D1Mock {
           const row = db.entries.find((e: any) => e.id === args[0]);
           return row ? { vector_ids: row.vector_ids } : null;
         }
+        // These branches match `as count` in lower case only. src/migration/embedding.ts
+        // writes `AS count`, so three of its queries fall through here and return null
+        // rather than a row — pre-existing, and those paths are covered against real SQLite
+        // in test/integration/embedding-migration.test.ts. Worth knowing before adding a
+        // fourth caller and trusting the double.
         if (s.includes("COUNT(*) as count") && s.includes("AVG(importance_score)")) {
           const count = db.entries.length;
           const scored = db.entries.filter((e: any) => typeof e.importance_score === "number");
@@ -238,8 +279,8 @@ export class D1Mock {
             const tags: string[] = JSON.parse(e.tags ?? "[]");
             if (!hardcoded.every(t => tags.includes(t))) return false;
             return likePatterns.every((p: string) => {
-              const tag = p.replace(/%"/g, "").replace(/"%/g, "");
-              return tags.includes(tag);
+              const tag = tagFromLikePattern(p);
+              return tagMatchesLike(tags, tag);
             });
           });
           return match ? { id: match.id } : null;
@@ -248,14 +289,14 @@ export class D1Mock {
       },
       async all() {
         if (
-          s === "SELECT id FROM entries WHERE tags LIKE ?" ||
-          s === "SELECT id, vector_ids FROM entries WHERE tags LIKE ?" ||
-          s === "SELECT id, vector_ids, content, tags, source, created_at FROM entries WHERE tags LIKE ?"
+          sBare === "SELECT id FROM entries WHERE tags LIKE ?" ||
+          sBare === "SELECT id, vector_ids FROM entries WHERE tags LIKE ?" ||
+          sBare === "SELECT id, vector_ids, content, tags, source, created_at FROM entries WHERE tags LIKE ?"
         ) {
           const pattern = String(args[0]);
-          const tag = pattern.replace(/%"/g, "").replace(/"%/g, "");
+          const tag = tagFromLikePattern(pattern);
           const results = db.entries
-            .filter((e: any) => (JSON.parse(e.tags ?? "[]") as string[]).includes(tag))
+            .filter((e: any) => tagMatchesLike(JSON.parse(e.tags ?? "[]"), tag))
             .map((e: any) => ({ id: e.id, vector_ids: e.vector_ids ?? "[]", content: e.content, tags: e.tags, source: e.source, created_at: e.created_at }));
           return { results };
         }
@@ -346,6 +387,14 @@ export class D1Mock {
           const row = db.entries.find((e: any) => e.id === args[0]);
           return { results: row ? [{ tags: row.tags }] : [] };
         }
+        if (s.startsWith("SELECT id, tags, content FROM entries WHERE id IN")) {
+          // Staleness retry re-read: fresh tags and content for every row whose CAS lost,
+          // in one statement. Rows deleted mid-pass simply do not come back.
+          const results = db.entries
+            .filter((e: any) => args.includes(e.id))
+            .map((e: any) => ({ id: e.id, tags: e.tags, content: e.content }));
+          return { results };
+        }
         if (s.includes("COALESCE(updated_at, created_at) < ?") && s.includes("SELECT id, content, tags FROM entries")) {
           const cutoff = Number(args[0]);
           const limitMatch = s.match(/LIMIT (\d+)/);
@@ -429,12 +478,12 @@ export class D1Mock {
           // compressTag raw entries query — tag match, system-tag exclusion, and the
           // recall/age/contradiction eligibility predicate (cutoff is the 2nd bind param).
           const tagPattern = args[0] as string;
-          const tag = tagPattern.replace(/%"/g, "").replace(/"%/g, "");
+          const tag = tagFromLikePattern(tagPattern);
           const cutoff = Number(args[1]);
           const results = [...db.entries]
             .filter((e: any) => {
               const tags: string[] = JSON.parse(e.tags ?? "[]");
-              if (!tags.includes(tag)) return false;
+              if (!tagMatchesLike(tags, tag)) return false;
               if (tags.includes("synthesized") || tags.includes("auto-pattern") || tags.includes("rolled-up")) return false;
               if (!(e.importance_score == null || e.importance_score < COMPRESSION_IMPORTANCE_THRESHOLD)) return false;
               const rc = e.recall_count; // NULL/undefined → recall clause is falsy → protected (matches SQL)
@@ -457,7 +506,6 @@ export class D1Mock {
           // Digest-candidate query (nightly compression + /stats): per-tag count of
           // entries that pass the compression eligibility predicate. Cutoff is args[0].
           const cutoff = Number(args[0]);
-          const SYSTEM = ["synthesized", "auto-pattern", "duplicate-candidate", "contradiction-resolved", "rolled-up"];
           const counts = new Map<string, number>();
           for (const e of db.entries as any[]) {
             const tags: string[] = JSON.parse(e.tags ?? "[]");
@@ -467,8 +515,10 @@ export class D1Mock {
             if (!(rc === 0 || (rc < COMPRESSION_MIN_RECALL && e.created_at < cutoff))) continue;
             if (!(e.contradiction_wins == null || e.contradiction_wins === 0)) continue;
             for (const t of tags) {
-              if (SYSTEM.includes(t)) continue;
-              if (t.startsWith("status:") || t.startsWith("kind:")) continue;
+              // The same predicate isTopicTagSql() is generated from, rather than a second
+              // copy of the rule: a double that filters differently from production hides
+              // exactly the bugs it is supposed to catch.
+              if (!isTopicTag(t)) continue;
               counts.set(t, (counts.get(t) ?? 0) + 1);
             }
           }
@@ -542,8 +592,8 @@ export class D1Mock {
           let rows = [...db.entries];
           if (s.includes("tags LIKE ?")) {
             const pattern = String(filterArgs[argIdx++]);
-            const tag = pattern.replace(/%"/g, "").replace(/"%/g, "");
-            rows = rows.filter((e: any) => (JSON.parse(e.tags ?? "[]") as string[]).includes(tag));
+            const tag = tagFromLikePattern(pattern);
+            rows = rows.filter((e: any) => tagMatchesLike(JSON.parse(e.tags ?? "[]"), tag));
           }
           if (s.includes("created_at >= ?")) {
             const after = Number(filterArgs[argIdx++]);

--- a/test/helpers/sqlite-d1.ts
+++ b/test/helpers/sqlite-d1.ts
@@ -50,7 +50,7 @@ class SqliteStatement {
 
 export interface SqliteD1 {
   /** Shaped like `env.DB`. */
-  db: { prepare(sql: string): SqliteStatement };
+  db: { prepare(sql: string): SqliteStatement; exec(sql: string): Promise<void> };
   /** Insert an entry directly, bypassing the capture pipeline. */
   seed(entry: {
     id: string;
@@ -99,7 +99,14 @@ export function makeSqliteD1(): SqliteD1 {
   }
 
   return {
-    db: { prepare: (sql: string) => new SqliteStatement(raw, sql) },
+    db: {
+      prepare: (sql: string) => new SqliteStatement(raw, sql),
+      // Present so a whole-Worker request against this facade runs the real
+      // initializeDatabase path rather than failing on a missing method. The
+      // schema is already applied above; that DDL is idempotent, and the ALTERs
+      // raise the same "duplicate column name" D1 does, which init.ts expects.
+      exec: async (sql: string) => { raw.exec(sql); },
+    },
     seed({ id, content, createdAt, tags = [], source = "api", vectorIds = [] }) {
       raw
         .prepare(

--- a/test/helpers/sqlite-d1.ts
+++ b/test/helpers/sqlite-d1.ts
@@ -12,8 +12,16 @@
  * for real against the project's own `db/schema.sql`. A wrong comparison then
  * fails the test instead of passing a string match.
  *
+ * The schema migration in `src/db/init.ts` is the other case, and the sharper
+ * one: `d1-mock`'s `exec()` is a no-op, so it cannot express "that column is
+ * already there" or "that table is not" — the two facts the migration now reads
+ * before it writes. Against real SQLite a probe that misreports an empty
+ * database as migrated leaves the tables uncreated and the next statement fails,
+ * which is exactly the regression worth catching. Pass `{ schema: false }` for a
+ * database with nothing in it at all.
+ *
  * Only the surface the code under test uses is implemented — `prepare`, `bind`,
- * `all`, `first`, `run`. Reach for `d1-mock` for everything else.
+ * `all`, `first`, `run`, `exec`. Reach for `d1-mock` for everything else.
  */
 import { DatabaseSync } from "node:sqlite";
 import { readFileSync } from "node:fs";
@@ -51,6 +59,13 @@ class SqliteStatement {
 export interface SqliteD1 {
   /** Shaped like `env.DB`. */
   db: { prepare(sql: string): SqliteStatement; exec(sql: string): Promise<void> };
+  /**
+   * One entry per D1 call made through `db` — which is one entry per subrequest,
+   * since `prepare()` here is only ever followed by a single execution.
+   */
+  issued: string[];
+  /** Column names currently on `entries`, straight from SQLite. */
+  columns(): string[];
   /** Insert an entry directly, bypassing the capture pipeline. */
   seed(entry: {
     id: string;
@@ -72,11 +87,11 @@ export interface SqliteD1 {
  * column rename breaks these tests, which is the point — the migration's SQL
  * names columns.
  */
-export function makeSqliteD1(): SqliteD1 {
+export function makeSqliteD1({ schema: applySchema = true }: { schema?: boolean } = {}): SqliteD1 {
   const raw = new DatabaseSync(":memory:");
   // The schema uses D1-flavoured DDL; execute it statement by statement so one
   // unsupported pragma cannot take the whole file down silently.
-  const schema = readFileSync(SCHEMA, "utf8");
+  const schema = applySchema ? readFileSync(SCHEMA, "utf8") : "";
   for (const statement of schema.split(";")) {
     // Strip comment lines rather than skipping any chunk that starts with one:
     // splitting on ";" leaves the preceding comment attached to the statement
@@ -98,14 +113,27 @@ export function makeSqliteD1(): SqliteD1 {
     }
   }
 
+  const issued: string[] = [];
+
   return {
+    issued,
     db: {
-      prepare: (sql: string) => new SqliteStatement(raw, sql),
+      prepare: (sql: string) => {
+        issued.push(sql);
+        return new SqliteStatement(raw, sql);
+      },
       // Present so a whole-Worker request against this facade runs the real
       // initializeDatabase path rather than failing on a missing method. The
       // schema is already applied above; that DDL is idempotent, and the ALTERs
       // raise the same "duplicate column name" D1 does, which init.ts expects.
-      exec: async (sql: string) => { raw.exec(sql); },
+      exec: async (sql: string) => {
+        issued.push(sql);
+        raw.exec(sql);
+      },
+    },
+    columns() {
+      return (raw.prepare(`SELECT name FROM pragma_table_info('entries')`).all() as { name: string }[])
+        .map(r => r.name);
     },
     seed({ id, content, createdAt, tags = [], source = "api", vectorIds = [] }) {
       raw

--- a/test/integration/digest-candidates.test.ts
+++ b/test/integration/digest-candidates.test.ts
@@ -1,0 +1,154 @@
+/**
+ * The digest-candidate query, run for real.
+ *
+ * Its correctness IS the SQL: which tags come back decides which tags get compressed, and
+ * a nightly run only compresses COMPRESSION_MAX_TAGS_PER_RUN of them. `test/helpers/d1-mock.ts`
+ * cannot evaluate SQL — its digest-candidate branch calls isTopicTag(), the TypeScript half
+ * of the rule — so a WHERE clause that drifted from that predicate would pass every
+ * mock-based test in the suite. This runs the clause itself against real SQLite.
+ *
+ * The WHERE fragments are imported rather than retyped, so this exercises the same strings
+ * src/compression/nightly.ts and src/routes/admin.ts embed.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  compressionEligibilitySql,
+  isTopicTag,
+  isTopicTagSql,
+  COMPRESSION_MIN_AGE_MS,
+} from "../../src/compression/eligibility";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { tagLikePattern, TAG_LIKE_ESCAPE } from "../../src/memory/tag-sql";
+
+let sqlite: SqliteD1 | null = null;
+
+afterEach(() => {
+  sqlite?.close();
+  sqlite = null;
+});
+
+async function candidateTags(seed: (s: SqliteD1) => void): Promise<string[]> {
+  sqlite = makeSqliteD1();
+  seed(sqlite);
+  const { results } = await sqlite.db.prepare(`
+    SELECT value as tag, COUNT(*) as count
+    FROM entries, json_each(entries.tags)
+    WHERE ${isTopicTagSql()}
+      AND entries.tags NOT LIKE '%"rolled-up"%'
+      AND entries.tags NOT LIKE '%"synthesized"%'
+      AND entries.tags NOT LIKE '%"auto-pattern"%'
+      AND ${compressionEligibilitySql("entries.")}
+    GROUP BY value
+    HAVING count > 10
+    ORDER BY count DESC
+  `).bind(Date.now() - COMPRESSION_MIN_AGE_MS).all();
+  return (results as { tag: string }[]).map(r => r.tag);
+}
+
+describe("digest-candidate query", () => {
+  it("excludes the tags the system writes, and keeps the ones the user does", async () => {
+    const tags = await candidateTags(s => {
+      // Eleven entries carrying a real topic plus every reserved namespace, exactly as an
+      // entry looks after classification and a staleness pass have both run over it.
+      for (let i = 0; i < 11; i++) {
+        s.seed({
+          id: `e-${i}`, content: `memory ${i}`, createdAt: 1,
+          tags: ["work", "kind:semantic", "status:canonical", "volatility:state", "stale:as-of"],
+        });
+      }
+    });
+
+    expect(tags).toEqual(["work"]);
+  });
+
+  it("does not let a bulk-written system tag outrank a real topic", async () => {
+    const tags = await candidateTags(s => {
+      // Distinct counts, so ORDER BY fully determines the order — SQLite does not promise
+      // anything about ties, and the assertion below is about position.
+      for (let i = 0; i < 12; i++) s.seed({ id: `a-${i}`, content: "m", createdAt: 1, tags: ["work"] });
+      for (let i = 0; i < 11; i++) s.seed({ id: `b-${i}`, content: "m", createdAt: 1, tags: ["family"] });
+      // The staleness pass tags in bulk, so its tags carry the higher count.
+      for (let i = 0; i < 25; i++) {
+        s.seed({ id: `c-${i}`, content: "m", createdAt: 1, tags: ["volatility:state", "stale:as-of"] });
+      }
+    });
+
+    // Ordered by count DESC, so a failure here is the system tags sitting at the head of
+    // the list and taking the slots real topics would have had.
+    expect(tags).toEqual(["work", "family"]);
+  });
+
+  // A mixed-case reserved tag must never become a candidate. If one does, compressTag
+  // selects its sources with `tags LIKE '%"Kind:Semantic"%'` — LIKE ignores ASCII case — so
+  // it rolls up every entry carrying `kind:semantic`, which is most of the table. Nothing
+  // lowercases the tags src/integrations/mirror.ts inserts, so this is reachable.
+  //
+  // Only the tag-value predicate is under test. Mixed-case forms of the bookkeeping tags
+  // (`SYNTHESIZED`, `Rolled-Up`) are deliberately absent from this fixture: the surrounding
+  // row-level filters are `entries.tags NOT LIKE '%"synthesized"%'`, which already ignores
+  // case, so such a row is dropped whole before any tag value is considered.
+  it("reserves the namespace whatever its case", async () => {
+    const reserved = ["Status:Active", "Kind:Personal", "Volatility:High", "Stale:As-Of"];
+    const tags = await candidateTags(s => {
+      for (let i = 0; i < 11; i++) {
+        s.seed({ id: `e-${i}`, content: "m", createdAt: 1, tags: ["holiday-plans", ...reserved] });
+      }
+    });
+
+    expect(tags).toEqual(["holiday-plans"]);
+    for (const tag of reserved) expect(isTopicTag(tag)).toBe(false);
+  });
+
+  it("reserves the namespace rather than the bare word", async () => {
+    const tags = await candidateTags(s => {
+      for (let i = 0; i < 11; i++) {
+        s.seed({ id: `e-${i}`, content: "m", createdAt: 1, tags: ["volatility", "stale", "status", "kind"] });
+      }
+    });
+
+    expect(tags.sort()).toEqual(["kind", "stale", "status", "volatility"]);
+  });
+});
+
+/**
+ * The other half of compressTag: once a tag is chosen, this is the query that decides which
+ * entries get rolled up. Its correctness is also the SQL, and for a reason the D1 mock
+ * structurally cannot reach — the mock compares decoded tag strings, so LIKE wildcards in
+ * the tag itself simply do not exist there. Every row this selects has its content appended
+ * to and is marked `rolled-up`, permanently, so selecting one row too many is data loss.
+ */
+describe("compressTag source selector", () => {
+  async function selected(tag: string): Promise<string[]> {
+    sqlite = makeSqliteD1();
+    // 11 entries on the tag being compressed, 9 on a near-miss neighbour that differs only
+    // where a LIKE wildcard would paper over the difference.
+    for (let i = 0; i < 11; i++) sqlite.seed({ id: `own-${i}`, content: "m", createdAt: 1, tags: ["q3_planning"] });
+    for (let i = 0; i < 9; i++) sqlite.seed({ id: `other-${i}`, content: "m", createdAt: 1, tags: ["q3-planning"] });
+    // The clause from src/compression/digest.ts, built from the same exported pieces.
+    const { results } = await sqlite.db.prepare(
+      `SELECT id FROM entries WHERE tags LIKE ? ${TAG_LIKE_ESCAPE} ORDER BY id`,
+    ).bind(tagLikePattern(tag)).all();
+    return (results as { id: string }[]).map(r => r.id);
+  }
+
+  // `#q3_planning` is the ordinary multi-word hashtag convention and src/text/hashtags.ts
+  // matches \w, so underscore tags arrive without anyone doing anything unusual. Unescaped,
+  // `_` is a single-character wildcard and this also rolls up every `q3-planning` entry.
+  it("does not match a neighbouring tag through an underscore wildcard", async () => {
+    const ids = await selected("q3_planning");
+    expect(ids).toHaveLength(11);
+    expect(ids.every(id => id.startsWith("own-"))).toBe(true);
+  });
+
+  // Reachable through the API's tags[] array and the integrations mirror, neither of which
+  // constrains the characters in a tag. Unescaped this selects the entire table.
+  it("does not match everything through a percent wildcard", async () => {
+    expect(await selected("%")).toEqual([]);
+    expect(await selected("%planning%")).toEqual([]);
+  });
+
+  it("still matches the ordinary tag it is given", async () => {
+    expect(await selected("q3-planning")).toHaveLength(9);
+    expect(await selected("q3_planning")).toHaveLength(11);
+  });
+});

--- a/test/integration/digest.test.ts
+++ b/test/integration/digest.test.ts
@@ -1,0 +1,95 @@
+/**
+ * GET /digest hands compressTag an arbitrary user-supplied string, which makes it the one
+ * path where the guard inside compressTag is the ONLY thing standing between a request and
+ * a rollup. The nightly path is protected twice — the candidate query filters the tag list
+ * before compressTag ever sees it — so a guard that is too narrow shows up here and nowhere
+ * else. It went unnoticed because this route had no test at all.
+ *
+ * Compressing a system tag is not a no-op: compressTag selects sources with `tags LIKE
+ * '%"<tag>"%'` and marks every one of them `rolled-up` with a `[Digest: …]` suffix appended
+ * to its content, permanently. `duplicate-candidate` and `contradiction-resolved` are the
+ * dangerous ones — unlike synthesized/auto-pattern/rolled-up they have no row-level
+ * exclusion anywhere, so every entry carrying one is selectable.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import worker from "../../src/index";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+describe("GET /digest", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  function seed(tags: string[], n = 12) {
+    const old = Date.now() - 200 * 24 * 3600 * 1000;
+    for (let i = 0; i < n; i++) {
+      db.entries.push({
+        id: `e-${i}`, content: `Memory ${i}`, tags: JSON.stringify(tags), source: "api",
+        created_at: old + i, updated_at: old + i, vector_ids: "[]",
+        recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+      });
+    }
+  }
+
+  // Compared against the state before the request rather than against absolutes: some of
+  // these fixtures are seeded with the very tag under test, so "nothing changed" is the
+  // assertion — no row added, none marked, no content appended to.
+  const snapshot = () => db.entries.map(e => ({ id: e.id, tags: e.tags, content: e.content }));
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await worker.fetch(req("GET", "/digest?tag=work", { token: null }), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("requires a tag", async () => {
+    const res = await worker.fetch(req("GET", "/digest"), env, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    "duplicate-candidate",
+    "Duplicate-Candidate",
+    "contradiction-resolved",
+    "synthesized",
+    "rolled-up",
+    "stale:as-of",
+    "Stale:As-Of",
+    "kind:semantic",
+    "Kind:Semantic",
+    "status:canonical",
+    "volatility:state",
+  ])("refuses to compress the system tag %s", async (tag) => {
+    seed([tag, "work"]);
+    const before = snapshot();
+
+    const res = await worker.fetch(req("GET", `/digest?tag=${encodeURIComponent(tag)}`), env, ctx);
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.entry_id).toBeUndefined();
+    expect(data.source_count).toBe(0);
+    expect(env.AI.run).not.toHaveBeenCalled(); // rejected before any work at all
+    expect(snapshot()).toEqual(before);
+  });
+
+  // The guard must not have become a blanket refusal — an ordinary tag still compresses.
+  it("still compresses an ordinary tag", async () => {
+    seed(["holiday-plans"]);
+
+    const res = await worker.fetch(req("GET", "/digest?tag=holiday-plans"), env, ctx);
+
+    const data = await res.json() as any;
+    expect(data.entry_id).toBeTruthy();
+    expect(data.source_count).toBe(12);
+    expect(db.entries.filter(e => JSON.parse(e.tags).includes("rolled-up"))).toHaveLength(12);
+  });
+});

--- a/test/integration/graph-read-budget.test.ts
+++ b/test/integration/graph-read-budget.test.ts
@@ -1,0 +1,186 @@
+/**
+ * #281 — the dashboard graph view must not read the whole edges table.
+ *
+ * Driven against real SQLite (`test/helpers/sqlite-d1.ts`) rather than the string-matching
+ * D1 mock, because the bug *is* the query plan. The mock slices a sorted array, so it
+ * hands back exactly the right rows whether or not SQLite could have found them without
+ * scanning and sorting every edge first — it cannot fail on this.
+ *
+ * What the plan costs, measured on workerd D1 through Miniflare (`meta.rows_read`):
+ *
+ *   edges     query                             before    after
+ *   50,000    ORDER BY weight DESC LIMIT 6000   100,000   6,000
+ *   200,000   ORDER BY weight DESC LIMIT 6000   400,000   6,000
+ *   200,000   ORDER BY weight DESC (no LIMIT)   400,000   200,000
+ *   200,000   one whole GET /graph              1,499,398 38,598
+ *
+ * Two separate things go wrong, and the middle rows are what separate them. Without an
+ * index on weight there is no ordered path to it, so SQLite reads every row into a temp
+ * b-tree and applies the LIMIT afterwards — rows_read is 2x the edge count and the LIMIT
+ * buys nothing. With the index but no LIMIT the sort is gone, but the scan still runs to
+ * the end of the table. Only index *and* LIMIT together bound the read, which is why the
+ * cap in buildGraph is part of this fix rather than a separate tidy-up. D1's free plan
+ * allows 5M rows read per day and fails every query account-wide until 00:00 UTC once that
+ * is spent: three /graph requests at 200k edges, and fewer as the brain grows.
+ *
+ * node:sqlite exposes no step counters, so the assertions stand on the plan instead:
+ * "USE TEMP B-TREE FOR ORDER BY" is SQLite stating it must materialise and sort every row
+ * before the LIMIT can apply, which is precisely the 2x-edge-count reads above, while an
+ * index scan feeding a LIMIT stops after LIMIT rows. The plan is asserted on the exact SQL
+ * `buildGraph` issues, captured from the binding rather than restated here, so it cannot
+ * drift into testing a query the Worker does not run.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { buildGraph, GRAPH_VIEW_MAX_NODES } from "../../src/graph/traverse";
+import { initializeDatabase, resetDatabaseInit } from "../../src/db/init";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestEnv } from "../helpers/make-env";
+import type { Env } from "../../src/env";
+
+/** The one statement this issue is about, whatever else buildGraph runs alongside it. */
+const STRONGEST_EDGES = /FROM edges ORDER BY weight DESC/;
+
+let sqlite: SqliteD1 | null = null;
+afterEach(() => { sqlite?.close(); sqlite = null; });
+
+/**
+ * `n` edges over `n / 4` nodes with weights spread across 0..1, inserted by one recursive
+ * CTE — a per-row INSERT from JS is the slow part of a 20,000-edge fixture, not SQLite.
+ */
+function seedGraph(db: SqliteD1, n: number): void {
+  const nodes = Math.max(2, Math.floor(n / 4));
+  db.db.prepare(
+    `WITH RECURSIVE seq(i) AS (SELECT 0 UNION ALL SELECT i + 1 FROM seq WHERE i + 1 < ${n})
+     INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at)
+     SELECT 'e' || i, 'n' || (i / 4), 'n' || (((i / 4) + ((i % 4) + 1) * 997) % ${nodes}),
+            'relates_to', (i % 1000) / 1000.0, 'inferred', '{}', 0, 0
+     FROM seq`
+  ).run();
+  for (let i = 0; i < nodes; i++) db.seed({ id: `n${i}`, content: `Memory ${i}`, createdAt: 1000 + i });
+}
+
+/** env.DB over real SQLite, recording every statement so the plan can be taken later. */
+function recordingEnv(db: SqliteD1): { env: Env; statements: string[] } {
+  const statements: string[] = [];
+  const DB = {
+    prepare(sql: string) {
+      statements.push(sql.replace(/\s+/g, " ").trim());
+      return db.db.prepare(sql);
+    },
+  } as unknown as D1Database;
+  return { env: makeTestEnv(undefined, { DB }), statements };
+}
+
+async function planOf(db: SqliteD1, sql: string): Promise<string> {
+  const { results } = await db.db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all();
+  return (results as { detail: string }[]).map(r => r.detail).join(" | ");
+}
+
+describe("GET /graph read budget", () => {
+  it("always bounds the strongest-edges query with a LIMIT, even with no caller limit", async () => {
+    sqlite = makeSqliteD1();
+    seedGraph(sqlite, 400);
+    const { env, statements } = recordingEnv(sqlite);
+
+    await buildGraph({}, env);
+
+    // An unbounded ORDER BY has nothing for the index scan to stop at, so it reads to the
+    // end of the table however small the caller intended the view to be.
+    const strongest = statements.filter(s => STRONGEST_EDGES.test(s));
+    expect(strongest).toHaveLength(1);
+    expect(strongest[0]).toMatch(/LIMIT \d+$/);
+  });
+
+  it("plans that query as an index scan with no whole-table sort", async () => {
+    sqlite = makeSqliteD1();
+    seedGraph(sqlite, 2_000);
+    const { env, statements } = recordingEnv(sqlite);
+
+    await buildGraph({}, env);
+
+    const plan = await planOf(sqlite, statements.find(s => STRONGEST_EDGES.test(s))!);
+    expect(plan).toContain("USING INDEX idx_edges_weight");
+    expect(plan).not.toContain("TEMP B-TREE");
+  });
+
+  it("keeps the same bounded plan as the edge table grows", async () => {
+    // The failure mode is a cost that scales with the brain, so the property under test is
+    // that it does not: same plan, same LIMIT, 50x the edges.
+    const plans: string[] = [];
+    for (const edges of [500, 25_000]) {
+      const db = makeSqliteD1();
+      try {
+        seedGraph(db, edges);
+        const { env, statements } = recordingEnv(db);
+        await buildGraph({}, env);
+        plans.push(await planOf(db, statements.find(s => STRONGEST_EDGES.test(s))!));
+      } finally {
+        db.close();
+      }
+    }
+    expect(plans[0]).toBe(plans[1]);
+    expect(plans[1]).not.toContain("TEMP B-TREE");
+  });
+
+  it("caps the view at GRAPH_VIEW_MAX_NODES however large a limit is asked for", async () => {
+    sqlite = makeSqliteD1();
+    seedGraph(sqlite, 400);
+    const { env, statements } = recordingEnv(sqlite);
+
+    await buildGraph({ limit: GRAPH_VIEW_MAX_NODES * 100 }, env);
+
+    const strongest = statements.find(s => STRONGEST_EDGES.test(s))!;
+    expect(strongest).toContain(`LIMIT ${GRAPH_VIEW_MAX_NODES * 4}`);
+  });
+
+  it("still returns the strongest edges first, not an arbitrary subset", async () => {
+    // The cheap alternative to the index was dropping ORDER BY entirely. It is not what
+    // shipped, so the ordering it would have cost has to stay observable.
+    sqlite = makeSqliteD1();
+    for (let i = 0; i < 6; i++) sqlite.seed({ id: `n${i}`, content: `Memory ${i}`, createdAt: 1000 + i });
+    const weights: [string, string, number][] = [["n0", "n1", 0.95], ["n2", "n3", 0.10], ["n4", "n5", 0.60]];
+    for (const [source, target, weight] of weights) {
+      await sqlite.db.prepare(
+        `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at)
+         VALUES (?, ?, ?, 'relates_to', ?, 'inferred', '{}', 0, 0)`
+      ).bind(`${source}-${target}`, source, target, weight).run();
+    }
+    const { env } = recordingEnv(sqlite);
+
+    const { nodes } = await buildGraph({ limit: 2 }, env);
+
+    expect(nodes.map(n => n.id)).toEqual(["n0", "n1"]);
+  });
+});
+
+describe("edges schema drift", () => {
+  // db/schema.sql runs on `npm run db:migrate`; src/db/init.ts runs on every cold isolate
+  // and is the only thing that reaches a brain migrated before an index existed. A brain
+  // is served by whichever ran last, so an index present in one and missing from the other
+  // means the read budget above holds on some brains and not others.
+  afterEach(resetDatabaseInit);
+
+  // Autoindexes are excluded — they come from the PRIMARY KEY and UNIQUE constraints, so
+  // they exist wherever the table does and say nothing about drift.
+  const EDGE_INDEXES = `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'edges' AND name NOT LIKE 'sqlite_%' ORDER BY name`;
+
+  it("creates the same edges indexes at runtime as a fresh migration does", async () => {
+    sqlite = makeSqliteD1(); // db/schema.sql, applied for real
+    const { results } = await sqlite.db.prepare(EDGE_INDEXES).all();
+    const fromSchemaFile = (results as { name: string }[]).map(r => r.name);
+
+    const raw = new DatabaseSync(":memory:");
+    try {
+      resetDatabaseInit();
+      const DB = { exec: async (sql: string) => { raw.exec(sql); } } as unknown as D1Database;
+      await initializeDatabase(makeTestEnv(undefined, { DB }));
+      const fromInit = (raw.prepare(EDGE_INDEXES).all() as { name: string }[]).map(r => r.name);
+
+      expect(fromInit).toEqual(fromSchemaFile);
+      expect(fromInit).toContain("idx_edges_weight");
+    } finally {
+      raw.close();
+    }
+  });
+});

--- a/test/integration/integrations.test.ts
+++ b/test/integration/integrations.test.ts
@@ -226,6 +226,27 @@ describe("integrations routes", () => {
       expect(db.entries).toHaveLength(7);
     });
 
+    // #290: the mirror store resolved config inside createEntry, so every item in
+    // a batch paid its own KV read for a value that cannot change mid-batch — on
+    // top of the D1, Workers AI and Vectorize calls the item already costs. The
+    // store is built once per sync, which is the scope the read belongs at.
+    it("resolves config once per sync batch, not once per mirrored item", async () => {
+      fixture.pages = Array.from({ length: 5 }, (_, i) =>
+        notionPage(`p${i}`, `Note ${i}`, `2026-01-0${i + 1}T00:00:00.000Z`)
+      );
+      for (let i = 0; i < 5; i++) fixture.blocks[`p${i}`] = [paragraph(`body ${i}`)];
+      await connect();
+
+      const reads: string[] = [];
+      const kv = env.OAUTH_KV;
+      env.OAUTH_KV = { ...kv, get: (key: string) => { reads.push(key); return kv.get(key); } } as any;
+
+      const result = await (await sync()).json() as any;
+
+      expect(result).toMatchObject({ created: 5 });
+      expect(reads.filter(k => k === "config:overrides")).toHaveLength(1);
+    });
+
     it("records the error and returns 502 when the Notion API fails", async () => {
       fixture.pages = [notionPage("p1", "Note", "2026-01-01T00:00:00.000Z")];
       fixture.blocks["p1"] = [paragraph("test")];

--- a/test/integration/list.test.ts
+++ b/test/integration/list.test.ts
@@ -56,13 +56,17 @@ describe("GET /list", () => {
     expect(data.length).toBeLessThanOrEqual(100);
   });
 
-  it("returns a valid response when ?n= is non-numeric", async () => {
+  // This used to assert a 200 with an array body, which only ever held because
+  // D1Mock reads the bound LIMIT with Number() and slices by it. Real D1 rejects
+  // a NaN LIMIT at execution with SQLITE_MISMATCH, so the route answered 500 —
+  // see test/integration/query-param-validation.test.ts, which runs the same
+  // request against real SQLite.
+  it("rejects a non-numeric ?n= rather than passing it to the database", async () => {
     db.entries.push({ id: "x", content: "One", tags: "[]", source: "api", created_at: 1000, vector_ids: "[]" });
 
     const res = await worker.fetch(req("GET", "/list?n=abc"), env, ctx);
-    expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(Array.isArray(data)).toBe(true);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ ok: false, error: "n must be an integer" });
   });
 
   // ── Filter parity with list_recent (?tag, ?after, ?before) ──────────────────

--- a/test/integration/query-param-validation.test.ts
+++ b/test/integration/query-param-validation.test.ts
@@ -1,0 +1,264 @@
+/**
+ * #277 — every integer query parameter reached the database unvalidated.
+ *
+ * `parseInt` returns NaN for a non-numeric value and the Math.min/Math.max
+ * clamps around it do not sanitise that (`Math.min(NaN, 100)` is NaN), so the
+ * bad value went through to D1. Where it landed decided what the caller saw:
+ *
+ *   GET /list?n=abc        HTTP 500 — NaN bound as LIMIT ? is SQLITE_MISMATCH
+ *   GET /list?after=abc    200 with [] — created_at >= NaN matches nothing
+ *   GET /recall?after=abc  the same empty result, reported as a success
+ *   GET /recall?hops=abc   graph expansion silently skipped (h < NaN is false)
+ *   GET /recall?topK=abc   .slice(0, NaN) — no results
+ *   GET /graph?limit=abc   every row in `edges` returned, no LIMIT clause
+ *
+ * The silent ones are the reason this is a 400 and not a fallback: a caller
+ * filtering by a malformed date got "you have no matching memories" instead of
+ * "your request was malformed", and could not tell the difference.
+ *
+ * The /list cases run against real SQLite rather than D1Mock. The mock reads a
+ * bound LIMIT with Number() and slices by it, which turns the 500 into a quiet
+ * empty array — the bug is invisible to it. node:sqlite is the same engine D1
+ * runs, and it raises the same "datatype mismatch" on a NaN LIMIT, so removing
+ * the guard makes these tests fail the way production did.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import worker from "../../src/index";
+import { buildGraph, GRAPH_VIEW_MAX_NODES } from "../../src/graph/traverse";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+import { D1Mock } from "../helpers/d1-mock";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+describe("integer query parameters (#277)", () => {
+  // ── GET /list, against real SQLite ─────────────────────────────────────────
+
+  describe("GET /list", () => {
+    let sqlite: SqliteD1;
+    let env: Env;
+
+    beforeEach(() => {
+      sqlite = makeSqliteD1();
+      for (let i = 0; i < 5; i++) {
+        sqlite.seed({ id: `e${i}`, content: `Entry ${i}`, createdAt: 1000 + i * 1000 });
+      }
+      env = makeTestEnv(undefined, { DB: sqlite.db as unknown as D1Database });
+    });
+
+    afterEach(() => sqlite.close());
+
+    it("answers 400 instead of the D1 datatype mismatch that made ?n= a 500", async () => {
+      const res = await worker.fetch(req("GET", "/list?n=abc"), env, ctx);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ ok: false, error: "n must be an integer" });
+    });
+
+    // The one that mattered most: this used to be a 200 carrying [], which reads
+    // as an empty brain rather than a rejected request.
+    it("answers 400 instead of an empty list when ?after= is not a timestamp", async () => {
+      const res = await worker.fetch(req("GET", "/list?after=yesterday"), env, ctx);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ ok: false, error: "after must be an integer" });
+    });
+
+    it("answers 400 instead of an empty list when ?before= is not a timestamp", async () => {
+      const res = await worker.fetch(req("GET", "/list?before=2026-01-01"), env, ctx);
+      expect(res.status).toBe(400);
+    });
+
+    // SQLite reads a negative LIMIT as no limit at all, so this was a second way
+    // to ask an authenticated route for an unbounded read of `entries`.
+    it("does not read the whole table for a negative ?n=", async () => {
+      const res = await worker.fetch(req("GET", "/list?n=-1"), env, ctx);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual([]);
+    });
+
+    it("still answers valid parameters against real SQL", async () => {
+      const res = await worker.fetch(req("GET", "/list?n=2&after=2000&before=4000"), env, ctx);
+      expect(res.status).toBe(200);
+      const data = await res.json() as any[];
+      expect(data.map(e => e.id)).toEqual(["e3", "e2"]);
+    });
+
+    it("still caps ?n= at 100 rather than rejecting it", async () => {
+      const res = await worker.fetch(req("GET", "/list?n=100000"), env, ctx);
+      expect(res.status).toBe(200);
+      expect((await res.json() as any[]).length).toBe(5);
+    });
+  });
+
+  // ── GET /recall ────────────────────────────────────────────────────────────
+
+  describe("GET /recall", () => {
+    let env: Env;
+
+    beforeEach(() => {
+      env = makeTestEnv(makeTestDb());
+    });
+
+    it.each([
+      ["after", "/recall?query=memory&after=yesterday"],
+      ["before", "/recall?query=memory&before=soon"],
+      ["topK", "/recall?query=memory&topK=lots"],
+      ["hops", "/recall?query=memory&hops=deep"],
+    ])("answers 400 for a malformed ?%s=", async (name, path) => {
+      const res = await worker.fetch(req("GET", path), env, ctx);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ ok: false, error: `${name} must be an integer` });
+    });
+
+    it("rejects before running the search, so nothing is billed for a bad request", async () => {
+      const db = makeTestDb();
+      env = makeTestEnv(db);
+      const vectorize = env.VECTORIZE as any;
+      await worker.fetch(req("GET", "/recall?query=memory&topK=lots"), env, ctx);
+      expect(vectorize.query).not.toHaveBeenCalled();
+    });
+
+    it("still accepts and clamps valid parameters", async () => {
+      const res = await worker.fetch(req("GET", "/recall?query=memory&topK=999&hops=99&after=1"), env, ctx);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── GET /graph ─────────────────────────────────────────────────────────────
+
+  describe("GET /graph", () => {
+    it("answers 400 for a malformed ?limit= rather than returning every edge", async () => {
+      const env = makeTestEnv(makeTestDb());
+      const res = await worker.fetch(req("GET", "/graph?limit=all"), env, ctx);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ ok: false, error: "limit must be an integer" });
+    });
+  });
+
+  // ── buildGraph's own ceiling ───────────────────────────────────────────────
+  //
+  // Defence in depth, independent of the route. buildGraph resolved "no usable
+  // limit" to Infinity, and Number.isFinite(Infinity) is false, so it chose the
+  // branch with no LIMIT clause and took back every row in `edges`. The LIMIT
+  // bounds rows returned rather than rows read — `weight` is unindexed, so the
+  // scan happens either way — but the returned rows are what fix the node set,
+  // and the node set is what decides how many D1 queries the request costs:
+  // 1 + ceil(N/100) + ceil(N/50), against a 50-subrequest free-plan budget.
+
+  describe("buildGraph", () => {
+    class RecordingD1 extends D1Mock {
+      sql: string[] = [];
+      prepare(sql: string) {
+        this.sql.push(sql.replace(/\s+/g, " ").trim());
+        return super.prepare(sql);
+      }
+    }
+
+    let db: RecordingD1;
+    let env: Env;
+
+    beforeEach(() => {
+      db = new RecordingD1();
+      for (let i = 0; i < 6; i++) {
+        db.entries.push({ id: `n${i}`, content: `Memory ${i}`, tags: "[]", source: "api", created_at: 1000, vector_ids: "[]", importance_score: 0 });
+      }
+      for (let i = 0; i < 5; i++) {
+        db.edges.push({ id: `e${i}`, source_id: `n${i}`, target_id: `n${i + 1}`, type: "relates_to", weight: 0.7, provenance: "inferred", metadata: "{}", created_at: 1, updated_at: 1 });
+      }
+      env = makeTestEnv(db as unknown as D1Mock);
+    });
+
+    const edgeScan = (recorded: string[]) =>
+      recorded.find(s => s.startsWith("SELECT source_id, target_id FROM edges"));
+
+    it.each([
+      ["omitted", undefined],
+      ["NaN", NaN],
+      ["Infinity", Infinity],
+      ["zero", 0],
+      ["negative", -5],
+    ])("always bounds the edge scan when limit is %s", async (_label, limit) => {
+      await buildGraph({ limit }, env);
+      expect(edgeScan(db.sql)).toBe(
+        `SELECT source_id, target_id FROM edges ORDER BY weight DESC LIMIT ${GRAPH_VIEW_MAX_NODES * 4}`,
+      );
+    });
+
+    it("still honours a caller's smaller limit", async () => {
+      const { nodes } = await buildGraph({ limit: 3 }, env);
+      expect(nodes).toHaveLength(3);
+      expect(edgeScan(db.sql)).toBe("SELECT source_id, target_id FROM edges ORDER BY weight DESC LIMIT 12");
+    });
+
+    it("caps a caller's oversized limit at the ceiling", async () => {
+      await buildGraph({ limit: GRAPH_VIEW_MAX_NODES * 10 }, env);
+      expect(edgeScan(db.sql)).toBe(
+        `SELECT source_id, target_id FROM edges ORDER BY weight DESC LIMIT ${GRAPH_VIEW_MAX_NODES * 4}`,
+      );
+    });
+
+    function seedOversized() {
+      const big = new RecordingD1();
+      const total = GRAPH_VIEW_MAX_NODES + 500;
+      for (let i = 0; i < total; i++) {
+        big.entries.push({ id: `n${i}`, content: `Memory ${i}`, tags: "[]", source: "api", created_at: 1000, vector_ids: "[]", importance_score: 0 });
+      }
+      for (let i = 0; i < total - 1; i++) {
+        big.edges.push({ id: `e${i}`, source_id: `n${i}`, target_id: `n${i + 1}`, type: "relates_to", weight: 0.7, provenance: "inferred", metadata: "{}", created_at: 1, updated_at: 1 });
+      }
+      return big;
+    }
+
+    it("caps the node set itself, not only the edge scan", async () => {
+      const big = seedOversized();
+      const { nodes } = await buildGraph({}, makeTestEnv(big as unknown as D1Mock));
+      expect(nodes).toHaveLength(GRAPH_VIEW_MAX_NODES);
+    });
+
+    // Truncation has to be partial, not corrupt: a node the view drops must not
+    // leave an edge pointing at it.
+    it("returns a self-consistent graph when it truncates", async () => {
+      const big = seedOversized();
+      const { nodes, edges } = await buildGraph({}, makeTestEnv(big as unknown as D1Mock));
+      const ids = new Set(nodes.map(n => n.id));
+      expect(edges.every(e => ids.has(e.source) && ids.has(e.target))).toBe(true);
+    });
+
+    /**
+     * The constraint that sets GRAPH_VIEW_MAX_NODES. Workers allow 50
+     * subrequests per invocation on the free plan, and buildGraph spends
+     * 1 + ceil(N/100) + ceil(N/50) D1 queries for N nodes plus one KV read for
+     * the config. That is what makes the node cap a hard limit rather than a
+     * taste question: at N=1634 the request exceeds the budget and the graph tab
+     * is dead for every free-plan brain that size, with runGraphPass adding the
+     * edges that get it there on its own.
+     *
+     * Raising the cap without recomputing this is the mistake this test exists
+     * to catch, so it asserts the measured cost rather than a ratio.
+     *
+     * SCOPE: this measures the request's own D1 and KV calls on a warm isolate.
+     * It deliberately does not cover the cold-isolate path, where
+     * initializeDatabase fires under waitUntil and spends ~12 more from the same
+     * budget, putting the first request against a fresh isolate at ~59 — over
+     * the limit. Green here is not evidence that case is safe; it is #282.
+     */
+    it("keeps a full-size /graph request inside the free-plan subrequest budget", async () => {
+      const FREE_PLAN_SUBREQUESTS = 50;
+      const big = seedOversized();
+
+      let kvReads = 0;
+      const kv = makeTestEnv().OAUTH_KV;
+      const countingKv = { ...kv, get: async (...args: any[]) => { kvReads++; return (kv.get as any)(...args); } };
+      const bigEnv = makeTestEnv(big as unknown as D1Mock, { OAUTH_KV: countingKv as unknown as KVNamespace });
+
+      const res = await worker.fetch(req("GET", "/graph"), bigEnv, ctx);
+      expect(res.status).toBe(200);
+
+      const N = GRAPH_VIEW_MAX_NODES;
+      const predicted = 1 + Math.ceil(N / 100) + Math.ceil(N / 50);
+      expect(big.sql).toHaveLength(predicted);
+      expect(big.sql.length + kvReads).toBeLessThanOrEqual(FREE_PLAN_SUBREQUESTS);
+    });
+  });
+});

--- a/test/integration/recall-d1-limits.test.ts
+++ b/test/integration/recall-d1-limits.test.ts
@@ -1,0 +1,241 @@
+/**
+ * The two statements in recall whose size is decided by data rather than by the
+ * code that builds them: the keyword arm's OR chain of `content LIKE ?` terms,
+ * and the hydration `id IN (…)` list. D1 caps bound parameters at 100 and
+ * expression-tree depth at 100, and both statements are one constant away from
+ * either ceiling.
+ *
+ * #276 is what that looks like in production. `distillToRareTerms` narrows a
+ * query to its MAX_QUERY_TERMS rarest terms by counting how often each occurs
+ * across the corpus; with no rows to count it hands the query back whole, the
+ * keyword arm turns every token into its own LIKE clause, and past roughly 120
+ * words the request fails outright. A fresh install was one long question away
+ * from a recall that could not answer, until the user saved their first memory.
+ *
+ * Driven against real SQLite (`test/helpers/sqlite-d1.ts`) so the empty corpus
+ * is genuinely empty — the frequency aggregate returns `total: 0` because there
+ * is nothing to count, not because a mock said so. The D1 limits are layered on
+ * top, because nothing else here enforces them: the D1 mock evaluates no SQL,
+ * and `node:sqlite` accepts 999 OR'd terms against its own depth ceiling of
+ * 1000. A test run against either would pass while the Worker returned a 500.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import worker from "../../src/index";
+import { recallEntries } from "../../src/recall/search";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestEnv, makeVectorizeMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+
+// Measured against the Workers runtime for this issue: 119 words recalled, 120
+// (100 tokens) returned a 500, and depth was the limit that bound first.
+const D1_MAX_BOUND_PARAMS = 100;
+const D1_MAX_EXPR_DEPTH = 100;
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+// 120 coined words: every one clears the minimum token length and none is a
+// stopword, so the token count is exactly the word count. A real 120-word
+// question lands on the same 100 tokens once stopwords are stripped.
+const LONG_QUERY = Array.from({ length: 120 }, (_, i) => `topic${i}`).join(" ");
+
+interface Executed { sql: string; params: unknown[] }
+
+/**
+ * A D1 facade that enforces the two limits the real one enforces, and records
+ * what was executed. `failWhen` fails a single statement, for the exit that
+ * needs a database error rather than an empty corpus to fire.
+ */
+function withD1Limits(
+  inner: SqliteD1["db"],
+  executed: Executed[],
+  failWhen: (sql: string) => boolean = () => false,
+) {
+  const check = (sql: string, params: unknown[]) => {
+    executed.push({ sql, params });
+    if (failWhen(sql)) throw new Error("D1_ERROR: network error: SQLITE_ERROR");
+    // An N-way OR chain parses one level deeper than N, which is why 99 LIKE
+    // terms are accepted and 100 are not. "ORDER BY" cannot match: the "OR"
+    // there is not followed by whitespace. Checked before the parameter budget
+    // because that is the order the runtime reported them in — parsing first.
+    if (exprDepth(sql) > D1_MAX_EXPR_DEPTH) {
+      throw new Error(`D1_ERROR: Expression tree is too large (maximum depth ${D1_MAX_EXPR_DEPTH}): SQLITE_ERROR`);
+    }
+    if (params.length > D1_MAX_BOUND_PARAMS) {
+      throw new Error("D1_ERROR: too many SQL variables: SQLITE_ERROR");
+    }
+  };
+  const wrap = (sql: string, stmt: any, params: unknown[]): any => ({
+    bind: (...args: unknown[]) => wrap(sql, stmt.bind(...args), args),
+    all: async () => { check(sql, params); return stmt.all(); },
+    first: async () => { check(sql, params); return stmt.first(); },
+    run: async () => { check(sql, params); return stmt.run(); },
+  });
+  return { prepare: (sql: string) => wrap(sql, inner.prepare(sql), []) };
+}
+
+const exprDepth = (sql: string) => sql.split(/\s+OR\s+/i).length + 1;
+
+const keywordStatements = (executed: Executed[]) =>
+  executed.filter(e => e.sql.includes("FROM entries WHERE content LIKE"));
+
+const hydrationStatements = (executed: Executed[]) =>
+  executed.filter(e => e.sql.includes("created_at, updated_at FROM entries WHERE id IN"));
+
+describe("recall stays inside D1's statement limits", () => {
+  let sqlite: SqliteD1;
+  let executed: Executed[];
+
+  beforeEach(async () => {
+    sqlite = makeSqliteD1();
+    executed = [];
+    // `updated_at` is one of the columns src/db/init.ts adds by ALTER at
+    // runtime rather than in schema.sql, and that path goes through `exec`,
+    // which this facade does not implement. Recall's hydration selects it.
+    await sqlite.db.prepare(`ALTER TABLE entries ADD COLUMN updated_at INTEGER`).run();
+  });
+
+  afterEach(() => sqlite.close());
+
+  const envWith = (failWhen?: (sql: string) => boolean, overrides: Partial<Env> = {}): Env =>
+    makeTestEnv(undefined, {
+      DB: withD1Limits(sqlite.db, executed, failWhen) as unknown as D1Database,
+      ...overrides,
+    });
+
+  describe("the keyword clause, on an empty brain (#276)", () => {
+    it("answers a 120-word query with no memories stored", async () => {
+      const res = await worker.fetch(
+        req("GET", `/recall?query=${encodeURIComponent(LONG_QUERY)}`),
+        envWith(),
+        ctx,
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json() as any;
+      expect(data.ok).toBe(true);
+      expect(data.results).toEqual([]);
+
+      const [keyword] = keywordStatements(executed);
+      expect(keyword).toBeDefined();
+      // One parameter per LIKE term plus the row limit.
+      expect(keyword.params.length).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS);
+      expect(exprDepth(keyword.sql)).toBeLessThanOrEqual(D1_MAX_EXPR_DEPTH);
+    });
+
+    it("answers a 120-word query when the frequency scan itself fails", async () => {
+      // The other exit that returns the query uncapped, and the reason the cap
+      // lives where the clause is built rather than at one distillation exit:
+      // here the corpus is not empty, the statistics are simply unavailable.
+      sqlite.seed({ id: "e1", content: "topic0 is written down", createdAt: 1000 });
+      const scanFailed = (sql: string) => sql.includes("SUM(CASE WHEN content LIKE");
+
+      const res = await worker.fetch(
+        req("GET", `/recall?query=${encodeURIComponent(LONG_QUERY)}`),
+        envWith(scanFailed),
+        ctx,
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json() as any;
+      expect(data.ok).toBe(true);
+      expect(data.results.map((r: any) => r.id)).toEqual(["e1"]);
+
+      const [keyword] = keywordStatements(executed);
+      expect(keyword.params.length).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS);
+      expect(exprDepth(keyword.sql)).toBeLessThanOrEqual(D1_MAX_EXPR_DEPTH);
+    });
+
+    it("still distills to the rarest terms, and still finds them, once a memory exists", async () => {
+      sqlite.seed({ id: "e1", content: "topic0 is written down", createdAt: 1000 });
+      const env = envWith();
+
+      const long = await worker.fetch(
+        req("GET", `/recall?query=${encodeURIComponent(LONG_QUERY)}`),
+        env,
+        ctx,
+      );
+      expect(long.status).toBe(200);
+      // Distillation can rank terms again, so the keyword arm sees three of them
+      // plus the row limit — the cap is a backstop, not the narrowing.
+      expect(keywordStatements(executed)[0].params.length).toBe(4);
+
+      executed.length = 0;
+      const short = await worker.fetch(req("GET", "/recall?query=topic0"), env, ctx);
+      expect(short.status).toBe(200);
+      const data = await short.json() as any;
+      expect(data.results.map((r: any) => r.id)).toEqual(["e1"]);
+    });
+  });
+
+  describe("the hydration id list", () => {
+    // Today this list cannot outgrow one statement: the route and the MCP tool
+    // both clamp topK to 20, and expandGraph stops at GRAPH_MAX_NODES (50), so
+    // the worst case is 70 ids. recallEntries itself does not clamp, so calling
+    // it directly is the honest way to ask what the query does when the list
+    // does outgrow one statement — which is one constant in another file away.
+    const N = 150;
+    const ids = Array.from({ length: N }, (_, i) => `e${i}`);
+
+    it("chunks the ids rather than binding them all in one statement", async () => {
+      for (const [i, id] of ids.entries()) {
+        sqlite.seed({ id, content: `memory ${i} about topic0`, createdAt: 1000 + i });
+      }
+      const env = envWith(undefined, {
+        VECTORIZE: makeVectorizeMock({
+          query: vi.fn().mockResolvedValue({
+            matches: ids.map((id, i) => ({
+              id,
+              score: 1 - i / (N * 2),
+              metadata: { parentId: id, created_at: 1000 + i },
+            })),
+          }),
+        }),
+      });
+
+      const { matches } = await recallEntries(
+        { query: "topic0", topK: N, synthesize: false }, env, ctx,
+      );
+
+      // Every seed hydrated exactly once: nothing dropped at a batch boundary,
+      // nothing counted twice by an overlapping slice.
+      expect(matches.length).toBe(N);
+      expect(new Set(matches.map(m => m.id)).size).toBe(N);
+      expect([...matches.map(m => m.id)].sort()).toEqual([...ids].sort());
+      expect(matches.every(m => m.content === `memory ${ids.indexOf(m.id)} about topic0`)).toBe(true);
+
+      const hydration = hydrationStatements(executed);
+      expect(hydration.length).toBe(2);
+      expect(hydration.map(h => h.params.length)).toEqual([100, 50]);
+      expect(Math.max(...hydration.map(h => h.params.length))).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS);
+    });
+
+    it("leaves room for the time-filter bindings it shares the budget with", async () => {
+      for (const [i, id] of ids.entries()) {
+        sqlite.seed({ id, content: `memory ${i} about topic0`, createdAt: 1000 + i });
+      }
+      const env = envWith(undefined, {
+        VECTORIZE: makeVectorizeMock({
+          query: vi.fn().mockResolvedValue({
+            matches: ids.map((id, i) => ({
+              id,
+              score: 1 - i / (N * 2),
+              metadata: { parentId: id, created_at: 1000 + i },
+            })),
+          }),
+        }),
+      });
+
+      // `after` and `before` are bound on every batch, so the id slice has to be
+      // smaller than the parameter budget, not equal to it.
+      const { matches } = await recallEntries(
+        { query: "topic0", topK: N, after: 1000, before: 1000 + N, synthesize: false }, env, ctx,
+      );
+
+      expect(matches.length).toBe(N);
+      const hydration = hydrationStatements(executed);
+      expect(hydration.map(h => h.params.length)).toEqual([100, 54]);
+      expect(Math.max(...hydration.map(h => h.params.length))).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS);
+    });
+  });
+});

--- a/test/integration/stats.test.ts
+++ b/test/integration/stats.test.ts
@@ -192,11 +192,19 @@ describe("GET /stats — digest candidates", () => {
     expect(data.digest_candidates.some((c: any) => c.tag === "work")).toBe(false);
   });
 
-  it("excludes reserved namespaced tags (kind:* / status:*) from digest candidates", async () => {
+  // /stats reports what the nightly run would compress, so it has to apply the same rule.
+  // volatility:* and stale:as-of are written in bulk by the staleness pass, so they carry
+  // high counts and would otherwise sit at the top of a list of "digest candidates" that
+  // can never produce a digest.
+  //
+  // Scope: this runs against the D1 mock, whose digest-candidate branch calls isTopicTag(),
+  // so it covers the predicate rather than the SQL /stats actually issues. The query itself
+  // is covered by test/integration/digest-candidates.test.ts against real SQLite.
+  it("excludes reserved namespaced tags (kind:* / status:* / volatility:* / stale:as-of) from digest candidates", async () => {
     for (let i = 0; i < 12; i++) {
       db.entries.push({
         ...compressible(`e-${i}`, "work"),
-        tags: JSON.stringify(["work", "kind:semantic", "status:canonical"]),
+        tags: JSON.stringify(["work", "kind:semantic", "status:canonical", "volatility:state", "stale:as-of"]),
       });
     }
     const res = await worker.fetch(req("GET", "/stats"), env, ctx);
@@ -205,5 +213,7 @@ describe("GET /stats — digest candidates", () => {
     expect(tags).toContain("work");                  // topical tag still a candidate
     expect(tags).not.toContain("kind:semantic");     // namespaced excluded
     expect(tags).not.toContain("status:canonical");  // namespaced excluded
+    expect(tags).not.toContain("volatility:state");  // written by the staleness pass
+    expect(tags).not.toContain("stale:as-of");       // written by the staleness pass
   });
 });

--- a/test/integration/tag-filter-escaping.test.ts
+++ b/test/integration/tag-filter-escaping.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tag filters, run for real.
+ *
+ * A tag is user data and it goes into a LIKE pattern, where `_` matches any character and
+ * `%` matches everything. `#q3_planning` is the ordinary multi-word hashtag convention and
+ * src/text/hashtags.ts matches \w, so underscore tags arrive without anyone doing anything
+ * unusual; the API's tags[] array and the integrations mirror accept any string at all.
+ *
+ * These are read paths, so the failure is over-broad results rather than the permanent
+ * rollup the same bug caused in compressTag — a `#q3_planning` filter also returning
+ * `q3-planning` entries is wrong but recoverable. `?tag=%` is the sharper one: the filter
+ * silently stops filtering and returns the whole brain, which looks like a valid answer.
+ *
+ * test/helpers/d1-mock.ts cannot cover any of this — it compares decoded tag strings, so
+ * LIKE wildcards in the tag do not exist there. That is stated on the helper itself.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { buildEntryFilterQuery } from "../../src/capture/entry";
+import { recallEntries } from "../../src/recall/search";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { initializeDatabase, resetDatabaseInit } from "../../src/db/init";
+import { makeTestDb, makeTestEnv, makeVectorizeMock } from "../helpers/make-env";
+import worker from "../../src/index";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+import { tagLikePattern } from "../../src/memory/tag-sql";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+let sqlite: SqliteD1 | null = null;
+
+afterEach(() => {
+  sqlite?.close();
+  sqlite = null;
+});
+
+/**
+ * An Env whose DB is real SQLite.
+ *
+ * `makeSqliteD1` applies db/schema.sql, which deliberately omits the columns
+ * initializeDatabase adds by ALTER (updated_at, staleness_checked_at, the counters) — so
+ * `exec` really executes and seedEnv runs the real initializeDatabase over it. Listing
+ * those columns here instead would be a second copy of the migration, wrong the moment one
+ * is added.
+ *
+ * `batch` runs sequentially, which is enough for the read paths under test. Vectorize
+ * returns one vector per requested id so the tag-scoped branch has something to score;
+ * WHICH ids it is asked for is decided entirely by the tag query, which is the point.
+ */
+function envOver(s: SqliteD1): Env {
+  const DB = {
+    prepare: (sql: string) => s.db.prepare(sql),
+    exec: async (sql: string) => s.db.prepare(sql).run(),
+    batch: async (stmts: any[]) => Promise.all(stmts.map(st => st.run())),
+  } as unknown as D1Database;
+  const VECTORIZE = {
+    ...makeVectorizeMock(),
+    getByIds: async (ids: string[]) =>
+      ids.map(id => ({ id, values: new Array(384).fill(0.1), metadata: { parentId: id.replace(/^v-/, "") } })),
+  } as unknown as VectorizeIndex;
+  return makeTestEnv(undefined, { DB, VECTORIZE });
+}
+
+/** Seeded SQLite plus an Env over it, with the real schema migration applied. */
+async function seedEnv(): Promise<Env> {
+  sqlite = seeded();
+  const env = envOver(sqlite);
+  resetDatabaseInit();
+  await initializeDatabase(env);
+  return env;
+}
+
+const OWN = Array.from({ length: 11 }, (_, i) => `own-${i}`).sort();
+const OTHER = Array.from({ length: 9 }, (_, i) => `other-${i}`).sort();
+
+/**
+ * Eleven entries on an underscore tag, nine on the neighbour a `_` wildcard would reach.
+ * Every entry carries a vector id so the tag-scoped recall path has something to fetch.
+ */
+function seeded(): SqliteD1 {
+  const s = makeSqliteD1();
+  OWN.forEach((id, i) => s.seed({ id, content: `planning note ${i}`, createdAt: 1000 + i, tags: ["q3_planning"], vectorIds: [`v-${id}`] }));
+  OTHER.forEach((id, i) => s.seed({ id, content: `planning note ${i}`, createdAt: 2000 + i, tags: ["q3-planning"], vectorIds: [`v-${id}`] }));
+  return s;
+}
+
+describe("GET /entries and /list tag filter", () => {
+  // buildEntryFilterQuery is the real builder both routes use, so this exercises the
+  // shipped SQL and bindings rather than a copy of them.
+  async function ids(tag: string): Promise<string[]> {
+    sqlite = seeded();
+    const { sql, bindings } = buildEntryFilterQuery({ n: 100, tag });
+    const { results } = await sqlite.db.prepare(sql).bind(...bindings).all();
+    return (results as { id: string }[]).map(r => r.id).sort();
+  }
+
+  it("does not reach a neighbouring tag through an underscore wildcard", async () => {
+    expect(await ids("q3_planning")).toEqual(OWN);
+  });
+
+  it("does not return everything for a percent tag", async () => {
+    expect(await ids("%")).toEqual([]);
+    expect(await ids("%planning%")).toEqual([]);
+  });
+
+  it("still returns exactly the entries carrying the tag it was given", async () => {
+    expect(await ids("q3-planning")).toEqual(OTHER);
+  });
+});
+
+describe("tag-scoped recall candidate query", () => {
+  /**
+   * Two halves, because neither alone is worth much. This half captures the statement
+   * recallEntries actually issues and checks it carries an escaped pattern and the ESCAPE
+   * clause; the half below proves that combination behaves correctly in SQLite. Asserting
+   * only the second would pass against a recallEntries that never adopted the helpers —
+   * it did, when this test was first written that way.
+   */
+  it("issues an escaped pattern and an ESCAPE clause", async () => {
+    const db = makeTestDb();
+    db.entries.push({
+      id: "e-0", content: "m", tags: JSON.stringify(["q3_planning"]), source: "api",
+      created_at: 1, updated_at: 1, vector_ids: JSON.stringify(["v-0"]),
+      recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+    });
+    const prepared: string[] = [];
+    const bound: unknown[][] = [];
+    const DB = {
+      prepare(sql: string) {
+        const flat = sql.replace(/\s+/g, " ").trim();
+        prepared.push(flat);
+        const stmt = db.prepare(sql);
+        return {
+          ...stmt,
+          bind: (...args: unknown[]) => { if (flat.includes("tags LIKE ?")) bound.push(args); return stmt.bind(...args); },
+        };
+      },
+      exec: (sql: string) => db.exec(sql),
+      batch: (stmts: any[]) => db.batch(stmts),
+    } as unknown as D1Database;
+    const env = makeTestEnv(db, { DB });
+
+    await recallEntries({ query: "planning", topK: 5, tag: "q3_planning" }, env, ctx);
+
+    const tagQuery = prepared.find(s => s.includes("FROM entries WHERE tags LIKE ?"));
+    expect(tagQuery).toBeDefined();
+    expect(tagQuery).toContain("ESCAPE");
+    expect(bound[0]?.[0]).toBe(tagLikePattern("q3_planning"));
+    expect(bound[0]?.[0]).not.toBe(`%"q3_planning"%`); // the unescaped form
+  });
+
+  /**
+   * The behavioural half: the real recallEntries against real SQLite, asserting on the
+   * entries it comes back with.
+   *
+   * This deliberately does not rebuild the query. An earlier version of this test did, and
+   * it passed with search.ts's escaping removed — it was proving the helper works, not that
+   * recall uses it. Only the entry ids answer the question the test is named for.
+   */
+  async function recalled(tag: string): Promise<string[]> {
+    const env = await seedEnv();
+    const { matches } = await recallEntries(
+      { query: "planning", topK: 50, tag, synthesize: false },
+      env,
+      ctx,
+    );
+    return matches.map(m => m.id).sort();
+  }
+
+  it("returns only the entries carrying an underscore tag", async () => {
+    expect(await recalled("q3_planning")).toEqual(OWN);
+  });
+
+  it("returns nothing for a percent tag rather than the whole brain", async () => {
+    expect(await recalled("%")).toEqual([]);
+    expect(await recalled("%planning%")).toEqual([]);
+  });
+
+  it("still returns the entries carrying an ordinary tag", async () => {
+    expect(await recalled("q3-planning")).toEqual(OTHER);
+  });
+});
+
+/**
+ * The route, end to end: a real HTTP request through the worker, against real SQLite,
+ * asserting on the response body. `?tag=%` returning the whole brain is the case that
+ * looks most like a valid answer and is therefore least likely to be noticed.
+ */
+describe("GET /list tag filter, end to end", () => {
+  async function listed(tag: string): Promise<string[]> {
+    const env = await seedEnv();
+    const res = await worker.fetch(
+      req("GET", `/list?n=100&tag=${encodeURIComponent(tag)}`),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    return ((await res.json()) as { id: string }[]).map(r => r.id).sort();
+  }
+
+  it("does not reach a neighbouring tag through an underscore wildcard", async () => {
+    expect(await listed("q3_planning")).toEqual(OWN);
+  });
+
+  it("does not return every entry for a percent tag", async () => {
+    expect(await listed("%")).toEqual([]);
+  });
+
+  it("still returns the entries carrying an ordinary tag", async () => {
+    expect(await listed("q3-planning")).toEqual(OTHER);
+  });
+});

--- a/test/integration/tag-vocabulary-cache.test.ts
+++ b/test/integration/tag-vocabulary-cache.test.ts
@@ -1,0 +1,472 @@
+/**
+ * #288 — recall must not scan the tag table on every call.
+ *
+ * `SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value` is a
+ * full table scan expanded once per tag per row, and `inferQueryTags` ran it on
+ * every recall. Measured on workerd D1 through Miniflare (`meta.rows_read`), one
+ * `recallEntries({ query, topK: 5 })` at four tags an entry:
+ *
+ *   entries   tag scan   whole recall   whole recall    GET /tags   recalls/day
+ *                            (before)        (after)   before→after   before→after
+ *   1,000        9,000         11,000          2,000     9,000 → 0     454 → 2,500
+ *   5,000       45,000         55,000         10,000    45,000 → 0      90 →   500
+ *   20,000     180,000        220,000         40,000   180,000 → 0      22 →   125
+ *
+ * D1's free plan allows 5M rows read per day and fails every query on the account
+ * until 00:00 UTC once that is spent. The scan was 82% of a recall, and the MCP
+ * clients this project ships instructions for recall at the start of every
+ * conversation and every few messages after — so 90 a day on a 5,000-memory brain
+ * was ordinary use, not a stress test.
+ *
+ * No rewrite makes that query sub-linear — every variant plans identically on real
+ * SQLite (`SCAN entries`, `SCAN json_each`, temp b-tree, with or without ORDER BY, as
+ * a GROUP BY, with a LIMIT, with an index on `tags`) — so the tests below are about
+ * the query *not running*, and about every way it can fail to run costing a boost
+ * rather than a result.
+ *
+ * The rebuild that remains does drop `ORDER BY value` and sort in JS, which is 44%
+ * off its rows read for identical output (5,000 entries: 45,000 → 25,000; 20,000:
+ * 180,000 → 100,000). Identical plans, different costs: the DISTINCT b-tree has to be
+ * walked back out to emit in order. `orders the vocabulary identically to the SQL it
+ * replaced` below is what keeps that honest.
+ *
+ * Driven against real SQLite (`test/helpers/sqlite-d1.ts`) with every statement
+ * recorded, because what is under test is which statements are issued.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { recallEntries } from "../../src/recall/search";
+import { inferQueryTags } from "../../src/recall/distill";
+import { captureEntry } from "../../src/capture/entry";
+import { handleEntriesRoutes } from "../../src/routes/entries";
+import {
+  getTagVocabulary,
+  rememberTags,
+  TAG_VOCABULARY_KEY,
+  TAG_VOCABULARY_MAX_AGE_MS,
+} from "../../src/tags/vocabulary";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestEnv, makeMemoryKV, makeKVMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+
+/** The one statement this issue is about. */
+const TAG_SCAN = /SELECT DISTINCT value FROM entries, json_each/;
+
+let sqlite: SqliteD1 | null = null;
+afterEach(() => { sqlite?.close(); sqlite = null; });
+
+/** Collects deferred work so a test can await what the Worker would run after responding. */
+function makeCtx(): ExecutionContext & { settle: () => Promise<void> } {
+  const pending: Promise<unknown>[] = [];
+  return {
+    waitUntil: (p: Promise<unknown>) => { pending.push(p); },
+    passThroughOnException: () => {},
+    props: {},
+    settle: async () => { await Promise.allSettled(pending.splice(0)); },
+  } as unknown as ExecutionContext & { settle: () => Promise<void> };
+}
+
+interface Harness {
+  env: Env;
+  issued: string[];
+  ctx: ExecutionContext & { settle: () => Promise<void> };
+  kv: KVNamespace;
+  scans: () => string[];
+}
+
+/**
+ * A brain with `tags` on every entry, real SQL underneath, and a KV that remembers
+ * what was written to it. `failScan` makes the tag scan — and only the tag scan —
+ * fail, which is how the degraded paths are reached without breaking recall itself.
+ */
+function harness(
+  entries: { id: string; content: string; tags: string[] }[],
+  opts: { failScan?: boolean; kv?: KVNamespace } = {},
+): Harness {
+  sqlite = makeSqliteD1();
+  // `updated_at` is added by ALTER in src/db/init.ts rather than in schema.sql, and
+  // that path goes through `exec`, which this facade does not run. Capture writes it
+  // and recall's hydration selects it.
+  sqlite.db.prepare(`ALTER TABLE entries ADD COLUMN updated_at INTEGER`).run();
+  entries.forEach((e, i) => sqlite!.seed({ ...e, createdAt: 1_700_000_000_000 + i }));
+
+  const issued: string[] = [];
+  const inner = sqlite.db;
+  const DB = {
+    prepare(sql: string) {
+      issued.push(sql.replace(/\s+/g, " ").trim());
+      if (opts.failScan && TAG_SCAN.test(sql)) {
+        const boom = () => Promise.reject(new Error("D1_ERROR: network error: SQLITE_ERROR"));
+        return { bind: () => ({ all: boom, first: boom, run: boom }), all: boom, first: boom, run: boom };
+      }
+      return inner.prepare(sql);
+    },
+    exec: (sql: string) => inner.exec(sql),
+  } as unknown as D1Database;
+
+  const kv = opts.kv ?? makeMemoryKV();
+  return {
+    env: makeTestEnv(undefined, { DB, OAUTH_KV: kv }),
+    issued,
+    ctx: makeCtx(),
+    kv,
+    scans: () => issued.filter(s => TAG_SCAN.test(s)),
+  };
+}
+
+/**
+ * Ten entries rather than three: `distillToRareTerms` drops any term occurring in
+ * more than QUERY_SATURATION_FRACTION of the corpus, and on a three-row brain a term
+ * in one row is already saturated — the query would be distilled to nothing and the
+ * recall assertions below would pass on an empty result set.
+ */
+const CORPUS = [
+  { id: "e1", content: "Signed the office lease renewal for the Dublin site", tags: ["work", "legal", "kind:semantic"] },
+  { id: "e2", content: "Quarterly planning session moved to Thursday", tags: ["work", "planning", "status:canonical"] },
+  { id: "e3", content: "Booked the dentist for next month", tags: ["health", "personal"] },
+  { id: "e4", content: "Ran five kilometres before breakfast", tags: ["health"] },
+  { id: "e5", content: "Drafted the supplier contract amendment", tags: ["legal"] },
+  { id: "e6", content: "Reviewed the hiring pipeline with the team", tags: ["work"] },
+  { id: "e7", content: "Bought a bicycle at the weekend", tags: ["personal"] },
+  { id: "e8", content: "Trip to the coast in autumn", tags: ["planning", "personal"] },
+  { id: "e9", content: "Filed the annual accounts", tags: ["legal", "work"] },
+  { id: "e10", content: "Renewed the gym membership", tags: ["health", "personal"] },
+];
+
+const ALL_TAGS = ["health", "kind:semantic", "legal", "personal", "planning", "status:canonical", "work"];
+
+describe("the tag vocabulary is scanned once, not per recall", () => {
+  it("scans on the first recall and never again while the cache is warm", async () => {
+    const h = harness(CORPUS);
+
+    await recallEntries({ query: "what did I decide about the office lease", topK: 5 }, h.env, h.ctx);
+    await h.ctx.settle();
+    expect(h.scans()).toHaveLength(1);
+
+    for (let i = 0; i < 5; i++) {
+      await recallEntries({ query: `notes on the quarterly planning session ${i}`, topK: 5 }, h.env, h.ctx);
+      await h.ctx.settle();
+    }
+    expect(h.scans()).toHaveLength(1);
+  });
+
+  it("caches what the scan found, under its own key", async () => {
+    const h = harness(CORPUS);
+    await getTagVocabulary(h.env);
+
+    const raw = await h.kv.get(TAG_VOCABULARY_KEY);
+    expect(raw).toBeTruthy();
+    const stored = JSON.parse(raw!);
+    expect(stored.tags).toEqual(ALL_TAGS);
+    expect(stored.rebuiltAt).toBeGreaterThan(0);
+  });
+
+  it("orders the vocabulary identically to the SQL it replaced", async () => {
+    // The rebuild drops `ORDER BY value` and sorts in JS instead, for 44% off its
+    // rows read. That is only free if the order is the same, and this asserts it
+    // against SQLite's own answer rather than against a hand-written expectation —
+    // a JS sort that disagreed with BINARY collation would reorder the dashboard's
+    // dropdown and pass a literal list quite happily.
+    const h = harness(CORPUS);
+    const { results } = await h.env.DB.prepare(
+      `SELECT DISTINCT value FROM entries, json_each(entries.tags) ORDER BY value`
+    ).all();
+    const fromSql = (results as { value: string }[]).map(r => r.value);
+
+    expect(await getTagVocabulary(h.env)).toEqual(fromSql);
+  });
+
+  it("never freezes on a timestamp from the future, however far ahead", async () => {
+    // `now - rebuiltAt < MAX_AGE` is satisfied by every future timestamp, so one that
+    // is merely clamped to `Date.now()` re-anchors on each read and passes forever:
+    // no rebuild is ever scheduled, so nothing can correct it, and a tag deleted from
+    // the brain stays in the dropdown for good. Clock skew between the writing isolate
+    // and the reading one can produce one; a hand-edited blob certainly can.
+    for (const rebuiltAt of [Date.now() + 365 * 86400000, Number.MAX_SAFE_INTEGER]) {
+      const h = harness(CORPUS);
+      await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({ tags: ["frozen"], rebuiltAt }));
+
+      expect(await getTagVocabulary(h.env)).toEqual(ALL_TAGS);
+      expect(h.scans()).toHaveLength(1);
+      sqlite?.close();
+      sqlite = null;
+    }
+  });
+
+  it("serves the future-dated list meanwhile rather than answering empty", async () => {
+    // Rejecting the timestamp must not reject the vocabulary with it: this is the
+    // same degradation as any other aged-out copy, so the caller gets something and
+    // the correction happens behind the response.
+    const h = harness(CORPUS);
+    await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({
+      tags: ["frozen"],
+      rebuiltAt: Date.now() + 365 * 86400000,
+    }));
+
+    expect(await getTagVocabulary(h.env, h.ctx)).toEqual(["frozen"]);
+    await h.ctx.settle();
+    expect(await getTagVocabulary(h.env, h.ctx)).toEqual(ALL_TAGS);
+  });
+
+  it("rebuilds behind the response once the cached copy ages out", async () => {
+    const h = harness(CORPUS);
+    await getTagVocabulary(h.env);
+    expect(h.scans()).toHaveLength(1);
+
+    await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({
+      tags: ["stale-only"],
+      rebuiltAt: Date.now() - TAG_VOCABULARY_MAX_AGE_MS - 1,
+    }));
+
+    // The aged copy is what the caller gets — it is handed back before the rebuild
+    // this call scheduled can have finished, which is the whole point of deferring it.
+    expect(await getTagVocabulary(h.env, h.ctx)).toEqual(["stale-only"]);
+
+    await h.ctx.settle();
+    expect(h.scans()).toHaveLength(2);
+    expect(await getTagVocabulary(h.env, h.ctx)).toContain("work");
+  });
+});
+
+describe("recall results are unchanged — only their cost", () => {
+  it("infers the same tags warm as it did cold", async () => {
+    const h = harness(CORPUS);
+
+    const cold = await inferQueryTags("notes about legal work", h.env);
+    expect(h.scans()).toHaveLength(1);
+
+    const warm = await inferQueryTags("notes about legal work", h.env);
+    expect(h.scans()).toHaveLength(1);
+    expect(warm).toEqual(cold);
+    expect(warm).toEqual(expect.arrayContaining(["legal", "work"]));
+  });
+
+  it("returns the same ordered matches warm as cold", async () => {
+    const h = harness(CORPUS);
+    const ids = async () => (await recallEntries({ query: "office lease renewal", topK: 5 }, h.env, h.ctx)).matches.map(m => m.id);
+
+    const cold = await ids();
+    await h.ctx.settle();
+    const warm = await ids();
+
+    expect(cold.length).toBeGreaterThan(0);
+    expect(warm).toEqual(cold);
+  });
+});
+
+describe("a tag captured just now is inferable on the next recall", () => {
+  it("write-through admits it without waiting for a rebuild", async () => {
+    const h = harness(CORPUS);
+    await getTagVocabulary(h.env); // the brain has been used before
+    expect(h.scans()).toHaveLength(1);
+
+    const result = await captureEntry("Moving the warehouse to #lakehouse next spring", [], "api", h.env, h.ctx);
+    expect(result.status).toBe("stored");
+    await h.ctx.settle();
+
+    const tags = await inferQueryTags("what is happening with lakehouse", h.env);
+    expect(tags).toContain("lakehouse");
+    // The whole point: no second scan bought that.
+    expect(h.scans()).toHaveLength(1);
+  });
+
+  it("does not revert a rebuild that landed while it was working", async () => {
+    // Write-through reads, merges, and writes. A rebuild that puts between that read
+    // and that write would be undone by it: the older `rebuiltAt` goes back, aging
+    // the cache out and buying a second full scan, and the older tag list resurrects
+    // whatever the rebuild had just pruned. Re-reading before the put narrows both.
+    const h = harness(CORPUS);
+    await getTagVocabulary(h.env);
+    const aged = Date.now() - TAG_VOCABULARY_MAX_AGE_MS - 1;
+    await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({ tags: ["gone", "work"], rebuiltAt: aged }));
+
+    // A rebuild lands in the middle of the write-through: after its read, before its put.
+    // Bound before the spy replaces the property, or the double would call itself.
+    // `get` is overloaded (single key vs bulk), so it is installed untyped.
+    const realGet = (h.kv.get as (k: string) => Promise<string | null>).bind(h.kv);
+    let interleaved = false;
+    vi.spyOn(h.kv, "get").mockImplementation((async (key: string) => {
+      const value = await realGet(key);
+      if (!interleaved) {
+        interleaved = true;
+        await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({ tags: ["work"], rebuiltAt: Date.now() }));
+      }
+      return value;
+    }) as never);
+
+    await rememberTags(h.env, ["lakehouse"]);
+
+    const after = JSON.parse((await realGet(TAG_VOCABULARY_KEY))!);
+    expect(after.tags).toEqual(["lakehouse", "work"]);   // the pruned tag stays pruned
+    expect(after.rebuiltAt).toBeGreaterThan(aged);        // and the cache is still fresh
+  });
+
+  it("does not postpone the rebuild by touching rebuiltAt", async () => {
+    // Advancing it on every capture would let an actively used brain never
+    // reconcile, so a deleted tag's last mention would never be pruned.
+    const h = harness(CORPUS);
+    await getTagVocabulary(h.env);
+    const before = JSON.parse((await h.kv.get(TAG_VOCABULARY_KEY))!).rebuiltAt;
+
+    await rememberTags(h.env, ["freshly-invented"]);
+
+    const after = JSON.parse((await h.kv.get(TAG_VOCABULARY_KEY))!);
+    expect(after.tags).toContain("freshly-invented");
+    expect(after.rebuiltAt).toBe(before);
+  });
+
+  it("leaves the cache alone when there is nothing cached yet", async () => {
+    // The row is already committed by then, so the scan that builds the first
+    // cache finds the tag by itself — writing a partial vocabulary would only
+    // invent a second source of truth.
+    const h = harness(CORPUS);
+    await rememberTags(h.env, ["lakehouse"]);
+    expect(await h.kv.get(TAG_VOCABULARY_KEY)).toBeNull();
+  });
+});
+
+describe("every way the cache can fail degrades, and none of them fails a request", () => {
+  it("answers recall when the scan itself is broken and nothing is cached", async () => {
+    const h = harness(CORPUS, { failScan: true });
+
+    const { matches } = await recallEntries({ query: "office lease renewal", topK: 5 }, h.env, h.ctx);
+
+    // Results, just without the tag boost that vocabulary would have fed.
+    expect(matches.length).toBeGreaterThan(0);
+    expect(await inferQueryTags("notes about legal work", h.env)).toEqual([]);
+  });
+
+  it("answers GET /tags with an empty list rather than a 500", async () => {
+    const h = harness(CORPUS, { failScan: true });
+
+    const res = await handleEntriesRoutes(req("GET", "/tags"), new URL("http://localhost/tags"), h.env, h.ctx);
+
+    expect(res!.status).toBe(200);
+    expect(await res!.json()).toEqual([]);
+  });
+
+  it("serves the last good vocabulary when a later scan breaks", async () => {
+    const h = harness(CORPUS);
+    await getTagVocabulary(h.env);
+
+    await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({
+      tags: ["work", "legal"],
+      rebuiltAt: Date.now() - TAG_VOCABULARY_MAX_AGE_MS - 1,
+    }));
+    const broken = harness([], { kv: h.kv, failScan: true });
+
+    expect(await getTagVocabulary(broken.env)).toEqual(["work", "legal"]);
+  });
+
+  it("falls back to scanning when KV is unavailable, which is exactly the old cost", async () => {
+    // makeKVMock reads null and swallows writes — the shape of a KV outage.
+    const h = harness(CORPUS, { kv: makeKVMock() });
+
+    expect(await inferQueryTags("notes about legal work", h.env)).toEqual(expect.arrayContaining(["legal", "work"]));
+    expect(await inferQueryTags("notes about legal work", h.env)).toEqual(expect.arrayContaining(["legal", "work"]));
+    expect(h.scans()).toHaveLength(2);
+  });
+
+  it("rebuilds rather than trusting a blob it cannot read", async () => {
+    for (const blob of ["not json at all", '{"tags":"work"}', "null", '{"rebuiltAt":123}']) {
+      const h = harness(CORPUS);
+      await h.kv.put(TAG_VOCABULARY_KEY, blob);
+      expect(await getTagVocabulary(h.env)).toContain("work");
+      expect(h.scans()).toHaveLength(1);
+      sqlite?.close();
+      sqlite = null;
+    }
+  });
+
+  it("serves a blob whose timestamp is unusable, and reconciles it", async () => {
+    const h = harness(CORPUS);
+    await h.kv.put(TAG_VOCABULARY_KEY, JSON.stringify({ tags: ["kept"], rebuiltAt: "yesterday" }));
+
+    expect(await getTagVocabulary(h.env, h.ctx)).toEqual(["kept"]);
+    await h.ctx.settle();
+    expect(await getTagVocabulary(h.env, h.ctx)).toContain("work");
+  });
+
+  it("still answers when the cache write fails", async () => {
+    const kv = makeMemoryKV();
+    vi.spyOn(kv, "put").mockRejectedValue(new Error("KV unavailable"));
+    const h = harness(CORPUS, { kv });
+
+    expect(await getTagVocabulary(h.env)).toContain("work");
+  });
+
+  it("keeps serving the aged copy when the rebuild behind the response fails", async () => {
+    // A rejection inside waitUntil is not a failed request, but it is an unhandled
+    // rejection unless it is caught — and the vocabulary it was refreshing has to
+    // survive the attempt rather than be cleared by it.
+    const kv = makeMemoryKV();
+    await kv.put(TAG_VOCABULARY_KEY, JSON.stringify({
+      tags: ["work", "legal"],
+      rebuiltAt: Date.now() - TAG_VOCABULARY_MAX_AGE_MS - 1,
+    }));
+    const h = harness(CORPUS, { kv, failScan: true });
+
+    expect(await getTagVocabulary(h.env, h.ctx)).toEqual(["work", "legal"]);
+    await expect(h.ctx.settle()).resolves.toBeUndefined();
+    expect(await getTagVocabulary(h.env, h.ctx)).toEqual(["work", "legal"]);
+  });
+
+  it("swallows a failed write-through rather than failing the capture behind it", async () => {
+    const kv = makeMemoryKV();
+    const h = harness(CORPUS, { kv });
+    await getTagVocabulary(h.env);
+    vi.spyOn(kv, "put").mockRejectedValue(new Error("KV unavailable"));
+
+    await expect(rememberTags(h.env, ["lakehouse"])).resolves.toBeUndefined();
+  });
+});
+
+describe("system tags", () => {
+  const SYSTEM = [
+    { id: "s1", content: "A rolled-up digest of several older memories", tags: ["synthesized", "rolled-up", "work"] },
+    { id: "s2", content: "A memory the staleness pass has looked at", tags: ["volatility:state", "stale:as-of", "work"] },
+  ];
+
+  it("are not part of the vocabulary query inference matches against", async () => {
+    // They say what the system did to an entry, not what it is about, and the only
+    // thing a query tag does is boost entries whose subject overlaps the question.
+    const h = harness(SYSTEM);
+
+    const tags = await inferQueryTags("show me the synthesized rolled-up notes", h.env);
+
+    expect(tags).not.toContain("synthesized");
+    expect(tags).not.toContain("rolled-up");
+  });
+
+  it("still reach GET /tags, which is a browse affordance rather than a ranking input", async () => {
+    const h = harness(SYSTEM);
+
+    const res = await handleEntriesRoutes(req("GET", "/tags"), new URL("http://localhost/tags"), h.env, h.ctx);
+
+    expect(await res!.json()).toEqual(["rolled-up", "stale:as-of", "synthesized", "volatility:state", "work"]);
+  });
+});
+
+describe("GET /tags", () => {
+  it("reads the vocabulary a recall warmed, and scans nothing of its own", async () => {
+    const h = harness(CORPUS);
+    await recallEntries({ query: "office lease renewal", topK: 5 }, h.env, h.ctx);
+    await h.ctx.settle();
+    expect(h.scans()).toHaveLength(1);
+
+    const res = await handleEntriesRoutes(req("GET", "/tags"), new URL("http://localhost/tags"), h.env, h.ctx);
+
+    expect(await res!.json()).toEqual(ALL_TAGS);
+    expect(h.scans()).toHaveLength(1);
+  });
+
+  it("warms the same vocabulary recall then reads", async () => {
+    const h = harness(CORPUS);
+    await handleEntriesRoutes(req("GET", "/tags"), new URL("http://localhost/tags"), h.env, h.ctx);
+    expect(h.scans()).toHaveLength(1);
+
+    await inferQueryTags("notes about legal work", h.env);
+
+    expect(h.scans()).toHaveLength(1);
+  });
+});

--- a/test/integration/update-parity.test.ts
+++ b/test/integration/update-parity.test.ts
@@ -1,0 +1,457 @@
+/**
+ * POST /update and the MCP `update` tool must leave the database in the SAME state.
+ *
+ * They were two implementations of one operation, and the MCP copy — the path every
+ * assistant client actually calls — quietly drifted (#289): it committed content against
+ * stale vectors when an embed failed, never moved updated_at, never reset the staleness
+ * tags, and never extracted hashtags. Every one of those is invisible from the
+ * MCP side alone; each only reads as a bug next to what the route does with the same
+ * input. Nothing compared them, so nothing failed.
+ *
+ * So this suite does not assert what update *should* write. It runs each scenario through
+ * both callers against the same starting row and asserts the resulting rows and vectors are
+ * identical — then, separately, pins the handful of facts that both must satisfy so a
+ * change that breaks them in both places is still caught. Add a scenario to CASES and both
+ * callers are covered by construction.
+ *
+ * Real workerd D1 through Miniflare, not test/helpers/d1-mock. The mock matches query
+ * strings, so it cannot tell a row that was written from one that was not — which is
+ * exactly the distinction the fail-closed path turns on — and it has diverged from
+ * production in this repo before, in both directions.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { Miniflare } from "miniflare";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import worker from "../../src/index";
+import { buildMcpServer } from "../../src/mcp/server";
+import { initializeDatabase, resetDatabaseInit } from "../../src/db/init";
+import { makeAIMock, makeMemoryKV, makeVectorizeMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+
+const ctx = { waitUntil: (_: Promise<unknown>) => {} } as unknown as ExecutionContext;
+
+const ENTRY_ID = "x1";
+/** Fixed, so the two runs of a scenario are byte-identical everywhere the code does not write. */
+const SEEDED_AT = Date.parse("2024-01-17T00:00:00Z");
+
+// ── The world both callers run against ──────────────────────────────────────────────────
+
+/** Vectorize with real insert/upsert/delete semantics, so "what is indexed" is observable. */
+function makeStatefulVectorize(seed: { id: string; content: string }[], overrides: Partial<VectorizeIndex> = {}) {
+  const store = new Map<string, any>();
+  for (const v of seed) store.set(v.id, { id: v.id, values: [], metadata: { content: v.content } });
+  const index = makeVectorizeMock({
+    insert: vi.fn(async (vectors: any[]): Promise<any> => {
+      for (const v of vectors) if (!store.has(v.id)) store.set(v.id, v);
+      return { mutationId: "m" };
+    }),
+    upsert: vi.fn(async (vectors: any[]): Promise<any> => {
+      for (const v of vectors) store.set(v.id, v);
+      return { mutationId: "m" };
+    }),
+    deleteByIds: vi.fn(async (ids: string[]): Promise<any> => {
+      for (const id of ids) store.delete(id);
+      return { mutationId: "m" };
+    }),
+    ...overrides,
+  });
+  return { store, index };
+}
+
+/** Workers AI that embeds normally, or refuses — a transient embed failure is one of these. */
+function makeAI({ embedFails }: { embedFails: boolean }): Ai {
+  if (!embedFails) return makeAIMock();
+  return {
+    run: vi.fn(async () => { throw new Error("AI binding overloaded"); }),
+  } as unknown as Ai;
+}
+
+type World = {
+  /** The entry as it exists before the update. */
+  seed: {
+    content: string;
+    tags: string[];
+    source?: string;
+    vectorIds?: string[];
+    createdAt?: number;
+    updatedAt?: number | null;
+  };
+  /** What is in Vectorize before the update, keyed by vector id. */
+  vectors?: { id: string; content: string }[];
+  /** A single embed call fails, with the index itself healthy — #212's transient case. */
+  embedFails?: boolean;
+  /** describe() throws: Vectorize is not reachable at all — #270's keyword-only deployment. */
+  vectorizeDown?: boolean;
+  /** Retiring the orphaned vectors fails. Non-fatal: the content is already committed. */
+  deleteFails?: boolean;
+  /** A connected integration owns entries with this source, making them read-only. */
+  connectedIntegration?: string;
+};
+
+// ── State capture ───────────────────────────────────────────────────────────────────────
+
+type Snapshot = {
+  row: Record<string, unknown> | null;
+  vectors: { id: string; content: unknown }[];
+};
+
+/**
+ * updated_at is Date.now(), so the two runs cannot produce the same number. Collapsing it
+ * to a marker keeps the comparison meaningful while still failing when one caller writes it
+ * and the other leaves it NULL — which is divergence (b), and the whole reason it is here.
+ * Freshness is asserted separately, against the clock.
+ */
+function normalize(snapshot: Snapshot): Snapshot {
+  if (!snapshot.row) return snapshot;
+  const row = { ...snapshot.row };
+  if (typeof row.updated_at === "number") row.updated_at = "<written>";
+  return { ...snapshot, row };
+}
+
+describe("POST /update and the MCP update tool write identical state (#289)", () => {
+  let mf: Miniflare;
+  let d1: D1Database;
+
+  beforeAll(async () => {
+    mf = new Miniflare({
+      modules: true,
+      script: "export default { fetch() { return new Response('ok'); } };",
+      d1Databases: { DB: "update-parity" },
+    });
+    d1 = (await mf.getD1Database("DB")) as unknown as D1Database;
+    // The real migration, so the columns under test are the ones production has —
+    // updated_at in particular is a runtime ALTER that db/schema.sql does not carry.
+    resetDatabaseInit();
+    await initializeDatabase({ DB: d1 } as Env);
+  }, 30_000);
+
+  afterAll(async () => {
+    await mf?.dispose();
+  });
+
+  function makeEnv(world: World) {
+    const { store, index } = makeStatefulVectorize(world.vectors ?? [], {
+      ...(world.vectorizeDown ? { describe: vi.fn(async () => { throw new Error("no such index"); }) } : {}),
+      ...(world.deleteFails ? { deleteByIds: vi.fn(async () => { throw new Error("delete failed"); }) } : {}),
+    });
+    const OAUTH_KV = makeMemoryKV();
+    const env = {
+      DB: d1,
+      VECTORIZE: index,
+      AI: makeAI({ embedFails: world.embedFails ?? world.vectorizeDown ?? false }),
+      AUTH_TOKEN: "test-token",
+      OAUTH_KV,
+    } as unknown as Env;
+    return { env, store, OAUTH_KV };
+  }
+
+  /**
+   * A world, from scratch. Called once per caller, so the second run starts from exactly
+   * the row the first one did rather than from what the first one left behind.
+   */
+  async function setUp(world: World) {
+    await d1.prepare(`DELETE FROM entries`).run();
+    const { env, store, OAUTH_KV } = makeEnv(world);
+    if (world.connectedIntegration) {
+      await OAUTH_KV.put(
+        `integrations:${world.connectedIntegration}`,
+        JSON.stringify({ provider: world.connectedIntegration, status: "connected", itemMap: {} }),
+      );
+    }
+    const s = world.seed;
+    await d1.prepare(
+      `INSERT INTO entries (id, content, tags, source, created_at, updated_at, vector_ids, recall_count, importance_score)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 0, 3)`,
+    ).bind(
+      ENTRY_ID,
+      s.content,
+      JSON.stringify(s.tags),
+      s.source ?? "claude",
+      s.createdAt ?? SEEDED_AT,
+      s.updatedAt ?? null,
+      JSON.stringify(s.vectorIds ?? [ENTRY_ID]),
+    ).run();
+    return { env, store };
+  }
+
+  async function capture(store: Map<string, any>): Promise<Snapshot> {
+    const row = await d1.prepare(`SELECT * FROM entries WHERE id = ?`).bind(ENTRY_ID).first();
+    return {
+      row: (row as Record<string, unknown> | null) ?? null,
+      vectors: [...store.values()]
+        .map(v => ({ id: v.id as string, content: v.metadata?.content }))
+        .sort((a, b) => a.id.localeCompare(b.id)),
+    };
+  }
+
+  /** POST /update, through the whole Worker. */
+  async function viaHttp(world: World, content: string) {
+    const { env, store } = await setUp(world);
+    const res = await worker.fetch(req("POST", "/update", { body: { id: ENTRY_ID, content } }), env, ctx);
+    const body = await res.json() as any;
+    return { snapshot: await capture(store), status: res.status, reply: body.message ?? body.error ?? "" };
+  }
+
+  /** The MCP `update` tool, through a real MCP client and transport. */
+  async function viaMcp(world: World, content: string) {
+    const { env, store } = await setUp(world);
+    const server = buildMcpServer(env, ctx);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "parity-client", version: "1.0.0" });
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+    try {
+      const result = await client.callTool({ name: "update", arguments: { id: ENTRY_ID, content } });
+      const reply = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+      return { snapshot: await capture(store), reply };
+    } finally {
+      await client.close();
+    }
+  }
+
+  // ── The scenarios ─────────────────────────────────────────────────────────────────────
+
+  type Case = {
+    name: string;
+    world: World;
+    content: string;
+    /** Facts both callers must satisfy. Parity alone would pass if both were wrong. */
+    expect: (snapshot: Snapshot) => void;
+  };
+
+  const tagsOf = (snapshot: Snapshot) => JSON.parse((snapshot.row!.tags as string) ?? "[]") as string[];
+
+  const CASES: Case[] = [
+    {
+      name: "healthy re-index",
+      world: { seed: { content: "I live in Berlin", tags: ["home"] }, vectors: [{ id: ENTRY_ID, content: "I live in Berlin" }] },
+      content: "I live in Lisbon",
+      expect: (s) => {
+        expect(s.row!.content).toBe("I live in Lisbon");
+        // The vector the entry is keyed by holds the new text, not the old.
+        expect(s.vectors).toEqual([{ id: ENTRY_ID, content: "I live in Lisbon" }]);
+        expect(JSON.parse(s.row!.vector_ids as string)).toEqual([ENTRY_ID]);
+      },
+    },
+    {
+      name: "(b) staleness verdicts are cleared and updated_at moves",
+      world: {
+        seed: {
+          content: "I live in Berlin",
+          tags: ["home", "volatility:state", "stale:as-of"],
+          updatedAt: SEEDED_AT,
+        },
+      },
+      content: "I live in Lisbon",
+      expect: (s) => {
+        // The verdicts described the content that was just replaced. Left behind, recall
+        // reports a seconds-old correction as years stale and hedges the answer built on it.
+        expect(tagsOf(s)).toEqual(["home"]);
+        // And a stationary updated_at leaves the row a permanent staleness-pass candidate,
+        // so the tag comes straight back on the next nightly run.
+        expect(s.row!.updated_at as number).toBeGreaterThan(Date.parse("2025-01-01T00:00:00Z"));
+      },
+    },
+    {
+      name: "(c) hashtags are extracted from the new content",
+      world: { seed: { content: "I live in Berlin", tags: ["home"] } },
+      content: "Moving to Lisbon #relocation",
+      expect: (s) => {
+        expect(s.row!.content).toBe("Moving to Lisbon");
+        expect(tagsOf(s)).toEqual(["home", "relocation"]);
+      },
+    },
+    {
+      name: "(c) extraction flattens whitespace, including inside a fenced code block",
+      world: { seed: { content: "old runbook", tags: ["ops"] } },
+      content: "Runbook:\n\n1. drain\n2. deploy\n\n```sh\nnpm run deploy\n```\n\nTicket #4821",
+      expect: (s) => {
+        // Spelled out because it is destructive and, for the MCP path, new: the private copy
+        // stored content verbatim. extractHashtags collapses every whitespace run to one
+        // space and removes every #token unconditionally, so line breaks, list structure and
+        // code fences do not survive a replacement, and a bare issue reference becomes a tag.
+        // This is not a regression — captureEntry has always done it, so `remember` through
+        // this same transport produces a byte-identical row, and POST /update already did it.
+        // Divergence was the bug; this is what agreeing with the rest of the write path costs.
+        //
+        // `append` deliberately does NOT flatten: it embeds the addition verbatim after a
+        // "[Update <date>]: " separator (src/capture/store.ts), so newlines survive there.
+        // Reach for append, not update, when the text's shape matters.
+        expect(s.row!.content).toBe("Runbook: 1. drain 2. deploy ```sh npm run deploy ``` Ticket");
+        expect(tagsOf(s)).toEqual(["ops", "4821"]);
+      },
+    },
+    {
+      name: "a hashtag already held as a tag is not duplicated",
+      world: { seed: { content: "Berlin flat", tags: ["home"] } },
+      content: "Lisbon flat #home",
+      expect: (s) => expect(tagsOf(s)).toEqual(["home"]),
+    },
+    {
+      name: "content that is nothing but hashtags is kept verbatim",
+      world: { seed: { content: "Berlin flat", tags: ["home"] } },
+      content: "#lisbon",
+      expect: (s) => {
+        expect(s.row!.content).toBe("#lisbon");
+        expect(tagsOf(s)).toEqual(["home", "lisbon"]);
+      },
+    },
+    {
+      name: "rolled-up is dropped: the digest marker it annotated is gone with the old content",
+      world: { seed: { content: "Berlin flat\n\n[Digest: d9]", tags: ["home", "rolled-up"] } },
+      content: "Lisbon flat",
+      expect: (s) => {
+        expect(tagsOf(s)).toEqual(["home"]);
+        expect(s.row!.content).toBe("Lisbon flat");
+      },
+    },
+    {
+      name: "(a) a transient embed failure against a healthy index fails closed",
+      world: {
+        seed: { content: "I live in Berlin", tags: ["home"] },
+        vectors: [{ id: ENTRY_ID, content: "I live in Berlin" }],
+        embedFails: true,
+      },
+      content: "I live in Lisbon",
+      expect: (s) => {
+        // Committing here would leave D1 saying Lisbon and Vectorize saying Berlin, with a
+        // non-empty vector_ids — so /vectorize-pending and /stats.unvectorized, which both
+        // select vector_ids = '[]', would never see it and recall would answer Berlin forever.
+        expect(s.row!.content).toBe("I live in Berlin");
+        expect(s.row!.updated_at).toBeNull();
+        expect(s.vectors).toEqual([{ id: ENTRY_ID, content: "I live in Berlin" }]);
+      },
+    },
+    {
+      name: "Vectorize unreachable commits keyword-only and keeps the old index",
+      world: {
+        seed: { content: "I live in Berlin", tags: ["home"] },
+        vectors: [{ id: ENTRY_ID, content: "I live in Berlin" }],
+        vectorizeDown: true,
+      },
+      content: "I live in Lisbon",
+      expect: (s) => {
+        // Keyword search reads entries.content, so the correction is still findable.
+        expect(s.row!.content).toBe("I live in Lisbon");
+        // The old vectors are the entry's only remaining semantic index — retiring them
+        // would make it unsearchable rather than merely stale.
+        expect(JSON.parse(s.row!.vector_ids as string)).toEqual([ENTRY_ID]);
+        expect(s.vectors).toEqual([{ id: ENTRY_ID, content: "I live in Berlin" }]);
+      },
+    },
+    {
+      name: "a multi-chunk entry shrinking to one chunk retires only the orphan",
+      world: {
+        seed: { content: "long original", tags: ["work"], vectorIds: [ENTRY_ID, `${ENTRY_ID}-chunk-1`] },
+        vectors: [
+          { id: ENTRY_ID, content: "long original" },
+          { id: `${ENTRY_ID}-chunk-1`, content: "long original tail" },
+        ],
+      },
+      content: "short replacement",
+      expect: (s) => {
+        // The re-embed reuses the entry id, so that vector must survive its own cleanup.
+        expect(s.vectors).toEqual([{ id: ENTRY_ID, content: "short replacement" }]);
+        expect(JSON.parse(s.row!.vector_ids as string)).toEqual([ENTRY_ID]);
+      },
+    },
+    {
+      name: "a failed retirement of the orphaned vector does not undo the update",
+      world: {
+        seed: { content: "long original", tags: ["work"], vectorIds: [ENTRY_ID, `${ENTRY_ID}-chunk-1`] },
+        vectors: [
+          { id: ENTRY_ID, content: "long original" },
+          { id: `${ENTRY_ID}-chunk-1`, content: "long original tail" },
+        ],
+        deleteFails: true,
+      },
+      content: "short replacement",
+      expect: (s) => {
+        // The new vectors are already in place, so the leftover orphan is a tidiness
+        // problem, not a correctness one — rolling the content back would be worse.
+        expect(s.row!.content).toBe("short replacement");
+        expect(JSON.parse(s.row!.vector_ids as string)).toEqual([ENTRY_ID]);
+      },
+    },
+    {
+      name: "an entry owned by a connected integration is refused before anything is written",
+      world: { seed: { content: "Synced page", tags: ["notion"], source: "notion" }, connectedIntegration: "notion" },
+      content: "Hand-edited",
+      expect: (s) => {
+        expect(s.row!.content).toBe("Synced page");
+        expect(s.row!.updated_at).toBeNull();
+      },
+    },
+  ];
+
+  it.each(CASES)("$name — both callers agree", async ({ world, content, expect: assertFacts }) => {
+    const http = await viaHttp(world, content);
+    const mcp = await viaMcp(world, content);
+
+    expect(normalize(mcp.snapshot)).toEqual(normalize(http.snapshot));
+    assertFacts(http.snapshot);
+    assertFacts(mcp.snapshot);
+  });
+
+  it("a missing entry leaves both callers with nothing to write", async () => {
+    const world: World = { seed: { content: "present", tags: [] } };
+
+    const { env: httpEnv, store: httpStore } = await setUp(world);
+    const res = await worker.fetch(req("POST", "/update", { body: { id: "nope", content: "x" } }), httpEnv, ctx);
+    expect(res.status).toBe(404);
+    const httpSnapshot = await capture(httpStore);
+
+    const { env: mcpEnv, store: mcpStore } = await setUp(world);
+    const server = buildMcpServer(mcpEnv, ctx);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "parity-client", version: "1.0.0" });
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+    let reply = "";
+    try {
+      const result = await client.callTool({ name: "update", arguments: { id: "nope", content: "x" } });
+      reply = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+    } finally {
+      await client.close();
+    }
+
+    expect(reply).toMatch(/No entry found with ID: nope/);
+    expect(normalize(await capture(mcpStore))).toEqual(normalize(httpSnapshot));
+  });
+
+  // ── The replies, which are the one thing that legitimately differs ─────────────────────
+
+  it("the MCP tool reports a failed re-index as a failure, not as a success", async () => {
+    // It used to answer "Updated entry x1. Re-embedded as 0 vector(s)." on this path, which
+    // reads as success and is what let a mis-indexed entry go unnoticed. The route already
+    // 500s here; the tool now says the same thing in its own voice.
+    const world: World = {
+      seed: { content: "I live in Berlin", tags: ["home"] },
+      vectors: [{ id: ENTRY_ID, content: "I live in Berlin" }],
+      embedFails: true,
+    };
+
+    const http = await viaHttp(world, "I live in Lisbon");
+    expect(http.status).toBe(500);
+    expect(http.reply).toMatch(/Your memory is unchanged/);
+
+    const mcp = await viaMcp(world, "I live in Lisbon");
+    expect(mcp.reply).not.toMatch(/^Updated entry/);
+    expect(mcp.reply).toMatch(/Your memory is unchanged/);
+  });
+
+  it("the MCP tool flags the keyword-only degrade instead of claiming a re-index", async () => {
+    const mcp = await viaMcp(
+      { seed: { content: "I live in Berlin", tags: ["home"] }, vectorizeDown: true },
+      "I live in Lisbon",
+    );
+    expect(mcp.reply).toMatch(/Updated entry x1/);
+    expect(mcp.reply).toMatch(/not re-indexed for semantic search/);
+    expect(mcp.reply).toMatch(/wrangler vectorize create/);
+  });
+
+  it("the MCP tool still reports the vector count on the healthy path", async () => {
+    const mcp = await viaMcp({ seed: { content: "I live in Berlin", tags: ["home"] } }, "I live in Lisbon");
+    expect(mcp.reply).toBe("Updated entry x1. Re-embedded as 1 vector(s).");
+  });
+});

--- a/test/unit/calendar.test.ts
+++ b/test/unit/calendar.test.ts
@@ -209,6 +209,149 @@ describe("parseAndExpand", () => {
     const occs = parseAndExpand(ics, ms("2026-07-01T00:00:00Z"), ms("2026-07-31T00:00:00Z"));
     expect(occs).toEqual([]);
   });
+
+  // ── The reach bound (#290) ──────────────────────────────────────────────
+  // The walk rejects spent occurrences from the iterator's own time so it does
+  // not have to build them, which is where the expansion's CPU went. These are
+  // the two cases where an occurrence whose recurrence time is BEFORE the
+  // window is nonetheless in it — i.e. exactly what a naive start-time skip
+  // would silently drop.
+
+  it("keeps a long-running instance that began before the window and is still running", () => {
+    const ics = calendar(
+      vevent([
+        "UID:long-run@test",
+        "DTSTAMP:20260101T000000Z",
+        // Weekly nine-day event: the instance starting 2026-06-29 runs to 07-08,
+        // so it overlaps a window that opens on 07-01 despite starting before it.
+        "DTSTART:20260105T090000Z",
+        "DTEND:20260114T170000Z",
+        "RRULE:FREQ=WEEKLY",
+        "SUMMARY:Long Conference",
+      ]),
+    );
+    const occs = parseAndExpand(ics, ms("2026-07-01T00:00:00Z"), ms("2026-07-02T00:00:00Z"));
+    expect(occs.length).toBeGreaterThan(0);
+    expect(occs.every(o => o.summary === "Long Conference")).toBe(true);
+    // At least one of them started before the window opened.
+    expect(occs.some(o => o.start < ms("2026-07-01T00:00:00Z"))).toBe(true);
+  });
+
+  // The bound is measured in absolute milliseconds; ical.js builds occurrences by
+  // adding a WALL-CLOCK duration in the event's own zone. These two cases are
+  // where those disagree. Both need a constructed calendar — a fuzz run over
+  // random windows practically never lands in the affected band.
+  const NEW_YORK_VTIMEZONE = [
+    "BEGIN:VTIMEZONE",
+    "TZID:America/New_York",
+    "BEGIN:DAYLIGHT",
+    "TZOFFSETFROM:-0500",
+    "TZOFFSETTO:-0400",
+    "TZNAME:EDT",
+    "DTSTART:19700308T020000",
+    "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU",
+    "END:DAYLIGHT",
+    "BEGIN:STANDARD",
+    "TZOFFSETFROM:-0400",
+    "TZOFFSETTO:-0500",
+    "TZNAME:EST",
+    "DTSTART:19701101T020000",
+    "RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU",
+    "END:STANDARD",
+    "END:VTIMEZONE",
+  ].join("\r\n");
+
+  it("keeps an instance that runs long because it spans a fall-back transition", () => {
+    // Weekly Sat 23:00–01:00 New York: two hours on the wall. The instance
+    // starting 2024-11-02 23:00 EDT ends at an 01:00 that happens twice, so it
+    // runs THREE absolute hours — an hour past where a wall-clock bound lands.
+    const ics = calendar(
+      NEW_YORK_VTIMEZONE,
+      vevent([
+        "UID:fallback@test",
+        "DTSTAMP:20240101T000000Z",
+        "DTSTART;TZID=America/New_York:20241005T230000",
+        "DTEND;TZID=America/New_York:20241006T010000",
+        "RRULE:FREQ=WEEKLY",
+        "SUMMARY:Late Show",
+      ]),
+    );
+    // Window opens 2.5h into that occurrence — inside the hour it is still
+    // running but a two-hour bound has already written off.
+    const occs = parseAndExpand(ics, ms("2024-11-03T05:30:00Z"), ms("2024-11-03T12:00:00Z"));
+    expect(occs.map(o => o.start)).toContain(ms("2024-11-03T03:00:00Z"));
+  });
+
+  // The single case above is one point inside one band. This sweeps the whole
+  // transition weekend against a reference expansion that cannot skip anything
+  // (its window opens a month earlier), which is the property that actually
+  // matters: the skip must never change the result, whatever minute the window
+  // happens to open on. A bound short by any amount fails here.
+  it("stays exact minute by minute across a DST transition", () => {
+    const ics = calendar(
+      NEW_YORK_VTIMEZONE,
+      vevent([
+        "UID:evening@test", "DTSTAMP:20240101T000000Z",
+        "DTSTART;TZID=America/New_York:20240106T230000",
+        "DTEND;TZID=America/New_York:20240107T010000",
+        "RRULE:FREQ=WEEKLY", "SUMMARY:Late Show",
+      ]),
+      // Master straddling the spring-forward gap: two hours on the wall, one
+      // absolute, so the whole series is bounded off that shorter measurement.
+      vevent([
+        "UID:gap-master@test", "DTSTAMP:20240101T000000Z",
+        "DTSTART;TZID=America/New_York:20240310T013000",
+        "DTEND;TZID=America/New_York:20240310T033000",
+        "RRULE:FREQ=WEEKLY", "SUMMARY:Sunday Session",
+      ]),
+      // An hour that lands inside the repeated hour itself.
+      vevent([
+        "UID:repeated-hour@test", "DTSTAMP:20240101T000000Z",
+        "DTSTART;TZID=America/New_York:20240107T013000",
+        "DTEND;TZID=America/New_York:20240107T023000",
+        "RRULE:FREQ=WEEKLY", "SUMMARY:Small Hours",
+      ]),
+    );
+    const windowEnd = ms("2024-11-10T00:00:00Z");
+    const reference = parseAndExpand(ics, ms("2024-10-01T00:00:00Z"), windowEnd);
+    expect(reference.length).toBeGreaterThan(0);
+
+    // Two-minute steps either side of the 06:00Z transition. The error this
+    // guards against is an offset change, so it is never finer than the
+    // half-hour Lord Howe shifts by, let alone the hour everywhere else.
+    for (let t = ms("2024-11-03T02:00:00Z"); t <= ms("2024-11-03T08:00:00Z"); t += 120_000) {
+      // parseAndExpand keeps an occurrence when it has not yet ended at the
+      // window's start, so the reference filtered by that rule is the answer.
+      const expected = reference.filter(o => o.end >= t).map(o => o.key).sort();
+      const actual = parseAndExpand(ics, t, windowEnd).map(o => o.key).sort();
+      expect(actual, `window opening ${new Date(t).toISOString()}`).toEqual(expected);
+    }
+  });
+
+  it("keeps an instance an override moved forward into the window", () => {
+    const ics = calendar(
+      vevent([
+        "UID:moved@test",
+        "DTSTAMP:20260101T000000Z",
+        "DTSTART:20260601T090000Z",
+        "DTEND:20260601T100000Z",
+        "RRULE:FREQ=WEEKLY",
+        "SUMMARY:Standup",
+      ]),
+      vevent([
+        "UID:moved@test",
+        // Nominally 2026-06-22, three weeks before the window — but pushed out
+        // to 2026-07-10, which is inside it.
+        "RECURRENCE-ID:20260622T090000Z",
+        "DTSTAMP:20260101T000000Z",
+        "DTSTART:20260710T090000Z",
+        "DTEND:20260710T100000Z",
+        "SUMMARY:Standup (moved)",
+      ]),
+    );
+    const occs = parseAndExpand(ics, ms("2026-07-09T00:00:00Z"), ms("2026-07-11T00:00:00Z"));
+    expect(occs.map(o => o.summary)).toContain("Standup (moved)");
+  });
 });
 
 describe("computeCalendarPlan", () => {

--- a/test/unit/compress-tag.test.ts
+++ b/test/unit/compress-tag.test.ts
@@ -270,6 +270,46 @@ describe("compressTag()", () => {
     expect(env.AI.run).not.toHaveBeenCalled();
   });
 
+  // The candidate query excludes these, so reaching here means something else called
+  // compressTag directly. It matters more than it looks: without the guard a digest gets
+  // built for "everything the staleness pass touched", and markSourcesRolledUp then rolls
+  // up every one of those sources — taking them out of the running for the real topics
+  // they were also tagged with.
+  it("refuses to compress a volatility:* namespaced tag", async () => {
+    seedEntries(db, "volatility:state", 15, { recall_count: 0 });
+    const { ctx } = makeCtx();
+    const result = await compressTag("volatility:state", env, ctx);
+    expect(result.synthesizedId).toBeNull();
+    expect(env.AI.run).not.toHaveBeenCalled();
+    for (const e of db.entries) expect(JSON.parse(e.tags)).not.toContain("rolled-up");
+  });
+
+  it("refuses to compress the stale:as-of tag", async () => {
+    seedEntries(db, "stale:as-of", 15, { recall_count: 0 });
+    const { ctx } = makeCtx();
+    const result = await compressTag("stale:as-of", env, ctx);
+    expect(result.synthesizedId).toBeNull();
+    expect(env.AI.run).not.toHaveBeenCalled();
+    for (const e of db.entries) expect(JSON.parse(e.tags)).not.toContain("rolled-up");
+  });
+
+  // Mixed case is the dangerous form, not a curiosity. The source selector below this guard
+  // is `tags LIKE '%"<tag>"%'`, and LIKE ignores ASCII case — so `Kind:Semantic` reaching
+  // compressTag does not roll up the entries tagged `Kind:Semantic`, it rolls up every
+  // entry tagged `kind:semantic`. The guard has to reject it before that query runs.
+  it.each(["Kind:Semantic", "Status:Active", "Volatility:State", "Stale:As-Of", "STALE:AS-OF"])(
+    "refuses to compress %s regardless of case",
+    async (tag) => {
+      seedEntries(db, tag.toLowerCase(), 15, { recall_count: 0 });
+      const { ctx } = makeCtx();
+      const result = await compressTag(tag, env, ctx);
+      expect(result.synthesizedId).toBeNull();
+      expect(result.entriesUsed).toBe(0);
+      expect(env.AI.run).not.toHaveBeenCalled();
+      for (const e of db.entries) expect(JSON.parse(e.tags)).not.toContain("rolled-up");
+    },
+  );
+
   // ── Marking sources rolled-up (#278) ─────────────────────────────────────────
   //
   // All four nightly jobs share one scheduled() invocation and therefore one

--- a/test/unit/compression-eligibility.test.ts
+++ b/test/unit/compression-eligibility.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { compressionEligibilitySql, COMPRESSION_MIN_RECALL } from "../../src/compression/eligibility";
+import { compressionEligibilitySql, COMPRESSION_MIN_RECALL, isReservedTag, isTopicTag, isTopicTagSql } from "../../src/compression/eligibility";
+import { STATUS_PREFIX } from "../../src/memory/status";
+import { KIND_PREFIX } from "../../src/memory/kind";
+import { VOLATILITY_PREFIX } from "../../src/memory/volatility";
+import { STALE_AS_OF } from "../../src/memory/stale";
 
 describe("compressionEligibilitySql", () => {
   it("includes the importance, recall+age, and contradiction-win clauses", () => {
@@ -29,5 +33,80 @@ describe("compressionEligibilitySql", () => {
   it("defaults to no prefix", () => {
     const sql = compressionEligibilitySql();
     expect(sql).not.toContain("entries.");
+  });
+});
+
+// The TS predicate and the SQL fragment are two encodings of one rule, and only the TS one
+// is reachable from the D1 mock — so a rule that exists in isTopicTag but not in
+// isTopicTagSql would pass every mock-based test while production kept the old behaviour.
+// These bind both encodings to the same constants.
+describe("reserved tags", () => {
+  const RESERVED = [`${STATUS_PREFIX}canonical`, `${KIND_PREFIX}semantic`, `${VOLATILITY_PREFIX}state`, STALE_AS_OF];
+
+  it("rejects every reserved namespace", () => {
+    for (const tag of RESERVED) {
+      expect(isReservedTag(tag)).toBe(true);
+      expect(isTopicTag(tag)).toBe(false);
+    }
+  });
+
+  it("excludes every reserved namespace from the SQL too", () => {
+    const sql = isTopicTagSql();
+    for (const prefix of [STATUS_PREFIX, KIND_PREFIX, VOLATILITY_PREFIX]) {
+      expect(sql).toContain(`value NOT LIKE '${prefix}%'`);
+    }
+    expect(sql).toContain(`value NOT LIKE '${STALE_AS_OF}'`);
+  });
+
+  // Reserving is case-INsensitive on both sides, and the asymmetry is the reason: a
+  // mixed-case reserved tag that reaches compressTag is matched against sources with
+  // `tags LIKE`, which ignores case, so it rolls up every entry carrying the lowercase
+  // system tag. Over-reserving costs one un-digested tag; under-reserving costs memories.
+  // GLOB or `<>` here would be case-sensitive and let those tags through.
+  it("reserves the namespace whatever its case", () => {
+    expect(isTopicTagSql()).not.toContain("GLOB");
+    expect(isTopicTagSql()).not.toContain("<>");
+    for (const tag of ["Status:Active", "Kind:Personal", "Volatility:High", "Stale:As-Of", "STALE:AS-OF"]) {
+      expect(isReservedTag(tag)).toBe(true);
+      expect(isTopicTag(tag)).toBe(false);
+    }
+  });
+
+  it("treats bookkeeping tags as non-topics whatever their case", () => {
+    for (const tag of ["SYNTHESIZED", "Duplicate-Candidate", "Rolled-Up", "Contradiction-Resolved"]) {
+      expect(isTopicTag(tag)).toBe(false);
+    }
+    expect(isTopicTagSql()).toContain("lower(value) NOT IN");
+  });
+
+  // The SQL now matches these with LIKE, where % and _ are wildcards. No constant contains
+  // one today; this keeps it that way, because a stray _ would silently widen the match.
+  it("keeps every constant free of LIKE metacharacters", () => {
+    const sql = isTopicTagSql();
+    const literals = [...sql.matchAll(/'([^']*)'/g)].map(m => m[1]);
+    expect(literals.length).toBeGreaterThan(0);
+    for (const literal of literals) {
+      expect(literal.replace(/%$/, "")).not.toMatch(/[%_]/);
+      expect(literal).toBe(literal.toLowerCase());
+    }
+  });
+
+  it("treats compression bookkeeping tags as non-topics without calling them reserved", () => {
+    for (const tag of ["synthesized", "auto-pattern", "duplicate-candidate", "contradiction-resolved", "rolled-up"]) {
+      expect(isTopicTag(tag)).toBe(false);
+      expect(isReservedTag(tag)).toBe(false); // compressTag's guard is about namespaces only
+      expect(isTopicTagSql()).toContain(`'${tag}'`);
+    }
+  });
+
+  it("reserves the namespace, not the bare word", () => {
+    for (const tag of ["volatility", "stale", "status", "kind", "work"]) {
+      expect(isTopicTag(tag)).toBe(true); // a user may legitimately tag something "stale"
+    }
+  });
+
+  it("applies to whatever column it is given", () => {
+    expect(isTopicTagSql("entries.tag")).toContain(`entries.tag NOT LIKE '${VOLATILITY_PREFIX}%'`);
+    expect(isTopicTagSql()).not.toContain("?"); // no placeholders — safe to inline anywhere
   });
 });

--- a/test/unit/config-parity.test.ts
+++ b/test/unit/config-parity.test.ts
@@ -93,8 +93,9 @@ describe("config rule coverage", () => {
 
   it("platform limits are absent from the config surface", () => {
     // Exposing these guarantees breakage rather than risking it: Vectorize
-    // rejects >20 ids per call, D1 caps bound params at 100.
-    for (const forbidden of ["VECTORIZE_GET_BY_IDS_BATCH", "D1_MAX_BOUND_PARAMS", "EDGE_QUERY_BATCH"]) {
+    // rejects >20 ids per call, D1 caps bound params at 100 and refuses an
+    // expression tree deeper than 100 (#276).
+    for (const forbidden of ["VECTORIZE_GET_BY_IDS_BATCH", "D1_MAX_BOUND_PARAMS", "EDGE_QUERY_BATCH", "KEYWORD_MAX_TOKENS"]) {
       expect(DEFAULTS).not.toHaveProperty(forbidden);
     }
   });

--- a/test/unit/cron-subrequest-budget.test.ts
+++ b/test/unit/cron-subrequest-budget.test.ts
@@ -1,8 +1,13 @@
 /**
  * All four nightly jobs are fired from a single scheduled() invocation (src/index.ts),
  * so they share ONE subrequest budget — 50 on the free plan. Each of them awaits
- * initializeDatabase, so before it was memoised the same dozen DDL statements were paid
+ * initializeDatabase, so before it was memoised the same thirteen DDL statements were paid
  * for once per job, and the pass that runs last could find the budget already spent.
+ *
+ * Memoisation cut that to thirteen; #282 cut the thirteen to a single catalogue read
+ * on any brain that is already migrated, which every brain is after its first request.
+ * The D1 mock answers the probe as a migrated brain, which is what a nightly cron always
+ * runs against — a brain with no schema has no entries to compress.
  *
  * This measures the whole invocation rather than any one job, because per-job budget
  * assertions are not true in situ.
@@ -67,7 +72,7 @@ describe("nightly cron D1 subrequest cost", () => {
     vi.restoreAllMocks();
   });
 
-  it("pays for the schema DDL once per invocation, not once per job", async () => {
+  it("probes the schema once per invocation, not once per job, and issues no DDL", async () => {
     const db = makeTestDb();
     const old = Date.now() - STALENESS_AGE_MS - 86400000;
     for (let i = 0; i < 25; i++) {
@@ -81,8 +86,10 @@ describe("nightly cron D1 subrequest cost", () => {
     await runCron(env);
 
     // The signature statement of initializeDatabase, once for the whole cron.
-    const ddl = statements.filter(s => s.startsWith("CREATE TABLE IF NOT EXISTS entries"));
-    expect(ddl).toHaveLength(1);
+    expect(statements.filter(s => s.startsWith("SELECT type AS kind, name FROM sqlite_master"))).toHaveLength(1);
+    // #282: the schema is already there, and the whole point is that finding that out no
+    // longer costs a CREATE and an ALTER per object.
+    expect(statements.filter(s => /^(CREATE|ALTER)\b/.test(s))).toEqual([]);
   });
 
   // The staleness pass used to be the largest consumer of this budget: one CAS per

--- a/test/unit/cron-subrequest-budget.test.ts
+++ b/test/unit/cron-subrequest-budget.test.ts
@@ -12,20 +12,25 @@
  * This measures the whole invocation rather than any one job, because per-job budget
  * assertions are not true in situ.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import worker from "../../src/index";
 import { resetDatabaseInit } from "../../src/db/init";
+import { SYNC_EVENT_BATCH } from "../../src/integrations/calendar";
 import { STALENESS_AGE_MS } from "../../src/staleness/pass";
-import { makeTestDb, makeTestEnv, makeVectorizeMock } from "../helpers/make-env";
+import { makeTestDb, makeTestEnv, makeVectorizeMock, makeMemoryKV } from "../helpers/make-env";
 import { D1Mock } from "../helpers/d1-mock";
+import type { Env } from "../../src/env";
+import { INTEGRATION_SYNC_CRON } from "../../src/integrations/mirror";
+import { INTEGRATION_PROVIDERS } from "../../src/integrations";
 
 const FREE_PLAN_SUBREQUESTS = 50;
+const MAINTENANCE_CRON = "0 1 * * *";
 
 // D1 bills EXECUTIONS: run/first/all/exec spend one each, and a batch() spends one however
 // many statements it carries. Counting prepares instead would price the batched writes in
 // the compression and staleness passes as if they were still one round trip per row —
 // which is exactly the cost this budget is meant to track.
-function countingEnv(db: D1Mock) {
+function countingEnv(db: D1Mock, overrides: Partial<Env> = {}) {
   const statements: string[] = [];
   const bill = (sql: string) => statements.push(sql.replace(/\s+/g, " ").trim());
   const wrap = (stmt: any, sql: string): any => ({
@@ -41,7 +46,7 @@ function countingEnv(db: D1Mock) {
     exec(sql: string) { bill(sql); return db.exec(sql); },
     batch: (stmts: any[]) => { bill("BATCH"); return db.batch(stmts.map((s: any) => s.__inner ?? s)); },
   } as unknown as D1Database;
-  return { env: makeTestEnv(db, { DB, VECTORIZE: makeVectorizeMock() }), statements, prepared };
+  return { env: makeTestEnv(db, { DB, VECTORIZE: makeVectorizeMock(), ...overrides }), statements, prepared };
 }
 
 // Each tag gets more than the ten eligible entries a digest needs, so nightly compression
@@ -59,10 +64,74 @@ function seedCompressibleTags(db: D1Mock, tagCount: number) {
   }
 }
 
-async function runCron(env: any) {
+// ─── Integration fixture ──────────────────────────────────────────────────────
+// A connected calendar with a backlog far larger than one batch, so the cron is
+// measured with the integration job doing as much work as it is ever allowed to.
+
+function icsUtc(ms: number): string {
+  return new Date(ms).toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+}
+
+function icsWithUpcomingEvents(count: number): string {
+  const now = Date.now();
+  const lines = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//Test//EN"];
+  for (let i = 0; i < count; i++) {
+    const start = now + (i + 1) * 3600_000; // hourly, inside the 30-day window
+    lines.push(
+      "BEGIN:VEVENT", `UID:evt-${i}@test`, `DTSTAMP:${icsUtc(now)}`,
+      `DTSTART:${icsUtc(start)}`, `DTEND:${icsUtc(start + 1800_000)}`,
+      `SUMMARY:Event ${i}`, "END:VEVENT",
+    );
+  }
+  lines.push("END:VCALENDAR");
+  return lines.join("\r\n");
+}
+
+// The feed URL carries the provider id so a stubbed fetch can tell the
+// connections apart when more than one is wired up.
+async function connectCalendar(
+  kv: KVNamespace,
+  eventCount: number,
+  providers: string[] = ["calendar-google"],
+): Promise<ReturnType<typeof vi.fn>> {
+  for (const [i, id] of providers.entries()) {
+    await kv.put(`integrations:${id}`, JSON.stringify({
+      provider: id,
+      authKind: "token",
+      credentials: { token: `https://cal.example/${id}/feed.ics` },
+      config: {},
+      status: "connected",
+      workspaceName: id,
+      lastSyncedAt: null,
+      lastSyncError: null,
+      itemMap: {},
+      createdAt: 0,
+      // Distinct so the rotation has a defined starting order.
+      updatedAt: i,
+    }));
+  }
+  const ics = icsWithUpcomingEvents(eventCount);
+  const fetchMock = vi.fn(async () => ({ ok: true, status: 200, text: async () => ics }) as any);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+// Consecutive runs in a test land in the same millisecond, which the real
+// schedule never does — and the rotation cursor is a timestamp, so equal
+// timestamps tie and registry order wins every time. Step a fake clock by an
+// hour per run so a multi-run test models the schedule it is describing.
+function hourlyClock(): (run: number) => void {
+  const base = Date.now();
+  const spy = vi.spyOn(Date, "now");
+  return (run: number) => spy.mockReturnValue(base + run * 3600_000);
+}
+
+// `cron` selects which invocation is being measured — the two schedules are two
+// separate budgets, so a run has to name the one it means (#290).
+async function runCron(env: any, cron = MAINTENANCE_CRON) {
   const pending: Promise<any>[] = [];
   const ctx = { waitUntil: (p: Promise<any>) => pending.push(p) } as any;
-  await (worker as any).scheduled({} as any, env, ctx);
+  await (worker as any).scheduled({ cron } as any, env, ctx);
   await Promise.allSettled(pending);
 }
 
@@ -137,5 +206,200 @@ describe("nightly cron D1 subrequest cost", () => {
 
     const tags: string[] = JSON.parse(db.entries.find(e => e.id === "job")!.tags);
     expect(tags).toContain("stale:as-of");
+  });
+
+  // ─── The integration sync's own invocation (#290) ──────────────────────────
+  // The mirror sync used to be the fourth job on this invocation, sized against
+  // an accounting that counted only the ONE outbound fetch a sync makes. What a
+  // batch actually costs is the bindings each mirrored item touches — two D1
+  // queries per created entry, three per updated one — so its five batches were
+  // 100 D1 queries in an invocation that allows 50 in total. Even one batch only
+  // fitted while the batch was creates and exactly one provider was connected.
+  // It now runs on its own schedule, so these are two budgets to keep, not one.
+
+  describe("the integration schedule", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("runs one batch, and records the cursor the next run resumes from", async () => {
+      const db = makeTestDb();
+      const kv = makeMemoryKV();
+      const fetchMock = await connectCalendar(kv, 120);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, INTEGRATION_SYNC_CRON);
+
+      // One batch is one feed fetch and one expansion of it — the expansion is
+      // the CPU half of #290, so paying it once per run is the point.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(db.entries.filter(e => e.source === "calendar-google")).toHaveLength(SYNC_EVENT_BATCH);
+
+      const saved = JSON.parse((await kv.get("integrations:calendar-google")) as string);
+      expect(Object.keys(saved.itemMap)).toHaveLength(SYNC_EVENT_BATCH);
+      expect(saved.lastSyncedAt).not.toBeNull();
+    });
+
+    it("keeps its own invocation inside the D1 budget", async () => {
+      const db = makeTestDb();
+      seedCompressibleTags(db, 7); // a big brain must not make the sync cost more
+      const kv = makeMemoryKV();
+      await connectCalendar(kv, 120);
+      const { env, statements } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, INTEGRATION_SYNC_CRON);
+
+      expect(db.entries.filter(e => e.source === "calendar-google")).toHaveLength(SYNC_EVENT_BATCH);
+      expect(statements.length).toBeLessThanOrEqual(FREE_PLAN_SUBREQUESTS);
+    });
+
+    // The multiplier the rotation exists to remove: syncing every connected
+    // provider in one invocation measured 70 D1 queries with two calendars.
+    it("syncs one provider per run however many are connected", async () => {
+      const db = makeTestDb();
+      seedCompressibleTags(db, 7);
+      const kv = makeMemoryKV();
+      const fetchMock = await connectCalendar(kv, 120, ["calendar-google", "calendar-outlook", "calendar-icloud"]);
+      const { env, statements } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, INTEGRATION_SYNC_CRON);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(db.entries.filter(e => e.source.startsWith("calendar-"))).toHaveLength(SYNC_EVENT_BATCH);
+      expect(statements.length).toBeLessThanOrEqual(FREE_PLAN_SUBREQUESTS);
+    });
+
+    it("rotates to the least recently attempted provider on the next run", async () => {
+      const db = makeTestDb();
+      const kv = makeMemoryKV();
+      await connectCalendar(kv, 120, ["calendar-google", "calendar-outlook"]);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, INTEGRATION_SYNC_CRON);
+      resetDatabaseInit();
+      await runCron(env, INTEGRATION_SYNC_CRON);
+
+      // Each got exactly one batch — the second run did not repeat the first's
+      // provider, which is what stops one connection starving the others.
+      expect(db.entries.filter(e => e.source === "calendar-google")).toHaveLength(SYNC_EVENT_BATCH);
+      expect(db.entries.filter(e => e.source === "calendar-outlook")).toHaveLength(SYNC_EVENT_BATCH);
+    });
+
+    // A provider whose token has expired writes updatedAt but never lastSyncedAt.
+    // Ordering the rotation by lastSyncedAt would therefore pick it every single
+    // run, forever, and the working connection would never sync again.
+    it("does not let a permanently failing provider starve a working one", async () => {
+      const db = makeTestDb();
+      const kv = makeMemoryKV();
+      await connectCalendar(kv, 120, ["calendar-google", "calendar-outlook"]);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+      const ics = icsWithUpcomingEvents(120);
+      // calendar-google's feed is broken; calendar-outlook's is fine.
+      vi.stubGlobal("fetch", vi.fn(async (url: any) => {
+        if (String(url).includes("calendar-google")) throw new Error("401 Unauthorized");
+        return { ok: true, status: 200, text: async () => ics } as any;
+      }));
+
+      const tick = hourlyClock();
+      for (let run = 0; run < 4; run++) {
+        tick(run);
+        resetDatabaseInit();
+        await runCron(env, INTEGRATION_SYNC_CRON);
+      }
+
+      const failing = JSON.parse((await kv.get("integrations:calendar-google")) as string);
+      expect(failing.status).toBe("error");
+      // The working provider kept getting turns rather than being locked out —
+      // four runs, so two of them were its.
+      expect(db.entries.filter(e => e.source === "calendar-outlook"))
+        .toHaveLength(2 * SYNC_EVENT_BATCH);
+    });
+
+    // The case above is an error the provider's own handler catches, so the
+    // provider persists updatedAt itself. This is the one where it does not:
+    // a throw escaping the handler is swallowed by job() in src/index.ts, and
+    // nothing about the record was written. If the rotation trusted providers to
+    // advance their own cursor, this provider would be re-selected every run
+    // forever — and, because its item map did not persist either, would re-mirror
+    // the same batch under fresh ids each time.
+    it("advances past a provider whose sync throws past its own handler", async () => {
+      const db = makeTestDb();
+      const kv = makeMemoryKV();
+      await connectCalendar(kv, 120, ["calendar-google", "calendar-outlook"]);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+      vi.spyOn(INTEGRATION_PROVIDERS["calendar-google"], "sync")
+        .mockRejectedValue(new Error("KV write failed inside saveIntegration"));
+
+      const tick = hourlyClock();
+      for (let run = 0; run < 4; run++) {
+        tick(run);
+        resetDatabaseInit();
+        await runCron(env, INTEGRATION_SYNC_CRON);
+      }
+
+      // Two of the four runs went to the provider that works.
+      expect(db.entries.filter(e => e.source === "calendar-outlook"))
+        .toHaveLength(2 * SYNC_EVENT_BATCH);
+      // And the thrower never mirrored anything, so there are no duplicate
+      // re-creations to find.
+      expect(db.entries.filter(e => e.source === "calendar-google")).toHaveLength(0);
+    });
+  });
+
+  // ─── Routing (#290) ────────────────────────────────────────────────────────
+  // The split only buys anything if scheduled() actually branches. A handler
+  // that ignored event.cron would run every job on BOTH triggers, which is
+  // strictly worse than before: the same shared cost, now paid hourly.
+
+  describe("cron routing", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("does not run the mirror sync on the maintenance schedule", async () => {
+      const db = makeTestDb();
+      const kv = makeMemoryKV();
+      const fetchMock = await connectCalendar(kv, 120);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, MAINTENANCE_CRON);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(db.entries.filter(e => e.source === "calendar-google")).toHaveLength(0);
+    });
+
+    it("does not run the maintenance jobs on the integration schedule", async () => {
+      const db = makeTestDb();
+      const old = Date.now() - STALENESS_AGE_MS - 86400000;
+      db.entries.push({
+        id: "job", content: "Bob works at Example Inc", tags: "[]",
+        source: "api", created_at: old, updated_at: old, vector_ids: "[]",
+      });
+      const kv = makeMemoryKV();
+      await connectCalendar(kv, 1);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, INTEGRATION_SYNC_CRON);
+
+      // The staleness pass is the cheapest maintenance job to detect: on the
+      // maintenance schedule this same entry comes back tagged.
+      const tags: string[] = JSON.parse(db.entries.find(e => e.id === "job")!.tags);
+      expect(tags).not.toContain("stale:as-of");
+    });
+
+    it("falls back to maintenance for an unrecognised schedule", async () => {
+      const db = makeTestDb();
+      const old = Date.now() - STALENESS_AGE_MS - 86400000;
+      db.entries.push({
+        id: "job", content: "Bob works at Example Inc", tags: "[]",
+        source: "api", created_at: old, updated_at: old, vector_ids: "[]",
+      });
+      const { env } = countingEnv(db);
+
+      await runCron(env, "*/5 * * * *");
+
+      const tags: string[] = JSON.parse(db.entries.find(e => e.id === "job")!.tags);
+      expect(tags).toContain("stale:as-of");
+    });
   });
 });

--- a/test/unit/cron-subrequest-budget.test.ts
+++ b/test/unit/cron-subrequest-budget.test.ts
@@ -16,14 +16,42 @@ import { D1Mock } from "../helpers/d1-mock";
 
 const FREE_PLAN_SUBREQUESTS = 50;
 
+// D1 bills EXECUTIONS: run/first/all/exec spend one each, and a batch() spends one however
+// many statements it carries. Counting prepares instead would price the batched writes in
+// the compression and staleness passes as if they were still one round trip per row —
+// which is exactly the cost this budget is meant to track.
 function countingEnv(db: D1Mock) {
   const statements: string[] = [];
+  const bill = (sql: string) => statements.push(sql.replace(/\s+/g, " ").trim());
+  const wrap = (stmt: any, sql: string): any => ({
+    bind: (...a: any[]) => wrap(stmt.bind(...a), sql),
+    run: () => { bill(sql); return stmt.run(); },
+    first: (...a: any[]) => { bill(sql); return stmt.first(...a); },
+    all: () => { bill(sql); return stmt.all(); },
+    __inner: stmt,
+  });
+  const prepared: string[] = [];
   const DB = {
-    prepare(sql: string) { statements.push(sql.replace(/\s+/g, " ").trim()); return db.prepare(sql); },
-    exec(sql: string) { statements.push(sql.replace(/\s+/g, " ").trim()); return db.exec(sql); },
-    batch: (stmts: any[]) => db.batch(stmts),
+    prepare(sql: string) { prepared.push(sql.replace(/\s+/g, " ").trim()); return wrap(db.prepare(sql), sql); },
+    exec(sql: string) { bill(sql); return db.exec(sql); },
+    batch: (stmts: any[]) => { bill("BATCH"); return db.batch(stmts.map((s: any) => s.__inner ?? s)); },
   } as unknown as D1Database;
-  return { env: makeTestEnv(db, { DB, VECTORIZE: makeVectorizeMock() }), statements };
+  return { env: makeTestEnv(db, { DB, VECTORIZE: makeVectorizeMock() }), statements, prepared };
+}
+
+// Each tag gets more than the ten eligible entries a digest needs, so nightly compression
+// actually runs. Without that the budget test measures a cron with its largest job idle.
+function seedCompressibleTags(db: D1Mock, tagCount: number) {
+  const old = Date.now() - STALENESS_AGE_MS - 86400000;
+  for (let t = 0; t < tagCount; t++) {
+    for (let i = 0; i < 11; i++) {
+      db.entries.push({
+        id: `t${t}-e${i}`, content: `Person ${i} works at Company ${t}`, tags: JSON.stringify([`topic-${t}`]),
+        source: "api", created_at: old + i, updated_at: old + i, vector_ids: "[]",
+        recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+      });
+    }
+  }
 }
 
 async function runCron(env: any) {
@@ -55,6 +83,22 @@ describe("nightly cron D1 subrequest cost", () => {
     // The signature statement of initializeDatabase, once for the whole cron.
     const ddl = statements.filter(s => s.startsWith("CREATE TABLE IF NOT EXISTS entries"));
     expect(ddl).toHaveLength(1);
+  });
+
+  // The staleness pass used to be the largest consumer of this budget: one CAS per
+  // candidate, and in situ it runs concurrently with the compression job's writes, so its
+  // guards lose and it pays for re-reads and retries on top. Batched, the whole pass is a
+  // candidate query and one write round trip.
+  it("keeps a nightly run with every job busy inside the budget", async () => {
+    const db = makeTestDb();
+    seedCompressibleTags(db, 7);
+    const { env, statements } = countingEnv(db);
+
+    await runCron(env);
+
+    expect(db.entries.filter(e => JSON.parse(e.tags).includes("synthesized")).length).toBeGreaterThan(0);
+    expect(db.entries.filter(e => e.staleness_checked_at != null)).toHaveLength(25);
+    expect(statements.length).toBeLessThanOrEqual(FREE_PLAN_SUBREQUESTS);
   });
 
   it("keeps a whole nightly run inside the free-plan subrequest budget", async () => {

--- a/test/unit/cron-triggers.test.ts
+++ b/test/unit/cron-triggers.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The cron strings in wrangler.jsonc and the one scheduled() routes on are the
+ * same fact written in two places, and nothing at build or deploy time checks
+ * they agree (#290).
+ *
+ * Drift is silent and it is expensive in one direction: if INTEGRATION_SYNC_CRON
+ * stops matching a configured schedule, every invocation falls through to the
+ * maintenance branch, the mirror sync never runs at all, and the only symptom is
+ * integrations quietly going stale. If a schedule is configured that nothing
+ * routes, it costs an invocation an hour to run maintenance again.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { INTEGRATION_SYNC_CRON } from "../../src/integrations/mirror";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+
+function configuredCrons(): string[] {
+  const raw = readFileSync(resolve(ROOT, "wrangler.jsonc"), "utf8");
+  // Strip // comments (wrangler.jsonc uses them) before parsing. Deliberately
+  // not a full JSONC parser: the file has no block comments and no strings
+  // containing "//" outside the URLs in comments, which this removes anyway.
+  const stripped = raw.replace(/^\s*\/\/.*$/gm, "");
+  const config = JSON.parse(stripped);
+  return config.triggers?.crons ?? [];
+}
+
+describe("cron triggers", () => {
+  it("configures the integration schedule the worker routes on", () => {
+    expect(configuredCrons()).toContain(INTEGRATION_SYNC_CRON);
+  });
+
+  it("configures a maintenance schedule distinct from the integration one", () => {
+    const crons = configuredCrons();
+    const maintenance = crons.filter(c => c !== INTEGRATION_SYNC_CRON);
+    expect(maintenance.length).toBeGreaterThan(0);
+  });
+
+  it("stays inside the free plan's five triggers", () => {
+    expect(configuredCrons().length).toBeLessThanOrEqual(5);
+  });
+
+  // The two schedules must not be able to fire in the same minute: that would
+  // put both invocations' work on the same wall clock, which is the contention
+  // the split exists to avoid.
+  it("does not schedule the two on a colliding minute", () => {
+    const minuteOf = (cron: string) => cron.trim().split(/\s+/)[0];
+    const integrationMinute = minuteOf(INTEGRATION_SYNC_CRON);
+    for (const cron of configuredCrons()) {
+      if (cron === INTEGRATION_SYNC_CRON) continue;
+      expect(minuteOf(cron), `${cron} shares a minute with ${INTEGRATION_SYNC_CRON}`)
+        .not.toBe(integrationMinute);
+    }
+  });
+});

--- a/test/unit/d1-mock-fidelity.test.ts
+++ b/test/unit/d1-mock-fidelity.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Pins the parts of test/helpers/d1-mock.ts whose whole job is to behave like D1 rather
+ * than to be convenient.
+ *
+ * A test double that filters differently from production does not fail — it passes, and
+ * takes the bug with it. Both properties below were added because that happened: the
+ * case-sensitive tag comparison hid a rollup bug where the candidate `Kind:Semantic`
+ * selected every entry tagged `kind:semantic`, and the pattern decoder was blind to the
+ * escaping compressTag now applies. Neither had anything pinning it, so reverting either
+ * one broke no test at all.
+ *
+ * The helper's own comment lists what it deliberately does NOT model. Those axes belong in
+ * a real-SQLite test — see test/integration/digest-candidates.test.ts.
+ */
+import { describe, it, expect } from "vitest";
+import { makeTestDb } from "../helpers/make-env";
+import { tagLikePattern } from "../../src/memory/tag-sql";
+
+describe("d1-mock LIKE fidelity", () => {
+  function seed(tags: string[]) {
+    const db = makeTestDb();
+    const old = Date.now() - 200 * 24 * 3600 * 1000;
+    tags.forEach((tag, i) => db.entries.push({
+      id: `e-${i}`, content: `Memory ${i}`, tags: JSON.stringify([tag]), source: "api",
+      created_at: old + i, updated_at: old + i, vector_ids: "[]",
+      recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+    }));
+    return db;
+  }
+
+  // `SELECT id FROM entries WHERE tags LIKE ?` — the shape compressTag uses to pick sources.
+  const select = (db: ReturnType<typeof makeTestDb>, pattern: string) =>
+    db.prepare("SELECT id FROM entries WHERE tags LIKE ?").bind(pattern).all();
+
+  it("matches tags case-insensitively, as SQLite's LIKE does", async () => {
+    const db = seed(["kind:semantic", "Kind:Semantic", "KIND:SEMANTIC", "unrelated"]);
+
+    const { results } = await select(db, `%"kind:semantic"%`);
+
+    expect((results as { id: string }[]).map(r => r.id)).toEqual(["e-0", "e-1", "e-2"]);
+  });
+
+  // compressTag escapes % and _ in the tag and pairs the clause with ESCAPE. A decoder that
+  // did not undo that would look for a tag spelled with a backslash and match nothing —
+  // silently turning every underscore-tagged fixture into an empty result.
+  it("decodes the escaping tagLikePattern applies", async () => {
+    const db = seed(["q3_planning", "q3-planning"]);
+
+    const { results } = await select(db, tagLikePattern("q3_planning"));
+
+    expect((results as { id: string }[]).map(r => r.id)).toEqual(["e-0"]);
+  });
+});

--- a/test/unit/db-init.test.ts
+++ b/test/unit/db-init.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { initializeDatabase, resetDatabaseInit } from "../../src/db/init";
 import { makeTestEnv } from "../helpers/make-env";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
 
 const MIGRATION: [column: string, alter: string][] = [
   ["recall_count", `ALTER TABLE entries ADD COLUMN recall_count INTEGER DEFAULT 0`],
@@ -11,17 +12,27 @@ const MIGRATION: [column: string, alter: string][] = [
   ["staleness_checked_at", `ALTER TABLE entries ADD COLUMN staleness_checked_at INTEGER`],
 ];
 const ALL_COLUMNS = MIGRATION.map(([column]) => column);
+const ALL_OBJECTS = ["entries", "idx_entries_created_at", "idx_entries_source", "edges", "idx_edges_source", "idx_edges_target", "idx_edges_weight"];
+const BASE_COLUMNS = ["id", "content", "tags", "source", "created_at", "vector_ids"];
+
+/** The catalogue read that opens every init. Spelled out so tests can exclude it by name. */
+const PROBE = /^SELECT type AS kind, name FROM sqlite_master\b/;
 
 type Row = { created_at: number; updated_at?: number | null };
 
 // D1Mock's exec() never throws, so it cannot express "this column already exists".
 // This stand-in models what the migration path turns on, verified against real workerd
-// D1 via Miniflare: D1 rejects an ALTER for a column the table already has, and a column
-// added to a populated table reads NULL on every pre-existing row. Every statement is
-// recorded so a test can assert what a cold start costs — ALTERs are recorded even when
-// they go on to throw.
-function makeMigrationDb(existingColumns: string[] = [], rows: Row[] = []) {
-  const columns = new Set(existingColumns);
+// D1 via Miniflare: D1 rejects an ALTER for a column the table already has, a column
+// added to a populated table reads NULL on every pre-existing row, and the probe reports
+// exactly the tables, indexes and columns that are there. Every statement is recorded so
+// a test can assert what a cold start costs — ALTERs are recorded even when they throw.
+//
+// `objects` defaults from the columns: a brain carrying migration columns necessarily has
+// the table they sit on, and a brain carrying none is the fresh case where nothing exists.
+// Pass it explicitly for anything in between.
+function makeMigrationDb(existingColumns: string[] = [], rows: Row[] = [], existingObjects?: string[]) {
+  const columns = new Set(existingColumns.length ? [...BASE_COLUMNS, ...existingColumns] : []);
+  const objects = new Set(existingObjects ?? (existingColumns.length ? ALL_OBJECTS : []));
   const execd: string[] = [];
   const prepared: string[] = [];
 
@@ -33,6 +44,12 @@ function makeMigrationDb(existingColumns: string[] = [], rows: Row[] = []) {
         if (columns.has(added[1])) throw new Error(`D1_EXEC_ERROR: duplicate column name: ${added[1]}`);
         columns.add(added[1]);
         if (added[1] === "updated_at") rows.forEach(r => { r.updated_at = null; });
+        return;
+      }
+      const created = sql.match(/CREATE (?:TABLE|INDEX) IF NOT EXISTS (\w+)/);
+      if (created) {
+        objects.add(created[1]);
+        if (created[1] === "entries") BASE_COLUMNS.forEach(c => columns.add(c));
       }
     },
     prepare(sql: string) {
@@ -40,7 +57,14 @@ function makeMigrationDb(existingColumns: string[] = [], rows: Row[] = []) {
       const make = (args: unknown[]) => ({
         bind: (...next: unknown[]) => make(next),
         first: async () => null,
-        all: async () => ({ results: [] }),
+        all: async () => ({
+          results: PROBE.test(sql)
+            ? [
+              ...[...objects].map(name => ({ kind: name.startsWith("idx_") ? "index" : "table", name })),
+              ...[...columns].map(name => ({ kind: "column", name })),
+            ]
+            : [],
+        }),
         run: async () => ({ meta: { changes: 0 } }),
       });
       return make([]);
@@ -51,8 +75,9 @@ function makeMigrationDb(existingColumns: string[] = [], rows: Row[] = []) {
 }
 
 const rowsAged = (n: number): Row[] => Array.from({ length: n }, (_, i) => ({ created_at: 1000 + i }));
+/** Statements that touch entry *rows*. The probe reads the catalogue, not the table. */
 const touchesEntries = (statements: string[]) =>
-  statements.filter(s => /\bentries\b/.test(s) && !/^(CREATE|ALTER)\b/.test(s));
+  statements.filter(s => /\bentries\b/.test(s) && !/^(CREATE|ALTER)\b/.test(s) && !PROBE.test(s));
 
 describe("initializeDatabase updated_at migration", () => {
   // initializeDatabase memoises per isolate, so each case needs a clean slate.
@@ -64,54 +89,82 @@ describe("initializeDatabase updated_at migration", () => {
   // unindexed column (D1 bills rows_read); a backfill would be one row written per entry
   // (D1 caps rows written per day) for a value no reader can distinguish from NULL.
 
-  it("issues no query at all on a fresh, unmigrated brain", async () => {
+  it("issues no entry-row query at all on a fresh, unmigrated brain", async () => {
     const { env, execd, prepared, rows } = makeMigrationDb([], rowsAged(3));
 
     await initializeDatabase(env);
 
-    expect(prepared).toEqual([]);
+    expect(prepared.filter(s => !PROBE.test(s))).toEqual([]);
     expect(touchesEntries(execd)).toEqual([]);
     // The rows are left NULL on purpose — readers coalesce updated_at to created_at.
     expect(rows.every(r => r.updated_at === null)).toBe(true);
   });
 
-  it("issues no query at all on an already-migrated brain", async () => {
+  it("issues no entry-row query at all on an already-migrated brain", async () => {
     const { env, execd, prepared } = makeMigrationDb(ALL_COLUMNS, [{ created_at: 1000, updated_at: 1000 }]);
 
     await initializeDatabase(env);
 
-    expect(prepared).toEqual([]);
+    expect(prepared.filter(s => !PROBE.test(s))).toEqual([]);
     expect(touchesEntries(execd)).toEqual([]);
   });
 
-  it("adds nothing on later cold starts", async () => {
-    const { env, execd, prepared } = makeMigrationDb([], rowsAged(1));
+  // #282. Twelve blind statements were spent per cold isolate discovering that a migrated
+  // brain — every brain after its first request — needed none of them, out of a 50-per-
+  // invocation free-plan budget that ensureDbReady spends inside the triggering request.
+  describe("cost on a migrated brain", () => {
+    it("costs one statement and issues no DDL when the schema is already complete", async () => {
+      const { env, execd, prepared } = makeMigrationDb(ALL_COLUMNS, rowsAged(1));
 
-    // Each reset stands in for a fresh isolate, which is what a cold start actually is.
-    await initializeDatabase(env);
-    const afterFirst = execd.length;
-    resetDatabaseInit();
-    await initializeDatabase(env);
-    resetDatabaseInit();
-    await initializeDatabase(env);
+      await initializeDatabase(env);
 
-    expect(prepared).toEqual([]);
-    expect(execd).toHaveLength(afterFirst * 3); // same DDL each time, nothing extra
-    expect(touchesEntries(execd)).toEqual([]);
+      expect(execd).toEqual([]);
+      expect(prepared).toHaveLength(1);
+      expect(prepared[0]).toMatch(PROBE);
+    });
+
+    it("costs one statement on every cold start after the first", async () => {
+      const { env, execd, prepared } = makeMigrationDb([], rowsAged(1));
+
+      // Each reset stands in for a fresh isolate, which is what a cold start actually is.
+      await initializeDatabase(env);
+      const migrated = execd.length;
+      resetDatabaseInit();
+      await initializeDatabase(env);
+      resetDatabaseInit();
+      await initializeDatabase(env);
+
+      expect(migrated).toBe(13); // the one-off cost of creating a brain: 7 objects + 6 columns
+      expect(execd).toHaveLength(migrated); // the two later cold starts added nothing
+      expect(prepared).toHaveLength(3); // one probe each, and nothing else
+      expect(touchesEntries(execd)).toEqual([]);
+    });
+
+    it("issues only the ALTERs a partially-migrated brain is missing", async () => {
+      const present = ["recall_count", "importance_score"];
+      const { env, execd, prepared } = makeMigrationDb(present, rowsAged(1));
+
+      await initializeDatabase(env);
+
+      const missing = MIGRATION.filter(([column]) => !present.includes(column));
+      expect(execd).toEqual(missing.map(([, alter]) => alter));
+      expect(prepared).toHaveLength(1);
+    });
   });
 
   // All four nightly jobs await initializeDatabase inside one scheduled() invocation,
-  // sharing a single subrequest budget. Without memoisation the DDL is paid for once per
+  // sharing a single subrequest budget. Without memoisation the work is paid for once per
   // job. Callers must still await real completion — ensureDbReady's waitUntil does not.
   describe("memoisation", () => {
     it("runs the schema work once per isolate no matter how many callers await it", async () => {
-      const { env, execd } = makeMigrationDb([], rowsAged(1));
+      const { env, execd, prepared } = makeMigrationDb([], rowsAged(1));
 
       await initializeDatabase(env);
       const once = execd.length;
       await Promise.all([initializeDatabase(env), initializeDatabase(env), initializeDatabase(env)]);
 
       expect(execd).toHaveLength(once);
+      expect(prepared).toHaveLength(1); // not even the probe is re-issued
     });
 
     it("shares one in-flight promise across concurrent callers", async () => {
@@ -125,14 +178,13 @@ describe("initializeDatabase updated_at migration", () => {
     it("resetDatabaseInit clears the memo so a later call redoes the work", async () => {
       // Named for what it actually exercises — the test seam, not the failure path. The
       // rejection tests below are the ones that cover failure.
-      const { env, execd } = makeMigrationDb([], rowsAged(1));
+      const { env, prepared } = makeMigrationDb([], rowsAged(1));
 
       await initializeDatabase(env);
-      const once = execd.length;
       resetDatabaseInit();
       await initializeDatabase(env);
 
-      expect(execd).toHaveLength(once * 2);
+      expect(prepared).toHaveLength(2); // the second call went back to the database
     });
   });
 
@@ -142,15 +194,19 @@ describe("initializeDatabase updated_at migration", () => {
   // failure is still retryable. Most likely trigger is a brand-new brain, where the very
   // first request must create every table against a D1 database made seconds earlier.
   describe("failure is not latched", () => {
-    /** DB whose exec fails until `failing` is cleared. */
+    beforeEach(() => { vi.spyOn(console, "warn").mockImplementation(() => {}); });
+    afterEach(() => { vi.restoreAllMocks(); });
+
+    /** DB whose statements all fail until `failing` is cleared. */
     function flakyDb() {
       const state = { failing: true, execd: [] as string[] };
+      const fail = () => { throw new Error("D1_ERROR: Network connection lost."); };
       const DB = {
         async exec(sql: string) {
-          if (state.failing) throw new Error("D1_ERROR: Network connection lost.");
+          if (state.failing) fail();
           state.execd.push(sql);
         },
-        prepare: () => { throw new Error("unexpected prepare"); },
+        prepare: () => ({ all: async () => (state.failing ? fail() : { results: [] }) }),
       } as unknown as D1Database;
       return { state, env: makeTestEnv(undefined, { DB }) };
     }
@@ -180,7 +236,7 @@ describe("initializeDatabase updated_at migration", () => {
           if (failEdges && sql.includes("CREATE TABLE IF NOT EXISTS edges")) throw new Error("D1_ERROR: Network connection lost.");
           execd.push(sql);
         },
-        prepare: () => { throw new Error("unexpected prepare"); },
+        prepare: () => ({ all: async () => ({ results: [] }) }),
       } as unknown as D1Database;
       const env = makeTestEnv(undefined, { DB });
 
@@ -193,9 +249,17 @@ describe("initializeDatabase updated_at migration", () => {
     });
 
     it("still swallows the routine duplicate-column ALTER error", async () => {
-      // The one expected failure: every run after the first. It must NOT reject.
-      const { env } = makeMigrationDb(ALL_COLUMNS, []);
-      await expect(initializeDatabase(env)).resolves.toBeUndefined();
+      // The probe closes the ordinary case, but not the race: two isolates can cold-start
+      // on the same brain at once, both read a schema without `updated_at`, and both try
+      // to add it. The loser must not reject.
+      const DB = {
+        async exec(sql: string) {
+          if (sql.startsWith("ALTER TABLE")) throw new Error("D1_EXEC_ERROR: duplicate column name: updated_at");
+        },
+        prepare: () => ({ all: async () => ({ results: [] }) }),
+      } as unknown as D1Database;
+
+      await expect(initializeDatabase(makeTestEnv(undefined, { DB }))).resolves.toBeUndefined();
     });
 
     it("rejects on an ALTER failure that is not duplicate-column", async () => {
@@ -205,7 +269,7 @@ describe("initializeDatabase updated_at migration", () => {
             throw new Error("D1_ERROR: database is locked");
           }
         },
-        prepare: () => { throw new Error("unexpected prepare"); },
+        prepare: () => ({ all: async () => ({ results: [] }) }),
       } as unknown as D1Database;
 
       await expect(initializeDatabase(makeTestEnv(undefined, { DB }))).rejects.toThrow(/database is locked/);
@@ -217,8 +281,11 @@ describe("initializeDatabase updated_at migration", () => {
 
     await initializeDatabase(env);
 
-    for (const [, alter] of MIGRATION) expect(execd).toContain(alter);
-    expect(prepared).toEqual([]);
+    for (const [column, alter] of MIGRATION) {
+      if (["recall_count", "importance_score"].includes(column)) continue;
+      expect(execd).toContain(alter);
+    }
+    expect(prepared.filter(s => !PROBE.test(s))).toEqual([]);
   });
 
   // The backfill this replaced wrote one row per entry. On a 50,000-entry brain that was
@@ -233,5 +300,219 @@ describe("initializeDatabase updated_at migration", () => {
     expect(all.filter(s => /UPDATE\s+entries/i.test(s))).toEqual([]);
     expect(all.filter(s => /updated_at IS NULL/i.test(s))).toEqual([]);
     expect(rows.filter(r => r.updated_at == null)).toHaveLength(50_000);
+  });
+});
+
+/**
+ * The probe against a real database.
+ *
+ * The failure that would actually hurt is a probe that reports a schema as PRESENT when
+ * it is not: the DDL is skipped, initializeDatabase resolves, and a brand-new brain
+ * serves every subsequent request against tables that were never created. No mock can
+ * catch that — d1-mock's exec() is a no-op and the stand-in above answers its own probe —
+ * so these run the real statements against real SQLite, which is what D1 is.
+ */
+describe("initializeDatabase against real SQLite", () => {
+  let d1: SqliteD1;
+  const envFor = (sqlite: SqliteD1) => makeTestEnv(undefined, { DB: sqlite.db as unknown as D1Database });
+
+  beforeEach(resetDatabaseInit);
+  afterEach(() => { d1?.close(); vi.restoreAllMocks(); });
+
+  async function objectNames(sqlite: SqliteD1): Promise<string[]> {
+    const { results } = await sqlite.db
+      .prepare(`SELECT name FROM sqlite_master WHERE type IN ('table','index')`)
+      .all() as { results: { name: string }[] };
+    return results.map(r => r.name);
+  }
+
+  it("migrates a genuinely empty database", async () => {
+    d1 = makeSqliteD1({ schema: false });
+    expect(await objectNames(d1)).toEqual([]); // nothing at all, the state a new brain is in
+
+    await initializeDatabase(envFor(d1));
+
+    for (const name of ALL_OBJECTS) expect(await objectNames(d1)).toContain(name);
+    expect(d1.columns()).toEqual([...BASE_COLUMNS, ...ALL_COLUMNS]);
+  });
+
+  it("leaves a migrated database usable, not merely present", async () => {
+    // The tables existing is not the claim worth making — the claim is that the columns
+    // every reader selects are really there. A missing ALTER passes an existence check
+    // and then fails at the first SELECT.
+    d1 = makeSqliteD1({ schema: false });
+    await initializeDatabase(envFor(d1));
+
+    await d1.db
+      .prepare(`INSERT INTO entries (id, content, tags, source, created_at, vector_ids) VALUES (?, ?, '[]', 'api', ?, '[]')`)
+      .bind("e1", "hello", 1000)
+      .run();
+    const { results } = await d1.db
+      .prepare(`SELECT id, COALESCE(updated_at, created_at) AS updated_at, staleness_checked_at, recall_count, importance_score, contradiction_wins, contradiction_losses FROM entries`)
+      .all() as { results: Record<string, unknown>[] };
+
+    expect(results).toEqual([{
+      id: "e1", updated_at: 1000, staleness_checked_at: null,
+      recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+    }]);
+  });
+
+  it("costs one statement on an already-migrated brain", async () => {
+    d1 = makeSqliteD1({ schema: false });
+    await initializeDatabase(envFor(d1));
+    const cold = d1.issued.length;
+    d1.issued.length = 0;
+
+    resetDatabaseInit(); // a second cold isolate against the brain the first one migrated
+    await initializeDatabase(envFor(d1));
+
+    expect(cold).toBe(14); // one probe, then the thirteen statements a new brain needs
+    expect(d1.issued).toHaveLength(1);
+    expect(d1.issued[0]).toMatch(PROBE);
+  });
+
+  it("adds only what a partially-migrated brain is missing", async () => {
+    // db/schema.sql is a real intermediate state: it ships entries with four of the six
+    // ALTER columns, so a brain installed from it is owed updated_at and
+    // staleness_checked_at and nothing else.
+    d1 = makeSqliteD1();
+    expect(d1.columns()).not.toContain("updated_at");
+
+    await initializeDatabase(envFor(d1));
+
+    expect(d1.issued.filter(s => /^ALTER/.test(s))).toEqual([
+      `ALTER TABLE entries ADD COLUMN updated_at INTEGER`,
+      `ALTER TABLE entries ADD COLUMN staleness_checked_at INTEGER`,
+    ]);
+    expect(d1.issued.filter(s => /^CREATE/.test(s))).toEqual([]);
+    expect(d1.columns()).toEqual([...BASE_COLUMNS, ...ALL_COLUMNS]);
+  });
+
+  it("adds only the weight index to a brain migrated before #281", async () => {
+    // The newest object, and the one most likely to be the only thing a brain is missing:
+    // every install that migrated before #281 has the complete schema apart from this.
+    d1 = makeSqliteD1({ schema: false });
+    await initializeDatabase(envFor(d1));
+    await d1.db.exec(`DROP INDEX idx_edges_weight`);
+    resetDatabaseInit();
+    d1.issued.length = 0;
+
+    await initializeDatabase(envFor(d1));
+
+    expect(d1.issued).toEqual([
+      expect.stringMatching(PROBE),
+      `CREATE INDEX IF NOT EXISTS idx_edges_weight ON edges(weight DESC)`,
+    ]);
+    expect(await objectNames(d1)).toContain("idx_edges_weight");
+  });
+
+  it("adds the edges table to a brain that predates it", async () => {
+    // The other real intermediate state (issue #16 added edges to brains that already had
+    // entries). Tables and indexes are probed independently of columns, so this is not
+    // the same path as the ALTERs above.
+    d1 = makeSqliteD1({ schema: false });
+    await d1.db.exec(`CREATE TABLE entries (id TEXT PRIMARY KEY, content TEXT NOT NULL, tags TEXT NOT NULL DEFAULT '[]', source TEXT NOT NULL DEFAULT 'api', created_at INTEGER NOT NULL, vector_ids TEXT NOT NULL DEFAULT '[]')`);
+    d1.issued.length = 0;
+
+    await initializeDatabase(envFor(d1));
+
+    expect(await objectNames(d1)).toContain("edges");
+    expect(d1.issued.filter(s => s.startsWith("CREATE TABLE IF NOT EXISTS entries"))).toEqual([]);
+    expect(d1.columns()).toEqual([...BASE_COLUMNS, ...ALL_COLUMNS]);
+  });
+
+  it("leaves existing rows untouched when it adds a column", async () => {
+    d1 = makeSqliteD1();
+    d1.seed({ id: "old", content: "written before the migration", createdAt: 1000 });
+
+    await initializeDatabase(envFor(d1));
+
+    // Not backfilled: readers coalesce updated_at to created_at, and writing it would
+    // cost one row written per entry for a value nothing downstream can distinguish.
+    expect(d1.rows()).toEqual([expect.objectContaining({
+      id: "old", content: "written before the migration", created_at: 1000,
+      updated_at: null, staleness_checked_at: null,
+    })]);
+  });
+
+  // Degrading to the pre-#282 cost is the acceptable failure; skipping the DDL is not.
+  // A probe may only report a thing PRESENT if it actually saw it, so every way of not
+  // seeing it has to end in the statement being issued. Each of these would otherwise
+  // leave a brand-new brain resolving initializeDatabase against tables that do not exist.
+  describe("a probe that cannot be trusted still migrates", () => {
+    /** Real SQLite for the DDL, `probe` for what the probe appears to return. */
+    function dbWhoseProbe(probe: () => unknown) {
+      return {
+        prepare: (sql: string) => (PROBE.test(sql) ? { all: async () => probe() } : d1.db.prepare(sql)),
+        exec: (sql: string) => d1.db.exec(sql),
+      } as unknown as D1Database;
+    }
+
+    async function expectFullyMigrated() {
+      for (const name of ALL_OBJECTS) expect(await objectNames(d1)).toContain(name);
+      expect(d1.columns()).toEqual([...BASE_COLUMNS, ...ALL_COLUMNS]);
+    }
+
+    beforeEach(() => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      d1 = makeSqliteD1({ schema: false });
+    });
+
+    it("applies the whole schema when the probe throws", async () => {
+      // The guard against the probe's one statement being unsupported on some future D1
+      // and taking first-request migration down with it.
+      await initializeDatabase(makeTestEnv(undefined, {
+        DB: dbWhoseProbe(() => { throw new Error("D1_ERROR: unsupported statement"); }),
+      }));
+
+      await expectFullyMigrated();
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("applies the whole schema when the probe returns a shape it cannot read", async () => {
+      await initializeDatabase(makeTestEnv(undefined, { DB: dbWhoseProbe(() => ({ success: true })) }));
+
+      await expectFullyMigrated();
+    });
+
+    it("does not accept a name held by the wrong kind of object", async () => {
+      // SQLite puts tables and indexes in one namespace. A user table that has taken an
+      // index's name is not that index, and matching on the name alone would resolve init
+      // having silently never created it. Issuing the CREATE gets SQLite's collision
+      // error instead — which is what happened before the probe existed.
+      await d1.db.exec(`CREATE TABLE idx_entries_source (id TEXT)`);
+
+      await expect(initializeDatabase(makeTestEnv(undefined, { DB: d1.db as unknown as D1Database })))
+        .rejects.toThrow(/already a table named idx_entries_source/);
+    });
+
+    it("treats a row it cannot classify as missing rather than present", async () => {
+      // `kind` is what separates a column from a table. A row that has lost it names
+      // something, but nothing that licenses skipping a statement.
+      await initializeDatabase(makeTestEnv(undefined, {
+        DB: dbWhoseProbe(() => ({
+          results: [
+            ...ALL_OBJECTS.map(name => ({ name })), // no kind
+            ...ALL_COLUMNS.map(name => ({ kind: "column", name: { toString: () => name } })), // not a string
+            { kind: "trigger", name: "entries" },
+          ],
+        })),
+      }));
+
+      await expectFullyMigrated();
+    });
+  });
+
+  it("survives two isolates migrating the same brain at once", async () => {
+    // Both probe an unmigrated brain, both decide every ALTER is owed, and the loser gets
+    // `duplicate column name` — the race the tolerance in applySchema exists for. D1 has
+    // no transactional DDL to serialise them.
+    d1 = makeSqliteD1({ schema: false });
+    const first = initializeDatabase(envFor(d1));
+    resetDatabaseInit(); // the second isolate has its own memo
+    const second = initializeDatabase(envFor(d1));
+
+    await expect(Promise.all([first, second])).resolves.toBeDefined();
+    expect(d1.columns()).toEqual([...BASE_COLUMNS, ...ALL_COLUMNS]);
   });
 });

--- a/test/unit/int-param.test.ts
+++ b/test/unit/int-param.test.ts
@@ -1,0 +1,113 @@
+/**
+ * #277 — integer query parameters reached the database unvalidated.
+ *
+ * `parseInt` yields NaN for anything it cannot start reading, and NaN survives
+ * every clamp (`Math.min(NaN, 100)` is NaN), so the bad value landed in D1:
+ * `LIMIT NaN` is a SQLITE_MISMATCH, and `created_at >= NaN` matches nothing, so
+ * a malformed date filter answered 200 with an empty list.
+ *
+ * These are the parser's own rules. The end-to-end consequences are covered in
+ * test/integration/query-param-validation.test.ts.
+ */
+import { describe, it, expect } from "vitest";
+import { intParam } from "../../src/lib/http";
+
+function parse(query: string, name: string, opts?: any) {
+  const url = new URL(`http://localhost/list?${query}`);
+  return intParam(url, name, opts);
+}
+
+async function errorOf(res: Response): Promise<unknown> {
+  return res.json();
+}
+
+describe("intParam", () => {
+  it("reads a plain integer", () => {
+    expect(parse("n=42", "n")).toBe(42);
+  });
+
+  it("returns the documented default when the parameter is absent", () => {
+    expect(parse("", "n", { fallback: 20 })).toBe(20);
+  });
+
+  it("returns undefined for an absent parameter that has no default", () => {
+    expect(parse("", "after")).toBeUndefined();
+  });
+
+  // Only absence gets the default. Treating `?after=` as absent would drop the
+  // filter and answer with more rows than were asked for — the exact failure the
+  // 400 exists to prevent — so a present-but-empty value is rejected instead.
+  it("rejects a present-but-empty value rather than defaulting it", () => {
+    expect(parse("n=", "n", { fallback: 20 })).toBeInstanceOf(Response);
+    expect(parse("after=", "after")).toBeInstanceOf(Response);
+  });
+
+  // `?after` with no `=` parses to the same empty value.
+  it("rejects a valueless parameter", () => {
+    expect(parse("after", "after")).toBeInstanceOf(Response);
+  });
+
+  it("rejects a whitespace-only value", () => {
+    expect(parse("n=%20%20", "n", { fallback: 20 })).toBeInstanceOf(Response);
+  });
+
+  it("clamps rather than rejects an out-of-range value", () => {
+    expect(parse("n=200", "n", { fallback: 20, min: 0, max: 100 })).toBe(100);
+    expect(parse("topK=999", "topK", { fallback: 5, min: 1, max: 20 })).toBe(20);
+    expect(parse("hops=-4", "hops", { fallback: 0, min: 0, max: 3 })).toBe(0);
+  });
+
+  it("rejects a non-numeric value with a 400 naming the parameter", async () => {
+    const res = parse("after=abc", "after");
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(400);
+    expect(await errorOf(res as Response)).toEqual({ ok: false, error: "after must be an integer" });
+  });
+
+  it("rejects a fractional value", () => {
+    expect(parse("n=2.5", "n", { fallback: 20 })).toBeInstanceOf(Response);
+  });
+
+  // Beyond 2^53 the arithmetic that follows is no longer exact, so the value
+  // that would reach D1 is not the one the caller wrote.
+  it("rejects an integer too large to represent exactly", () => {
+    expect(parse("after=99999999999999999999", "after")).toBeInstanceOf(Response);
+  });
+
+  /**
+   * The parameter values called out on #277, old parsing against new.
+   *
+   * Every value that is a well-formed integer is unchanged, including the
+   * whitespace-padded and explicitly-signed forms. The four that change are the
+   * four where `parseInt` returned a number the caller never wrote: it stops at
+   * the first character it cannot use, so "7abc" was 7, "1e3" was 1 and "0x10"
+   * was 0 — the same silent-substitution failure #277 is about, one layer up.
+   */
+  const CASES: { raw: string; old: number; now: number | "400" }[] = [
+    { raw: "5",     old: 5,    now: 5 },
+    { raw: "0",     old: 0,    now: 0 },
+    { raw: "-3",    old: -3,   now: -3 },
+    { raw: "100",   old: 100,  now: 100 },
+    { raw: "1000",  old: 1000, now: 1000 },
+    { raw: "  7  ", old: 7,    now: 7 },
+    { raw: "7abc",  old: 7,    now: "400" },
+    { raw: "1e3",   old: 1,    now: "400" },
+    { raw: "0x10",  old: 0,    now: "400" },
+    { raw: "+5",    old: 5,    now: 5 },
+  ];
+
+  it.each(CASES)("parses $raw the same way parseInt did, or rejects it ($now)", ({ raw, old, now }) => {
+    // The old expression, verbatim, so the comparison is against real behaviour
+    // rather than a description of it.
+    expect(parseInt(raw, 10)).toBe(old);
+
+    const result = parse(`v=${encodeURIComponent(raw)}`, "v");
+    if (now === "400") {
+      expect(result).toBeInstanceOf(Response);
+      expect((result as Response).status).toBe(400);
+    } else {
+      expect(result).toBe(now);
+      expect(result).toBe(old); // unchanged from the old parsing
+    }
+  });
+});

--- a/test/unit/nightly-compression.test.ts
+++ b/test/unit/nightly-compression.test.ts
@@ -120,6 +120,78 @@ describe("runNightlyCompression() tag bound", () => {
     expect(put).not.toHaveBeenCalled();
   });
 
+  /**
+   * The staleness pass writes volatility: and stale:as-of across up to 25 entries a night,
+   * so those tags carry a higher entry count than most real topics. They are not topics and
+   * never produce a digest — but the candidate list is ordered by count and only the first
+   * COMPRESSION_MAX_TAGS_PER_RUN are taken, so if they appear at all they take slots from
+   * the tags that would have produced one. The user-visible symptom is compression quietly
+   * doing half as much, with nothing logged.
+   *
+   * Scope: this covers the PREDICATE, not the query. The D1 mock's digest-candidate branch
+   * calls isTopicTag(), so a WHERE clause that drifted from it would leave this test green
+   * — verified by mutation. test/integration/digest-candidates.test.ts runs the clause
+   * itself against real SQLite and is what actually covers the SQL.
+   */
+  it("does not let system tags take digest slots from real topics", async () => {
+    seedTags(db, 5, 15);
+    // Mark entries the way the staleness pass does: on top of their existing topic tags.
+    for (const e of db.entries.slice(0, 25)) {
+      e.tags = JSON.stringify([...JSON.parse(e.tags), "volatility:state", "stale:as-of"]);
+    }
+
+    await runCron(env);
+
+    expect(digestedTags(db).size).toBe(COMPRESSION_MAX_TAGS_PER_RUN);
+    const synthesized = db.entries.filter(e => JSON.parse(e.tags ?? "[]").includes("synthesized"));
+    for (const e of synthesized) {
+      const tags: string[] = JSON.parse(e.tags);
+      expect(tags.some(t => t.startsWith("volatility:") || t === "stale:as-of")).toBe(false);
+    }
+  });
+
+  /**
+   * The damage, not the predicate.
+   *
+   * A reserved tag admitted in mixed case does not merely waste a digest slot. compressTag
+   * selects the entries it rolls up with `tags LIKE '%"<tag>"%'`, and LIKE ignores ASCII
+   * case, so the candidate `Kind:Semantic` selects every entry tagged `kind:semantic` —
+   * classified entries, which is most of them. Those entries get `rolled-up` and a
+   * `[Digest: …]` suffix appended to their content permanently, drop out of staleness and
+   * future compression, and lose recall weight. Here `holiday-plans` has only nine entries,
+   * far under the ten a digest needs, so nothing about it is a legitimate candidate — and
+   * yet it was the collateral when this regressed.
+   *
+   * The mirror path (src/integrations/mirror.ts) inserts tags without lowercasing, which is
+   * how a mixed-case system tag gets into the table in the first place.
+   */
+  it("does not roll up unrelated entries when a system tag arrives in mixed case", async () => {
+    const old = Date.now() - 200 * 24 * 3600 * 1000;
+    for (let i = 0; i < 11; i++) {
+      db.entries.push({
+        id: `mirror-${i}`, content: `Mirrored note ${i}`, tags: JSON.stringify(["Kind:Semantic"]),
+        source: "notion", created_at: old + i, updated_at: old + i, vector_ids: "[]",
+        recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+      });
+    }
+    for (let i = 0; i < 9; i++) {
+      db.entries.push({
+        id: `holiday-${i}`, content: `Holiday idea ${i}`, tags: JSON.stringify(["holiday-plans", "kind:semantic"]),
+        source: "api", created_at: old + i, updated_at: old + i, vector_ids: "[]",
+        recall_count: 0, importance_score: 0, contradiction_wins: 0, contradiction_losses: 0,
+      });
+    }
+
+    await runCron(env);
+
+    for (let i = 0; i < 9; i++) {
+      const row = db.entries.find(e => e.id === `holiday-${i}`)!;
+      expect(JSON.parse(row.tags)).not.toContain("rolled-up");
+      expect(row.content).toBe(`Holiday idea ${i}`); // content never appended to
+    }
+    expect(db.entries.filter(e => JSON.parse(e.tags).includes("synthesized"))).toHaveLength(0);
+  });
+
   it("starts from the top when the cursor cannot be read", async () => {
     seedTags(db, 20);
     const failingKV = {

--- a/test/unit/staleness-pass.test.ts
+++ b/test/unit/staleness-pass.test.ts
@@ -238,9 +238,16 @@ describe("runStalenessPass", () => {
 describe("runStalenessPass D1 round-trip cost", () => {
   const SUBREQUEST_BUDGET = 50;
 
+  /**
+   * `prepared` is the pass's own statements. initializeDatabase's schema probe is dropped
+   * because it is not per-row cost and it is memoised across the whole invocation, so
+   * counting it would make these assertions depend on whether some earlier test in the
+   * file happened to warm the memo first. The cron budget test is where init's cost lives.
+   */
   function countingEnv(db: D1Mock, overrides: Partial<D1Database> = {}) {
     const prepared: string[] = [];
     const execd: string[] = [];
+    const isSchemaProbe = (sql: string) => sql.startsWith("SELECT type AS kind, name FROM sqlite_master");
     const billed = { run: 0, first: 0, all: 0, exec: 0, batch: 0, batched: [] as number[],
       get total() { return this.run + this.first + this.all + this.exec + this.batch; } };
     const wrap = (stmt: any): any => ({
@@ -251,7 +258,7 @@ describe("runStalenessPass D1 round-trip cost", () => {
       __inner: stmt,
     });
     const DB = {
-      prepare(sql: string) { prepared.push(sql); return wrap(db.prepare(sql)); },
+      prepare(sql: string) { if (!isSchemaProbe(sql)) prepared.push(sql); return wrap(db.prepare(sql)); },
       exec(sql: string) { billed.exec++; execd.push(sql); return db.exec(sql); },
       batch: (stmts: any[]) => {
         billed.batch++;

--- a/test/unit/staleness-pass.test.ts
+++ b/test/unit/staleness-pass.test.ts
@@ -228,21 +228,39 @@ describe("runStalenessPass", () => {
   });
 });
 
-// A free-plan Worker invocation gets 50 subrequests, and every D1 statement spends one.
-// The nightly cron already runs several jobs against that budget, so the staleness pass
-// has to be cheap or it never gets to run at all on a free deployment.
+// A free-plan Worker invocation gets 50 subrequests, and the nightly cron already runs
+// several jobs against that budget, so the staleness pass has to be cheap or it never gets
+// to run at all on a free deployment.
+//
+// What D1 bills is EXECUTIONS, not prepares: run/first/all/exec spend one each, and a
+// batch() spends one however many statements it carries. `billed` counts it that way —
+// counting prepares would price a batch as if it were still one write per row.
 describe("runStalenessPass D1 round-trip cost", () => {
   const SUBREQUEST_BUDGET = 50;
 
-  function countingEnv(db: D1Mock) {
+  function countingEnv(db: D1Mock, overrides: Partial<D1Database> = {}) {
     const prepared: string[] = [];
     const execd: string[] = [];
+    const billed = { run: 0, first: 0, all: 0, exec: 0, batch: 0, batched: [] as number[],
+      get total() { return this.run + this.first + this.all + this.exec + this.batch; } };
+    const wrap = (stmt: any): any => ({
+      bind: (...a: any[]) => wrap(stmt.bind(...a)),
+      run: () => { billed.run++; return stmt.run(); },
+      first: (...a: any[]) => { billed.first++; return stmt.first(...a); },
+      all: () => { billed.all++; return stmt.all(); },
+      __inner: stmt,
+    });
     const DB = {
-      prepare(sql: string) { prepared.push(sql); return db.prepare(sql); },
-      exec(sql: string) { execd.push(sql); return db.exec(sql); },
-      batch: (stmts: any[]) => db.batch(stmts),
+      prepare(sql: string) { prepared.push(sql); return wrap(db.prepare(sql)); },
+      exec(sql: string) { billed.exec++; execd.push(sql); return db.exec(sql); },
+      batch: (stmts: any[]) => {
+        billed.batch++;
+        billed.batched.push(stmts.length);
+        return db.batch(stmts.map((s: any) => s.__inner ?? s));
+      },
+      ...overrides,
     } as unknown as D1Database;
-    return { env: makeTestEnv(db, { DB }), prepared, execd };
+    return { env: makeTestEnv(db, { DB }), prepared, execd, billed };
   }
 
   function seedAged(db: D1Mock, n: number) {
@@ -260,35 +278,89 @@ describe("runStalenessPass D1 round-trip cost", () => {
     }
   }
 
-  it("re-reads no tags it already selected", async () => {
+  it("re-reads no row it already selected", async () => {
     const db = makeTestDb();
     seedAged(db, STALENESS_PASS_LIMIT);
     const { env, prepared } = countingEnv(db);
 
     await runStalenessPass(env, {} as ExecutionContext);
 
-    // The candidate query already returned tags for all 25 rows; a per-row SELECT is
-    // pure duplication. Optimistic concurrency is preserved by the CAS guard instead.
-    expect(prepared.filter(s => s.startsWith("SELECT tags, content FROM entries WHERE id = ?"))).toEqual([]);
+    // The candidate query already returned tags and content for all 25 rows; re-reading
+    // any of them is pure duplication. Optimistic concurrency is preserved by the CAS
+    // guard instead, and the retry re-read below only fires for rows that actually lost.
+    expect(prepared.filter(s => s.startsWith("SELECT id, tags, content FROM entries WHERE id IN"))).toEqual([]);
+    expect(prepared.filter(s => s.includes("FROM entries WHERE id = ?"))).toEqual([]);
     expect(db.entries.filter(e => e.staleness_checked_at != null)).toHaveLength(STALENESS_PASS_LIMIT);
   });
 
-  it("spends nothing per row beyond the write it has to make", async () => {
+  it("spends one subrequest on the whole write set, not one per row", async () => {
     const db = makeTestDb();
     seedAged(db, STALENESS_PASS_LIMIT);
-    const { env, prepared, execd } = countingEnv(db);
+    const { env, prepared, billed } = countingEnv(db);
 
     await runStalenessPass(env, {} as ExecutionContext);
 
-    // One candidate query plus one CAS write per entry — nothing per-row on the read side.
+    // One candidate query plus one batch carrying every CAS — nothing per-row on either
+    // side. The DDL is not counted here because it is memoised across the whole
+    // invocation; see test/unit/cron-subrequest-budget.test.ts, where the 50 actually binds.
     expect(prepared.filter(s => s.includes("COALESCE(updated_at, created_at) <"))).toHaveLength(1);
-    expect(prepared.filter(s => s.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")))
-      .toHaveLength(STALENESS_PASS_LIMIT);
-    // The pass's own cost: 1 candidate query + 25 CAS writes. The DDL is not counted
-    // here because it is memoised across the whole invocation — see the cron budget test
-    // in test/unit/cron-subrequest-budget.test.ts, which is where the 50 actually binds.
-    expect(prepared).toHaveLength(STALENESS_PASS_LIMIT + 1);
-    expect(execd.length).toBeLessThanOrEqual(SUBREQUEST_BUDGET);
+    expect(billed.batched).toEqual([STALENESS_PASS_LIMIT]);
+    expect(billed.run).toBe(0);
+    expect(billed.total).toBe(2);
+    expect(billed.total).toBeLessThanOrEqual(SUBREQUEST_BUDGET);
+    expect(db.entries.filter(e => e.staleness_checked_at != null)).toHaveLength(STALENESS_PASS_LIMIT);
+  });
+
+  // batch() is atomic on D1, so a losing CAS must not look like a failure: it comes back
+  // as changes: 0 with the rest of the batch committed (verified against workerd). What
+  // this pins is the code's half of that contract — that per-statement results are mapped
+  // back to the right rows, so only the loser is retried and the winners are left alone.
+  it("retries only the row whose CAS lost, not the batch", async () => {
+    const db = makeTestDb();
+    seedAged(db, 5);
+    const { env, prepared, billed } = countingEnv(db);
+    const original = db.prepare.bind(db);
+    let flipped = false;
+    (db as any).prepare = (sql: string) => {
+      if (!flipped && sql.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")) {
+        flipped = true; // only job-0's guard is invalidated
+        db.entries[0].tags = '["touched-by-someone-else"]';
+      }
+      return original(sql);
+    };
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    expect(prepared.filter(s => s.startsWith("SELECT id, tags, content FROM entries WHERE id IN"))).toHaveLength(1);
+    expect(billed.batched).toEqual([5, 1]); // the retry batch carries the loser alone
+    for (const row of db.entries) {
+      const tags: string[] = JSON.parse(row.tags);
+      expect(tags).toContain("stale:as-of");
+      expect(row.staleness_checked_at).toBeGreaterThan(0);
+    }
+    expect(JSON.parse(db.entries[0].tags)).toContain("touched-by-someone-else");
+  });
+
+  // A genuine SQL error rolls the whole batch back, so every row in it would keep a NULL
+  // cursor and camp the front of the next run's queue. Degrade to the per-row writes this
+  // replaced rather than lose the run.
+  it("falls back to per-row writes when the batch is rejected", async () => {
+    const db = makeTestDb();
+    seedAged(db, 3);
+    let batches = 0;
+    const { env, billed } = countingEnv(db, {
+      // Reject without applying anything, the way an atomic batch fails.
+      batch: (async () => { batches++; throw new Error("D1_ERROR: no such column"); }) as any,
+    });
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    expect(batches).toBe(1);
+    expect(billed.run).toBe(3); // one write per row, exactly as before the batching
+    for (const row of db.entries) {
+      expect(JSON.parse(row.tags)).toContain("stale:as-of");
+      expect(row.staleness_checked_at).toBeGreaterThan(0);
+    }
   });
 
   // The classification is derived from content, but the tag mutation is a no-op for an
@@ -397,10 +469,168 @@ describe("runStalenessPass D1 round-trip cost", () => {
     expect(db.entries[0].staleness_checked_at).toBeGreaterThan(0);
   });
 
+  // Nothing below strands a row: a row the pass could not settle still leaves the front of
+  // the queue, so a later run gets to it. The failure mode this guards against is a row
+  // that quietly holds one of the 25 slots forever.
+  it("advances the cursor for a row whose tags cannot be classified", async () => {
+    const db = makeTestDb();
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "corrupt",
+      content: "Alice works at Acme Corp",
+      tags: '"not-an-array"', // parses, but not into anything classify can walk
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    const { env } = countingEnv(db);
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    expect(db.entries[0].tags).toBe('"not-an-array"'); // untouched — no verdict was invented
+    expect(db.entries[0].staleness_checked_at).toBeGreaterThan(0);
+  });
+
+  it("advances the cursor when the retry re-read fails", async () => {
+    const db = makeTestDb();
+    seedAged(db, 1);
+    const { env } = countingEnv(db);
+    const original = db.prepare.bind(db);
+    let flipped = false;
+    (db as any).prepare = (sql: string) => {
+      if (sql.startsWith("SELECT id, tags, content FROM entries WHERE id IN")) {
+        return { bind: () => ({ all: async () => { throw new Error("D1_ERROR: connection lost"); } }) };
+      }
+      if (!flipped && sql.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")) {
+        flipped = true;
+        db.entries[0].tags = '["touched-by-someone-else"]';
+      }
+      return original(sql);
+    };
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    expect(db.entries[0].staleness_checked_at).toBeGreaterThan(0);
+  });
+
+  it("advances the cursor for a row whose write fails on the fallback path too", async () => {
+    const db = makeTestDb();
+    seedAged(db, 3);
+    const original = db.prepare.bind(db);
+    (db as any).prepare = (sql: string) => {
+      const stmt = original(sql);
+      const isCas = sql.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?");
+      const isCursor = sql.startsWith("UPDATE entries SET staleness_checked_at = ?");
+      if (!isCas && !isCursor) return stmt;
+      return {
+        bind: (...args: any[]) => {
+          const bound = stmt.bind(...args);
+          // The two statements bind the id in different positions — casWrite is
+          // (tags, now, id, …) and cursorWrite is (now, id) — so a single index would
+          // silently miss one of them and leave this test looking like coverage it is not.
+          const id = isCas ? args[2] : args[1];
+          // Only job-1's CAS ever fails. Its cursor write is deliberately left working,
+          // because the guarantee under test is that the cursor still lands when the
+          // verdict cannot; the test below covers a cursor write that fails.
+          if (!isCas || id !== "job-1") return bound;
+          return { ...bound, run: async () => { throw new Error("D1_ERROR: write failed"); } };
+        },
+      };
+    };
+    const { env } = countingEnv(db, {
+      batch: (async () => { throw new Error("D1_ERROR: batch rejected"); }) as any,
+    });
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const byId = (id: string) => db.entries.find(e => e.id === id)!;
+    expect(JSON.parse(byId("job-0").tags)).toContain("stale:as-of");
+    expect(JSON.parse(byId("job-2").tags)).toContain("stale:as-of");
+    expect(JSON.parse(byId("job-1").tags)).not.toContain("stale:as-of"); // never settled
+    for (const id of ["job-0", "job-1", "job-2"]) {
+      expect(byId(id).staleness_checked_at).toBeGreaterThan(0); // but not stranded either
+    }
+  });
+
+  // A row that short-circuits to a cursor advance — deprecated, or unparseable tags — has
+  // no CAS to lose, so it never enters the retry set. That makes the failure of its one
+  // write the only thing standing between it and a permanently NULL cursor, which would
+  // put it first in every future candidate query forever. One transient failure is enough
+  // to cause it: everything after the first batch here succeeds.
+  it("advances the cursor for a non-retryable row whose first write fails", async () => {
+    const db = makeTestDb();
+    const old = Date.now() - STALENESS_AGE_MS - 86400000;
+    db.entries.push({
+      id: "corrupt",
+      content: "Alice works at Acme Corp",
+      tags: '"not-an-array"', // parses, but not into anything classify can walk
+      source: "api",
+      created_at: old,
+      updated_at: old,
+      vector_ids: "[]",
+    });
+    let writeAttempts = 0;
+    const original = db.prepare.bind(db);
+    (db as any).prepare = (sql: string) => {
+      const stmt = original(sql);
+      if (!sql.startsWith("UPDATE entries SET staleness_checked_at = ?")) return stmt;
+      return {
+        bind: (...args: any[]) => {
+          const bound = stmt.bind(...args);
+          return {
+            ...bound,
+            run: async () => {
+              if (writeAttempts++ === 0) throw new Error("D1_ERROR: transient");
+              return bound.run();
+            },
+          };
+        },
+      };
+    };
+    let batches = 0;
+    const { env } = countingEnv(db, {
+      batch: (async (stmts: any[]) => {
+        if (batches++ === 0) throw new Error("D1_ERROR: batch rejected");
+        return db.batch(stmts.map((s: any) => s.__inner ?? s));
+      }) as any,
+    });
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    expect(writeAttempts).toBeGreaterThan(1); // the failed cursor write was actually retried
+    expect(db.entries[0].staleness_checked_at).toBeGreaterThan(0);
+    expect(db.entries[0].tags).toBe('"not-an-array"'); // still no verdict invented
+  });
+
+  // Deprecated rows are excluded by the candidate query, so the only way one reaches the
+  // pass is by being deprecated after it was selected. It must not be classified: the
+  // cursor moves and nothing else.
+  it("short-circuits a row deprecated mid-pass to a cursor advance", async () => {
+    const db = makeTestDb();
+    seedAged(db, 1);
+    const { env } = countingEnv(db);
+    const original = db.prepare.bind(db);
+    let deprecated = false;
+    (db as any).prepare = (sql: string) => {
+      if (!deprecated && sql.startsWith("UPDATE entries SET tags = ?, staleness_checked_at = ?")) {
+        deprecated = true;
+        db.entries[0].tags = '["status:deprecated"]';
+      }
+      return original(sql);
+    };
+
+    await runStalenessPass(env, {} as ExecutionContext);
+
+    const tags: string[] = JSON.parse(db.entries[0].tags);
+    expect(tags).toEqual(["status:deprecated"]);
+    expect(db.entries[0].staleness_checked_at).toBeGreaterThan(0);
+  });
+
   it("still re-reads tags when a concurrent write makes the CAS lose", async () => {
     const db = makeTestDb();
     seedAged(db, 1);
-    const { env, prepared } = countingEnv(db);
+    const { env, prepared, billed } = countingEnv(db);
     // Flip the row's tags out from under the pass on the first CAS attempt, exactly as a
     // concurrent writer would. The retry must go back to the database for fresh tags.
     const original = db.prepare.bind(db);
@@ -415,7 +645,8 @@ describe("runStalenessPass D1 round-trip cost", () => {
 
     await runStalenessPass(env, {} as ExecutionContext);
 
-    expect(prepared.filter(s => s.startsWith("SELECT tags, content FROM entries WHERE id = ?"))).toHaveLength(1);
+    expect(prepared.filter(s => s.startsWith("SELECT id, tags, content FROM entries WHERE id IN"))).toHaveLength(1);
+    expect(billed.first).toBe(0); // the re-read is the batched one, not a per-row lookup
     const tags: string[] = JSON.parse(db.entries[0].tags);
     expect(tags).toContain("touched-by-someone-else"); // retry built on the fresh tags
     expect(tags).toContain("stale:as-of");

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -35,9 +35,23 @@
 	"assets": {
 		"directory": "./public"
 	},
+	// Two schedules, because they are two budgets. A Worker invocation gets 50 D1
+	// queries and 10 ms of CPU on the free plan, and the nightly maintenance pass
+	// already spends 30 of those queries — leaving too little for a mirror sync to
+	// do useful work without pushing the whole invocation over (#290). Splitting
+	// them gives the integration sync its own allowance. scheduled() in
+	// src/index.ts routes on the cron string; INTEGRATION_SYNC_CRON in
+	// src/integrations/mirror.ts must match the second entry exactly, and
+	// test/unit/cron-triggers.test.ts fails if it drifts.
 	"triggers": {
 		"crons": [
-			"0 1 * * *"
+			// Nightly maintenance: compression, graph pass, staleness pass.
+			"0 1 * * *",
+			// Integrations. Hourly, because one provider syncs per run (see
+			// runScheduledIntegrationSync) — a nightly rotation would leave a user
+			// with several connections waiting days between syncs. Offset to :30 so
+			// it never fires in the same minute as the nightly job.
+			"30 * * * *"
 		]
 	}
 }


### PR DESCRIPTION
## Summary

Eight blockers, all found and fixed by measurement rather than reading. Every one was reproduced on real workerd D1 or real SQLite before being fixed, and every fix was adversarially validated — **each validation round found something real**, including three data-destroying bugs that only surfaced under attack.

Closes #276, #277, #278, #281, #282, #288, #289, #290.

## What was wrong, and what it cost

**Free-plan quota exhaustion** — the class that takes D1 offline **account-wide** until 00:00 UTC, not just the failing route:

| | before | after |
|---|---|---|
| nightly cron, 60 tags | 437 subrequests, 20.2 ms CPU | **30 D1, flat at any brain shape** |
| recall @ 5,000 entries | 55,000 rows read (90/day) | **10,000 (500/day)** |
| `GET /graph` @ 200k edges | 1,499,398 rows read, 1,501 statements | **38,598 rows, 46 statements** |
| `GET /tags` | 45,000 rows | **0** |
| cold isolate schema init | 13 blind statements | **1 probe** |
| integration cron, 1 calendar | 105 D1 | **21, flat in provider count** |
| `GET /list?n=-1` | read the entire `entries` table | rejected |
| `GET /graph?limit=abc` | read the entire `edges` table | bounded |

**Data destruction** — four separate ways reserved or metacharacter-bearing tags could roll unrelated memories into a digest, permanently rewriting their content:

- a mirrored `Kind:Semantic` tag conflated with `kind:semantic` and rolled up **9 unrelated memories**
- a `#q3_planning` hashtag matched `q3-planning` entries and rolled them up **with no user action**
- `compressTag("%")` selected **18 unrelated entries**
- `GET /digest?tag=Duplicate-Candidate` bypassed the guard entirely

**Silent wrong answers** — the MCP `update` tool had a private copy of the update logic and had drifted three ways: it committed content against stale vectors (permanently mis-indexed, invisible to every repair path), never moved `updated_at`, and never reset staleness tags — so a memory corrected seconds earlier came back flagged *"true as of two years ago, verify before asserting"*.

## Where the leverage was

Almost every quota bug was **unbounded on an axis nobody was measuring**. Compression was bounded per tag but not in tag count. `LIMIT` bounded rows *returned* but not rows *read*. `Math.min(NaN, 100)` is `NaN`, so clamps that looked like validation propagated bad values instead of catching them. Recall's cost scaled with the size of the thing it exists to search.

And one measurement trap worth recording: the reserved-tag bug made the cron look **cheaper** — 29 subrequests versus 42 — because two compression slots did no work. A budget-only assertion would have *rewarded* the regression. The test asserts real topics digested.

## Verification

- **1275 tests** (from 1216), typecheck clean, `wrangler deploy --dry-run` clean, installer bundle clean, `cargo test` 243 passing
- Every test file also runs individually in isolation, plus shuffled-seed and serial runs
- `SB_VERSION` → **2.2.2**. 2.2.1 already shipped bundled into app 1.2.1, and the desktop app offers a Worker update only when the version it bundles is newer than the one deployed — so anything at or below 2.2.1 would silently never reach app users.

## Known and documented, not fixed

**Integration CPU.** A mid-size calendar now fits under the 10 ms cron limit (12.4 → 7.9 ms), but 60 long-running series remains at ~22 ms. The residual is ical.js walking from `DTSTART`; the same limit already applied to the HTTP "Sync now" path, so it predates the trigger split, and it degrades before any write — costing progress, never consistency.

**Recall is still linear in brain size** — ~2× the entry count after the tag cache, from `distillToRareTerms`'s aggregate and the keyword arm's scan. Better, not bounded. That needs FTS5 or an inverted index, not another cache.

**`makeMirrorStore.updateEntry`** is a third copy of the update path with the same shape as #289's bug (a), but it is not user-triggered and self-heals on the next sync.


## Verified against production D1

The schema probe (#282) depends on `pragma_table_info` working on the remote service, which had only been confirmed on workerd. Run against the live database:

```
served_by: v3-prod (ENAM/IAD, primary)   success: true
rows_read: 23   rows_written: 0   sql_duration_ms: 0.71
column 12 | index 8 | table 3
```

Exactly the 23 rows the code predicts, with `kind` discrimination intact. `initializeDatabase` costs 1 subrequest on a migrated brain, not 13.

2.2.2 is also already deployed to the maintainer's own brain (version `7c0335fb`), with both cron triggers registered.
