### PR TITLE
v2.2.3: model-supplied volatility verdicts, and a repair to the Worker release path

### DIFF
--- a/AI_Instructions/CHATGPT_INSTRUCTIONS.md
+++ b/AI_Instructions/CHATGPT_INSTRUCTIONS.md
@@ -9,3 +9,5 @@ Rules:
 - Respect exclusions: if told "don't remember this" or "off the record", don't store it.
 
 Tags: personal, work, task, idea, context, claude-response + a topic tag. Always tag tasks as task. Source: chatgpt.
+
+Volatility: on remember/append/update, pass `volatility` when you can tell how long the fact stays true — durable (never changes), state (true for now, can move), volatile (true briefly). Omit it when unsure; a wrong verdict is worse than none, because state and volatile add a "verify before asserting" warning to every future recall.

--- a/AI_Instructions/CLAUDE_INSTRUCTIONS.md
+++ b/AI_Instructions/CLAUDE_INSTRUCTIONS.md
@@ -52,6 +52,14 @@ Tags to use:
 - claude-response — summaries of important responses or recommendations
 - [auto-detected project/topic tag] — always combine with one of the above (e.g. ["task", "second-brain"])
 
+Volatility (optional, on remember / append / update):
+Pass `volatility` whenever you can judge how long the fact will stay true. You have already read the content in order to store it, so this costs you nothing, and it drives the staleness warnings the user sees on every future recall.
+- durable — never changes (a birthday, where someone grew up, something that already happened)
+- state — true for now but can move (an employer, a city, a current plan or priority)
+- volatile — true only briefly (a meeting, a deadline, this week's focus)
+Omit it when you are unsure. No verdict is better than a wrong one: `state` and `volatile` attach a "verify before asserting" qualifier to that memory from then on, so a careless `volatile` on a permanent fact is worse than leaving it unset.
+On append the existing verdict is kept unless you pass a new one. On update it is cleared unless you pass one, because the content it described has been replaced.
+
 Always set source to "claude-desktop" when storing.
 
 MCP availability (Claude Code and other lazy-loading clients):

--- a/AI_Instructions/CODEX_INSTRUCTIONS.md
+++ b/AI_Instructions/CODEX_INSTRUCTIONS.md
@@ -52,6 +52,14 @@ Tags to use:
 - codex-response — summaries of important responses or recommendations
 - [auto-detected project/topic tag] — always combine with one of the above (e.g. ["task", "second-brain"])
 
+Volatility (optional, on remember / append / update):
+Pass `volatility` whenever you can judge how long the fact will stay true. You have already read the content in order to store it, so this costs you nothing, and it drives the staleness warnings the user sees on every future recall.
+- durable — never changes (a birthday, where someone grew up, something that already happened)
+- state — true for now but can move (an employer, a city, a current plan or priority)
+- volatile — true only briefly (a meeting, a deadline, this week's focus)
+Omit it when you are unsure. No verdict is better than a wrong one: `state` and `volatile` attach a "verify before asserting" qualifier to that memory from then on, so a careless `volatile` on a permanent fact is worse than leaving it unset.
+On append the existing verdict is kept unless you pass a new one. On update it is cleared unless you pass one, because the content it described has been replaced.
+
 Always set source to "codex" when storing.
 
 MCP availability (Codex CLI and other lazy-loading clients):

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "second-brain-installer",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -3761,7 +3761,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "second-brain-desktop"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain-desktop"
-version = "1.2.2"
+version = "1.2.3"
 description = "Second Brain desktop app — one-click setup and a native shell for your own memory dashboard"
 edition = "2021"
 rust-version = "1.82"

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Second Brain",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "identifier": "com.secondbrain.desktop",
   "build": {
     "beforeDevCommand": "npm run bundle-worker && npm run dev",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -26,7 +26,12 @@ const DRY = !!process.env.DRY_RUN;
 const POLL_SECONDS = 10;
 const POLL_MAX_MINUTES = 45;
 
-const WORKER_SRC = resolve(ROOT, "src/index.ts");
+// Derived from one relative constant so the path and the error message cannot
+// drift apart again — SB_VERSION moved from src/index.ts to src/env.ts in the
+// v2.1 modularisation and this script kept pointing at the old file, which made
+// `deploy:worker` fail on every invocation.
+const WORKER_SRC_REL = "src/env.ts";
+const WORKER_SRC = resolve(ROOT, WORKER_SRC_REL);
 const APP_VERSION_FILES = {
   tauriConf: resolve(ROOT, "installer/src-tauri/tauri.conf.json"),
   installerPkg: resolve(ROOT, "installer/package.json"),
@@ -82,7 +87,7 @@ function readWorkerVersion() {
   const m = readFileSync(WORKER_SRC, "utf8").match(
     /export\s+const\s+SB_VERSION\s*=\s*["']([^"']+)["']/,
   );
-  if (!m) fail("couldn't find SB_VERSION in src/index.ts");
+  if (!m) fail(`couldn't find SB_VERSION in ${WORKER_SRC_REL}`);
   return m[1];
 }
 

--- a/src/capture/entry.ts
+++ b/src/capture/entry.ts
@@ -8,6 +8,7 @@ import { checkDuplicateAndContradiction } from "./duplicate";
 import { deprecateEntry } from "./lifecycle";
 import { deleteStaleVectors, reembedOrThrow, storeEntry } from "./store";
 import { tagsAfterWrite } from "../memory/stale";
+import { getVolatility, withVolatility } from "../memory/volatility";
 import { TAG_LIKE_ESCAPE, tagLikePattern } from "../memory/tag-sql";
 import { rememberTags } from "../tags/vocabulary";
 
@@ -93,7 +94,16 @@ export async function captureEntry(
       }
 
       if (newVectorIds) {
-        const refreshedTags = tagsAfterWrite(existingTags);
+        // The rest of the incoming tag list is deliberately discarded on a merge, which
+        // predates this and is left alone — but the volatility verdict cannot be, because
+        // it is the one value the tool schema tells the caller wins permanently. Dropping
+        // it here reported "merged" on a write that silently threw the judgment away, and
+        // the merge bumps updated_at, so the nightly pass would not revisit the entry for
+        // 90 days to re-derive anything. The caller judged the content being merged in, so
+        // its verdict describes the combined body more recently than the target's does.
+        const incomingVerdict = getVolatility(t);
+        const stripped = tagsAfterWrite(existingTags);
+        const refreshedTags = incomingVerdict ? withVolatility(stripped, incomingVerdict) : stripped;
         const now = Date.now();
         await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
           .bind(newContent, JSON.stringify(refreshedTags), now, targetId).run();

--- a/src/capture/store.ts
+++ b/src/capture/store.ts
@@ -8,7 +8,8 @@ import { chunkText } from "../text/chunk";
 import { rememberTags } from "../tags/vocabulary";
 import { extractHashtags } from "../text/hashtags";
 import { isVectorizeUnavailable } from "../vectorize/health";
-import { tagsAfterWrite } from "../memory/stale";
+import { tagsAfterWrite, tagsAfterAppend } from "../memory/stale";
+import { withVolatility, type Volatility } from "../memory/volatility";
 
 export async function storeEntry(
   env: Env,
@@ -119,7 +120,8 @@ export async function updateEntryContent(
   env: Env,
   id: string,
   newContent: string,
-  config: Readonly<Config> = DEFAULTS
+  config: Readonly<Config> = DEFAULTS,
+  volatility?: Volatility
 ): Promise<UpdateEntryResult> {
   // vector_ids has to be read before any mutation: storeEntry overwrites it, and the
   // cleanup below needs to know which vectors the entry had on the way in.
@@ -140,7 +142,10 @@ export async function updateEntryContent(
   // Content that is nothing but hashtags cleans down to "", which would blank the entry —
   // keep it as written in that case and let the tags be extracted anyway.
   const finalContent = cleanContent || newContent;
-  const mergedTags = tagsAfterWrite([...new Set([...existingTags, ...hashtags])])
+  // A caller-supplied verdict is applied after the strip, not before: tagsAfterWrite
+  // removes every volatility tag, so applying it first would throw the value away.
+  const strippedTags = tagsAfterWrite([...new Set([...existingTags, ...hashtags])]);
+  const mergedTags = (volatility ? withVolatility(strippedTags, volatility) : strippedTags)
     // `rolled-up` is a claim about content that no longer exists: the nightly digest wrote
     // it in the same statement that appended a `[Digest: <id>]` marker to the body, and a
     // full replacement destroys that marker. Left in place it costs the corrected memory a
@@ -191,7 +196,8 @@ export async function appendToEntry(
   addition: string,
   tags: string[],
   source: string,
-  config: Readonly<Config> = DEFAULTS
+  config: Readonly<Config> = DEFAULTS,
+  volatility?: Volatility
 ): Promise<boolean> {
   const row = await env.DB.prepare(
     `SELECT vector_ids FROM entries WHERE id = ?`
@@ -203,9 +209,14 @@ export async function appendToEntry(
   const separator = `\n\n[Update ${timestamp}]: `;
   const newContent = existingContent + separator + addition;
 
+  // Computed once and used by both branches below so they cannot drift. Unlike a
+  // replacement this keeps any existing volatility verdict (see tagsAfterAppend); a
+  // caller-supplied one still overrides it.
+  const appendedTags = tagsAfterAppend(tags);
+  const refreshedTags = volatility ? withVolatility(appendedTags, volatility) : appendedTags;
+
   if (newContent.length > CHUNK_MAX_CHARS) {
     const newVectorIds = await reembedOrDegrade(env, id, newContent, tags, source, config);
-    const refreshedTags = tagsAfterWrite(tags);
     const now = Date.now();
 
     await env.DB.prepare(`UPDATE entries SET content = ?, tags = ?, updated_at = ? WHERE id = ?`)
@@ -263,7 +274,6 @@ export async function appendToEntry(
     indexed = false;
   }
 
-  const refreshedTags = tagsAfterWrite(tags);
   const now = Date.now();
 
   await env.DB.prepare(

--- a/src/env.ts
+++ b/src/env.ts
@@ -8,4 +8,4 @@ export interface Env extends Omit<Cloudflare.Env, "VECTORIZE_GRACE_MS"> {
 // Worker version, echoed by GET /health. The desktop app compares this against
 // the version it bundles to offer a one-click "update your Second Brain".
 // Bump (semver) when the Worker changes; see installer/README "Worker versioning".
-export const SB_VERSION = "2.2.2";
+export const SB_VERSION = "2.2.3";

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -12,9 +12,29 @@ import { getConnections } from "../graph/traverse";
 import { isManagedMirror, mirrorEditError } from "../integrations/mirror";
 import { KIND_VALUES, type MemoryKind } from "../memory/kind";
 import { STATUS_VALUES, type MemoryStatus } from "../memory/status";
+import { VOLATILITY_VALUES, withVolatility, type Volatility } from "../memory/volatility";
 import { recallEntries } from "../recall/search";
 import { renderRecallText } from "../recall/render";
 import { RECALL_OUTPUT_BUDGET, SNIPPET_MAX_CHARS, snippetOf, truncationNote } from "../recall/snippet";
+
+// Asking the calling model for this is the whole point: it has already read the content
+// in order to decide to store it, so the judgment is free, and it is a far better
+// classifier than the regex fallback in staleness/heuristic.ts, which abstains on most
+// real content. Sent once per session as part of the tool schema rather than repeated in
+// recall output, and worded to make abstaining the safe move — a wrong verdict is worse
+// than none, because `state` and `volatile` earn a "verify before asserting" qualifier
+// on every future recall.
+const VOLATILITY_DESCRIPTION =
+  "How likely is this to stop being true? "
+  + "durable = never changes (a birthday, where someone grew up, something that already happened). "
+  + "state = true for now but can move (an employer, a city, a current plan or priority). "
+  + "volatile = true only briefly (a meeting, a deadline, this week's focus). "
+  + "Omit it when you are unsure — no verdict is better than a wrong one.";
+
+const volatilityParam = z
+  .enum([...VOLATILITY_VALUES] as [string, ...string[]])
+  .optional()
+  .describe(VOLATILITY_DESCRIPTION);
 
 export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
   const server = new McpServer({ name: "second-brain", version: "1.0.0" });
@@ -28,10 +48,21 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         content: z.string().describe("The idea, task, or note to store"),
         tags: z.array(z.string()).optional().describe("Optional tags for filtering"),
         source: z.string().optional().describe("Origin: phone, browser, voice, claude"),
+        volatility: volatilityParam,
       },
     },
-    async ({ content, tags, source }) => {
-      const result = await captureEntry(content, tags ?? [], source ?? "claude", env, ctx);
+    async ({ content, tags, source, volatility }) => {
+      // Folded into the tag list rather than threaded through captureEntry: tags are
+      // already the carrier for every other reserved namespace (kind:, status:).
+      // withVolatility clears the namespace case-insensitively before appending, so a
+      // caller passing its own "volatility:"-prefixed tag alongside a conflicting enum
+      // value cannot leave two verdicts on one entry. That filter has to stay
+      // case-insensitive: captureEntry lowercases tags *after* this runs, so a
+      // case-sensitive one let "Volatility:durable" through to become a second verdict,
+      // and the injected one won.
+      const baseTags = tags ?? [];
+      const withVerdict = volatility ? withVolatility(baseTags, volatility as Volatility) : baseTags;
+      const result = await captureEntry(content, withVerdict, source ?? "claude", env, ctx);
       if (result.status === "blocked") {
         return { content: [{ type: "text", text: `Duplicate detected (${(result.score * 100).toFixed(0)}% match) — not stored. Existing entry ID: ${result.matchId}` }] };
       }
@@ -62,9 +93,10 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       inputSchema: {
         id: z.string().describe("Entry ID to append to — from recall or list_recent"),
         addition: z.string().describe("The new information to add to the existing entry"),
+        volatility: volatilityParam,
       },
     },
-    async ({ id, addition }) => {
+    async ({ id, addition, volatility }) => {
       const row = await env.DB.prepare(
         `SELECT id, content, tags, source FROM entries WHERE id = ?`
       ).bind(id).first() as Record<string, any> | null;
@@ -92,7 +124,7 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
 
       let indexed: boolean;
       try {
-        indexed = await appendToEntry(env, id, existingContent, a, tags, source, await resolveConfig(env));
+        indexed = await appendToEntry(env, id, existingContent, a, tags, source, await resolveConfig(env), volatility as Volatility | undefined);
       } catch (e) {
         console.error("Append failed:", e);
         return {
@@ -118,9 +150,10 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
       inputSchema: {
         id: z.string().describe("Entry ID to update — from recall or list_recent"),
         content: z.string().describe("The new content to replace the existing entry with"),
+        volatility: volatilityParam,
       },
     },
-    async ({ id, content }) => {
+    async ({ id, content, volatility }) => {
       const newContent = content.trim();
       if (!newContent) {
         return { content: [{ type: "text", text: "Content cannot be empty." }] };
@@ -139,7 +172,7 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext): McpServer {
         return { content: [{ type: "text", text: mirrorEditError(row.source as string) }] };
       }
 
-      const result = await updateEntryContent(env, id, newContent, await resolveConfig(env));
+      const result = await updateEntryContent(env, id, newContent, await resolveConfig(env), volatility as Volatility | undefined);
 
       // Only reachable if the entry was deleted between the guard read and the write.
       if (result.status === "not_found") {

--- a/src/memory/stale.ts
+++ b/src/memory/stale.ts
@@ -20,6 +20,24 @@ export function tagsAfterWrite(tags: string[]): string[] {
   return withoutVolatility(withoutStaleAsOf(tags));
 }
 
+/**
+ * Tag treatment for an append, which keeps the original content and adds to it.
+ *
+ * The as-of qualifier clears because updated_at moves and it would otherwise report a
+ * date this entry no longer has. The volatility verdict is kept, because it describes a
+ * fact that is still present in the body — the same reasoning that keeps `rolled-up` on
+ * an append and drops it on a replacement (see capture/store.ts).
+ *
+ * Stripping it here would also make the verdict depend on how a memory was edited rather
+ * than on what it says: the same fact would be classified or not according to whether the
+ * user appended to it, a distinction the user never made. Recovery is not prompt either,
+ * because the pass reconsiders a row only once it has gone untouched past the age gate,
+ * and an append resets that clock.
+ */
+export function tagsAfterAppend(tags: string[]): string[] {
+  return withoutStaleAsOf(tags);
+}
+
 export function formatAsOfQualifier(updatedAt: number): string {
   const date = new Date(updatedAt).toLocaleDateString();
   return `true as of ${date}, verify before asserting`;

--- a/src/memory/volatility.ts
+++ b/src/memory/volatility.ts
@@ -2,18 +2,36 @@ export const VOLATILITY_VALUES = ["durable", "state", "volatile"] as const;
 export type Volatility = (typeof VOLATILITY_VALUES)[number];
 export const VOLATILITY_PREFIX = "volatility:";
 
+// Every match here is case-insensitive, which the rest of the reserved-tag machinery
+// already is (isReservedTag lowercases; isTopicTagSql uses a case-insensitive LIKE).
+// Matching case-sensitively made this namespace claimable: a caller-supplied tag of
+// `Volatility:durable` slipped past the filter in withVolatility, was lowercased
+// afterwards by captureEntry, and left the entry carrying two verdicts — with the
+// injected one winning, because getVolatility returns the first match. That turned an
+// unvalidated string inside `tags[]` into an override for the validated enum.
+const isVolatilityTag = (t: string) => t.toLowerCase().startsWith(VOLATILITY_PREFIX);
+
+/**
+ * The first *valid* verdict, not the first tag in the namespace. Stopping at the first
+ * match and rejecting it made a junk tag able to shadow a real one: `volatility:sometimes`
+ * ahead of `volatility:durable` reported the entry as unclassified, which lowered its
+ * recall floor and invited the nightly pass to overwrite a verdict a caller had set.
+ * Nothing stops a caller writing raw tags in this namespace, so reading has to tolerate it.
+ */
 export function getVolatility(tags: string[]): Volatility | null {
-  const tag = tags.find(t => t.startsWith(VOLATILITY_PREFIX));
-  if (!tag) return null;
-  const value = tag.slice(VOLATILITY_PREFIX.length) as Volatility;
-  return (VOLATILITY_VALUES as readonly string[]).includes(value) ? value : null;
+  for (const tag of tags) {
+    if (!isVolatilityTag(tag)) continue;
+    const value = tag.slice(VOLATILITY_PREFIX.length).toLowerCase();
+    if ((VOLATILITY_VALUES as readonly string[]).includes(value)) return value as Volatility;
+  }
+  return null;
 }
 
 export function withVolatility(tags: string[], volatility: Volatility): string[] {
-  const cleaned = tags.filter(t => !t.startsWith(VOLATILITY_PREFIX));
+  const cleaned = tags.filter(t => !isVolatilityTag(t));
   return [...cleaned, `${VOLATILITY_PREFIX}${volatility}`];
 }
 
 export function withoutVolatility(tags: string[]): string[] {
-  return tags.filter(t => !t.startsWith(VOLATILITY_PREFIX));
+  return tags.filter(t => !isVolatilityTag(t));
 }

--- a/src/routes/capture.ts
+++ b/src/routes/capture.ts
@@ -5,6 +5,21 @@ import { json, requireAuth } from "../lib/http";
 import { captureEntry } from "../capture/entry";
 import { appendToEntry, updateEntryContent } from "../capture/store";
 import { isManagedMirror, mirrorEditError } from "../integrations/mirror";
+import { VOLATILITY_VALUES, withVolatility, type Volatility } from "../memory/volatility";
+
+/**
+ * Zod guards the MCP tools; these routes have no schema layer, so an unrecognised value
+ * has to be rejected here rather than dropped. Silently ignoring it would hand a caller
+ * that sent "Volatile" or "temporary" a 200 and no verdict, with nothing to tell them
+ * the field did not take.
+ */
+function readVolatility(raw: unknown): { value?: Volatility; error?: string } {
+  if (raw === undefined || raw === null) return {};
+  if (typeof raw !== "string" || !(VOLATILITY_VALUES as readonly string[]).includes(raw)) {
+    return { error: `volatility must be one of: ${VOLATILITY_VALUES.join(", ")}` };
+  }
+  return { value: raw as Volatility };
+}
 
 export async function handleCaptureRoutes(
   request: Request,
@@ -17,11 +32,18 @@ export async function handleCaptureRoutes(
     const authErr = requireAuth(request, env);
     if (authErr) return authErr;
 
-    let body: { content?: string; tags?: string[]; source?: string };
+    let body: { content?: string; tags?: string[]; source?: string; volatility?: unknown };
     try { body = await request.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
     if (!body.content?.trim()) return json({ ok: false, error: "content is required" }, 400);
 
-    const result = await captureEntry(body.content, body.tags ?? [], body.source ?? "api", env, ctx);
+    const captureVol = readVolatility(body.volatility);
+    if (captureVol.error) return json({ ok: false, error: captureVol.error }, 400);
+
+    const captureTags = captureVol.value
+      ? withVolatility(body.tags ?? [], captureVol.value)
+      : body.tags ?? [];
+
+    const result = await captureEntry(body.content, captureTags, body.source ?? "api", env, ctx);
 
     if (result.status === "blocked") {
       return json({
@@ -62,10 +84,13 @@ export async function handleCaptureRoutes(
     const authErr = requireAuth(request, env);
     if (authErr) return authErr;
 
-    let body: { id?: string; addition?: string };
+    let body: { id?: string; addition?: string; volatility?: unknown };
     try { body = await request.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
     if (!body.id?.trim()) return json({ ok: false, error: "id is required" }, 400);
     if (!body.addition?.trim()) return json({ ok: false, error: "addition is required" }, 400);
+
+    const appendVol = readVolatility(body.volatility);
+    if (appendVol.error) return json({ ok: false, error: appendVol.error }, 400);
 
     const id = body.id.trim();
     const addition = body.addition.trim();
@@ -88,7 +113,7 @@ export async function handleCaptureRoutes(
 
     let indexed: boolean;
     try {
-      indexed = await appendToEntry(env, id, existingContent, addition, tags, source, await resolveConfig(env));
+      indexed = await appendToEntry(env, id, existingContent, addition, tags, source, await resolveConfig(env), appendVol.value);
     } catch (e) {
       return json({ ok: false, error: `Append failed: ${(e as Error).message}` }, 500);
     }
@@ -108,10 +133,13 @@ export async function handleCaptureRoutes(
     const authErr = requireAuth(request, env);
     if (authErr) return authErr;
 
-    let body: { id?: string; content?: string };
+    let body: { id?: string; content?: string; volatility?: unknown };
     try { body = await request.json(); } catch { return json({ ok: false, error: "Invalid JSON" }, 400); }
     if (!body.id?.trim()) return json({ ok: false, error: "id is required" }, 400);
     if (!body.content?.trim()) return json({ ok: false, error: "content is required" }, 400);
+
+    const updateVol = readVolatility(body.volatility);
+    if (updateVol.error) return json({ ok: false, error: updateVol.error }, 400);
 
     const id = body.id.trim();
     const newContent = body.content.trim();
@@ -129,7 +157,7 @@ export async function handleCaptureRoutes(
       return json({ ok: false, error: mirrorEditError(row.source as string) }, 409);
     }
 
-    const result = await updateEntryContent(env, id, newContent, await resolveConfig(env));
+    const result = await updateEntryContent(env, id, newContent, await resolveConfig(env), updateVol.value);
 
     // Only reachable if the entry was deleted between the guard read and the write.
     if (result.status === "not_found") {

--- a/test/integration/volatility-tagging.test.ts
+++ b/test/integration/volatility-tagging.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import worker from "../../src/index";
+import { captureEntry } from "../../src/capture/entry";
+import { makeTestEnv, makeTestDb, makeVectorizeMock } from "../helpers/make-env";
+import { req } from "../helpers/make-request";
+import type { Env } from "../../src/env";
+import { D1Mock } from "../helpers/d1-mock";
+import { tagsAfterAppend, tagsAfterWrite, STALE_AS_OF } from "../../src/memory/stale";
+import { getVolatility } from "../../src/memory/volatility";
+import { runStalenessPass, STALENESS_AGE_MS } from "../../src/staleness/pass";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as any;
+
+function makeCtx() {
+  const pending: Promise<any>[] = [];
+  return {
+    ctx: { waitUntil: (p: Promise<any>) => pending.push(p) } as any as ExecutionContext,
+    drain: () => Promise.allSettled(pending),
+  };
+}
+
+function makeContradictionAI(response: string) {
+  return {
+    run: vi.fn().mockImplementation(async (model: string) => {
+      if (model === "@cf/baai/bge-small-en-v1.5") return { data: [new Array(384).fill(0.1)] };
+      return new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(response)}}\n\n`));
+          c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+          c.close();
+        },
+      });
+    }),
+  } as any;
+}
+
+const tagsOf = (db: D1Mock, id: string): string[] =>
+  JSON.parse(db.entries.find((e: any) => e.id === id)!.tags ?? "[]");
+
+const seed = (db: D1Mock, id: string, tags: string[], content = "Original note") => {
+  db.entries.push({
+    id, content, tags: JSON.stringify(tags), source: "api",
+    created_at: 1, updated_at: 1, vector_ids: "[]",
+  });
+};
+
+// Just over CHUNK_MAX_CHARS (1600), which routes appendToEntry down its full re-embed
+// branch instead of the incremental one. Both branches write tags, so both are exercised.
+const LONG = "a".repeat(1601);
+
+describe("volatility supplied by the calling model", () => {
+  let env: Env;
+  let db: D1Mock;
+
+  beforeEach(() => {
+    db = makeTestDb();
+    env = makeTestEnv(db);
+  });
+
+  describe("tag helpers", () => {
+    it("tagsAfterAppend clears the as-of qualifier but keeps the verdict", () => {
+      const out = tagsAfterAppend(["work", "volatility:durable", STALE_AS_OF]);
+      expect(out).toContain("volatility:durable");
+      expect(out).not.toContain(STALE_AS_OF);
+      expect(out).toContain("work");
+    });
+
+    it("tagsAfterWrite still clears both — a replacement discards the verdict", () => {
+      const out = tagsAfterWrite(["work", "volatility:durable", STALE_AS_OF]);
+      expect(out).not.toContain("volatility:durable");
+      expect(out).not.toContain(STALE_AS_OF);
+      expect(out).toContain("work");
+    });
+  });
+
+  describe("POST /capture", () => {
+    it("stores the supplied verdict as a volatility tag", async () => {
+      const res = await worker.fetch(
+        req("POST", "/capture", { body: { content: "Rahil is head of product at Acme", volatility: "state" } }),
+        env, ctx,
+      );
+      expect(res.status).toBe(200);
+      const id = (await res.json() as any).id;
+      expect(getVolatility(tagsOf(db, id))).toBe("state");
+    });
+
+    it("stores no verdict when the field is omitted — omission is the abstain", async () => {
+      const res = await worker.fetch(
+        req("POST", "/capture", { body: { content: "Some note" } }), env, ctx,
+      );
+      const id = (await res.json() as any).id;
+      expect(getVolatility(tagsOf(db, id))).toBeNull();
+    });
+
+    it("keeps the caller's own tags alongside the verdict", async () => {
+      const res = await worker.fetch(
+        req("POST", "/capture", { body: { content: "A note", tags: ["work", "acme"], volatility: "volatile" } }),
+        env, ctx,
+      );
+      const tags = tagsOf(db, (await res.json() as any).id);
+      expect(tags).toEqual(expect.arrayContaining(["work", "acme", "volatility:volatile"]));
+    });
+
+    it("rejects an unknown value with 400 and writes nothing", async () => {
+      const res = await worker.fetch(
+        req("POST", "/capture", { body: { content: "A note", volatility: "temporary" } }), env, ctx,
+      );
+      expect(res.status).toBe(400);
+      expect(db.entries).toHaveLength(0);
+    });
+
+    it("rejects a value that differs only by case — the tag namespace is exact", async () => {
+      const res = await worker.fetch(
+        req("POST", "/capture", { body: { content: "A note", volatility: "Volatile" } }), env, ctx,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    // captureEntry lowercases tags after withVolatility has already filtered the
+    // namespace, so a case-sensitive filter let a caller's own tag through to become a
+    // second verdict — and getVolatility returns the first match, so the unvalidated
+    // one won over the enum. That made `tags[]` an override for a validated field.
+    it("a differently-cased volatility tag cannot smuggle in a second verdict", async () => {
+      const res = await worker.fetch(
+        req("POST", "/capture", { body: { content: "A note", tags: ["Volatility:durable"], volatility: "volatile" } }),
+        env, ctx,
+      );
+      const tags = tagsOf(db, (await res.json() as any).id);
+      expect(tags.filter(t => t.toLowerCase().startsWith("volatility:"))).toEqual(["volatility:volatile"]);
+      expect(getVolatility(tags)).toBe("volatile");
+    });
+
+    it("an invalid cased tag cannot shadow the validated verdict", async () => {
+      const res = await worker.fetch(
+        req("POST", "/capture", { body: { content: "A note", tags: ["Volatility:sometimes"], volatility: "durable" } }),
+        env, ctx,
+      );
+      // Previously getVolatility found the junk tag first, failed its enum check and
+      // returned null — which also let the nightly pass overwrite the caller's verdict.
+      expect(getVolatility(tagsOf(db, (await res.json() as any).id))).toBe("durable");
+    });
+
+    // Nothing stops a caller writing raw tags in the reserved namespace without using the
+    // enum at all, so withVolatility never runs and both tags reach the row. Reading has
+    // to tolerate that: a junk verdict ahead of a real one used to report the entry as
+    // unclassified, which lowered its recall floor and invited the pass to overwrite it.
+    it("an invalid verdict written directly into tags cannot shadow a valid one", async () => {
+      const res = await worker.fetch(
+        req("POST", "/capture", { body: { content: "A note", tags: ["volatility:sometimes", "volatility:durable"] } }),
+        env, ctx,
+      );
+      expect(getVolatility(tagsOf(db, (await res.json() as any).id))).toBe("durable");
+    });
+
+    it("cannot produce two verdicts when tags already carry one", async () => {
+      const res = await worker.fetch(
+        req("POST", "/capture", { body: { content: "A note", tags: ["volatility:durable"], volatility: "volatile" } }),
+        env, ctx,
+      );
+      const tags = tagsOf(db, (await res.json() as any).id);
+      expect(tags.filter(t => t.startsWith("volatility:"))).toEqual(["volatility:volatile"]);
+    });
+  });
+
+  describe("POST /append", () => {
+    it("preserves an existing verdict when none is supplied", async () => {
+      seed(db, "e1", ["work", "volatility:durable"]);
+      const res = await worker.fetch(
+        req("POST", "/append", { body: { id: "e1", addition: "One more detail" } }), env, ctx,
+      );
+      expect(res.status).toBe(200);
+      expect(getVolatility(tagsOf(db, "e1"))).toBe("durable");
+    });
+
+    it("preserves the verdict on the long-content re-embed branch too", async () => {
+      seed(db, "e1", ["volatility:durable"], LONG);
+      await worker.fetch(req("POST", "/append", { body: { id: "e1", addition: "More" } }), env, ctx);
+      expect(getVolatility(tagsOf(db, "e1"))).toBe("durable");
+    });
+
+    it("overrides the existing verdict when one is supplied", async () => {
+      seed(db, "e1", ["volatility:durable"]);
+      await worker.fetch(
+        req("POST", "/append", { body: { id: "e1", addition: "Now it moves", volatility: "state" } }), env, ctx,
+      );
+      expect(getVolatility(tagsOf(db, "e1"))).toBe("state");
+    });
+
+    it("clears the as-of qualifier, because updated_at has moved", async () => {
+      seed(db, "e1", ["volatility:state", STALE_AS_OF]);
+      await worker.fetch(req("POST", "/append", { body: { id: "e1", addition: "Fresh info" } }), env, ctx);
+      const tags = tagsOf(db, "e1");
+      expect(tags).not.toContain(STALE_AS_OF);
+      expect(getVolatility(tags)).toBe("state");
+    });
+
+    it("rejects an unknown value with 400 and leaves the entry untouched", async () => {
+      seed(db, "e1", ["volatility:durable"], "Untouched");
+      const res = await worker.fetch(
+        req("POST", "/append", { body: { id: "e1", addition: "x", volatility: "sometimes" } }), env, ctx,
+      );
+      expect(res.status).toBe(400);
+      expect(db.entries.find((e: any) => e.id === "e1")!.content).toBe("Untouched");
+    });
+  });
+
+  describe("POST /update", () => {
+    it("discards the old verdict when none is supplied — the content it described is gone", async () => {
+      seed(db, "e1", ["work", "volatility:durable", STALE_AS_OF]);
+      const res = await worker.fetch(
+        req("POST", "/update", { body: { id: "e1", content: "Completely different fact" } }), env, ctx,
+      );
+      expect(res.status).toBe(200);
+      const tags = tagsOf(db, "e1");
+      expect(getVolatility(tags)).toBeNull();
+      expect(tags).not.toContain(STALE_AS_OF);
+      expect(tags).toContain("work");
+    });
+
+    it("applies a supplied verdict, which must survive the strip", async () => {
+      seed(db, "e1", ["volatility:durable", STALE_AS_OF]);
+      await worker.fetch(
+        req("POST", "/update", { body: { id: "e1", content: "New fact", volatility: "volatile" } }), env, ctx,
+      );
+      const tags = tagsOf(db, "e1");
+      expect(getVolatility(tags)).toBe("volatile");
+      expect(tags).not.toContain(STALE_AS_OF);
+    });
+
+    it("rejects an unknown value with 400 and leaves the entry untouched", async () => {
+      seed(db, "e1", [], "Untouched");
+      const res = await worker.fetch(
+        req("POST", "/update", { body: { id: "e1", content: "New", volatility: "" } }), env, ctx,
+      );
+      expect(res.status).toBe(400);
+      expect(db.entries.find((e: any) => e.id === "e1")!.content).toBe("Untouched");
+    });
+  });
+
+  // The dedup path rewrites the TARGET entry and discards the incoming tag list. That
+  // predates this feature and is left alone — except for the verdict, which the tool
+  // schema promises wins permanently. Dropping it returned "merged" (a success) on a
+  // write that threw the judgment away, and the merge bumps updated_at, so the nightly
+  // pass would not revisit the entry for 90 days to re-derive anything.
+  describe("duplicate merge and replace paths", () => {
+    const mergingEnv = (db: D1Mock, action: string) => makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({
+        query: vi.fn().mockResolvedValue({
+          matches: [{ id: "target", score: 0.88, metadata: { parentId: "target" } }],
+        }),
+      }),
+      AI: makeContradictionAI(action),
+    });
+
+    const seedTarget = (db: D1Mock, tags: string) => db.entries.push({
+      id: "target", content: "I prefer dark mode", tags, source: "api",
+      created_at: Date.now(), vector_ids: '["target"]', recall_count: 0, importance_score: 2,
+    });
+
+    it("carries the caller's verdict onto a merged entry", async () => {
+      seedTarget(db, '["work"]');
+      const { ctx: c } = makeCtx();
+      const result = await captureEntry(
+        "I like dark mode at night", ["volatility:durable"], "api",
+        mergingEnv(db, '{"action":"merge","target_id":"target","merged_content":"Dark mode, especially at night"}'), c,
+      );
+      expect(result.status).toBe("merged");
+      expect(getVolatility(tagsOf(db, "target"))).toBe("durable");
+    });
+
+    it("carries the caller's verdict onto a replaced entry", async () => {
+      seedTarget(db, '["work"]');
+      const { ctx: c } = makeCtx();
+      await captureEntry(
+        "I switched to light mode", ["volatility:state"], "api",
+        mergingEnv(db, '{"action":"replace","target_id":"target"}'), c,
+      );
+      expect(getVolatility(tagsOf(db, "target"))).toBe("state");
+    });
+
+    it("does not strip a verdict the caller is actively supplying", async () => {
+      // The net-loss case: the target already held this verdict and the caller sent the
+      // same one, yet the row came back carrying none at all.
+      seedTarget(db, '["work","volatility:durable"]');
+      const { ctx: c } = makeCtx();
+      await captureEntry(
+        "I like dark mode at night", ["volatility:durable"], "api",
+        mergingEnv(db, '{"action":"merge","target_id":"target","merged_content":"Dark mode at night"}'), c,
+      );
+      expect(getVolatility(tagsOf(db, "target"))).toBe("durable");
+    });
+  });
+
+  describe("precedence over the regex classifier", () => {
+    it("the nightly pass does not overwrite a verdict the model supplied", async () => {
+      const old = Date.now() - STALENESS_AGE_MS - 86400000;
+      // Wording the regex classifier reads as `state` ("works at"), tagged `durable` by the
+      // caller. The caller's verdict has to win, or the model's judgment is decorative.
+      db.entries.push({
+        id: "job", content: "Alice works at Acme Corp", tags: JSON.stringify(["volatility:durable"]),
+        source: "api", created_at: old, updated_at: old, vector_ids: "[]",
+      });
+
+      await runStalenessPass(makeTestEnv(db), {} as ExecutionContext);
+
+      const tags = tagsOf(db, "job");
+      expect(getVolatility(tags)).toBe("durable");
+      // durable is not stale-flagged, so the pass must also not have added the qualifier.
+      expect(tags).not.toContain(STALE_AS_OF);
+    });
+
+    it("still classifies entries the model left unjudged", async () => {
+      const old = Date.now() - STALENESS_AGE_MS - 86400000;
+      db.entries.push({
+        id: "job", content: "Alice works at Acme Corp", tags: "[]",
+        source: "api", created_at: old, updated_at: old, vector_ids: "[]",
+      });
+
+      await runStalenessPass(makeTestEnv(db), {} as ExecutionContext);
+
+      expect(getVolatility(tagsOf(db, "job"))).toBe("state");
+    });
+  });
+});

--- a/test/unit/updated-at-coalesced.test.ts
+++ b/test/unit/updated-at-coalesced.test.ts
@@ -47,9 +47,25 @@ const HYDRATION_EXEMPTION = {
 
 type Finding = { kind: string; detail: string };
 
+/**
+ * Comments, stripped before anything else looks for backticks. Prose that mentions a
+ * column in markdown backticks is otherwise indistinguishable from a SQL template
+ * literal, and got reported as a schema violation. Real SQL never lives inside a
+ * comment, so this removes false positives without narrowing what the guard catches.
+ * Doing it before the backtick scan also stops a stray pair inside a comment from
+ * pairing across the comment boundary and swallowing real code.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter(l => !l.trim().startsWith("//") && !l.trim().startsWith("*"))
+    .join("\n");
+}
+
 /** SQL string literals in a source file, normalised to one line. */
 function sqlLiterals(source: string): string[] {
-  return [...source.matchAll(/`([^`]*)`/g)]
+  return [...stripComments(source).matchAll(/`([^`]*)`/g)]
     .map(m => m[1].replace(/\s+/g, " ").trim())
     .filter(s => /\bupdated_at\b/.test(s));
 }
@@ -109,12 +125,7 @@ function rawSqlReads(sql: string, relPath: string): Finding[] {
  * stripped first so column references inside them are not double-counted here.
  */
 function rawTsReads(source: string): { text: string; coalesced: boolean }[] {
-  const code = source
-    .replace(/`[^`]*`/g, "")
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .split("\n")
-    .filter(l => !l.trim().startsWith("//") && !l.trim().startsWith("*"))
-    .join("\n");
+  const code = stripComments(source).replace(/`[^`]*`/g, "");
 
   const out: { text: string; coalesced: boolean }[] = [];
   for (const m of code.matchAll(/\bupdated_at\b/g)) {


### PR DESCRIPTION
Worker 2.2.3, app 1.2.3. Both bumps are in this PR, so merging it is enough to tag `installer-v1.2.3` straight from `main`; no separate release PR.

## Volatility verdicts supplied by the calling model

Volatility decides whether a memory earns a "verify before asserting" qualifier at recall, a lowered recency floor, and the compound staleness banner. Until now the only thing that assigned it was a fixed list of English phrases in `staleness/heuristic.ts`: birthday, works at, lives in, meeting. A brain whose memories are not phrased that way gets no verdict at all.

Widening that list was the obvious fix and the wrong one. The false positive rate was brought to zero by *narrowing* those patterns, so every phrase added spends that margin, and the end state is a hand-coded language model.

A model has already read the content by the time it calls `remember`, so this asks it instead. `remember`, `append` and `update` take an optional `volatility` enum (`durable | state | volatile`), carried in the MCP tool schema. Schemas are delivered once per session and attach to a parameter the model has to fill, which it acts on far more reliably than prose in a response payload. Omitting the field is the abstain, matching the classifier's own `null`.

`append` and `update` accepted no tag input at all before this, so a good share of the diff is that plumbing.

### Update discards the verdict, append keeps it

A replacement means the verdict describes content that no longer exists, which is the reasoning already applied to `rolled-up`. An append keeps the original fact in the body, so the verdict still holds, and stripping it there would make classification depend on how a memory was edited rather than on what it says. Both clear the as-of qualifier, since the write moves `updated_at` and the qualifier would otherwise report a date the entry no longer has.

Worth noting the old behaviour was laundering verdicts: append stripped the tag *and* bumped `updated_at`, and the nightly pass only reconsiders rows that have gone untouched past the age gate, so an entry sat at the wrong recency floor for at least 90 days after every append with nothing able to correct it.

Precedence needed no change. The pass writes a verdict only when one is absent, so a supplied value wins and the regex becomes a backstop for writers that are not models.

## Three defects found in validation and fixed here

- **The reserved namespace was claimable.** `withVolatility` filtered case sensitively but `captureEntry` lowercases tags afterwards, so a caller tag of `Volatility:durable` survived the filter, became a second verdict, and won. That turned an unvalidated string inside `tags[]` into an override for the validated enum. All matching in this namespace is now case insensitive, as the rest of the reserved tag machinery already was.
- **`getVolatility` stopped at the first tag in the namespace** and rejected it if invalid, so a junk verdict sitting ahead of a real one reported the entry as unclassified, lowering its recall floor and inviting the pass to overwrite a caller's verdict. It now returns the first valid verdict.
- **The dedup merge path discarded the verdict.** `remember` answered "merged", a success, on a write that threw the judgment away, and the merge bumps `updated_at`, putting the entry out of the pass's reach. The caller's verdict now survives the strip.

## Release tooling

`npm run deploy:worker` has been dead since v2.1. Commit 371a8f9 moved `SB_VERSION` from `src/index.ts` to `src/env.ts` and this script kept looking in the old file, so it aborted on every invocation. The app half worked, which is why it went unnoticed. The path and the error message now derive from one constant.

## Verification

- 1299 tests pass, up from 1275. Every commit is green in isolation.
- Quota audit against the free plan: zero new D1, Vectorize, AI or KV calls on any request path, with SQL statement sequences byte identical before and after. Tag growth is constant rather than per append; 50 sequential appends leave the same three tags and the same row size.
- Regression sweep across recall, compression, the mirror sync path, the tag vocabulary, the dashboard and export: no blocking regressions. Compression already excludes `volatility:` through `RESERVED_TAG_PREFIXES`, and append on a mirrored entry is refused with a 409 before any tag work.
- Each fix is mutation tested. Reverting any one of them turns the suite red.
- Bundle is 688 KB gzipped against the 3 MB free tier ceiling.

## Known consequence, deliberate

`volatility:state` outranks the `task` proxy in `getRecencyFloor`, so a task a model labels `state` gets a 0.6 floor instead of 0.15 and decays more slowly. This is unreachable through the regex, which maps `task` straight to `volatile`, so only a model can produce the combination. It is consistent with explicit beating proxy, which the same ladder already does for `status:canonical` and importance.
