### PR TITLE
Carry updated_at through /export

### DIFF
--- a/src/routes/entries.ts
+++ b/src/routes/entries.ts
@@ -39,7 +39,7 @@ export async function handleEntriesRoutes(
     if (authErr) return authErr;
 
     const { results: entryRows } = await env.DB.prepare(
-      `SELECT id, content, tags, source, created_at, recall_count, importance_score, contradiction_wins, contradiction_losses FROM entries ORDER BY created_at DESC`
+      `SELECT id, content, tags, source, created_at, COALESCE(updated_at, created_at) AS last_updated, recall_count, importance_score, contradiction_wins, contradiction_losses FROM entries ORDER BY created_at DESC`
     ).all() as { results: Record<string, any>[] };
     const { results: edgeRows } = await env.DB.prepare(
       `SELECT source_id, target_id, type, weight, provenance, created_at FROM edges`
@@ -47,12 +47,24 @@ export async function handleEntriesRoutes(
 
     // vector_ids are deliberately excluded — they're deployment-specific and an
     // import tool re-embeds anyway. Tags are parsed so the file holds real arrays.
+    //
+    // updated_at is carried because it is load-bearing on the way back in, not for
+    // display: recall reads it as the entry's age (src/recall/search.ts) and the
+    // staleness pass selects on it (src/staleness/pass.ts). Without it a restore
+    // silently rewrites every entry's last-touched time to its creation time, so
+    // anything edited long after it was written comes back looking untouched —
+    // ranked staler than it is, and eligible for a staleness verdict sooner.
+    // Coalesced in SQL because rows written before that column existed hold NULL, and
+    // the export should carry a number the importer can use directly. Aliased to
+    // `last_updated` rather than `updated_at` so the projection is not itself a bare
+    // read of the column — see test/unit/updated-at-coalesced.test.ts.
     const entries = entryRows.map(r => ({
       id: r.id,
       content: r.content,
       tags: JSON.parse(r.tags ?? "[]"),
       source: r.source,
       created_at: r.created_at,
+      updated_at: r.last_updated ?? r.created_at,
       recall_count: r.recall_count ?? 0,
       importance_score: r.importance_score ?? 0,
       contradiction_wins: r.contradiction_wins ?? 0,

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -587,12 +587,14 @@ export class D1Mock {
             .map((e: any) => ({ id: e.id, content: e.content, tags: e.tags, source: e.source, created_at: e.created_at }));
           return { results: rows };
         }
-        if (s.startsWith("SELECT id, content, tags, source, created_at, recall_count, importance_score, contradiction_wins, contradiction_losses FROM entries ORDER BY created_at DESC")) {
-          // GET /export: every entry, newest first, no LIMIT.
+        if (s.startsWith("SELECT id, content, tags, source, created_at, COALESCE(updated_at, created_at) AS last_updated, recall_count, importance_score, contradiction_wins, contradiction_losses FROM entries ORDER BY created_at DESC")) {
+          // GET /export: every entry, newest first, no LIMIT. `last_updated` models the
+          // COALESCE, so a row that never had updated_at written exports its created_at.
           const results = [...db.entries]
             .sort((a: any, b: any) => b.created_at - a.created_at)
             .map((e: any) => ({
               id: e.id, content: e.content, tags: e.tags, source: e.source, created_at: e.created_at,
+              last_updated: e.updated_at ?? e.created_at,
               recall_count: e.recall_count ?? 0, importance_score: e.importance_score ?? 0,
               contradiction_wins: e.contradiction_wins ?? 0, contradiction_losses: e.contradiction_losses ?? 0,
             }));

--- a/test/integration/export.test.ts
+++ b/test/integration/export.test.ts
@@ -39,6 +39,30 @@ describe("GET /export", () => {
     expect(data.entries[0].id).toBe("e149");
   });
 
+  // updated_at is what a restore needs to put an entry back where it was: recall reads
+  // it as the entry's age and the staleness pass selects on it. An export without it
+  // silently resets every restored entry's last-touched time to its creation time.
+  it("carries updated_at so a restore can put an entry back where it was", async () => {
+    seedEntry(db, "edited", "Edited later", [], 1000);
+    db.entries[0].updated_at = 9000;
+
+    const res = await worker.fetch(req("GET", "/export"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.entries[0].updated_at).toBe(9000);
+    expect(data.entries[0].created_at).toBe(1000);
+  });
+
+  // Rows written before the column existed hold NULL. Exporting that verbatim would
+  // hand the importer a null to insert, so the fallback happens on the way out.
+  it("falls back to created_at for rows written before updated_at existed", async () => {
+    seedEntry(db, "old", "Never edited", [], 1000);
+    db.entries[0].updated_at = null;
+
+    const res = await worker.fetch(req("GET", "/export"), env, ctx);
+    const data = await res.json() as any;
+    expect(data.entries[0].updated_at).toBe(1000);
+  });
+
   it("includes edges and parses tags to real arrays", async () => {
     seedEntry(db, "a", "Memory A", ["work", "kind:semantic"]);
     seedEntry(db, "b", "Memory B", ["idea"]);


### PR DESCRIPTION
`/export` is the input to a restore, and `updated_at` is what puts an entry back where it was. It is read as the entry's age by recall (`src/recall/search.ts`) and selected on by the staleness pass (`src/staleness/pass.ts`), but the export never carried it.

Without the field, a restore collapses every entry's last-touched time to its creation time. An entry created two years ago and edited last week comes back looking two years untouched: ranked staler than it is, and eligible for a staleness verdict immediately.

## Notes

Coalesced in SQL, because rows written before the column existed hold NULL and the export should carry a number the importer can use directly.

Aliased to `last_updated` rather than `updated_at`. The natural spelling — `COALESCE(updated_at, created_at) AS updated_at` — is rejected by `test/unit/updated-at-coalesced.test.ts`, because the alias is itself an occurrence of the column outside a COALESCE. That is the guard working as intended, so the projection is named differently instead of the guard being widened.

Additive to the v2 format, so existing readers are unaffected.

## Tests

Two cases in `test/integration/export.test.ts`: an entry edited after creation exports both timestamps distinctly, and a row whose `updated_at` is NULL exports `created_at` in its place. The D1 mock models the COALESCE so the null case is exercised through the same contract the route relies on.

Full suite: 1301 passing.