### PR TITLE
Release app 1.2.4 + Worker 2.2.4

### DIFF
--- a/.github/workflows/installer-release.yml
+++ b/.github/workflows/installer-release.yml
@@ -140,20 +140,24 @@ jobs:
             # signature is present rather than that it chains to a trusted root.
             $policy = if ($env:SIGNPATH_SIGNING_POLICY_SLUG) { $env:SIGNPATH_SIGNING_POLICY_SLUG } else { "test-signing" }
             $trusted = if ($policy -like "test*") { "0" } else { "1" }
-            # A test policy is for validating the pipeline, never for shipping. Signed
-            # with an untrusted certificate an installer is worse off than unsigned:
-            # Windows warns either way, but the signature details name a test
-            # certificate, which reads as a mistake. Nothing downstream would catch
-            # it — the build passes and the release publishes — so refuse here, where
-            # the message can say what to do.
+            # A test policy is for validating the pipeline, never for shipping: signed
+            # with an untrusted certificate an installer is worse off than unsigned,
+            # because the signature details name a test certificate, which reads as a
+            # mistake rather than an absence. But a release must not be hostage to
+            # the signing setup either — the certificate's issuance is on SignPath's
+            # timeline, not ours, and app releases are also how Worker fixes reach
+            # users. So a tag build under a test policy publishes UNSIGNED, loudly:
+            # the status quo from before SignPath was configured, and the warning
+            # names the variable to flip once the release certificate exists.
             if ($trusted -eq "0" -and $env:GITHUB_REF -like "refs/tags/installer-v*") {
-              throw "Refusing to publish a release signed by the '$policy' policy: it is backed by a certificate Windows does not trust. Point the SIGNPATH_SIGNING_POLICY_SLUG repository variable at your release policy before tagging."
+              Write-Host "::warning::SIGNPATH_SIGNING_POLICY_SLUG is '$policy', whose certificate Windows does not trust. Publishing this release UNSIGNED. Point the variable at your release policy once its certificate is issued."
+            } else {
+              Write-Host "Signing enabled: SignPath policy '$policy' (signed after the build)."
+              Add-Content -Path $env:GITHUB_ENV -Value "SIGNPATH_POLICY=$policy"
+              Add-Content -Path $env:GITHUB_ENV -Value "WIN_SIGNPATH=1"
+              Add-Content -Path $env:GITHUB_ENV -Value "WIN_SIGNED=1"
+              Add-Content -Path $env:GITHUB_ENV -Value "WIN_SIGN_TRUSTED=$trusted"
             }
-            Write-Host "Signing enabled: SignPath policy '$policy' (signed after the build)."
-            Add-Content -Path $env:GITHUB_ENV -Value "SIGNPATH_POLICY=$policy"
-            Add-Content -Path $env:GITHUB_ENV -Value "WIN_SIGNPATH=1"
-            Add-Content -Path $env:GITHUB_ENV -Value "WIN_SIGNED=1"
-            Add-Content -Path $env:GITHUB_ENV -Value "WIN_SIGN_TRUSTED=$trusted"
           } else {
             Write-Host "::notice::Neither WINDOWS_CERTIFICATE nor SIGNPATH_API_TOKEN configured - producing an UNSIGNED Windows build (testing only)."
           }

--- a/installer/README.md
+++ b/installer/README.md
@@ -141,7 +141,7 @@ Because SignPath's key lives in an HSM, the installer is signed **after** the bu
 - **The updater signature.** `tauri-action` signs the *unsigned* installer's bytes, so the signature no longer matches once SignPath has signed it. The workflow regenerates the `.sig` over the signed file.
 - **The updater URL.** `latest.json` addresses assets by numeric id (`…/releases/assets/504326110`), and replacing an asset deletes it and mints a new id. The `publish` job re-derives both the URL and the signature from the release's live state.
 
-While `SIGNPATH_SIGNING_POLICY_SLUG` is `test-signing`, CI asserts only that a signature is present — `signtool verify /pa` cannot succeed against a self-signed certificate, so requiring it would prove nothing. Verification tightens to a full chain check automatically when you switch to `release-signing`. Signing requests under `release-signing` also wait for your approval in the SignPath dashboard; the default timeout is 10 minutes.
+While `SIGNPATH_SIGNING_POLICY_SLUG` is `test-signing`, dispatch builds sign with the test certificate and CI asserts only that a signature is present — `signtool verify /pa` cannot succeed against a self-signed certificate, so requiring it would prove nothing. Tag builds under a test policy publish **unsigned**, with a warning in the job output: a test-signed installer reaching users would read as a mistake, but a release should not be hostage to the certificate's issuance either. Verification tightens to a full chain check automatically when you switch to `release-signing`. Signing requests under `release-signing` also wait for your approval in the SignPath dashboard; the workflow allows an hour.
 
 ### In-app updates — updater signing key (one-time)
 

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "second-brain-installer",
   "private": true,
-  "version": "1.2.3",
+  "version": "1.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -3761,7 +3761,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "second-brain-desktop"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain-desktop"
-version = "1.2.3"
+version = "1.2.4"
 description = "Second Brain desktop app — one-click setup and a native shell for your own memory dashboard"
 edition = "2021"
 rust-version = "1.82"

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Second Brain",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "identifier": "com.secondbrain.desktop",
   "build": {
     "beforeDevCommand": "npm run bundle-worker && npm run dev",

--- a/src/env.ts
+++ b/src/env.ts
@@ -8,4 +8,4 @@ export interface Env extends Omit<Cloudflare.Env, "VECTORIZE_GRACE_MS"> {
 // Worker version, echoed by GET /health. The desktop app compares this against
 // the version it bundles to offer a one-click "update your Second Brain".
 // Bump (semver) when the Worker changes; see installer/README "Worker versioning".
-export const SB_VERSION = "2.2.3";
+export const SB_VERSION = "2.2.4";


### PR DESCRIPTION
Bumps the app to 1.2.4 and  to 2.2.4. Tag builds + publishes; app users are then offered the Worker update.