### PR TITLE
Restore from backup in the dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -278,6 +278,7 @@
         <div class="digest-section" id="digest-section" style="display: none"></div>
         <div class="digest-section" id="vectorize-section" style="display: none"></div>
         <div class="digest-section" id="classify-section" style="display: none"></div>
+        <div class="digest-section" id="restore-section" style="display: none"></div>
         <div class="theme-row">
           <span class="theme-row-label">Appearance</span>
           <div class="theme-toggle" id="theme-toggle">
@@ -296,8 +297,9 @@
           <i class="ti ti-clock"></i> View all memories
         </button>
         <button class="menu-item" onclick="openIntegrations()"><i class="ti ti-plug"></i> Integrations</button>
-        <button class="menu-item" onclick="exportMemories('json')"><i class="ti ti-download"></i> Export as JSON</button>
+        <button class="menu-item" onclick="exportMemories('json')"><i class="ti ti-download"></i> Back up as JSON</button>
         <button class="menu-item" onclick="exportMemories('markdown')"><i class="ti ti-markdown"></i> Export as Markdown</button>
+        <button class="menu-item" id="restore-btn" onclick="restoreFromBackup()"><i class="ti ti-upload"></i> Restore from backup</button>
         <div class="about-credits" id="about-credits" aria-label="About Second Brain"></div>
         <button class="menu-item danger" onclick="logout()"><i class="ti ti-logout"></i> Disconnect</button>
       </div>

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -275,6 +275,194 @@ async function runClassify(btn) {
   }
 }
 
+// ---- Restore from backup -------------------------------------------------
+//
+// The counterpart to "Back up as JSON", and a two-stage flow by design. Stage
+// one walks POST /import's cursor — one call per page, because a whole restore
+// in one request would blow the D1 free plan's per-invocation query budget, and
+// a 5,000-entry file is ~125 sequential calls nobody should run by hand. Stage
+// two matters just as much: imported entries carry no embeddings, so recall
+// cannot see them until they are indexed. A restore that ends before search
+// works would look complete and be broken — so the flow carries the user
+// straight into "Make searchable", which spends Workers AI quota only when
+// they choose to.
+
+/**
+ * Walk the /import cursor until entries and edges are both exhausted.
+ *
+ * Split from the DOM so the paging protocol is testable: `post` is
+ * `(query) => Promise<summary>`, `onProgress` gets running totals per page.
+ * Re-running after a failure is safe — the server skips existing ids — which
+ * is why this throws on error and lets the caller offer a retry.
+ */
+async function runImportLoop(payload, post, onProgress) {
+  const totals = { imported: 0, skipped: 0, failed: 0, edges_imported: 0, edges_skipped: 0, edges_failed: 0 }
+  let offset = 0
+  let edgeOffset = 0
+  const totalEntries = (payload.entries || []).length
+  const totalEdges = (payload.edges || []).length
+
+  for (;;) {
+    const data = await post(`offset=${offset}&edge_offset=${edgeOffset}`)
+    totals.imported += data.imported || 0
+    totals.skipped += data.skipped || 0
+    totals.failed += data.failed || 0
+    totals.edges_imported += data.edges_imported || 0
+    totals.edges_skipped += data.edges_skipped || 0
+    totals.edges_failed += data.edges_failed || 0
+
+    // Apply the fallback BEFORE the stall check: a pre-cursor Worker echoes no
+    // next_offset at all, and comparing against undefined would wave it through
+    // into an infinite loop — the exact case the check exists for.
+    const nextOffset = data.next_offset ?? offset
+    const nextEdgeOffset = data.next_edge_offset ?? edgeOffset
+    const stalled = nextOffset === offset && nextEdgeOffset === edgeOffset
+    offset = nextOffset
+    edgeOffset = nextEdgeOffset
+    if (onProgress) onProgress({ done: Math.min(offset + edgeOffset, totalEntries + totalEdges), total: totalEntries + totalEdges, totals })
+
+    if ((data.remaining_entries || 0) === 0 && (data.remaining_edges || 0) === 0) return totals
+    if (stalled) throw new Error('Server did not advance the import cursor — is the Worker up to date?')
+  }
+}
+
+function restoreSection() {
+  return document.getElementById('restore-section')
+}
+
+function renderRestoreProgress(label, done, total) {
+  const el = restoreSection()
+  el.style.display = ''
+  el.innerHTML = `
+    <div class="digest-section-label">Restore</div>
+    <p class="digest-note">${label}</p>
+    <button class="digest-btn digest-btn--loading" disabled><i class="ti ti-loader-2"></i> ${done.toLocaleString()} of ${total.toLocaleString()}</button>
+  `
+}
+
+function renderRestoreFailure(message) {
+  const el = restoreSection()
+  el.style.display = ''
+  el.innerHTML = `
+    <div class="digest-section-label">Restore</div>
+    <p class="digest-note">${message} Your backup file is untouched, and it's safe to try again — anything already restored will be skipped, not duplicated.</p>
+    <button class="digest-btn" onclick="restoreFromBackup()">Try again →</button>
+  `
+}
+
+function renderRestoreDone(totals) {
+  const el = restoreSection()
+  const parts = [`${totals.imported.toLocaleString()} restored`]
+  if (totals.edges_imported) parts.push(`${totals.edges_imported.toLocaleString()} connections`)
+  if (totals.skipped) parts.push(`${totals.skipped.toLocaleString()} already present`)
+  const failures = totals.failed + totals.edges_failed
+  const failNote = failures
+    ? ` ${failures.toLocaleString()} ${failures === 1 ? 'item' : 'items'} couldn't be restored — usually rows edited by hand; the rest are unaffected.`
+    : ''
+  const needsIndexing = totals.imported > 0
+  el.style.display = ''
+  el.innerHTML = `
+    <div class="digest-section-label">Restore</div>
+    <p class="digest-note"><i class="ti ti-check"></i> ${parts.join(' · ')}.${failNote}${
+      needsIndexing ? ' Restored memories can\'t be searched until they\'re indexed.' : ''
+    }</p>
+    ${needsIndexing ? '<button class="digest-btn" onclick="indexRestored(this)">Make searchable →</button>' : ''}
+  `
+}
+
+/** Stage two: the same /vectorize-pending loop the "Not indexed" section runs,
+ * kept inside the restore flow so finishing doesn't require finding another
+ * button elsewhere in the menu. */
+async function indexRestored(btn) {
+  btn.disabled = true
+  btn.classList.add('digest-btn--loading')
+  btn.innerHTML = '<i class="ti ti-loader-2"></i> Indexing…'
+  try {
+    let remaining = 1
+    let totalProcessed = 0
+    while (remaining > 0) {
+      const res = await fetch(`${WORKER_URL}/vectorize-pending`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+      })
+      if (!res.ok) throw new Error(`Server error: ${res.status}`)
+      const data = await res.json()
+      remaining = data.remaining ?? 0
+      totalProcessed += data.processed ?? 0
+      btn.innerHTML = `<i class="ti ti-loader-2"></i> Indexing… ${totalProcessed.toLocaleString()} done${remaining ? `, ${remaining.toLocaleString()} to go` : ''}`
+      if ((data.processed ?? 0) === 0 && remaining > 0) break
+    }
+    btn.classList.remove('digest-btn--loading')
+    if (remaining > 0) {
+      // Workers AI quota ran dry mid-backfill — the daily reset finishes the job.
+      btn.disabled = false
+      btn.innerHTML = `${remaining.toLocaleString()} left — daily AI limit reached, try tomorrow`
+    } else {
+      btn.innerHTML = '<i class="ti ti-check"></i> All restored memories are searchable'
+      btn.style.color = 'var(--good)'
+    }
+    await loadMenuStats()
+    loadRecent()
+  } catch {
+    btn.classList.remove('digest-btn--loading')
+    btn.disabled = false
+    btn.innerHTML = '<i class="ti ti-wifi-off"></i> Failed — tap to retry'
+    btn.style.color = 'var(--danger)'
+    btn.onclick = () => indexRestored(btn)
+  }
+}
+
+function pickBackupFile() {
+  return new Promise((resolveFile) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.json,application/json'
+    // A cancelled picker fires no event; the unresolved promise is harmless.
+    input.onchange = () => resolveFile(input.files && input.files[0] ? input.files[0] : null)
+    input.click()
+  })
+}
+
+async function restoreFromBackup() {
+  const file = await pickBackupFile()
+  if (!file) return
+
+  let payload
+  try {
+    payload = JSON.parse(await file.text())
+  } catch {
+    renderRestoreFailure(`<strong>${file.name}</strong> isn't valid JSON.`)
+    return
+  }
+  if (!payload || !Array.isArray(payload.entries)) {
+    renderRestoreFailure(`<strong>${file.name}</strong> doesn't look like a Second Brain backup — it has no entries list. Use a file created by "Back up as JSON".`)
+    return
+  }
+
+  const total = payload.entries.length + (payload.edges || []).length
+  renderRestoreProgress(`Restoring from <strong>${file.name}</strong>…`, 0, total)
+  try {
+    const totals = await runImportLoop(
+      payload,
+      async (query) => {
+        const res = await fetch(`${WORKER_URL}/import?${query}`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${AUTH_TOKEN}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        if (!res.ok) throw new Error(`Server error: ${res.status}`)
+        return res.json()
+      },
+      ({ done }) => renderRestoreProgress(`Restoring from <strong>${file.name}</strong>…`, done, total),
+    )
+    renderRestoreDone(totals)
+    await loadMenuStats()
+    loadRecent()
+  } catch (e) {
+    renderRestoreFailure('The restore stopped partway.')
+  }
+}
+
 async function exportMemories(format) {
   closeMenu()
   try {

--- a/test/ui/restore-loop.test.ts
+++ b/test/ui/restore-loop.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The dashboard's /import cursor walk (runImportLoop in public/js/settings.js).
+ *
+ * The paging protocol is the part of "Restore from backup" that can actually go
+ * wrong: the client must pass next_offset / next_edge_offset back verbatim, keep
+ * going while either remaining count is nonzero, and fail loudly against a
+ * Worker that never advances the cursor (any pre-2.2.4 deploy) instead of
+ * looping forever. The DOM handler around it is thin; this exercises the loop
+ * directly in the same VM harness dashboard-modules uses.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import vm from "node:vm";
+import { describe, it, expect } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+
+function loadRunImportLoop(): (payload: any, post: any, onProgress?: any) => Promise<any> {
+  const src = readFileSync(resolve(ROOT, "public/js/settings.js"), "utf8");
+  const ctx: any = { window: {}, document: {}, fetch: () => {}, console };
+  ctx.globalThis = ctx;
+  vm.createContext(ctx);
+  vm.runInContext(src, ctx);
+  return ctx.runImportLoop;
+}
+
+/** A Worker-side double: pages positionally, exactly like importExportPayload. */
+function fakeWorker(entryCount: number, edgeCount: number, limit: number) {
+  const calls: string[] = [];
+  const post = async (query: string) => {
+    calls.push(query);
+    const offset = Number(new URLSearchParams(query).get("offset"));
+    const edgeOffset = Number(new URLSearchParams(query).get("edge_offset"));
+    const page = Math.max(0, Math.min(limit, entryCount - offset));
+    const next_offset = offset + page;
+    const entriesDone = next_offset >= entryCount;
+    const edgePage = entriesDone ? Math.max(0, Math.min(limit, edgeCount - edgeOffset)) : 0;
+    const next_edge_offset = edgeOffset + edgePage;
+    return {
+      imported: page,
+      skipped: 0,
+      failed: 0,
+      edges_imported: edgePage,
+      edges_skipped: 0,
+      edges_failed: 0,
+      next_offset,
+      next_edge_offset,
+      remaining_entries: entryCount - next_offset,
+      remaining_edges: edgeCount - next_edge_offset,
+    };
+  };
+  return { post, calls };
+}
+
+describe("runImportLoop", () => {
+  it("walks entries then edges to completion and accumulates totals", async () => {
+    const runImportLoop = loadRunImportLoop();
+    const { post, calls } = fakeWorker(100, 50, 40);
+    const payload = { entries: new Array(100), edges: new Array(50) };
+
+    const totals = await runImportLoop(payload, post);
+
+    expect(totals.imported).toBe(100);
+    expect(totals.edges_imported).toBe(50);
+    // 3 entry pages (40+40+20); the third also runs edge page 1 (40); one more
+    // call finishes the last 10 edges.
+    expect(calls).toEqual([
+      "offset=0&edge_offset=0",
+      "offset=40&edge_offset=0",
+      "offset=80&edge_offset=0",
+      "offset=100&edge_offset=40",
+    ]);
+  });
+
+  it("reports progress after every page", async () => {
+    const runImportLoop = loadRunImportLoop();
+    const { post } = fakeWorker(80, 0, 40);
+    const seen: number[] = [];
+
+    await runImportLoop({ entries: new Array(80), edges: [] }, post, ({ done }: any) => seen.push(done));
+
+    expect(seen).toEqual([40, 80]);
+  });
+
+  it("fails loudly against a Worker that never advances the cursor", async () => {
+    const runImportLoop = loadRunImportLoop();
+    // A pre-cursor Worker echoes no next_offset; ?? keeps the cursor at 0 and
+    // remaining stays positive — the loop must throw, not spin.
+    const post = async () => ({
+      imported: 0, skipped: 40, failed: 0,
+      edges_imported: 0, edges_skipped: 0, edges_failed: 0,
+      remaining_entries: 60, remaining_edges: 0,
+    });
+
+    await expect(runImportLoop({ entries: new Array(100), edges: [] }, post))
+      .rejects.toThrow(/did not advance/);
+  });
+
+  it("propagates a page failure instead of swallowing it", async () => {
+    const runImportLoop = loadRunImportLoop();
+    let n = 0;
+    const { post } = fakeWorker(100, 0, 40);
+    const flaky = async (q: string) => {
+      if (++n === 2) throw new Error("Server error: 500");
+      return post(q);
+    };
+
+    await expect(runImportLoop({ entries: new Array(100), edges: [] }, flaky))
+      .rejects.toThrow(/500/);
+  });
+});


### PR DESCRIPTION
POST /import shipped in 2.2.4 API-only: restoring a 5,000-entry backup meant ~125 hand-run curl calls walking the cursor. This puts the loop where it belongs — the dashboard owns the mechanical repetition, and a non-technical user can restore a brain without a terminal.

## The experience

The settings menu's export items become a lifecycle that explains itself: **Back up as JSON** (relabeled — it's the restore format), Export as Markdown, **Restore from backup**.

Restore runs in a section using the existing digest-section pattern: live counts while the cursor walks (`Restoring… 2,440 of 5,050`), then an honest summary — restored, connections, already present, failures if any.

It's a two-stage flow by design. Imported entries carry no embeddings, so a restore that ended at "restored" would look complete while recall returns nothing. The done-state says so and offers **Make searchable →**, which runs the `/vectorize-pending` loop in the same section. Indexing is offered rather than automatic because it spends Workers AI quota, and quota exhaustion mid-backfill is reported plainly: *"1,200 left — daily AI limit reached, try tomorrow."*

Failure copy is written for the person actually restoring: the file is untouched, retrying is safe, nothing gets duplicated.

## Notes

- The cursor walk lives in `runImportLoop`, split from the DOM so the paging protocol is testable. It fails loudly against a Worker that never advances the cursor (any pre-2.2.4 deploy) instead of looping forever — the stall check applies the `??` fallback *before* comparing, because a missing `next_offset` compared against a number waves the stall through. That exact bug hung the first version of its own test.
- `test/ui/restore-loop.test.ts` pins the walk sequence, progress callbacks, stall detection, and error propagation. The existing handler harness auto-verifies the new `onclick` functions exist.
- Dashboard-only — no Worker source changes. Ships inside the Worker's assets, so it reaches users as 2.2.5/1.2.5.
- Exercised live against a production brain (1,874 entries) before this PR.

Suite: 1343 passing.