### PR TITLE
Project: localize the dashboard UI for English and Italian

### DIFF
--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -896,6 +896,12 @@ pub fn set_locale(locale: String, app: AppHandle) -> Result<(), String> {
         menus.apply_locale(locale);
         menus.rebuild_tray_menu(&app).map_err(|e| e.to_string())?;
     }
+    // Push the new language into an already-open dashboard window. Without this,
+    // changing Language in Settings left the brain webview on the old locale
+    // until the window was destroyed and recreated.
+    if let Ok((worker_url, _)) = dashboard_credentials(&app.state::<SetupSession>(), locale) {
+        windows::sync_brain_locale(&app, &worker_url, locale, true);
+    }
     Ok(())
 }
 

--- a/installer/src-tauri/src/windows.rs
+++ b/installer/src-tauri/src/windows.rs
@@ -163,6 +163,9 @@ fn open_wrapper_window_impl(
         .map(|l| l.get())
         .unwrap_or(Locale::En);
     if let Some(w) = app.get_webview_window("brain") {
+        // Align dashboard locale with the app without reloading when it already
+        // matches — reopening the brain otherwise would flash a full reload.
+        sync_brain_locale(app, worker_url, locale, false);
         if open_integrations {
             let _ = w.eval("try { openIntegrations() } catch (_) {}");
         }
@@ -179,6 +182,7 @@ fn open_wrapper_window_impl(
     // serde_json turns the values into safely-escaped JS string literals.
     let origin_js = serde_json::to_string(&origin).expect("string serializes");
     let token_js = serde_json::to_string(auth_token).expect("string serializes");
+    let locale_js = serde_json::to_string(locale.as_str()).expect("string serializes");
     let mut init = format!(
         r#"(function () {{
   // Tells the dashboard it is running inside the desktop app, so it can hide
@@ -190,6 +194,7 @@ fn open_wrapper_window_impl(
     if (location.origin === {origin_js}) {{
       localStorage.setItem('sb_url', {origin_js});
       localStorage.setItem('sb_token', {token_js});
+      localStorage.setItem('sb-locale', {locale_js});
     }}
   }} catch (_) {{}}
 }})();"#
@@ -244,6 +249,49 @@ fn open_wrapper_window_impl(
         })
         .build()?;
     Ok(())
+}
+
+/// Writes `sb-locale` into an open brain window (origin-guarded) and reloads
+/// when the stored value differs — or always when `force_reload` is set (language
+/// change from Settings). Same pattern as token refresh: never write off-origin.
+pub fn sync_brain_locale(
+    app: &AppHandle,
+    worker_url: &str,
+    locale: Locale,
+    force_reload: bool,
+) {
+    let Some(window) = app.get_webview_window("brain") else {
+        return;
+    };
+    let Some(origin) = brain_origin(worker_url) else {
+        return;
+    };
+    match window.url() {
+        Ok(showing) if showing_the_brain(showing.as_str(), &origin) => {}
+        Ok(_) => return,
+        Err(e) => {
+            log::warn!("could not read the dashboard window's address: {e}");
+            return;
+        }
+    }
+    let locale_js = serde_json::to_string(locale.as_str()).expect("string serializes");
+    let origin_js = serde_json::to_string(&origin).expect("string serializes");
+    let force = if force_reload { "true" } else { "false" };
+    let script = format!(
+        r#"(function () {{
+  try {{
+    if (location.origin !== {origin_js}) return;
+    var next = {locale_js};
+    var prev = localStorage.getItem('sb-locale');
+    if (prev === next && !{force}) return;
+    localStorage.setItem('sb-locale', next);
+    location.reload();
+  }} catch (_) {{}}
+}})();"#
+    );
+    if let Err(e) = window.eval(&script) {
+        log::warn!("could not sync the dashboard window's locale: {e}");
+    }
 }
 
 /// Re-points an already-open dashboard window at a new password, then reloads it.

--- a/public/credits.js
+++ b/public/credits.js
@@ -25,9 +25,9 @@ window.renderAboutCredits = function renderAboutCredits() {
   };
 
   root.innerHTML = `
-    <div class="about-credits-label">About</div>
-    <p class="about-credits-line"><span class="about-credits-kicker">Created by</span> ${personLine(creator)}</p>
-    <p class="about-credits-kicker">Maintainers</p>
+    <div class="about-credits-label">${escHtml(t('menu.about'))}</div>
+    <p class="about-credits-line"><span class="about-credits-kicker">${escHtml(t('menu.createdBy'))}</span> ${personLine(creator)}</p>
+    <p class="about-credits-kicker">${escHtml(t('menu.maintainers'))}</p>
     <ul class="about-credits-list">
       ${maintainers.map((p) => `<li>${personLine(p)}</li>`).join("")}
     </ul>

--- a/public/index.html
+++ b/public/index.html
@@ -335,6 +335,13 @@
         <div class="menu-group">
           <div class="menu-group-label" data-i18n="menu.groupThisApp">This app</div>
           <div class="theme-row">
+            <span class="theme-row-label" data-i18n="menu.language">Language</span>
+            <div class="theme-toggle" id="locale-toggle">
+              <button data-locale-val="en" onclick="setLocale('en')" title="English" data-i18n="menu.localeEn" data-i18n-attr="title"><span data-i18n="menu.localeEn">English</span></button>
+              <button data-locale-val="it" onclick="setLocale('it')" title="Italian" data-i18n="menu.localeIt" data-i18n-attr="title"><span data-i18n="menu.localeIt">Italian</span></button>
+            </div>
+          </div>
+          <div class="theme-row">
             <span class="theme-row-label" data-i18n="menu.appearance">Appearance</span>
             <div class="theme-toggle" id="theme-toggle">
               <button data-theme-val="light" onclick="setTheme('light')" title="Light" data-i18n="menu.themeLight" data-i18n-attr="title"><i class="ti ti-sun"></i></button>

--- a/public/index.html
+++ b/public/index.html
@@ -26,8 +26,8 @@
         <div class="brain-logo">
           <i class="ti ti-brain"></i>
         </div>
-        <h1>Second Brain</h1>
-        <p>Enter your Bearer token to connect to your personal memory layer. This is the password you chose when you set up Second Brain.</p>
+        <h1 data-i18n="auth.brand">Second Brain</h1>
+        <p data-i18n="auth.subtitle">Enter your Bearer token to connect to your personal memory layer. This is the password you chose when you set up Second Brain.</p>
         <form
           class="field-group"
           onsubmit="
@@ -37,8 +37,8 @@
         >
           <input type="text" name="username" value="user" autocomplete="username" style="display: none" />
           <input type="url" id="auth-url" autocomplete="off" autocapitalize="none" />
-          <input type="password" id="auth-token" placeholder="Bearer token (your setup password)" autocomplete="current-password" />
-          <button id="auth-connect" type="submit">Connect</button>
+          <input type="password" id="auth-token" placeholder="Bearer token (your setup password)" data-i18n="auth.tokenPlaceholder" data-i18n-attr="placeholder" autocomplete="current-password" />
+          <button id="auth-connect" type="submit" data-i18n="auth.connect">Connect</button>
         </form>
         <div id="auth-error"></div>
       </div>
@@ -52,21 +52,21 @@
           </div>
           <div>
             <div class="sb-brand-name">Second Brain</div>
-            <div class="sb-brand-status" id="sb-status">always remembers</div>
+            <div class="sb-brand-status" id="sb-status" data-i18n="nav.statusEmpty">always remembers</div>
           </div>
         </div>
         <!-- Two destinations, not four. Recall and Remember were verbs and the
              home input does both; Recent and Graph were two projections of one
              corpus, so they are one place with a view toggle. -->
         <nav class="sb-nav">
-          <button class="sb-tab active" id="sb-tab-home" onclick="switchTab('home')"><i class="ti ti-home"></i><span>Home</span></button>
-          <button class="sb-tab" id="sb-tab-memories" onclick="switchTab('memories')"><i class="ti ti-stack-2"></i><span>Memories</span></button>
+          <button class="sb-tab active" id="sb-tab-home" onclick="switchTab('home')"><i class="ti ti-home"></i><span data-i18n="nav.home">Home</span></button>
+          <button class="sb-tab" id="sb-tab-memories" onclick="switchTab('memories')"><i class="ti ti-stack-2"></i><span data-i18n="nav.memories">Memories</span></button>
         </nav>
         <div class="sb-footer">
           <!-- In the desktop app there is no address bar and no reload, so this
                is the only way to get fresh data without quitting. -->
-          <button class="sb-footer-btn refresh-now" onclick="refreshAll()" title="Refresh"><i class="ti ti-refresh"></i><span>Refresh</span></button>
-          <button class="sb-footer-btn" onclick="openMenu()"><i class="ti ti-settings"></i><span>Settings</span></button>
+          <button class="sb-footer-btn refresh-now" onclick="refreshAll()" title="Refresh" data-i18n="nav.refresh" data-i18n-attr="title"><i class="ti ti-refresh"></i><span data-i18n="nav.refresh">Refresh</span></button>
+          <button class="sb-footer-btn" onclick="openMenu()"><i class="ti ti-settings"></i><span data-i18n="nav.settings">Settings</span></button>
         </div>
       </div>
 
@@ -77,9 +77,9 @@
           </div>
           <div class="topbar-info">
             <div class="topbar-name">Second Brain</div>
-            <div class="topbar-status" id="topbar-status">always remembers</div>
+            <div class="topbar-status" id="topbar-status" data-i18n="nav.statusEmpty">always remembers</div>
           </div>
-          <button class="topbar-menu refresh-now" onclick="refreshAll()" aria-label="Refresh"><i class="ti ti-refresh"></i></button>
+          <button class="topbar-menu refresh-now" onclick="refreshAll()" aria-label="Refresh" data-i18n="nav.refresh" data-i18n-attr="aria-label"><i class="ti ti-refresh"></i></button>
           <button class="topbar-menu" onclick="openMenu()"><i class="ti ti-dots"></i></button>
         </div>
 
@@ -91,35 +91,35 @@
               <div class="home" id="home">
                 <div class="home-greet">
                   <span class="home-mark"><i class="ti ti-sparkles"></i></span>
-                  <span id="home-greeting">Hello</span>
+                  <span id="home-greeting" data-i18n="home.greetingDefault">Hello</span>
                 </div>
                 <div class="home-sub" id="home-sub"></div>
                 <div class="home-input">
                   <textarea
                     class="home-field"
                     id="home-field"
-                    placeholder="Ask, or tell me something to remember"
+                    placeholder="Ask, or tell me something to remember" data-i18n="home.placeholder" data-i18n-attr="placeholder"
                     rows="1"
                     onkeydown="handleHomeKey(event)"
                     oninput="onHomeInput(this)"
                   ></textarea>
                   <div class="home-row">
-                    <button class="home-mode" id="home-mode" onclick="toggleHomeMode()" title="Switch between asking and remembering">
-                      <span class="home-mode-dot"></span><span id="home-mode-label">will search</span>
+                    <button class="home-mode" id="home-mode" onclick="toggleHomeMode()" title="Switch between asking and remembering" data-i18n="home.modeTitle" data-i18n-attr="title">
+                      <span class="home-mode-dot"></span><span id="home-mode-label" data-i18n="home.willSearch">will search</span>
                     </button>
                     <button class="send-btn" onclick="submitHome()"><i class="ti ti-arrow-up"></i></button>
                   </div>
                 </div>
                 <!-- The one thing worth keeping from the deleted Remember tab:
                      it was the only place hashtags were ever taught. -->
-                <div class="home-hint">Add <span class="hashtag">#tags</span> anywhere to file it</div>
+                <div class="home-hint" data-i18n="home.hintHtml" data-i18n-html>Add <span class="hashtag">#tags</span> anywhere to file it</div>
                 <div class="home-topics" id="home-topics"></div>
                 <div class="home-more" id="home-more"></div>
               </div>
               <div class="brief" id="brief" style="display: none"></div>
               <div class="recall-hero" id="recall-welcome" style="display: none">
-                <div class="eyebrow">Recall</div>
-                <div class="hero-line">Ask me anything you've stored away &mdash; I'll find it and answer in your own words.</div>
+                <div class="eyebrow" data-i18n="recall.eyebrow">Recall</div>
+                <div class="hero-line" data-i18n="recall.hero">Ask me anything you've stored away &mdash; I'll find it and answer in your own words.</div>
               </div>
               <!-- Answers append after this point. Home, the brief and the hero
                    above are siblings of the conversation, not part of it — see
@@ -129,30 +129,30 @@
               <div class="filter-inner">
                 <i class="ti ti-tag" style="color: var(--text-tertiary); font-size: 13px; flex-shrink: 0"></i>
                 <select class="filter-field" id="tag-filter-recall" onchange="onTagChange(this.value)">
-                  <option value="">All tags</option>
+                  <option value="" data-i18n="recall.allTags">All tags</option>
                 </select>
               </div>
             </div>
             <div class="suggestions-row">
-              <button class="suggestion-pill" onclick="sendSuggestion('What am I working on?')">What am I working on?</button>
-              <button class="suggestion-pill" onclick="sendSuggestion('What did I decide recently?')">What did I decide recently?</button>
-              <button class="suggestion-pill" onclick="sendSuggestion('Show my tasks')">Show my tasks</button>
-              <button class="suggestion-pill" onclick="sendSuggestion('What are my goals?')">What are my goals?</button>
-              <button class="suggestion-pill" onclick="sendSuggestion('What ideas do I have?')">What ideas do I have?</button>
-              <button class="suggestion-pill" onclick="sendSuggestion('What happened last week?')">Last week</button>
-              <button class="suggestion-pill" onclick="sendSuggestion('What did I decide this month?')">This month</button>
+              <button class="suggestion-pill" onclick="sendSuggestion(t('recall.sugWorkingOn'))" data-i18n="recall.sugWorkingOn">What am I working on?</button>
+              <button class="suggestion-pill" onclick="sendSuggestion(t('recall.sugDecidedRecently'))" data-i18n="recall.sugDecidedRecently">What did I decide recently?</button>
+              <button class="suggestion-pill" onclick="sendSuggestion(t('recall.sugTasks'))" data-i18n="recall.sugTasks">Show my tasks</button>
+              <button class="suggestion-pill" onclick="sendSuggestion(t('recall.sugGoals'))" data-i18n="recall.sugGoals">What are my goals?</button>
+              <button class="suggestion-pill" onclick="sendSuggestion(t('recall.sugIdeas'))" data-i18n="recall.sugIdeas">What ideas do I have?</button>
+              <button class="suggestion-pill" onclick="sendSuggestion(t('recall.sugLastWeekQuery'))" data-i18n="recall.sugLastWeek">Last week</button>
+              <button class="suggestion-pill" onclick="sendSuggestion(t('recall.sugThisMonthQuery'))" data-i18n="recall.sugThisMonth">This month</button>
             </div>
             <div class="input-bar">
               <div class="input-inner">
                 <!-- The way out of a conversation. Without it the only route
                      back to home was pressing the tab you were already on. -->
-                <button id="recall-clear-btn" class="refresh-btn" onclick="clearRecall()" style="display: none" title="Back to home">
+                <button id="recall-clear-btn" class="refresh-btn" onclick="clearRecall()" style="display: none" title="Back to home" data-i18n="recall.backHome" data-i18n-attr="title">
                   <i class="ti ti-home"></i>
                 </button>
                 <textarea
                   class="input-field"
                   id="recall-input"
-                  placeholder="Ask your brain..."
+                  placeholder="Ask your brain..." data-i18n="recall.placeholder" data-i18n-attr="placeholder"
                   rows="1"
                   onkeydown="handleRecallKey(event)"
                   oninput="autoResize(this)"
@@ -172,14 +172,14 @@
               <div class="filter-inner mem-filters" id="mem-filters">
                 <i class="ti ti-tag" style="color: var(--text-tertiary); font-size: 13px; flex-shrink: 0"></i>
                 <select class="filter-field" id="tag-filter-recent" onchange="onTagChange(this.value)">
-                  <option value="">All tags</option>
+                  <option value="" data-i18n="recall.allTags">All tags</option>
                 </select>
                 <select class="filter-field" id="time-filter-recent" onchange="onTimeRangeChange(this.value)" style="min-width: 0">
-                  <option value="">All time</option>
-                  <option value="today">Today</option>
-                  <option value="7">Last 7 days</option>
-                  <option value="30">Last 30 days</option>
-                  <option value="month">This month</option>
+                  <option value="" data-i18n="memories.allTime">All time</option>
+                  <option value="today" data-i18n="memories.today">Today</option>
+                  <option value="7" data-i18n="memories.last7">Last 7 days</option>
+                  <option value="30" data-i18n="memories.last30">Last 30 days</option>
+                  <option value="month" data-i18n="memories.thisMonth">This month</option>
                 </select>
               </div>
               <!-- This used to read "Knowledge / Events / Unsorted", which stopped
@@ -187,64 +187,64 @@
                    palette (graph-canvas.js). The canvas draws its own legend with
                    the real colours and counts, so this says what the picture is
                    instead of mislabelling it. -->
-              <div class="mem-caption" id="mem-legend" hidden>Grouped by tag &middot; tap a memory to open it</div>
-              <div class="view-toggle" role="tablist" aria-label="How to view your memories">
-                <button class="view-toggle-btn active" id="mem-view-list" role="tab" aria-selected="true" onclick="setMemoryView('list')" title="By time">
-                  <i class="ti ti-list"></i><span>List</span>
+              <div class="mem-caption" id="mem-legend" hidden data-i18n="memories.legend">Grouped by tag · tap a memory to open it</div>
+              <div class="view-toggle" role="tablist" aria-label="How to view your memories" data-i18n="memories.viewAria" data-i18n-attr="aria-label">
+                <button class="view-toggle-btn active" id="mem-view-list" role="tab" aria-selected="true" onclick="setMemoryView('list')" title="By time" data-i18n="memories.viewListTitle" data-i18n-attr="title">
+                  <i class="ti ti-list"></i><span data-i18n="memories.viewList">List</span>
                 </button>
-                <button class="view-toggle-btn" id="mem-view-graph" role="tab" aria-selected="false" onclick="setMemoryView('graph')" title="By connection">
-                  <i class="ti ti-affiliate"></i><span>Graph</span>
+                <button class="view-toggle-btn" id="mem-view-graph" role="tab" aria-selected="false" onclick="setMemoryView('graph')" title="By connection" data-i18n="memories.viewGraphTitle" data-i18n-attr="title">
+                  <i class="ti ti-affiliate"></i><span data-i18n="memories.viewGraph">Graph</span>
                 </button>
               </div>
             </div>
 
             <div id="recent-list">
-              <div class="empty-state"><i class="ti ti-clock"></i><span>Loading memories...</span></div>
+              <div class="empty-state"><i class="ti ti-clock"></i><span data-i18n="memories.loading">Loading memories...</span></div>
             </div>
 
             <div class="mem-graph" id="mem-graph" hidden>
               <canvas id="graph-canvas"></canvas>
-              <div class="graph-empty" id="graph-empty" style="display: none">No connections yet — link memories, or let them auto-connect as you add more.</div>
+              <div class="graph-empty" id="graph-empty" style="display: none" data-i18n="graph.empty">No connections yet — link memories, or let them auto-connect as you add more.</div>
               <!-- Floating over the canvas rather than in the bar: the bar is
                    already carrying the legend and the view toggle on a phone. -->
               <div class="graph-controls">
-                <button class="graph-btn" onclick="graphZoom(0.8)" title="Zoom out"><i class="ti ti-minus"></i></button>
-                <button class="graph-btn" onclick="graphZoom(1.25)" title="Zoom in"><i class="ti ti-plus"></i></button>
-                <button class="graph-btn" onclick="graphFit()" title="Fit to view"><i class="ti ti-maximize"></i></button>
-                <button class="graph-btn" onclick="loadGraph()" title="Re-lay out"><i class="ti ti-refresh"></i></button>
+                <button class="graph-btn" onclick="graphZoom(0.8)" title="Zoom out" data-i18n="graph.zoomOut" data-i18n-attr="title"><i class="ti ti-minus"></i></button>
+                <button class="graph-btn" onclick="graphZoom(1.25)" title="Zoom in" data-i18n="graph.zoomIn" data-i18n-attr="title"><i class="ti ti-plus"></i></button>
+                <button class="graph-btn" onclick="graphFit()" title="Fit to view" data-i18n="graph.fit" data-i18n-attr="title"><i class="ti ti-maximize"></i></button>
+                <button class="graph-btn" onclick="loadGraph()" title="Re-lay out" data-i18n="graph.relayout" data-i18n-attr="title"><i class="ti ti-refresh"></i></button>
               </div>
             </div>
           </div>
         </div>
 
         <div id="navbar">
-          <button class="nav-tab active" id="tab-home" onclick="switchTab('home')"><i class="ti ti-home"></i><span>Home</span></button>
-          <button class="nav-tab" id="tab-memories" onclick="switchTab('memories')"><i class="ti ti-stack-2"></i><span>Memories</span></button>
+          <button class="nav-tab active" id="tab-home" onclick="switchTab('home')"><i class="ti ti-home"></i><span data-i18n="nav.home">Home</span></button>
+          <button class="nav-tab" id="tab-memories" onclick="switchTab('memories')"><i class="ti ti-stack-2"></i><span data-i18n="nav.memories">Memories</span></button>
         </div>
       </div>
     </div>
 
     <div id="confirm-dialog">
       <div class="confirm-sheet">
-        <h3>Forget this memory?</h3>
-        <p>This can't be undone. The memory will be removed from your brain.</p>
+        <h3 data-i18n="memories.confirmTitle">Forget this memory?</h3>
+        <p data-i18n="memories.confirmBody">This can't be undone. The memory will be removed from your brain.</p>
         <div class="confirm-actions">
-          <button class="btn-cancel" onclick="closeConfirm()">Cancel</button>
-          <button class="btn-delete" onclick="confirmForget()">Forget</button>
+          <button class="btn-cancel" onclick="closeConfirm()" data-i18n="memories.cancel">Cancel</button>
+          <button class="btn-delete" onclick="confirmForget()" data-i18n="memories.forget">Forget</button>
         </div>
       </div>
     </div>
 
     <div id="append-sheet">
       <div class="append-inner">
-        <h3>Add an update</h3>
+        <h3 data-i18n="memories.appendTitle">Add an update</h3>
         <div class="append-context" id="append-context-preview"></div>
         <div class="append-input-wrap">
-          <textarea id="append-textarea" placeholder="What's changed or new?" rows="3"></textarea>
+          <textarea id="append-textarea" placeholder="What's changed or new?" data-i18n="memories.appendPlaceholder" data-i18n-attr="placeholder" rows="3"></textarea>
         </div>
         <div class="append-actions">
-          <button class="btn-append-cancel" onclick="closeAppend()">Cancel</button>
-          <button class="btn-append-save" id="append-save-btn" onclick="saveAppend()">Update</button>
+          <button class="btn-append-cancel" onclick="closeAppend()" data-i18n="memories.cancel">Cancel</button>
+          <button class="btn-append-save" id="append-save-btn" onclick="saveAppend()" data-i18n="memories.appendSave">Update</button>
         </div>
       </div>
     </div>
@@ -252,17 +252,17 @@
     <div id="edit-sheet">
       <div class="edit-inner">
         <div class="edit-header">
-          <h3>Edit memory</h3>
+          <h3 data-i18n="memories.editTitle">Edit memory</h3>
           <div class="edit-sub" id="edit-sub"></div>
         </div>
         <div class="append-input-wrap edit-input-wrap">
-          <textarea id="edit-textarea" placeholder="Edit your memory..."></textarea>
+          <textarea id="edit-textarea" placeholder="Edit your memory..." data-i18n="memories.editPlaceholder" data-i18n-attr="placeholder"></textarea>
         </div>
         <div class="edit-existing-tags" id="edit-existing-tags"></div>
-        <div class="edit-hint">Tap a tag to remove it. Use <span style="font-style: italic">#hashtags</span> in the text to add one.</div>
+        <div class="edit-hint" data-i18n="memories.editHintHtml" data-i18n-html>Tap a tag to remove it. Use <span style="font-style: italic">#hashtags</span> in the text to add one.</div>
         <div class="append-actions">
-          <button class="btn-append-cancel" onclick="closeEdit()">Cancel</button>
-          <button class="btn-append-save" id="edit-save-btn" onclick="saveEdit()">Save</button>
+          <button class="btn-append-cancel" onclick="closeEdit()" data-i18n="memories.cancel">Cancel</button>
+          <button class="btn-append-save" id="edit-save-btn" onclick="saveEdit()" data-i18n="memories.editSave">Save</button>
         </div>
       </div>
     </div>
@@ -271,7 +271,7 @@
     <div id="view-sheet">
       <div class="view-inner">
         <div class="view-header">
-          <h3>Memory</h3>
+          <h3 data-i18n="memories.viewTitle">Memory</h3>
           <button class="btn-close-icon" onclick="closeView()"><i class="ti ti-x"></i></button>
         </div>
         <!-- One scroll region between a fixed header and fixed actions. These
@@ -287,9 +287,9 @@
           <div class="view-related" id="view-related" style="display: none"></div>
         </div>
         <div class="view-actions">
-          <button class="btn-view-append" id="view-btn-append"><i class="ti ti-writing"></i> Append</button>
-          <button class="btn-view-edit" id="view-btn-edit"><i class="ti ti-pencil"></i> Edit</button>
-          <button class="btn-view-forget" id="view-btn-forget"><i class="ti ti-trash"></i> Forget</button>
+          <button class="btn-view-append" id="view-btn-append"><i class="ti ti-writing"></i> <span data-i18n="memories.append">Append</span></button>
+          <button class="btn-view-edit" id="view-btn-edit"><i class="ti ti-pencil"></i> <span data-i18n="memories.edit">Edit</span></button>
+          <button class="btn-view-forget" id="view-btn-forget"><i class="ti ti-trash"></i> <span data-i18n="memories.forget">Forget</span></button>
         </div>
       </div>
     </div>
@@ -307,12 +307,12 @@
            control here is an immediate verb — Digest, Restore, Export — and a
            "Save" that fired nine irreversible actions at once would be a trap. -->
       <div class="menu-inner">
-        <h3>Your brain</h3>
+        <h3 data-i18n="menu.title">Your brain</h3>
 
         <!-- Chores. Each section hides itself when there is nothing to do, so
              on a healthy brain this whole group disappears. -->
         <div class="menu-group" id="upkeep-group" hidden>
-          <div class="menu-group-label">Upkeep</div>
+          <div class="menu-group-label" data-i18n="menu.groupUpkeep">Upkeep</div>
           <div class="digest-section" id="patterns-section" style="display: none"></div>
           <div class="digest-section" id="digest-section" style="display: none"></div>
           <div class="digest-section" id="vectorize-section" style="display: none"></div>
@@ -321,29 +321,29 @@
         </div>
 
         <div class="menu-group">
-          <div class="menu-group-label">Data</div>
-          <button class="menu-item" onclick="exportMemories('json')"><i class="ti ti-download"></i> Back up as JSON</button>
-          <button class="menu-item" onclick="exportMemories('markdown')"><i class="ti ti-markdown"></i> Export as Markdown</button>
-          <button class="menu-item" id="restore-btn" onclick="restoreFromBackup()"><i class="ti ti-upload"></i> Restore from backup</button>
+          <div class="menu-group-label" data-i18n="menu.groupData">Data</div>
+          <button class="menu-item" onclick="exportMemories('json')"><i class="ti ti-download"></i> <span data-i18n="menu.backupJson">Back up as JSON</span></button>
+          <button class="menu-item" onclick="exportMemories('markdown')"><i class="ti ti-markdown"></i> <span data-i18n="menu.exportMarkdown">Export as Markdown</span></button>
+          <button class="menu-item" id="restore-btn" onclick="restoreFromBackup()"><i class="ti ti-upload"></i> <span data-i18n="menu.restore">Restore from backup</span></button>
         </div>
 
         <div class="menu-group">
-          <div class="menu-group-label">Connections</div>
-          <button class="menu-item" onclick="openIntegrations()"><i class="ti ti-plug"></i> Integrations</button>
+          <div class="menu-group-label" data-i18n="menu.groupConnections">Connections</div>
+          <button class="menu-item" onclick="openIntegrations()"><i class="ti ti-plug"></i> <span data-i18n="menu.integrations">Integrations</span></button>
         </div>
 
         <div class="menu-group">
-          <div class="menu-group-label">This app</div>
+          <div class="menu-group-label" data-i18n="menu.groupThisApp">This app</div>
           <div class="theme-row">
-            <span class="theme-row-label">Appearance</span>
+            <span class="theme-row-label" data-i18n="menu.appearance">Appearance</span>
             <div class="theme-toggle" id="theme-toggle">
-              <button data-theme-val="light" onclick="setTheme('light')" title="Light"><i class="ti ti-sun"></i></button>
-              <button data-theme-val="dark" onclick="setTheme('dark')" title="Dark"><i class="ti ti-moon"></i></button>
-              <button data-theme-val="auto" onclick="setTheme('auto')" title="Match system">Auto</button>
+              <button data-theme-val="light" onclick="setTheme('light')" title="Light" data-i18n="menu.themeLight" data-i18n-attr="title"><i class="ti ti-sun"></i></button>
+              <button data-theme-val="dark" onclick="setTheme('dark')" title="Dark" data-i18n="menu.themeDark" data-i18n-attr="title"><i class="ti ti-moon"></i></button>
+              <button data-theme-val="auto" onclick="setTheme('auto')" title="Match system" data-i18n="menu.themeMatchSystem" data-i18n-attr="title"><span data-i18n="menu.themeAuto">Auto</span></button>
             </div>
           </div>
-          <div class="about-credits" id="about-credits" aria-label="About Second Brain"></div>
-          <button class="menu-item danger" onclick="logout()"><i class="ti ti-logout"></i> Disconnect</button>
+          <div class="about-credits" id="about-credits" aria-label="About Second Brain" data-i18n="menu.aboutAria" data-i18n-attr="aria-label"></div>
+          <button class="menu-item danger" onclick="logout()"><i class="ti ti-logout"></i> <span data-i18n="menu.disconnect">Disconnect</span></button>
         </div>
       </div>
     </div>
@@ -352,13 +352,13 @@
       <div class="menu-inner">
         <div class="view-header">
           <div style="display: flex; align-items: center; gap: 10px">
-            <button class="btn-close-icon" id="integrations-back" onclick="backToMenu()" title="Back to settings"><i class="ti ti-arrow-left"></i></button>
-            <h3 style="margin-bottom: 0" id="integrations-title">Integrations</h3>
+            <button class="btn-close-icon" id="integrations-back" onclick="backToMenu()" title="Back to settings" data-i18n="integrations.backSettings" data-i18n-attr="title"><i class="ti ti-arrow-left"></i></button>
+            <h3 style="margin-bottom: 0" id="integrations-title" data-i18n="menu.integrations">Integrations</h3>
           </div>
           <button class="btn-close-icon" onclick="closeIntegrations()"><i class="ti ti-x"></i></button>
         </div>
-        <p class="digest-note" id="integrations-intro">Connect the tools where your context already lives. Synced content stays up to date and surfaces in recall like any other memory.</p>
-        <div id="integrations-list"><p class="digest-note">Loading&hellip;</p></div>
+        <p class="digest-note" id="integrations-intro" data-i18n="integrations.intro">Connect the tools where your context already lives. Synced content stays up to date and surfaces in recall like any other memory.</p>
+        <div id="integrations-list"><p class="digest-note" data-i18n="integrations.loading">Loading…</p></div>
       </div>
     </div>
 
@@ -369,29 +369,28 @@
       <div class="menu-inner patterns-inner">
         <div class="view-header">
           <div style="display: flex; align-items: center; gap: 10px">
-            <button class="btn-close-icon" onclick="backToMenuFromPatterns()" title="Back to settings"><i class="ti ti-arrow-left"></i></button>
-            <h3 style="margin-bottom: 0">Patterns noticed</h3>
+            <button class="btn-close-icon" onclick="backToMenuFromPatterns()" title="Back to settings" data-i18n="integrations.backSettings" data-i18n-attr="title"><i class="ti ti-arrow-left"></i></button>
+            <h3 style="margin-bottom: 0" data-i18n="patterns.title">Patterns noticed</h3>
           </div>
           <button class="btn-close-icon" onclick="closePatternsSheet()"><i class="ti ti-x"></i></button>
         </div>
-        <p class="digest-note" id="patterns-intro">
-          Your brain spotted these across several memories. Confirm one to make it a trusted, recallable fact; dismiss to discard it. Nothing here is searchable until you confirm it.
-        </p>
+        <p class="digest-note" id="patterns-intro" data-i18n="patterns.intro">Your brain spotted these across several memories. Confirm one to make it a trusted, recallable fact; dismiss to discard it. Nothing here is searchable until you confirm it.</p>
         <div class="patterns-bulkbar" id="patterns-bulkbar" hidden>
           <label class="patterns-selectall">
             <input type="checkbox" id="patterns-select-all" onchange="togglePatternSelectAll(this.checked)" />
-            <span id="patterns-selected-label">Select all</span>
+            <span id="patterns-selected-label" data-i18n="patterns.selectAll">Select all</span>
           </label>
           <div class="patterns-bulk-actions">
-            <button class="digest-btn" id="patterns-confirm-btn" onclick="resolveSelectedPatterns('confirm', this)" disabled>Confirm</button>
-            <button class="digest-btn danger" id="patterns-dismiss-btn" onclick="resolveSelectedPatterns('dismiss', this)" disabled>Dismiss</button>
+            <button class="digest-btn" id="patterns-confirm-btn" onclick="resolveSelectedPatterns('confirm', this)" disabled data-i18n="brief.confirm">Confirm</button>
+            <button class="digest-btn danger" id="patterns-dismiss-btn" onclick="resolveSelectedPatterns('dismiss', this)" disabled data-i18n="brief.dismiss">Dismiss</button>
           </div>
         </div>
-        <div id="patterns-list"><p class="digest-note">Loading&hellip;</p></div>
+        <div id="patterns-list"><p class="digest-note" data-i18n="integrations.loading">Loading…</p></div>
         <button class="digest-more" id="patterns-more" hidden onclick="loadMorePatterns(this)"></button>
       </div>
     </div>
 
+    <script src="js/i18n.js"></script>
     <script src="utils.js"></script>
     <script src="credits.js"></script>
     <script src="js/state.js"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2,6 +2,7 @@ function init() {
   initI18n()
   applyI18nDom()
   applyTheme()
+  applyLocale()
   // Before anything renders, so the Memories screen is already showing the
   // projection this user last chose rather than snapping to it after paint.
   initMemoryView()

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,4 +1,6 @@
 function init() {
+  initI18n()
+  applyI18nDom()
   applyTheme()
   // Before anything renders, so the Memories screen is already showing the
   // projection this user last chose rather than snapping to it after paint.

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -4,24 +4,24 @@ async function connect() {
   const err = document.getElementById('auth-error')
   const btn = document.getElementById('auth-connect')
   if (!url || !tok) {
-    err.textContent = 'Please fill in both fields.'
+    err.textContent = t('auth.fillBoth')
     return
   }
-  btn.textContent = 'Connecting...'
+  btn.textContent = t('auth.connecting')
   btn.disabled = true
   err.textContent = ''
   try {
     const res = await fetch(`${url}/list?n=1`, { headers: { Authorization: `Bearer ${tok}` } })
-    if (res.status === 401) throw new Error('Invalid token')
-    if (!res.ok) throw new Error(`Server error: ${res.status}`)
+    if (res.status === 401) throw new Error(t('auth.invalidToken'))
+    if (!res.ok) throw new Error(t('auth.serverError', { status: res.status }))
     localStorage.setItem('sb_url', url)
     localStorage.setItem('sb_token', tok)
     WORKER_URL = url
     AUTH_TOKEN = tok
     showApp()
   } catch (e) {
-    err.textContent = e.message || 'Could not connect.'
-    btn.textContent = 'Connect'
+    err.textContent = e.message || t('auth.couldNotConnect')
+    btn.textContent = t('auth.connect')
     btn.disabled = false
   }
 }

--- a/public/js/brief.js
+++ b/public/js/brief.js
@@ -40,12 +40,13 @@ function briefActivity(activity) {
   const bars = activity
     .map((d) => {
       const pct = Math.round((d.count / peak) * 100)
-      const when = new Date(d.day * 86400000).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-      return `<span class="spark-bar${d.count ? '' : ' spark-bar--empty'}" style="height:${Math.max(pct, 3)}%" title="${escAttr(when)}: ${d.count} ${d.count === 1 ? 'memory' : 'memories'}"></span>`
+      const when = formatDateUI(d.day * 86400000, { month: 'short', day: 'numeric' })
+      const title = tPlural('brief.activityTitle', d.count, { date: when })
+      return `<span class="spark-bar${d.count ? '' : ' spark-bar--empty'}" style="height:${Math.max(pct, 3)}%" title="${escAttr(title)}"></span>`
     })
     .join('')
   return `<div class="brief-panel">
-      <div class="brief-label">Last ${activity.length} days</div>
+      <div class="brief-label">${escHtml(t('brief.lastDays', { n: activity.length }))}</div>
       <div class="spark">${bars}</div>
     </div>`
 }
@@ -67,7 +68,7 @@ function briefSources(sources) {
     })
     .join('')
   return `<div class="brief-panel">
-      <div class="brief-label">Where from</div>
+      <div class="brief-label">${escHtml(t('brief.whereFrom'))}</div>
       ${rows}
     </div>`
 }
@@ -80,10 +81,10 @@ function briefAttention(a) {
   if (!a) return ''
   const items = []
   if (a.unindexed > 0) {
-    items.push(`<button class="attn" onclick="openMenu()"><i class="ti ti-eye-off"></i>${a.unindexed} not searchable</button>`)
+    items.push(`<button class="attn" onclick="openMenu()"><i class="ti ti-eye-off"></i>${escHtml(t('brief.attentionUnindexed', { n: a.unindexed }))}</button>`)
   }
   if (a.stale > 0) {
-    items.push(`<button class="attn" onclick="sendSuggestion('What might be out of date?')"><i class="ti ti-clock-exclamation"></i>${a.stale} may be out of date</button>`)
+    items.push(`<button class="attn" onclick="sendSuggestion('${escAttr(t('recall.sugOutOfDate'))}')"><i class="ti ti-clock-exclamation"></i>${escHtml(t('brief.attentionStale', { n: a.stale }))}</button>`)
   }
   if (!items.length) return ''
   return `<div class="brief-attention">${items.join('')}</div>`
@@ -104,21 +105,21 @@ function renderBrief(data) {
   for (const p of (data.patterns || []).slice(0, 2)) {
     cards.push(`
       <div class="brief-card" data-pattern="${escAttr(p.id)}">
-        <div class="brief-label">Pattern noticed</div>
+        <div class="brief-label">${escHtml(t('brief.patternNoticed'))}</div>
         <div class="brief-body">${escHtml(titleLine(p.content, 140))}</div>
         <div class="brief-actions">
-          <button class="digest-btn" onclick="briefResolvePattern('${escAttr(p.id)}', 'confirm', this)">Confirm</button>
-          <button class="digest-btn danger" onclick="briefResolvePattern('${escAttr(p.id)}', 'dismiss', this)">Dismiss</button>
+          <button class="digest-btn" onclick="briefResolvePattern('${escAttr(p.id)}', 'confirm', this)">${escHtml(t('brief.confirm'))}</button>
+          <button class="digest-btn danger" onclick="briefResolvePattern('${escAttr(p.id)}', 'dismiss', this)">${escHtml(t('brief.dismiss'))}</button>
         </div>
       </div>`)
   }
   if (data.resurface) {
     const when = data.resurface.created_at
-      ? new Date(data.resurface.created_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+      ? formatDateUI(data.resurface.created_at, { year: 'numeric', month: 'short', day: 'numeric' })
       : ''
     cards.push(`
       <div class="brief-card brief-card--quiet">
-        <div class="brief-label">Worth re-reading${when ? ` · from ${escHtml(when)}` : ''}</div>
+        <div class="brief-label">${escHtml(when ? `${t('brief.worthRereading')}${t('brief.fromDate', { date: when })}` : t('brief.worthRereading'))}</div>
         <div class="brief-body">${escHtml(titleLine(data.resurface.content, 180))}</div>
       </div>`)
   }
@@ -136,7 +137,7 @@ function renderBrief(data) {
   el.style.display = ''
   el.innerHTML =
     attention +
-    `<div class="brief-eyebrow">Your brain, lately</div>` +
+    `<div class="brief-eyebrow">${escHtml(t('brief.eyebrow'))}</div>` +
     (panels.length ? `<div class="brief-grid">${panels.join('')}</div>` : '') +
     cards.join('')
 }
@@ -146,7 +147,7 @@ async function briefResolvePattern(id, action, btn) {
   const card = btn.closest('.brief-card')
   card.querySelectorAll('button').forEach((b) => (b.disabled = true))
   btn.classList.add('digest-btn--loading')
-  btn.innerHTML = '<i class="ti ti-loader-2"></i> Working…'
+  btn.innerHTML = `<i class="ti ti-loader-2"></i> ${escHtml(t('upkeep.working'))}`
   try {
     const res = await fetch(`${WORKER_URL}/patterns/resolve`, {
       method: 'POST',
@@ -155,11 +156,11 @@ async function briefResolvePattern(id, action, btn) {
     })
     const data = await res.json()
     if (!data.ok) throw new Error(data.error || 'failed')
-    card.innerHTML = `<div class="brief-label">${action === 'confirm' ? 'Confirmed — now recallable' : 'Dismissed'}</div>`
+    card.innerHTML = `<div class="brief-label">${escHtml(action === 'confirm' ? t('brief.confirmed') : t('brief.dismissed'))}</div>`
     card.classList.add('brief-card--quiet')
   } catch {
     card.querySelectorAll('button').forEach((b) => (b.disabled = false))
     btn.classList.remove('digest-btn--loading')
-    btn.innerHTML = 'Failed — retry'
+    btn.innerHTML = escHtml(t('brief.failedRetry'))
   }
 }

--- a/public/js/download-app.js
+++ b/public/js/download-app.js
@@ -47,9 +47,9 @@ function sbDownloadIcon(os) {
 }
 
 function sbDownloadLabel(os) {
-  if (os === 'mac') return 'Download for Mac'
-  if (os === 'windows') return 'Download for Windows'
-  return 'Download the app'
+  if (os === 'mac') return t('download.mac')
+  if (os === 'windows') return t('download.windows')
+  return t('download.generic')
 }
 
 /** Swaps the href for the exact installer. Silent no-op on any failure. */
@@ -67,7 +67,7 @@ async function upgradeDownloadHref(os, anchor) {
     )
     if (asset && asset.browser_download_url) {
       anchor.href = asset.browser_download_url
-      if (release.tag_name) anchor.title = `${sbDownloadLabel(os)} (${release.tag_name})`
+      if (release.tag_name) anchor.title = t('download.withTag', { label: sbDownloadLabel(os), tag: release.tag_name })
     }
   } catch {
     // Offline, rate limited, or blocked — the releases page href still stands.

--- a/public/js/graph-canvas.js
+++ b/public/js/graph-canvas.js
@@ -34,7 +34,7 @@ async function loadGraph() {
     canvas.style.display = 'block'
     initGraphSim(canvas, data.nodes, data.edges)
   } catch (e) {
-    emptyEl.textContent = 'Could not load the graph.'
+    emptyEl.textContent = t('graph.loadFailed')
     emptyEl.style.display = 'block'
   }
 }
@@ -69,10 +69,6 @@ function initGraphSim(canvas, nodes, edges) {
 
   // Order clusters (largest first, sentinels last), assign palette colors + dense index.
   const CLUSTER_PALETTE = ['#fd540a', '#4a7c8c', '#7a9a5b', '#a9739e', '#c99a3f', '#5b8a8f', '#8c6f5b', '#6a7bb0', '#b0685f', '#5f8c6a', '#9a7bb0', '#7d8c4f']
-  // Memories the tags and the edges both failed to place. They are not a category —
-  // "Other" and "Untagged" were rings and legend rows describing nothing, and on a
-  // young brain they were most of the canvas. Muted, unringed, unlabelled: a brain
-  // with little structure should look like one.
   const LOOSE_CLUSTER = '__loose__'
   const LOOSE_COLOR = '#b8b3a8'
   const clusterHue = (s) => {

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -17,7 +17,8 @@ let homeMode = null
 let homeModeLocked = false
 
 /** Leading words that make a sentence a question even without a question mark. */
-const ASK_OPENERS = /^(who|what|when|where|why|how|which|whose|did|do|does|is|are|was|were|can|could|should|would|will|have|has|had|am|tell me|show me|find|search|remind me what|list)\b/i
+const ASK_OPENERS =
+  /^(who|what|when|where|why|how|which|whose|did|do|does|is|are|was|were|can|could|should|would|will|have|has|had|am|tell me|show me|find|search|remind me what|list|chi|cosa|quando|dove|perché|perche|come|quale|quali|di chi|hai|ho|è|sono|può|puoi|posso|possono|devo|deve|dovrei|vorrei|dimmi|mostrami|trova|cerca|elenca)\b/i
 
 /**
  * Read the sentence, not the user's mind.
@@ -28,12 +29,13 @@ const ASK_OPENERS = /^(who|what|when|where|why|how|which|whose|did|do|does|is|ar
  * search costs a moment, an unwanted memory costs a cleanup.
  */
 function detectHomeMode(text) {
-  const t = String(text || '').trim()
-  if (!t) return null
-  if (t.endsWith('?')) return 'ask'
-  if (ASK_OPENERS.test(t)) return 'ask'
+  const s = String(text || '').trim()
+  if (!s) return null
+  if (s.endsWith('?')) return 'ask'
+  if (ASK_OPENERS.test(s)) return 'ask'
   // "remember that…" / "note:" are explicit the other way.
-  if (/^(remember|note|todo|remind me to|log)\b/i.test(t)) return 'remember'
+  if (/^(remind me to|ricordami di|remember|note|todo|log|ricorda|nota|promemoria|registra)\b/i.test(s))
+    return 'remember'
   return 'remember'
 }
 
@@ -43,7 +45,7 @@ function applyHomeMode(mode) {
   const label = document.getElementById('home-mode-label')
   if (!btn || !label) return
   const asking = mode === 'ask'
-  label.textContent = asking ? 'will search' : 'will remember'
+  label.textContent = asking ? t('home.willSearch') : t('home.willRemember')
   btn.classList.toggle('home-mode--remember', !asking)
   btn.style.visibility = mode ? 'visible' : 'hidden'
 }
@@ -115,14 +117,14 @@ async function submitHome() {
     field.value = ''
     autoResize(field)
     if (result.duplicate) {
-      receipts.innerHTML = `<div class="receipt"><div class="receipt-headline"><span class="receipt-dot"></span>already kept</div><div class="receipt-note">Something very similar is already in your brain, so this was skipped.</div></div>`
+      receipts.innerHTML = `<div class="receipt"><div class="receipt-headline"><span class="receipt-dot"></span>${escHtml(t('home.receiptAlreadyKept'))}</div><div class="receipt-note">${escHtml(t('home.receiptAlreadyKeptNote'))}</div></div>`
     } else {
       receipts.innerHTML = ''
       receipts.appendChild(captureReceipt(result, tags))
     }
     refreshAll()
   } catch {
-    receipts.innerHTML = `<div class="receipt"><div class="receipt-headline"><span class="receipt-dot"></span>could not save</div><div class="receipt-note">Nothing was lost — the text is still in the box. Try again.</div></div>`
+    receipts.innerHTML = `<div class="receipt"><div class="receipt-headline"><span class="receipt-dot"></span>${escHtml(t('home.receiptCouldNotSave'))}</div><div class="receipt-note">${escHtml(t('home.receiptCouldNotSaveNote'))}</div></div>`
   } finally {
     field.disabled = false
     field.focus()
@@ -174,11 +176,11 @@ function returnHome() {
  */
 function greetingFor(date) {
   const h = date.getHours()
-  if (h < 5) return 'Still up'
-  if (h < 12) return 'Good morning'
-  if (h < 17) return 'Good afternoon'
-  if (h < 22) return 'Good evening'
-  return 'Late one'
+  if (h < 5) return t('home.greetingStillUp')
+  if (h < 12) return t('home.greetingMorning')
+  if (h < 17) return t('home.greetingAfternoon')
+  if (h < 22) return t('home.greetingEvening')
+  return t('home.greetingLate')
 }
 
 /** Fills the greeting and the one number worth putting above the input. */
@@ -191,11 +193,12 @@ function renderHome(data) {
   const sub = document.getElementById('home-sub')
   if (sub && data) {
     const bits = []
-    if (data.total) bits.push(`${data.total.toLocaleString()} ${data.total === 1 ? 'memory' : 'memories'}`)
+    if (data.total)
+      bits.push(tPlural('home.subMemory', data.total, { n: formatNumberUI(data.total) }))
     // Summed from the activity strip rather than reusing `captured`, which is a
     // 48-hour count and would have been labelled "this week" incorrectly.
     const week = (data.activity || []).slice(-7).reduce((n, d) => n + (d.count || 0), 0)
-    if (week) bits.push(`${week} this week`)
+    if (week) bits.push(t('home.subThisWeek', { n: formatNumberUI(week) }))
     sub.textContent = bits.join(' · ')
   }
 
@@ -216,6 +219,6 @@ function renderHome(data) {
 function askAbout(tag) {
   leaveHome()
   const input = document.getElementById('recall-input')
-  input.value = `What did I decide about ${tag}?`
+  input.value = t('home.askAbout', { tag })
   sendRecall()
 }

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -17,8 +17,15 @@ let homeMode = null
 let homeModeLocked = false
 
 /** Leading words that make a sentence a question even without a question mark. */
-const ASK_OPENERS =
-  /^(who|what|when|where|why|how|which|whose|did|do|does|is|are|was|were|can|could|should|would|will|have|has|had|am|tell me|show me|find|search|remind me what|list|chi|cosa|quando|dove|perché|perche|come|quale|quali|di chi|hai|ho|è|sono|può|puoi|posso|possono|devo|deve|dovrei|vorrei|dimmi|mostrami|trova|cerca|elenca)\b/i
+const ASK_OPENERS_EN =
+  /^(who|what|when|where|why|how|which|whose|did|do|does|is|are|was|were|can|could|should|would|will|have|has|had|am|tell me|show me|find|search|remind me what|list)\b/i
+/** Italian interrogatives only — statement starters like ho/sono/devo are excluded. */
+const ASK_OPENERS_IT =
+  /^(chi|cosa|quando|dove|perché|perche|come|quale|quali|di chi|può|puoi|posso|possono|dovrei|vorrei|dimmi|mostrami|trova|cerca|elenca)\b/i
+
+function askOpenersForLocale() {
+  return getLocale() === 'it' ? ASK_OPENERS_IT : ASK_OPENERS_EN
+}
 
 /**
  * Read the sentence, not the user's mind.
@@ -32,7 +39,7 @@ function detectHomeMode(text) {
   const s = String(text || '').trim()
   if (!s) return null
   if (s.endsWith('?')) return 'ask'
-  if (ASK_OPENERS.test(s)) return 'ask'
+  if (askOpenersForLocale().test(s)) return 'ask'
   // "remember that…" / "note:" are explicit the other way.
   if (/^(remind me to|ricordami di|remember|note|todo|log|ricorda|nota|promemoria|registra)\b/i.test(s))
     return 'remember'

--- a/public/js/i18n.js
+++ b/public/js/i18n.js
@@ -180,9 +180,6 @@ const I18N_EN = {
     zoomIn: 'Zoom in',
     fit: 'Fit to view',
     relayout: 'Re-lay out',
-    clusterOther: 'Other',
-    clusterUntagged: 'Untagged',
-    clusterAutoPatterns: 'Auto-patterns',
   },
   menu: {
     title: 'Your brain',
@@ -195,6 +192,9 @@ const I18N_EN = {
     restore: 'Restore from backup',
     integrations: 'Integrations',
     appearance: 'Appearance',
+    language: 'Language',
+    localeEn: 'English',
+    localeIt: 'Italian',
     themeLight: 'Light',
     themeDark: 'Dark',
     themeAuto: 'Auto',
@@ -296,22 +296,24 @@ const I18N_EN = {
     notionPlaceholder: 'Integration secret (ntn_…)',
     urlPlaceholder: 'https://…',
     notionHint:
-      'Create an internal <strong>connection</strong> (not a personal access token) at notion.so/my-integrations, share the pages you want synced with that connection, then paste its secret here.',
+      'Create an internal <strong>connection</strong> (not a personal access token) at <a href="https://app.notion.com/developers/connections" target="_blank" rel="noopener">app.notion.com/developers/connections</a>, share the pages you want synced with that connection, then paste its secret here.',
     needEmailPw: 'Enter your email and app password.',
     needSecret: 'Paste your secret first.',
     couldNotConnectShort: 'Could not connect',
     syncNow: 'Sync now',
     syncing: 'Syncing…',
     syncingProgress: 'Syncing… {n} {noun} so far',
-    synced: '{n} synced',
+    synced: { one: '{n} synced', other: '{n} synced' },
     syncFailed: 'Sync failed',
     lastSyncFailed: 'Last sync failed: {error}',
-    countSynced: '{n} {noun} synced',
+    countSynced: { one: '{n} {noun} synced', other: '{n} {noun} synced' },
     lastSync: 'Last sync: {when}',
     never: 'never',
     disconnectConfirm: 'Disconnect {name}? It will stop syncing.',
-    purgeConfirm:
-      'Also delete the {n} synced {noun}?\n\nOK = delete them\nCancel = keep them as regular memories',
+    purgeConfirm: {
+      one: 'Also delete the {n} synced {noun}?\n\nOK = delete them\nCancel = keep them as regular memories',
+      other: 'Also delete the {n} synced {noun}?\n\nOK = delete them\nCancel = keep them as regular memories',
+    },
     disconnecting: 'Disconnecting…',
     disconnectFailed: 'Disconnect failed',
     nounEvent: { one: 'event', other: 'events' },
@@ -567,9 +569,6 @@ const I18N_IT = {
     zoomIn: 'Aumenta zoom',
     fit: 'Adatta alla vista',
     relayout: 'Ridisponi',
-    clusterOther: 'Altro',
-    clusterUntagged: 'Senza tag',
-    clusterAutoPatterns: 'Pattern automatici',
   },
   menu: {
     title: 'Il tuo cervello',
@@ -582,6 +581,9 @@ const I18N_IT = {
     restore: 'Ripristina da backup',
     integrations: 'Integrazioni',
     appearance: 'Aspetto',
+    language: 'Lingua',
+    localeEn: 'Inglese',
+    localeIt: 'Italiano',
     themeLight: 'Chiaro',
     themeDark: 'Scuro',
     themeAuto: 'Auto',
@@ -684,22 +686,24 @@ const I18N_IT = {
     notionPlaceholder: 'Secret integrazione (ntn_…)',
     urlPlaceholder: 'https://…',
     notionHint:
-      'Crea una <strong>connection</strong> interna (non un personal access token) su notion.so/my-integrations, condividi le pagine da sincronizzare con quella connection, poi incolla qui il secret.',
+      'Crea una <strong>connection</strong> interna (non un personal access token) su <a href="https://app.notion.com/developers/connections" target="_blank" rel="noopener">app.notion.com/developers/connections</a>, condividi le pagine da sincronizzare con quella connection, poi incolla qui il secret.',
     needEmailPw: 'Inserisci email e password app.',
     needSecret: 'Incolla prima il secret.',
     couldNotConnectShort: 'Connessione non riuscita',
     syncNow: 'Sincronizza ora',
     syncing: 'Sincronizzazione…',
     syncingProgress: 'Sincronizzazione… {n} {noun} finora',
-    synced: '{n} sincronizzati',
+    synced: { one: '{n} sincronizzato', other: '{n} sincronizzati' },
     syncFailed: 'Sincronizzazione non riuscita',
     lastSyncFailed: 'Ultima sync non riuscita: {error}',
-    countSynced: '{n} {noun} sincronizzati',
+    countSynced: { one: '{n} {noun} sincronizzato', other: '{n} {noun} sincronizzati' },
     lastSync: 'Ultima sync: {when}',
     never: 'mai',
     disconnectConfirm: 'Disconnettere {name}? Smetterà di sincronizzare.',
-    purgeConfirm:
-      'Eliminare anche i {n} {noun} sincronizzati?\n\nOK = eliminali\nAnnulla = tienili come ricordi normali',
+    purgeConfirm: {
+      one: 'Eliminare anche il {n} {noun} sincronizzato?\n\nOK = eliminali\nAnnulla = tienili come ricordi normali',
+      other: 'Eliminare anche i {n} {noun} sincronizzati?\n\nOK = eliminali\nAnnulla = tienili come ricordi normali',
+    },
     disconnecting: 'Disconnessione…',
     disconnectFailed: 'Disconnessione non riuscita',
     nounEvent: { one: 'evento', other: 'eventi' },
@@ -859,6 +863,23 @@ function initI18n(forceLocale) {
     document.documentElement.lang = currentLocale
   }
   return currentLocale
+}
+
+function setLocale(loc) {
+  if (loc !== 'en' && loc !== 'it') return
+  try {
+    localStorage.setItem(SB_LOCALE_KEY, loc)
+  } catch (_) {
+    /* ignore */
+  }
+  location.reload()
+}
+
+function applyLocale() {
+  const loc = getLocale()
+  document.querySelectorAll('#locale-toggle [data-locale-val]').forEach((b) =>
+    b.classList.toggle('active', b.dataset.localeVal === loc),
+  )
 }
 
 /**

--- a/public/js/i18n.js
+++ b/public/js/i18n.js
@@ -1,0 +1,891 @@
+// Dashboard i18n (en / it). Same storage key as the desktop installer.
+// Classic script: exposes t, tPlural, initI18n, applyI18nDom, getLocale, localeTag, formatDateUI.
+
+const SB_LOCALE_KEY = 'sb-locale'
+
+const I18N_EN = {
+  auth: {
+    brand: 'Second Brain',
+    subtitle:
+      'Enter your Bearer token to connect to your personal memory layer. This is the password you chose when you set up Second Brain.',
+    tokenPlaceholder: 'Bearer token (your setup password)',
+    connect: 'Connect',
+    connecting: 'Connecting...',
+    connectingEllipsis: 'Connecting…',
+    fillBoth: 'Please fill in both fields.',
+    invalidToken: 'Invalid token',
+    couldNotConnect: 'Could not connect.',
+    serverError: 'Server error: {status}',
+  },
+  nav: {
+    home: 'Home',
+    memories: 'Memories',
+    refresh: 'Refresh',
+    settings: 'Settings',
+    statusEmpty: 'always remembers',
+    statusCount: {
+      one: '{n} memory stored',
+      other: '{n} memories stored',
+    },
+  },
+  home: {
+    greetingDefault: 'Hello',
+    greetingStillUp: 'Still up',
+    greetingMorning: 'Good morning',
+    greetingAfternoon: 'Good afternoon',
+    greetingEvening: 'Good evening',
+    greetingLate: 'Late one',
+    placeholder: 'Ask, or tell me something to remember',
+    modeTitle: 'Switch between asking and remembering',
+    willSearch: 'will search',
+    willRemember: 'will remember',
+    hintHtml: 'Add <span class="hashtag">#tags</span> anywhere to file it',
+    subMemory: { one: '{n} memory', other: '{n} memories' },
+    subThisWeek: '{n} this week',
+    askAbout: 'What did I decide about {tag}?',
+    receiptAlreadyKept: 'already kept',
+    receiptAlreadyKeptNote: 'Something very similar is already in your brain, so this was skipped.',
+    receiptCouldNotSave: 'could not save',
+    receiptCouldNotSaveNote: 'Nothing was lost — the text is still in the box. Try again.',
+    receiptStored: 'stored to brain',
+    receiptMerged: 'merged into an existing memory',
+    receiptMergedNote: 'You had written about this before, so the two are now one memory.',
+    receiptReplaced: 'replaced an outdated memory',
+    receiptReplacedNote: 'The older version is gone; this one supersedes it.',
+    receiptConflict: 'stored, and something older now disagrees',
+    receiptConflictNote:
+      'Your brain noticed this conflicts with an earlier memory and kept the newer one.',
+    receiptDraft: 'stored as a draft',
+    receiptDraftNote:
+      'This conflicts with a memory you have confirmed, so it is kept unconfirmed rather than overriding it.',
+    receiptSimilar: 'stored, close to something you already had',
+    receiptSimilarNote: 'Flagged as a possible duplicate so you can compare them later.',
+    receiptFiledUnder: 'filed under',
+    firstRunEyebrow: 'Getting started',
+    firstRunHero: 'Your Second Brain is empty. Here is where everything lives.',
+    firstRunStep1:
+      'The box above does both: write a statement and it is saved, ask a question and it is answered. It says which one it is about to do before you send.',
+    firstRunStep2:
+      'Memories is everything you have kept — as a list by date, or as a graph of how it connects.',
+    firstRunStep3:
+      'Settings is where you connect Claude, ChatGPT, Cursor, your email and calendar, so they read from and add to this same memory.',
+  },
+  recall: {
+    eyebrow: 'Recall',
+    hero: "Ask me anything you've stored away — I'll find it and answer in your own words.",
+    placeholder: 'Ask your brain...',
+    backHome: 'Back to home',
+    allTags: 'All tags',
+    sugWorkingOn: 'What am I working on?',
+    sugDecidedRecently: 'What did I decide recently?',
+    sugTasks: 'Show my tasks',
+    sugGoals: 'What are my goals?',
+    sugIdeas: 'What ideas do I have?',
+    sugLastWeek: 'Last week',
+    sugLastWeekQuery: 'What happened last week?',
+    sugThisMonth: 'This month',
+    sugThisMonthQuery: 'What did I decide this month?',
+    sugOutOfDate: 'What might be out of date?',
+    empty: "I couldn't find anything matching that. Try different words, or browse Memories.",
+    error: 'Something went wrong. Check your connection and try again.',
+    youAsked: 'You asked',
+    sourcesFound: { one: 'found · {n} source', other: 'found · {n} sources' },
+    citeTitle: 'Show source {n}',
+    citedAs: 'Cited as [{n}] in the answer',
+    relatedHop: { one: 'related · {n} hop', other: 'related · {n} hops' },
+  },
+  memories: {
+    allTime: 'All time',
+    today: 'Today',
+    yesterday: 'Yesterday',
+    last7: 'Last 7 days',
+    last30: 'Last 30 days',
+    thisMonth: 'This month',
+    weekOf: 'Week of {date}',
+    legend: 'Grouped by tag · tap a memory to open it',
+    viewAria: 'How to view your memories',
+    viewList: 'List',
+    viewListTitle: 'By time',
+    viewGraph: 'Graph',
+    viewGraphTitle: 'By connection',
+    loading: 'Loading memories...',
+    loadingShort: 'Loading...',
+    loadFailed: 'Could not load memories.',
+    empty: 'No memories yet. Use Remember to save your first one.',
+    vecOnTitle: 'Vectorized — searchable via recall',
+    vecPendingTitle: 'Vectorizing… (just captured)',
+    vecOffTitle: "Not vectorized — won't appear in recall",
+    vecNotIndexed: 'Not indexed',
+    append: 'Append',
+    edit: 'Edit',
+    forget: 'Forget',
+    forgetThis: 'Forget this memory',
+    moreActions: 'More actions',
+    confirmTitle: 'Forget this memory?',
+    confirmBody: "This can't be undone. The memory will be removed from your brain.",
+    cancel: 'Cancel',
+    appendTitle: 'Add an update',
+    appendPlaceholder: "What's changed or new?",
+    appendSave: 'Update',
+    saving: 'Saving...',
+    appendFailed: 'Append failed: {message}',
+    editTitle: 'Edit memory',
+    editPlaceholder: 'Edit your memory...',
+    editHintHtml:
+      'Tap a tag to remove it. Use <span style="font-style: italic">#hashtags</span> in the text to add one.',
+    editSave: 'Save',
+    editFailed: 'Edit failed: {message}',
+    removeTag: 'Remove tag {tag}',
+    viewTitle: 'Memory',
+    forgetting: 'Forgetting...',
+    forgetFailed: 'Could not forget: {message}',
+    metaCaptured: 'captured {relative}',
+    metaEdited: 'edited {relative}',
+    brainLabel: 'What your brain knows',
+    importance: 'Importance',
+    importanceTitle: 'Importance {n} of 5',
+    kind: 'Kind',
+    status: 'Status',
+    lifespan: 'Lifespan',
+    recalled: 'Recalled',
+    recalledTimes: { one: '{n} time', other: '{n} times' },
+    kindFact: 'Fact',
+    kindEvent: 'Event',
+    statusTrusted: 'Trusted',
+    statusUnconfirmed: 'Unconfirmed',
+    statusSuperseded: 'Superseded',
+    volDurable: 'Durable',
+    volDurableGloss: 'Not expected to change.',
+    volCurrent: 'Current',
+    volCurrentGloss: 'True for now — assistants verify this before relying on it.',
+    volShortLived: 'Short-lived',
+    volShortLivedGloss: 'True only briefly — assistants treat it as possibly stale.',
+    disagreed: {
+      one: 'Something newer has disagreed with this {n} time.',
+      other: 'Something newer has disagreed with this {n} times.',
+    },
+    notIndexedYet: 'Not indexed yet — recall cannot find this memory.',
+    related: 'Related',
+    youLinked: 'you linked',
+    systemLinked: 'system-linked',
+    autoLinked: 'auto-linked',
+    removeLink: 'Remove link',
+    removeLinkConfirm: 'Remove this link? The memories stay; only the connection is deleted.',
+    untitled: 'Untitled memory',
+  },
+  graph: {
+    empty: 'No connections yet — link memories, or let them auto-connect as you add more.',
+    loadFailed: 'Could not load the graph.',
+    zoomOut: 'Zoom out',
+    zoomIn: 'Zoom in',
+    fit: 'Fit to view',
+    relayout: 'Re-lay out',
+    clusterOther: 'Other',
+    clusterUntagged: 'Untagged',
+    clusterAutoPatterns: 'Auto-patterns',
+  },
+  menu: {
+    title: 'Your brain',
+    groupUpkeep: 'Upkeep',
+    groupData: 'Data',
+    groupConnections: 'Connections',
+    groupThisApp: 'This app',
+    backupJson: 'Back up as JSON',
+    exportMarkdown: 'Export as Markdown',
+    restore: 'Restore from backup',
+    integrations: 'Integrations',
+    appearance: 'Appearance',
+    themeLight: 'Light',
+    themeDark: 'Dark',
+    themeAuto: 'Auto',
+    themeMatchSystem: 'Match system',
+    aboutAria: 'About Second Brain',
+    about: 'About',
+    createdBy: 'Created by',
+    maintainers: 'Maintainers',
+    disconnect: 'Disconnect',
+    exportFailed: 'Export failed: {message}',
+    exportMdTitle: '# Second Brain Export',
+    exportMdExported: 'Exported: {date}',
+    exportMdMemory: '## Memory {n}',
+    exportMdDate: '**Date:** {date}',
+    exportMdTags: '**Tags:** {tags}',
+    exportMdSource: '**Source:** {source}',
+    exportMdRelationships: '## Relationships',
+  },
+  upkeep: {
+    working: 'Working…',
+    done: 'Done',
+    requestFailed: 'Request failed',
+    digestLabel: 'Ready to compress',
+    digestNote:
+      "Originals are never deleted — digest adds a summary and ranks originals lower in recall so they don't crowd results.",
+    digestEntries: { one: '{n} entry', other: '{n} entries' },
+    digestAction: 'Digest →',
+    digestMore: '{n} more ›',
+    digestFailed: 'Could not create digest',
+    digestPreserved: {
+      one: '{n} original memory preserved & still searchable',
+      other: '{n} original memories preserved & still searchable',
+    },
+    vectorizeLabel: 'Not indexed',
+    vectorizeNote: {
+      one: "{n} memory failed to embed and won't appear in recall.",
+      other: "{n} memories failed to embed and won't appear in recall.",
+    },
+    vectorizeAction: 'Vectorize now →',
+    vectorizeDone: 'Done — {n} re-indexed',
+    classifyLabel: 'Not classified',
+    classifyNote: {
+      one: '{n} memory has no kind or status tag yet (captured before classification existed).',
+      other: '{n} memories have no kind or status tag yet (captured before classification existed).',
+    },
+    classifyAction: 'Classify now →',
+    classifyDone: 'Done — {n} classified',
+    restoreLabel: 'Restore',
+    restoreProgress: 'Restoring from {filename}…',
+    restoreOf: '{done} of {total}',
+    restoreTryAgain: 'Try again →',
+    restoreFailureTail:
+      "Your backup file is untouched, and it's safe to try again — anything already restored will be skipped, not duplicated.",
+    restoreInvalidJson: "{filename} isn't valid JSON.",
+    restoreNotBackup:
+      "{filename} doesn't look like a Second Brain backup — it has no entries list. Use a file created by \"Back up as JSON\".",
+    restoreStopped: 'The restore stopped partway.',
+    restoreSummaryRestored: '{n} restored',
+    restoreSummaryConnections: '{n} connections',
+    restoreSummaryPresent: '{n} already present',
+    restoreFailNote:
+      "{n} item(s) couldn't be restored — usually rows edited by hand; the rest are unaffected.",
+    restoreNeedsIndex: "Restored memories can't be searched until they're indexed.",
+    restoreMakeSearchable: 'Make searchable →',
+    restoreIndexing: 'Indexing…',
+    restoreIndexingProgress: 'Indexing… {done} done, {remaining} to go',
+    restoreIndexingDoneOnly: 'Indexing… {done} done',
+    restoreQuotaLeft: '{n} left — daily AI limit reached, try tomorrow',
+    restoreAllSearchable: 'All restored memories are searchable',
+    restoreIndexFailed: 'Failed — tap to retry',
+    importStalled: 'Server did not advance the import cursor — is the Worker up to date?',
+    vectorizeBannerTitle: 'Semantic search is disabled. The Vectorize index "{name}" was not found.',
+    vectorizeBannerHowToFix: 'How to fix',
+    vectorizeBannerRunOnce: 'Run this once in your terminal:',
+    vectorizeBannerGui:
+      'Or grant the Workers Builds API token the account-level Vectorize Edit permission in the Cloudflare dashboard (My Profile, API Tokens), then redeploy so the build creates the index automatically.',
+  },
+  integrations: {
+    intro:
+      'Connect the tools where your context already lives. Synced content stays up to date and surfaces in recall like any other memory.',
+    loading: 'Loading…',
+    backSettings: 'Back to settings',
+    backList: 'Back to integrations',
+    loadFailed: 'Could not load integrations.',
+    none: 'No integrations available.',
+    emptyCategory: 'Nothing here yet.',
+    categoryKnowledge: 'Knowledge',
+    categoryCalendars: 'Calendars',
+    categoryEmail: 'Email',
+    categoryOther: 'Other',
+    summaryConnected: { one: '{n} connected', other: '{n} connected' },
+    notConnected: 'Not connected',
+    connected: 'Connected',
+    pasteSecret: 'Paste your secret',
+    emailPlaceholder: 'you@example.com',
+    emailAria: 'Email address',
+    appPassword: 'app password',
+    appPasswordAria: 'App password',
+    notionPlaceholder: 'Integration secret (ntn_…)',
+    urlPlaceholder: 'https://…',
+    notionHint:
+      'Create an internal <strong>connection</strong> (not a personal access token) at notion.so/my-integrations, share the pages you want synced with that connection, then paste its secret here.',
+    needEmailPw: 'Enter your email and app password.',
+    needSecret: 'Paste your secret first.',
+    couldNotConnectShort: 'Could not connect',
+    syncNow: 'Sync now',
+    syncing: 'Syncing…',
+    syncingProgress: 'Syncing… {n} {noun} so far',
+    synced: '{n} synced',
+    syncFailed: 'Sync failed',
+    lastSyncFailed: 'Last sync failed: {error}',
+    countSynced: '{n} {noun} synced',
+    lastSync: 'Last sync: {when}',
+    never: 'never',
+    disconnectConfirm: 'Disconnect {name}? It will stop syncing.',
+    purgeConfirm:
+      'Also delete the {n} synced {noun}?\n\nOK = delete them\nCancel = keep them as regular memories',
+    disconnecting: 'Disconnecting…',
+    disconnectFailed: 'Disconnect failed',
+    nounEvent: { one: 'event', other: 'events' },
+    nounEmail: { one: 'email', other: 'emails' },
+    nounItem: { one: 'item', other: 'items' },
+    nounMemory: { one: 'memory', other: 'memories' },
+  },
+  brief: {
+    eyebrow: 'Your brain, lately',
+    lastDays: 'Last {n} days',
+    whereFrom: 'Where from',
+    activityTitle: {
+      one: '{date}: {n} memory',
+      other: '{date}: {n} memories',
+    },
+    attentionUnindexed: '{n} not searchable',
+    attentionStale: '{n} may be out of date',
+    patternNoticed: 'Pattern noticed',
+    confirm: 'Confirm',
+    dismiss: 'Dismiss',
+    confirmed: 'Confirmed — now recallable',
+    dismissed: 'Dismissed',
+    failedRetry: 'Failed — retry',
+    worthRereading: 'Worth re-reading',
+    fromDate: '· from {date}',
+  },
+  patterns: {
+    title: 'Patterns noticed',
+    intro:
+      'Your brain spotted these across several memories. Confirm one to make it a trusted, recallable fact; dismiss to discard it. Nothing here is searchable until you confirm it.',
+    selectAll: 'Select all',
+    nSelected: '{n} selected',
+    confirmN: 'Confirm {n}',
+    dismissN: 'Dismiss {n}',
+    loadFailed: 'Could not load your patterns.',
+    emptyIntro: 'Nothing is waiting on you.',
+    emptyBody: 'Every pattern your brain noticed has been ruled on.',
+    noticedWhen: 'noticed {date}',
+    more: '{n} more ›',
+    failed: 'Failed',
+    upkeepNote: {
+      one: '{n} pattern is waiting on a decision. It stays out of recall until confirmed.',
+      other: '{n} patterns are waiting on a decision. They stay out of recall until confirmed.',
+    },
+    reviewOne: 'Review it →',
+    reviewAll: 'Review all →',
+  },
+  download: {
+    mac: 'Download for Mac',
+    windows: 'Download for Windows',
+    generic: 'Download the app',
+    withTag: '{label} ({tag})',
+  },
+  common: {
+    cancel: 'Cancel',
+    justNow: 'just now',
+    minutesAgo: '{n}m ago',
+    hoursAgo: '{n}h ago',
+    daysAgo: '{n}d ago',
+    weeksAgo: '{n}w ago',
+    monthsAgo: '{n}mo ago',
+    yearsAgo: '{n}y ago',
+    sourceManual: 'manual',
+    sourceCli: 'cli',
+    sourceEmail: 'email',
+    sourceChat: 'chat',
+    sourceBrowser: 'browser',
+    sourceDashboard: 'dashboard',
+    sourcePhone: 'phone',
+    sourceVoice: 'voice',
+    sourceImport: 'import',
+    sourceSystem: 'system',
+    sourceClaudeCode: 'claude code',
+  },
+}
+
+const I18N_IT = {
+  auth: {
+    brand: 'Second Brain',
+    subtitle:
+      'Inserisci il Bearer token per collegarti al tuo layer di memoria personale. È la password scelta durante la configurazione di Second Brain.',
+    tokenPlaceholder: 'Bearer token (la password di setup)',
+    connect: 'Connetti',
+    connecting: 'Connessione...',
+    connectingEllipsis: 'Connessione…',
+    fillBoth: 'Compila entrambi i campi.',
+    invalidToken: 'Token non valido',
+    couldNotConnect: 'Impossibile connettersi.',
+    serverError: 'Errore del server: {status}',
+  },
+  nav: {
+    home: 'Home',
+    memories: 'Ricordi',
+    refresh: 'Aggiorna',
+    settings: 'Impostazioni',
+    statusEmpty: 'ricorda sempre',
+    statusCount: {
+      one: '{n} ricordo salvato',
+      other: '{n} ricordi salvati',
+    },
+  },
+  home: {
+    greetingDefault: 'Ciao',
+    greetingStillUp: 'Ancora sveglio',
+    greetingMorning: 'Buongiorno',
+    greetingAfternoon: 'Buon pomeriggio',
+    greetingEvening: 'Buonasera',
+    greetingLate: 'Notte fonda',
+    placeholder: 'Chiedi, oppure dimmi qualcosa da ricordare',
+    modeTitle: 'Passa tra chiedere e ricordare',
+    willSearch: 'cercherà',
+    willRemember: 'ricorderà',
+    hintHtml: 'Aggiungi <span class="hashtag">#tag</span> ovunque per archiviarlo',
+    subMemory: { one: '{n} ricordo', other: '{n} ricordi' },
+    subThisWeek: '{n} questa settimana',
+    askAbout: 'Cosa ho deciso su {tag}?',
+    receiptAlreadyKept: 'già presente',
+    receiptAlreadyKeptNote: 'Qualcosa di molto simile è già nel tuo cervello, quindi è stato saltato.',
+    receiptCouldNotSave: 'salvataggio non riuscito',
+    receiptCouldNotSaveNote: 'Non è andato perso nulla — il testo è ancora nel riquadro. Riprova.',
+    receiptStored: 'salvato nel cervello',
+    receiptMerged: 'unito a un ricordo esistente',
+    receiptMergedNote: 'Ne avevi già scritto: ora i due sono un solo ricordo.',
+    receiptReplaced: 'ha sostituito un ricordo obsoleto',
+    receiptReplacedNote: 'La versione precedente non c’è più; questa la sostituisce.',
+    receiptConflict: 'salvato, e qualcosa di più vecchio ora non coincide',
+    receiptConflictNote:
+      'Il cervello ha notato un conflitto con un ricordo precedente e ha tenuto quello più recente.',
+    receiptDraft: 'salvato come bozza',
+    receiptDraftNote:
+      'È in conflitto con un ricordo che hai confermato, quindi resta non confermato invece di sovrascriverlo.',
+    receiptSimilar: 'salvato, vicino a qualcosa che avevi già',
+    receiptSimilarNote: 'Segnato come possibile duplicato così puoi confrontarli più tardi.',
+    receiptFiledUnder: 'archiviato sotto',
+    firstRunEyebrow: 'Per iniziare',
+    firstRunHero: 'Il tuo Second Brain è vuoto. Qui vive tutto.',
+    firstRunStep1:
+      'Il riquadro sopra fa entrambe le cose: scrivi un’affermazione e viene salvata, fai una domanda e viene risposta. Indica quale sta per fare prima di inviare.',
+    firstRunStep2:
+      'Ricordi è tutto ciò che hai tenuto — come elenco per data, o come grafo di come si collega.',
+    firstRunStep3:
+      'Impostazioni è dove colleghi Claude, ChatGPT, Cursor, email e calendario, così leggono e aggiungono a questa stessa memoria.',
+  },
+  recall: {
+    eyebrow: 'Richiamo',
+    hero: 'Chiedimi qualsiasi cosa tu abbia messo da parte — la trovo e rispondo con le tue parole.',
+    placeholder: 'Chiedi al tuo cervello...',
+    backHome: 'Torna alla home',
+    allTags: 'Tutti i tag',
+    sugWorkingOn: 'A cosa sto lavorando?',
+    sugDecidedRecently: 'Cosa ho deciso di recente?',
+    sugTasks: 'Mostra i miei task',
+    sugGoals: 'Quali sono i miei obiettivi?',
+    sugIdeas: 'Che idee ho?',
+    sugLastWeek: 'La settimana scorsa',
+    sugLastWeekQuery: 'Cosa è successo la settimana scorsa?',
+    sugThisMonth: 'Questo mese',
+    sugThisMonthQuery: 'Cosa ho deciso questo mese?',
+    sugOutOfDate: 'Cosa potrebbe essere datato?',
+    empty: 'Non ho trovato nulla di corrispondente. Prova altre parole, oppure sfoglia Ricordi.',
+    error: 'Qualcosa è andato storto. Controlla la connessione e riprova.',
+    youAsked: 'Hai chiesto',
+    sourcesFound: { one: 'trovato · {n} fonte', other: 'trovato · {n} fonti' },
+    citeTitle: 'Mostra fonte {n}',
+    citedAs: 'Citato come [{n}] nella risposta',
+    relatedHop: { one: 'correlato · {n} hop', other: 'correlato · {n} hop' },
+  },
+  memories: {
+    allTime: 'Tutto il tempo',
+    today: 'Oggi',
+    yesterday: 'Ieri',
+    last7: 'Ultimi 7 giorni',
+    last30: 'Ultimi 30 giorni',
+    thisMonth: 'Questo mese',
+    weekOf: 'Settimana del {date}',
+    legend: 'Raggruppati per tag · tocca un ricordo per aprirlo',
+    viewAria: 'Come vedere i tuoi ricordi',
+    viewList: 'Elenco',
+    viewListTitle: 'Per tempo',
+    viewGraph: 'Grafo',
+    viewGraphTitle: 'Per connessione',
+    loading: 'Caricamento ricordi...',
+    loadingShort: 'Caricamento...',
+    loadFailed: 'Impossibile caricare i ricordi.',
+    empty: 'Nessun ricordo ancora. Usa Ricorda per salvarne il primo.',
+    vecOnTitle: 'Vettorializzato — ricercabile nel richiamo',
+    vecPendingTitle: 'Vettorializzazione… (appena catturato)',
+    vecOffTitle: 'Non vettorializzato — non apparirà nel richiamo',
+    vecNotIndexed: 'Non indicizzato',
+    append: 'Aggiungi',
+    edit: 'Modifica',
+    forget: 'Dimentica',
+    forgetThis: 'Dimentica questo ricordo',
+    moreActions: 'Altre azioni',
+    confirmTitle: 'Dimenticare questo ricordo?',
+    confirmBody: 'Questa azione non si può annullare. Il ricordo verrà rimosso dal cervello.',
+    cancel: 'Annulla',
+    appendTitle: 'Aggiungi un aggiornamento',
+    appendPlaceholder: 'Cosa è cambiato o di nuovo?',
+    appendSave: 'Aggiorna',
+    saving: 'Salvataggio...',
+    appendFailed: 'Aggiunta non riuscita: {message}',
+    editTitle: 'Modifica ricordo',
+    editPlaceholder: 'Modifica il ricordo...',
+    editHintHtml:
+      'Tocca un tag per rimuoverlo. Usa <span style="font-style: italic">#hashtag</span> nel testo per aggiungerne uno.',
+    editSave: 'Salva',
+    editFailed: 'Modifica non riuscita: {message}',
+    removeTag: 'Rimuovi tag {tag}',
+    viewTitle: 'Ricordo',
+    forgetting: 'Eliminazione...',
+    forgetFailed: 'Impossibile dimenticare: {message}',
+    metaCaptured: 'catturato {relative}',
+    metaEdited: 'modificato {relative}',
+    brainLabel: 'Cosa sa il tuo cervello',
+    importance: 'Importanza',
+    importanceTitle: 'Importanza {n} su 5',
+    kind: 'Tipo',
+    status: 'Stato',
+    lifespan: 'Durata',
+    recalled: 'Richiamato',
+    recalledTimes: { one: '{n} volta', other: '{n} volte' },
+    kindFact: 'Fatto',
+    kindEvent: 'Evento',
+    statusTrusted: 'Affidabile',
+    statusUnconfirmed: 'Non confermato',
+    statusSuperseded: 'Sostituito',
+    volDurable: 'Durevole',
+    volDurableGloss: 'Non dovrebbe cambiare.',
+    volCurrent: 'Attuale',
+    volCurrentGloss: 'Vero per ora — gli assistenti lo verificano prima di farci affidamento.',
+    volShortLived: 'Effimero',
+    volShortLivedGloss: 'Vero solo per poco — gli assistenti lo trattano come possibilmente datato.',
+    disagreed: {
+      one: 'Qualcosa di più recente è in disaccordo con questo {n} volta.',
+      other: 'Qualcosa di più recente è in disaccordo con questo {n} volte.',
+    },
+    notIndexedYet: 'Non ancora indicizzato — il richiamo non può trovare questo ricordo.',
+    related: 'Correlati',
+    youLinked: 'collegato da te',
+    systemLinked: 'collegato dal sistema',
+    autoLinked: 'collegato automaticamente',
+    removeLink: 'Rimuovi collegamento',
+    removeLinkConfirm:
+      'Rimuovere questo collegamento? I ricordi restano; viene eliminata solo la connessione.',
+    untitled: 'Ricordo senza titolo',
+  },
+  graph: {
+    empty:
+      'Ancora nessuna connessione — collega i ricordi, oppure lasciali auto-collegare man mano che ne aggiungi.',
+    loadFailed: 'Impossibile caricare il grafo.',
+    zoomOut: 'Riduci zoom',
+    zoomIn: 'Aumenta zoom',
+    fit: 'Adatta alla vista',
+    relayout: 'Ridisponi',
+    clusterOther: 'Altro',
+    clusterUntagged: 'Senza tag',
+    clusterAutoPatterns: 'Pattern automatici',
+  },
+  menu: {
+    title: 'Il tuo cervello',
+    groupUpkeep: 'Manutenzione',
+    groupData: 'Dati',
+    groupConnections: 'Connessioni',
+    groupThisApp: 'Questa app',
+    backupJson: 'Backup come JSON',
+    exportMarkdown: 'Esporta come Markdown',
+    restore: 'Ripristina da backup',
+    integrations: 'Integrazioni',
+    appearance: 'Aspetto',
+    themeLight: 'Chiaro',
+    themeDark: 'Scuro',
+    themeAuto: 'Auto',
+    themeMatchSystem: 'Come il sistema',
+    aboutAria: 'Informazioni su Second Brain',
+    about: 'Informazioni',
+    createdBy: 'Creato da',
+    maintainers: 'Maintainer',
+    disconnect: 'Disconnetti',
+    exportFailed: 'Esportazione non riuscita: {message}',
+    exportMdTitle: '# Esportazione Second Brain',
+    exportMdExported: 'Esportato: {date}',
+    exportMdMemory: '## Ricordo {n}',
+    exportMdDate: '**Data:** {date}',
+    exportMdTags: '**Tag:** {tags}',
+    exportMdSource: '**Fonte:** {source}',
+    exportMdRelationships: '## Relazioni',
+  },
+  upkeep: {
+    working: 'In corso…',
+    done: 'Fatto',
+    requestFailed: 'Richiesta non riuscita',
+    digestLabel: 'Pronto da comprimere',
+    digestNote:
+      'Gli originali non vengono mai cancellati — il digest aggiunge un riepilogo e abbassa gli originali nel richiamo così non affollano i risultati.',
+    digestEntries: { one: '{n} voce', other: '{n} voci' },
+    digestAction: 'Digest →',
+    digestMore: 'altre {n} ›',
+    digestFailed: 'Impossibile creare il digest',
+    digestPreserved: {
+      one: '{n} ricordo originale conservato e ancora ricercabile',
+      other: '{n} ricordi originali conservati e ancora ricercabili',
+    },
+    vectorizeLabel: 'Non indicizzati',
+    vectorizeNote: {
+      one: '{n} ricordo non è stato incorporato e non apparirà nel richiamo.',
+      other: '{n} ricordi non sono stati incorporati e non appariranno nel richiamo.',
+    },
+    vectorizeAction: 'Vettorializza ora →',
+    vectorizeDone: 'Fatto — {n} reindicizzati',
+    classifyLabel: 'Non classificati',
+    classifyNote: {
+      one: '{n} ricordo non ha ancora tipo o stato (catturato prima della classificazione).',
+      other: '{n} ricordi non hanno ancora tipo o stato (catturati prima della classificazione).',
+    },
+    classifyAction: 'Classifica ora →',
+    classifyDone: 'Fatto — {n} classificati',
+    restoreLabel: 'Ripristino',
+    restoreProgress: 'Ripristino da {filename}…',
+    restoreOf: '{done} di {total}',
+    restoreTryAgain: 'Riprova →',
+    restoreFailureTail:
+      'Il file di backup è intatto ed è sicuro riprovare — ciò che è già ripristinato verrà saltato, non duplicato.',
+    restoreInvalidJson: '{filename} non è JSON valido.',
+    restoreNotBackup:
+      '{filename} non sembra un backup di Second Brain — non ha un elenco di voci. Usa un file creato con «Backup come JSON».',
+    restoreStopped: 'Il ripristino si è fermato a metà.',
+    restoreSummaryRestored: '{n} ripristinati',
+    restoreSummaryConnections: '{n} connessioni',
+    restoreSummaryPresent: '{n} già presenti',
+    restoreFailNote:
+      '{n} elemento/i non ripristinabili — di solito righe modificate a mano; il resto non è influenzato.',
+    restoreNeedsIndex: 'I ricordi ripristinati non si possono cercare finché non sono indicizzati.',
+    restoreMakeSearchable: 'Rendi ricercabili →',
+    restoreIndexing: 'Indicizzazione…',
+    restoreIndexingProgress: 'Indicizzazione… {done} fatti, {remaining} rimanenti',
+    restoreIndexingDoneOnly: 'Indicizzazione… {done} fatti',
+    restoreQuotaLeft: '{n} rimasti — limite AI giornaliero raggiunto, riprova domani',
+    restoreAllSearchable: 'Tutti i ricordi ripristinati sono ricercabili',
+    restoreIndexFailed: 'Non riuscito — tocca per riprovare',
+    importStalled: 'Il server non ha avanzato il cursore di import — il Worker è aggiornato?',
+    vectorizeBannerTitle:
+      'La ricerca semantica è disattivata. L’indice Vectorize «{name}» non è stato trovato.',
+    vectorizeBannerHowToFix: 'Come risolvere',
+    vectorizeBannerRunOnce: 'Esegui questo una volta nel terminale:',
+    vectorizeBannerGui:
+      'Oppure concedi al token API Workers Builds il permesso Vectorize Edit a livello account nella dashboard Cloudflare (Il mio profilo, Token API), poi ridistribuisci così la build crea l’indice automaticamente.',
+  },
+  integrations: {
+    intro:
+      'Collega gli strumenti dove vive già il tuo contesto. I contenuti sincronizzati restano aggiornati e emergono nel richiamo come qualsiasi altro ricordo.',
+    loading: 'Caricamento…',
+    backSettings: 'Torna alle impostazioni',
+    backList: 'Torna alle integrazioni',
+    loadFailed: 'Impossibile caricare le integrazioni.',
+    none: 'Nessuna integrazione disponibile.',
+    emptyCategory: 'Ancora nulla qui.',
+    categoryKnowledge: 'Conoscenza',
+    categoryCalendars: 'Calendari',
+    categoryEmail: 'Email',
+    categoryOther: 'Altro',
+    summaryConnected: { one: '{n} collegata', other: '{n} collegate' },
+    notConnected: 'Non collegata',
+    connected: 'Collegata',
+    pasteSecret: 'Incolla il secret',
+    emailPlaceholder: 'tu@esempio.com',
+    emailAria: 'Indirizzo email',
+    appPassword: 'password app',
+    appPasswordAria: 'Password app',
+    notionPlaceholder: 'Secret integrazione (ntn_…)',
+    urlPlaceholder: 'https://…',
+    notionHint:
+      'Crea una <strong>connection</strong> interna (non un personal access token) su notion.so/my-integrations, condividi le pagine da sincronizzare con quella connection, poi incolla qui il secret.',
+    needEmailPw: 'Inserisci email e password app.',
+    needSecret: 'Incolla prima il secret.',
+    couldNotConnectShort: 'Connessione non riuscita',
+    syncNow: 'Sincronizza ora',
+    syncing: 'Sincronizzazione…',
+    syncingProgress: 'Sincronizzazione… {n} {noun} finora',
+    synced: '{n} sincronizzati',
+    syncFailed: 'Sincronizzazione non riuscita',
+    lastSyncFailed: 'Ultima sync non riuscita: {error}',
+    countSynced: '{n} {noun} sincronizzati',
+    lastSync: 'Ultima sync: {when}',
+    never: 'mai',
+    disconnectConfirm: 'Disconnettere {name}? Smetterà di sincronizzare.',
+    purgeConfirm:
+      'Eliminare anche i {n} {noun} sincronizzati?\n\nOK = eliminali\nAnnulla = tienili come ricordi normali',
+    disconnecting: 'Disconnessione…',
+    disconnectFailed: 'Disconnessione non riuscita',
+    nounEvent: { one: 'evento', other: 'eventi' },
+    nounEmail: { one: 'email', other: 'email' },
+    nounItem: { one: 'elemento', other: 'elementi' },
+    nounMemory: { one: 'ricordo', other: 'ricordi' },
+  },
+  brief: {
+    eyebrow: 'Il tuo cervello, di recente',
+    lastDays: 'Ultimi {n} giorni',
+    whereFrom: 'Da dove',
+    activityTitle: {
+      one: '{date}: {n} ricordo',
+      other: '{date}: {n} ricordi',
+    },
+    attentionUnindexed: '{n} non ricercabili',
+    attentionStale: '{n} potrebbero essere datati',
+    patternNoticed: 'Pattern notato',
+    confirm: 'Conferma',
+    dismiss: 'Ignora',
+    confirmed: 'Confermato — ora richiamabile',
+    dismissed: 'Ignorato',
+    failedRetry: 'Non riuscito — riprova',
+    worthRereading: 'Da rileggere',
+    fromDate: '· dal {date}',
+  },
+  patterns: {
+    title: 'Pattern notati',
+    intro:
+      'Il cervello li ha individuati in più ricordi. Confermane uno per renderlo un fatto affidabile e richiamabile; ignoralo per scartarlo. Nulla qui è ricercabile finché non confermi.',
+    selectAll: 'Seleziona tutti',
+    nSelected: '{n} selezionati',
+    confirmN: 'Conferma {n}',
+    dismissN: 'Ignora {n}',
+    loadFailed: 'Impossibile caricare i pattern.',
+    emptyIntro: 'Niente in attesa.',
+    emptyBody: 'Ogni pattern notato dal cervello è stato valutato.',
+    noticedWhen: 'notato {date}',
+    more: 'altri {n} ›',
+    failed: 'Non riuscito',
+    upkeepNote: {
+      one: '{n} pattern è in attesa di una decisione. Resta fuori dal richiamo finché non è confermato.',
+      other:
+        '{n} pattern sono in attesa di una decisione. Restano fuori dal richiamo finché non sono confermati.',
+    },
+    reviewOne: 'Esaminarlo →',
+    reviewAll: 'Esaminarli tutti →',
+  },
+  download: {
+    mac: 'Scarica per Mac',
+    windows: 'Scarica per Windows',
+    generic: "Scarica l'app",
+    withTag: '{label} ({tag})',
+  },
+  common: {
+    cancel: 'Annulla',
+    justNow: 'adesso',
+    minutesAgo: '{n}m fa',
+    hoursAgo: '{n}h fa',
+    daysAgo: '{n}g fa',
+    weeksAgo: '{n}sett fa',
+    monthsAgo: '{n}mesi fa',
+    yearsAgo: '{n}a fa',
+    sourceManual: 'manuale',
+    sourceCli: 'cli',
+    sourceEmail: 'email',
+    sourceChat: 'chat',
+    sourceBrowser: 'browser',
+    sourceDashboard: 'dashboard',
+    sourcePhone: 'telefono',
+    sourceVoice: 'voce',
+    sourceImport: 'import',
+    sourceSystem: 'sistema',
+    sourceClaudeCode: 'claude code',
+  },
+}
+
+const I18N_CATALOGS = { en: I18N_EN, it: I18N_IT }
+
+let currentLocale = 'en'
+
+function resolveI18nPath(messages, path) {
+  const parts = String(path).split('.')
+  let node = messages
+  for (const part of parts) {
+    if (node == null || typeof node !== 'object') return undefined
+    node = node[part]
+  }
+  return typeof node === 'string' ? node : node
+}
+
+function interpolate(raw, params) {
+  if (!params) return raw
+  return raw.replace(/\{(\w+)\}/g, (_, key) =>
+    params[key] != null ? String(params[key]) : `{${key}}`,
+  )
+}
+
+/** Translate a dotted key. Optional `{name}` placeholders. */
+function t(path, params) {
+  let node = resolveI18nPath(I18N_CATALOGS[currentLocale], path)
+  if (node == null) node = resolveI18nPath(I18N_CATALOGS.en, path)
+  if (typeof node !== 'string') return path
+  return interpolate(node, params)
+}
+
+/** Plural helper: path.one / path.other with `{n}`. */
+function tPlural(path, n, params) {
+  const count = Number(n) || 0
+  const key = count === 1 ? `${path}.one` : `${path}.other`
+  return t(key, { n: String(count), ...(params || {}) })
+}
+
+function getLocale() {
+  return currentLocale
+}
+
+function localeTag() {
+  return currentLocale === 'it' ? 'it-IT' : 'en-US'
+}
+
+/** UI-only dates. Do not use for LLM/chat payload serialization. */
+function formatDateUI(value, options) {
+  const d = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString(localeTag(), options)
+}
+
+function formatNumberUI(n) {
+  return Number(n).toLocaleString(localeTag())
+}
+
+function readStoredLocale() {
+  try {
+    const stored = localStorage.getItem(SB_LOCALE_KEY)
+    if (stored === 'en' || stored === 'it') return stored
+  } catch (_) {
+    /* private mode */
+  }
+  const nav = (typeof navigator !== 'undefined' && navigator.language
+    ? navigator.language
+    : ''
+  ).toLowerCase()
+  if (nav.startsWith('it')) return 'it'
+  return 'en'
+}
+
+function initI18n(forceLocale) {
+  currentLocale =
+    forceLocale === 'en' || forceLocale === 'it' ? forceLocale : readStoredLocale()
+  try {
+    localStorage.setItem(SB_LOCALE_KEY, currentLocale)
+  } catch (_) {
+    /* ignore */
+  }
+  if (typeof document !== 'undefined' && document.documentElement) {
+    document.documentElement.lang = currentLocale
+  }
+  return currentLocale
+}
+
+/**
+ * Apply data-i18n / data-i18n-html / data-i18n-attr on elements under root.
+ * data-i18n → textContent
+ * data-i18n-html → innerHTML (trusted catalog strings only)
+ * data-i18n-attr="placeholder|title|aria-label" with data-i18n key on same el
+ */
+function applyI18nDom(root) {
+  const scope = root || document
+  if (!scope.querySelectorAll) return
+  scope.querySelectorAll('[data-i18n]').forEach((el) => {
+    const key = el.getAttribute('data-i18n')
+    if (!key) return
+    const attrList = el.getAttribute('data-i18n-attr')
+    if (attrList) {
+      const text = t(key)
+      attrList.split('|').forEach((attr) => {
+        const name = attr.trim()
+        if (name) el.setAttribute(name, text)
+      })
+      return
+    }
+    if (el.hasAttribute('data-i18n-html')) {
+      el.innerHTML = t(key)
+    } else {
+      el.textContent = t(key)
+    }
+  })
+}

--- a/public/js/integrations.js
+++ b/public/js/integrations.js
@@ -155,7 +155,9 @@ function renderIntegrationCard(info) {
   const last = info.lastSyncedAt
     ? new Date(info.lastSyncedAt).toLocaleString(localeTag())
     : t('integrations.never')
-  const count = t('integrations.countSynced', { n: info.itemCount, noun: integrationNoun(p, info.itemCount) })
+  const count = tPlural('integrations.countSynced', info.itemCount, {
+    noun: integrationNoun(p, info.itemCount),
+  })
   const err = info.lastSyncError
     ? `<div class="integration-error">${escHtml(t('integrations.lastSyncFailed', { error: info.lastSyncError }))}</div>`
     : ''
@@ -234,7 +236,7 @@ async function syncIntegration(provider, btn) {
       if ((data.created ?? 0) + (data.updated ?? 0) + (data.deleted ?? 0) === 0 && remaining > 0) break
     }
     btn.classList.remove('digest-btn--loading')
-    btn.innerHTML = `<i class="ti ti-check"></i> ${escHtml(t('integrations.synced', { n: processed }))}`
+    btn.innerHTML = `<i class="ti ti-check"></i> ${escHtml(tPlural('integrations.synced', processed))}`
     btn.style.color = 'var(--good)'
     setTimeout(loadIntegrations, 900)
     refreshAll()
@@ -252,8 +254,7 @@ async function disconnectIntegration(provider, btn) {
   let purge = false
   if (info.itemCount > 0) {
     purge = confirm(
-      t('integrations.purgeConfirm', {
-        n: info.itemCount,
+      tPlural('integrations.purgeConfirm', info.itemCount, {
         noun: tPlural('integrations.nounMemory', info.itemCount),
       }),
     )

--- a/public/js/integrations.js
+++ b/public/js/integrations.js
@@ -4,9 +4,9 @@
 // that have at least one registered provider are shown, so Email appears
 // automatically once email providers are registered.
 const CATEGORY_META = [
-  { id: 'knowledge', name: 'Knowledge', icon: 'ti-notebook' },
-  { id: 'calendar', name: 'Calendars', icon: 'ti-calendar' },
-  { id: 'email', name: 'Email', icon: 'ti-mail' },
+  { id: 'knowledge', icon: 'ti-notebook' },
+  { id: 'calendar', icon: 'ti-calendar' },
+  { id: 'email', icon: 'ti-mail' },
 ]
 
 const INTEGRATION_ICONS = {
@@ -15,11 +15,26 @@ const INTEGRATION_ICONS = {
   'calendar-outlook': 'ti-brand-windows',
   'calendar-icloud': 'ti-brand-apple',
 }
-// Notion keeps its bespoke connect copy; calendar providers ship their own connectHint.
-const NOTION_HINT =
-  'Create an internal <b>connection</b> (not a personal access token) at ' +
-  '<a href="https://app.notion.com/developers/connections" target="_blank" rel="noopener noreferrer">app.notion.com/developers/connections</a>, ' +
-  'share the pages you want remembered with it (page menu &rarr; Connections), then paste its secret here.'
+
+function integrationCategoryName(id) {
+  const keys = {
+    knowledge: 'integrations.categoryKnowledge',
+    calendar: 'integrations.categoryCalendars',
+    email: 'integrations.categoryEmail',
+    other: 'integrations.categoryOther',
+  }
+  return t(keys[id] || 'integrations.categoryOther')
+}
+
+function integrationNounKey(provider) {
+  if (provider.startsWith('calendar')) return 'integrations.nounEvent'
+  if (provider.startsWith('email')) return 'integrations.nounEmail'
+  return 'integrations.nounItem'
+}
+
+function integrationNoun(provider, n) {
+  return tPlural(integrationNounKey(provider), n)
+}
 
 async function loadIntegrations() {
   const el = document.getElementById('integrations-list')
@@ -29,7 +44,7 @@ async function loadIntegrations() {
     integrationsInfo = data.integrations || []
     renderIntegrations()
   } catch {
-    el.innerHTML = '<p class="digest-note">Could not load integrations.</p>'
+    el.innerHTML = `<p class="digest-note">${escHtml(t('integrations.loadFailed'))}</p>`
   }
 }
 
@@ -39,7 +54,7 @@ function integrationCategoryId(info) {
 }
 
 function categoryMeta(id) {
-  return CATEGORY_META.find((c) => c.id === id) || { id, name: 'Other', icon: 'ti-plug' }
+  return CATEGORY_META.find((c) => c.id === id) || { id, icon: 'ti-plug' }
 }
 
 // Categories present in the data, in CATEGORY_META order, with any leftover
@@ -57,13 +72,13 @@ function renderIntegrationsChrome() {
   const title = document.getElementById('integrations-title')
   const intro = document.getElementById('integrations-intro')
   if (currentCategory) {
-    title.textContent = categoryMeta(currentCategory).name
-    back.setAttribute('title', 'Back to integrations')
+    title.textContent = integrationCategoryName(currentCategory)
+    back.setAttribute('title', t('integrations.backList'))
     back.onclick = backToCategoryList
     intro.style.display = 'none'
   } else {
-    title.textContent = 'Integrations'
-    back.setAttribute('title', 'Back to settings')
+    title.textContent = t('menu.integrations')
+    back.setAttribute('title', t('integrations.backSettings'))
     back.onclick = backToMenu
     intro.style.display = ''
   }
@@ -73,7 +88,7 @@ function renderIntegrations() {
   renderIntegrationsChrome()
   const el = document.getElementById('integrations-list')
   if (!integrationsInfo.length) {
-    el.innerHTML = '<p class="digest-note">No integrations available.</p>'
+    el.innerHTML = `<p class="digest-note">${escHtml(t('integrations.none'))}</p>`
     return
   }
   if (currentCategory) {
@@ -81,7 +96,7 @@ function renderIntegrations() {
       .filter((i) => integrationCategoryId(i) === currentCategory)
       .map(renderIntegrationCard)
       .join('')
-    el.innerHTML = cards || '<p class="digest-note">Nothing here yet.</p>'
+    el.innerHTML = cards || `<p class="digest-note">${escHtml(t('integrations.emptyCategory'))}</p>`
     return
   }
   el.innerHTML = presentCategories().map(renderCategoryRow).join('')
@@ -90,12 +105,12 @@ function renderIntegrations() {
 function renderCategoryRow(cat) {
   const items = integrationsInfo.filter((i) => integrationCategoryId(i) === cat.id)
   const connected = items.filter((i) => i.connected).length
-  const summary = connected > 0 ? `${connected} connected` : 'Not connected'
+  const summary = connected > 0 ? tPlural('integrations.summaryConnected', connected) : t('integrations.notConnected')
   return `
     <button class="integration-category-row" onclick="openCategory('${cat.id}')">
       <i class="ti ${cat.icon}"></i>
-      <span class="integration-category-name">${escHtml(cat.name)}</span>
-      <span class="integration-category-summary">${summary}</span>
+      <span class="integration-category-name">${escHtml(integrationCategoryName(cat.id))}</span>
+      <span class="integration-category-summary">${escHtml(summary)}</span>
       <i class="ti ti-chevron-right integration-category-chevron"></i>
     </button>`
 }
@@ -113,42 +128,45 @@ function renderIntegrationCard(info) {
   const p = info.provider
   const icon = INTEGRATION_ICONS[p] || 'ti-plug'
   if (!info.connected) {
-    const hint = p === 'notion' ? NOTION_HINT : (info.connectHint || '')
-    const label = escHtml(info.connectLabel || 'Paste your secret')
+    const hint = p === 'notion' ? t('integrations.notionHint') : (info.connectHint || '')
+    const label = escHtml(info.connectLabel || t('integrations.pasteSecret'))
     const isEmail = p.startsWith('email')
     let inputs
     if (isEmail) {
       // Email needs two fields; connectIntegration packs them into the token.
       inputs =
-        `<input type="email" id="email-${p}" placeholder="you@example.com" aria-label="Email address" autocomplete="off" />` +
-        `<input type="password" id="tok-${p}" placeholder="${escHtml(info.connectPlaceholder || 'app password')}" aria-label="App password" autocomplete="off" />`
+        `<input type="email" id="email-${p}" placeholder="${escAttr(t('integrations.emailPlaceholder'))}" aria-label="${escAttr(t('integrations.emailAria'))}" autocomplete="off" />` +
+        `<input type="password" id="tok-${p}" placeholder="${escHtml(info.connectPlaceholder || t('integrations.appPassword'))}" aria-label="${escAttr(t('integrations.appPasswordAria'))}" autocomplete="off" />`
     } else {
-      const placeholder = escHtml(info.connectPlaceholder || (p === 'notion' ? 'Integration secret (ntn_…)' : 'https://…'))
+      const placeholder = escHtml(info.connectPlaceholder || (p === 'notion' ? t('integrations.notionPlaceholder') : t('integrations.urlPlaceholder')))
       inputs = `<input type="password" id="tok-${p}" placeholder="${placeholder}" aria-label="${label}" autocomplete="off" />`
     }
     return `
       <div class="integration-row">
-        <div class="integration-head"><i class="ti ${icon}"></i><span>${escHtml(info.name)}</span><span class="integration-state">Not connected</span></div>
+        <div class="integration-head"><i class="ti ${icon}"></i><span>${escHtml(info.name)}</span><span class="integration-state">${escHtml(t('integrations.notConnected'))}</span></div>
         <p class="digest-note">${hint}</p>
         <div class="integration-connect-row${isEmail ? ' integration-connect-col' : ''}">
           ${inputs}
-          <button class="digest-btn" onclick="connectIntegration('${p}', this)">Connect</button>
+          <button class="digest-btn" onclick="connectIntegration('${p}', this)">${escHtml(t('auth.connect'))}</button>
         </div>
         <div class="integration-error" id="err-${p}"></div>
       </div>`
   }
-  const last = info.lastSyncedAt ? new Date(info.lastSyncedAt).toLocaleString() : 'never'
-  const noun = p.startsWith('calendar') ? 'event' : p.startsWith('email') ? 'email' : 'item'
-  const count = `${info.itemCount} ${noun}${info.itemCount === 1 ? '' : 's'} synced`
-  const err = info.lastSyncError ? `<div class="integration-error">Last sync failed: ${escHtml(info.lastSyncError)}</div>` : ''
+  const last = info.lastSyncedAt
+    ? new Date(info.lastSyncedAt).toLocaleString(localeTag())
+    : t('integrations.never')
+  const count = t('integrations.countSynced', { n: info.itemCount, noun: integrationNoun(p, info.itemCount) })
+  const err = info.lastSyncError
+    ? `<div class="integration-error">${escHtml(t('integrations.lastSyncFailed', { error: info.lastSyncError }))}</div>`
+    : ''
   return `
     <div class="integration-row">
-      <div class="integration-head"><i class="ti ${icon}"></i><span>${escHtml(info.name)}</span><span class="integration-state connected">${escHtml(info.workspaceName || 'Connected')}</span></div>
-      <p class="digest-note" id="note-${p}">${count} &middot; Last sync: ${escHtml(last)}</p>
+      <div class="integration-head"><i class="ti ${icon}"></i><span>${escHtml(info.name)}</span><span class="integration-state connected">${escHtml(info.workspaceName || t('integrations.connected'))}</span></div>
+      <p class="digest-note" id="note-${p}">${escHtml(count)} &middot; ${escHtml(t('integrations.lastSync', { when: last }))}</p>
       ${err}
       <div class="integration-actions">
-        <button class="digest-btn" onclick="syncIntegration('${p}', this)"><i class="ti ti-refresh"></i> Sync now</button>
-        <button class="digest-btn danger" onclick="disconnectIntegration('${p}', this)">Disconnect</button>
+        <button class="digest-btn" onclick="syncIntegration('${p}', this)"><i class="ti ti-refresh"></i> ${escHtml(t('integrations.syncNow'))}</button>
+        <button class="digest-btn danger" onclick="disconnectIntegration('${p}', this)">${escHtml(t('menu.disconnect'))}</button>
       </div>
     </div>`
 }
@@ -159,14 +177,14 @@ async function connectIntegration(provider, btn) {
   if (provider.startsWith('email')) {
     const email = (document.getElementById(`email-${provider}`).value || '').trim()
     const pw = (document.getElementById(`tok-${provider}`).value || '').trim()
-    if (!email || !pw) { errEl.textContent = 'Enter your email and app password.'; return }
+    if (!email || !pw) { errEl.textContent = t('integrations.needEmailPw'); return }
     token = JSON.stringify({ email: email, appPassword: pw })
   } else {
     token = (document.getElementById(`tok-${provider}`).value || '').trim()
-    if (!token) { errEl.textContent = 'Paste your secret first.'; return }
+    if (!token) { errEl.textContent = t('integrations.needSecret'); return }
   }
   btn.disabled = true
-  btn.textContent = 'Connecting…'
+  btn.textContent = t('auth.connectingEllipsis')
   errEl.textContent = ''
   try {
     const res = await fetch(`${WORKER_URL}/integrations/${provider}/connect`, {
@@ -175,24 +193,23 @@ async function connectIntegration(provider, btn) {
       body: JSON.stringify({ token }),
     })
     const data = await res.json()
-    if (!res.ok || !data.ok) throw new Error(data.error || 'Could not connect')
+    if (!res.ok || !data.ok) throw new Error(data.error || t('integrations.couldNotConnectShort'))
     await loadIntegrations()
     // Kick off the first sync automatically.
     const syncBtn = document.querySelector(`[onclick^="syncIntegration('${provider}'"]`)
     if (syncBtn) syncIntegration(provider, syncBtn)
   } catch (e) {
-    errEl.textContent = e.message || 'Could not connect.'
+    errEl.textContent = e.message || t('auth.couldNotConnect')
     btn.disabled = false
-    btn.textContent = 'Connect'
+    btn.textContent = t('auth.connect')
   }
 }
 
 async function syncIntegration(provider, btn) {
   btn.disabled = true
   btn.classList.add('digest-btn--loading')
-  btn.innerHTML = '<i class="ti ti-loader-2"></i> Syncing…'
+  btn.innerHTML = `<i class="ti ti-loader-2"></i> ${escHtml(t('integrations.syncing'))}`
   const note = document.getElementById(`note-${provider}`)
-  const noun = provider.startsWith('calendar') ? 'event' : provider.startsWith('email') ? 'email' : 'item'
   try {
     // Each call processes a bounded batch and reports what's left — loop
     // until the backlog drains (same pattern as runVectorize).
@@ -204,21 +221,26 @@ async function syncIntegration(provider, btn) {
         headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
       })
       const data = await res.json()
-      if (!res.ok || !data.ok) throw new Error(data.error || 'Sync failed')
+      if (!res.ok || !data.ok) throw new Error(data.error || t('integrations.syncFailed'))
       processed += (data.created ?? 0) + (data.updated ?? 0)
       remaining = data.remaining ?? 0
-      if (note) note.textContent = `Syncing… ${processed} ${noun}${processed === 1 ? '' : 's'} so far`
+      if (note) {
+        note.textContent = t('integrations.syncingProgress', {
+          n: processed,
+          noun: integrationNoun(provider, processed),
+        })
+      }
       // A batch with zero progress means everything in it failed — stop.
       if ((data.created ?? 0) + (data.updated ?? 0) + (data.deleted ?? 0) === 0 && remaining > 0) break
     }
     btn.classList.remove('digest-btn--loading')
-    btn.innerHTML = `<i class="ti ti-check"></i> ${processed} synced`
+    btn.innerHTML = `<i class="ti ti-check"></i> ${escHtml(t('integrations.synced', { n: processed }))}`
     btn.style.color = 'var(--good)'
     setTimeout(loadIntegrations, 900)
     refreshAll()
   } catch (e) {
     btn.classList.remove('digest-btn--loading')
-    btn.innerHTML = '<i class="ti ti-alert-triangle"></i> Sync failed'
+    btn.innerHTML = `<i class="ti ti-alert-triangle"></i> ${escHtml(t('integrations.syncFailed'))}`
     btn.style.color = 'var(--danger)'
     setTimeout(loadIntegrations, 3000)
   }
@@ -226,15 +248,18 @@ async function syncIntegration(provider, btn) {
 
 async function disconnectIntegration(provider, btn) {
   const info = integrationsInfo.find((i) => i.provider === provider) || {}
-  if (!confirm(`Disconnect ${info.name || provider}? It will stop syncing.`)) return
+  if (!confirm(t('integrations.disconnectConfirm', { name: info.name || provider }))) return
   let purge = false
   if (info.itemCount > 0) {
     purge = confirm(
-      `Also delete the ${info.itemCount} synced memor${info.itemCount === 1 ? 'y' : 'ies'}?\n\nOK = delete them\nCancel = keep them as regular memories`,
+      t('integrations.purgeConfirm', {
+        n: info.itemCount,
+        noun: tPlural('integrations.nounMemory', info.itemCount),
+      }),
     )
   }
   btn.disabled = true
-  btn.textContent = 'Disconnecting…'
+  btn.textContent = t('integrations.disconnecting')
   try {
     const res = await fetch(`${WORKER_URL}/integrations/${provider}/disconnect`, {
       method: 'POST',
@@ -242,12 +267,12 @@ async function disconnectIntegration(provider, btn) {
       body: JSON.stringify({ purge }),
     })
     const data = await res.json()
-    if (!res.ok || !data.ok) throw new Error(data.error || 'Disconnect failed')
+    if (!res.ok || !data.ok) throw new Error(data.error || t('integrations.disconnectFailed'))
     await loadIntegrations()
     if (purge) refreshAll()
   } catch (e) {
     btn.disabled = false
-    btn.textContent = 'Disconnect'
-    alert(e.message || 'Disconnect failed')
+    btn.textContent = t('menu.disconnect')
+    alert(e.message || t('integrations.disconnectFailed'))
   }
 }

--- a/public/js/memory-crud.js
+++ b/public/js/memory-crud.js
@@ -26,15 +26,15 @@ async function saveAppend() {
   if (!addition || !pendingAppendId) return
   const btn = document.getElementById('append-save-btn')
   btn.disabled = true
-  btn.textContent = 'Saving...'
+  btn.textContent = t('memories.saving')
   try {
     await apiMcp('append', { id: pendingAppendId, addition })
     closeAppend()
     refreshAll()
   } catch (e) {
     btn.disabled = false
-    btn.textContent = 'Update'
-    alert('Append failed: ' + e.message)
+    btn.textContent = t('memories.appendSave')
+    alert(t('memories.appendFailed', { message: e.message }))
   }
 }
 
@@ -70,8 +70,8 @@ function renderEditTags() {
   if (!el) return
   el.innerHTML = pendingEditTags
     .map(
-      (t, i) =>
-        `<button type="button" class="tag-chip tag-chip--removable" onclick="removeEditTag(${i})" aria-label="Remove tag ${escAttr(t)}">${escHtml(t)}<i class="ti ti-x"></i></button>`,
+      (tag, i) =>
+        `<button type="button" class="tag-chip tag-chip--removable" onclick="removeEditTag(${i})" aria-label="${escAttr(t('memories.removeTag', { tag }))}">${escHtml(tag)}<i class="ti ti-x"></i></button>`,
     )
     .join('')
 }
@@ -92,7 +92,7 @@ async function saveEdit() {
   if (!newContent || !pendingEditId) return
   const btn = document.getElementById('edit-save-btn')
   btn.disabled = true
-  btn.textContent = 'Saving...'
+  btn.textContent = t('memories.saving')
   try {
     const res = await fetch(`${WORKER_URL}/update`, {
       method: 'POST',
@@ -101,13 +101,13 @@ async function saveEdit() {
       // src/tags/system.ts — so an edit cannot delete a conclusion the brain reached.
       body: JSON.stringify({ id: pendingEditId, content: newContent, tags: pendingEditTags }),
     })
-    if (!res.ok) throw new Error(`Server error: ${res.status}`)
+    if (!res.ok) throw new Error(t('auth.serverError', { status: res.status }))
     closeEdit()
     refreshAll()
   } catch (e) {
     btn.disabled = false
-    btn.textContent = 'Save'
-    alert('Edit failed: ' + e.message)
+    btn.textContent = t('memories.editSave')
+    alert(t('memories.editFailed', { message: e.message }))
   }
 }
 
@@ -128,7 +128,7 @@ async function confirmForget() {
   const btn = document.querySelector('#confirm-dialog .btn-delete')
   if (btn) {
     btn.disabled = true
-    btn.textContent = 'Forgetting...'
+    btn.textContent = t('memories.forgetting')
   }
 
   try {
@@ -145,11 +145,11 @@ async function confirmForget() {
     // from under its own exit animation.
     refreshAll({ list: false })
   } catch (e) {
-    alert('Could not forget: ' + e.message)
+    alert(t('memories.forgetFailed', { message: e.message }))
   } finally {
     if (btn) {
       btn.disabled = false
-      btn.textContent = 'Forget'
+      btn.textContent = t('memories.forget')
     }
   }
 }
@@ -162,20 +162,26 @@ async function confirmForget() {
 // reachable from the UI. This is the one place that shows it, in plain
 // language rather than the tag syntax it is stored as.
 
-/** `kind:semantic` → "Fact", and so on. Unknown values render as themselves. */
-const VIEW_KIND_LABELS = { semantic: 'Fact', episodic: 'Event' }
+/** `kind:semantic` → localized label. Unknown values render as themselves. */
+function viewKindLabel(kind) {
+  if (kind === 'semantic') return t('memories.kindFact')
+  if (kind === 'episodic') return t('memories.kindEvent')
+  return kind
+}
 
-const VIEW_STATUS_LABELS = {
-  canonical: 'Trusted',
-  draft: 'Unconfirmed',
-  deprecated: 'Superseded',
+function viewStatusLabel(status) {
+  if (status === 'canonical') return t('memories.statusTrusted')
+  if (status === 'draft') return t('memories.statusUnconfirmed')
+  if (status === 'deprecated') return t('memories.statusSuperseded')
+  return status
 }
 
 /** Volatility is a promise about the future, so it is worth spelling out. */
-const VIEW_VOLATILITY = {
-  durable: ['Durable', 'Not expected to change.'],
-  state: ['Current', 'True for now — assistants verify this before relying on it.'],
-  volatile: ['Short-lived', 'True only briefly — assistants treat it as possibly stale.'],
+function viewVolatility(volatility) {
+  if (volatility === 'durable') return [t('memories.volDurable'), t('memories.volDurableGloss')]
+  if (volatility === 'state') return [t('memories.volCurrent'), t('memories.volCurrentGloss')]
+  if (volatility === 'volatile') return [t('memories.volShortLived'), t('memories.volShortLivedGloss')]
+  return null
 }
 
 function tagValue(tags, prefix) {
@@ -186,7 +192,7 @@ function tagValue(tags, prefix) {
 /** Importance as five dots — a number out of five means nothing on its own. */
 function importanceDots(score) {
   const n = Math.max(0, Math.min(5, Math.round(Number(score) || 0)))
-  return `<span class="dots" title="Importance ${n} of 5">${'●'.repeat(n)}${'○'.repeat(5 - n)}</span>`
+  return `<span class="dots" title="${escAttr(t('memories.importanceTitle', { n }))}">${'●'.repeat(n)}${'○'.repeat(5 - n)}</span>`
 }
 
 function renderViewMeta(entry) {
@@ -196,11 +202,11 @@ function renderViewMeta(entry) {
   const updated = Number(entry.updated_at) || 0
   const parts = [`<span class="view-meta-item"><i class="ti ${badge.icon}"></i>${escHtml(badge.label)}</span>`]
   if (created) {
-    parts.push(`<span class="view-meta-item" title="${escAttr(new Date(created).toLocaleString())}">captured ${escHtml(relativeTime(created))}</span>`)
+    parts.push(`<span class="view-meta-item" title="${escAttr(new Date(created).toLocaleString(localeTag()))}">${escHtml(t('memories.metaCaptured', { relative: relativeTime(created) }))}</span>`)
   }
   // Only worth saying when it actually differs — every row has an updated_at.
   if (updated && created && Math.abs(updated - created) > 60000) {
-    parts.push(`<span class="view-meta-item" title="${escAttr(new Date(updated).toLocaleString())}">edited ${escHtml(relativeTime(updated))}</span>`)
+    parts.push(`<span class="view-meta-item" title="${escAttr(new Date(updated).toLocaleString(localeTag()))}">${escHtml(t('memories.metaEdited', { relative: relativeTime(updated) }))}</span>`)
   }
   el.innerHTML = parts.join('')
 }
@@ -217,35 +223,36 @@ function renderViewBrain(entry) {
   const notes = []
 
   if (typeof entry.importance_score === 'number') {
-    rows.push(`<div class="view-brain-row"><span>Importance</span>${importanceDots(entry.importance_score)}</div>`)
+    rows.push(`<div class="view-brain-row"><span>${escHtml(t('memories.importance'))}</span>${importanceDots(entry.importance_score)}</div>`)
   }
   if (kind) {
-    rows.push(`<div class="view-brain-row"><span>Kind</span><strong>${escHtml(VIEW_KIND_LABELS[kind] || kind)}</strong></div>`)
+    rows.push(`<div class="view-brain-row"><span>${escHtml(t('memories.kind'))}</span><strong>${escHtml(viewKindLabel(kind))}</strong></div>`)
   }
   if (status) {
-    rows.push(`<div class="view-brain-row"><span>Status</span><strong>${escHtml(VIEW_STATUS_LABELS[status] || status)}</strong></div>`)
+    rows.push(`<div class="view-brain-row"><span>${escHtml(t('memories.status'))}</span><strong>${escHtml(viewStatusLabel(status))}</strong></div>`)
   }
-  if (volatility && VIEW_VOLATILITY[volatility]) {
-    const [label, gloss] = VIEW_VOLATILITY[volatility]
-    rows.push(`<div class="view-brain-row"><span>Lifespan</span><strong>${escHtml(label)}</strong></div>`)
+  const volPair = volatility ? viewVolatility(volatility) : null
+  if (volPair) {
+    const [label, gloss] = volPair
+    rows.push(`<div class="view-brain-row"><span>${escHtml(t('memories.lifespan'))}</span><strong>${escHtml(label)}</strong></div>`)
     // Held back to the end: a sentence between two rows breaks the list it is
     // explaining, and the panel reads as facts first, then the caveats.
     notes.push(gloss)
   }
   if (typeof entry.recall_count === 'number' && entry.recall_count > 0) {
-    rows.push(`<div class="view-brain-row"><span>Recalled</span><strong>${entry.recall_count} time${entry.recall_count === 1 ? '' : 's'}</strong></div>`)
+    rows.push(`<div class="view-brain-row"><span>${escHtml(t('memories.recalled'))}</span><strong>${escHtml(tPlural('memories.recalledTimes', entry.recall_count))}</strong></div>`)
   }
   // Losing a contradiction means something newer disagreed with this. Silence
   // when it has never happened; it is not a scoreboard.
   const losses = Number(entry.contradiction_losses) || 0
   if (losses > 0) {
-    notes.push(`Something newer has disagreed with this ${losses} time${losses === 1 ? '' : 's'}.`)
+    notes.push(tPlural('memories.disagreed', losses))
   }
   for (const note of notes) {
     rows.push(`<div class="view-brain-note">${escHtml(note)}</div>`)
   }
   if (entry.indexed === false) {
-    rows.push(`<div class="view-brain-note view-brain-note--warn">Not indexed yet — recall cannot find this memory.</div>`)
+    rows.push(`<div class="view-brain-note view-brain-note--warn">${escHtml(t('memories.notIndexedYet'))}</div>`)
   }
 
   if (!rows.length) {
@@ -254,7 +261,7 @@ function renderViewBrain(entry) {
     return
   }
   el.style.display = ''
-  el.innerHTML = `<div class="view-brain-label">What your brain knows</div>${rows.join('')}`
+  el.innerHTML = `<div class="view-brain-label">${escHtml(t('memories.brainLabel'))}</div>${rows.join('')}`
 }
 
 /**
@@ -352,13 +359,20 @@ async function loadRelated(id, el) {
       return
     }
     el.innerHTML =
-      `<div class="view-related-label">Related</div>` +
+      `<div class="view-related-label">${escHtml(t('memories.related'))}</div>` +
       data.connections
         .map(
           (c) => {
-            const who = c.provenance === 'explicit' ? 'you linked' : c.provenance === 'system' ? 'system-linked' : 'auto-linked'
-            const when = c.linkedAt ? ' · ' + new Date(c.linkedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : ''
-            return `<div class="related-item" data-id="${escHtml(c.id)}" data-type="${escHtml(c.type)}"><button class="related-open"><span class="related-type">${escHtml(c.label)} · ${who}${when}</span>${escHtml((c.content || '').slice(0, 80))}</button><button class="related-unlink" title="Remove link"><i class="ti ti-unlink"></i></button></div>`
+            const who =
+              c.provenance === 'explicit'
+                ? t('memories.youLinked')
+                : c.provenance === 'system'
+                  ? t('memories.systemLinked')
+                  : t('memories.autoLinked')
+            const when = c.linkedAt
+              ? ' · ' + formatDateUI(c.linkedAt, { year: 'numeric', month: 'short', day: 'numeric' })
+              : ''
+            return `<div class="related-item" data-id="${escHtml(c.id)}" data-type="${escHtml(c.type)}"><button class="related-open"><span class="related-type">${escHtml(c.label)} · ${escHtml(who)}${escHtml(when)}</span>${escHtml((c.content || '').slice(0, 80))}</button><button class="related-unlink" title="${escAttr(t('memories.removeLink'))}"><i class="ti ti-unlink"></i></button></div>`
           },
         )
         .join('')
@@ -369,7 +383,7 @@ async function loadRelated(id, el) {
         if (c) openView({ id: c.id, content: c.content, tags: c.tags }, null)
       }
       row.querySelector('.related-unlink').onclick = async () => {
-        if (!confirm('Remove this link? The memories stay; only the connection is deleted.')) return
+        if (!confirm(t('memories.removeLinkConfirm'))) return
         try {
           await fetch(`${WORKER_URL}/unlink`, {
             method: 'POST',

--- a/public/js/nav.js
+++ b/public/js/nav.js
@@ -7,12 +7,12 @@ async function loadTags() {
     ;['tag-filter-recent', 'tag-filter-recall'].forEach((id) => {
       const sel = document.getElementById(id)
       if (!sel) return
-      sel.innerHTML = '<option value="">All tags</option>'
-      tags.forEach((t) => {
+      sel.innerHTML = `<option value="">${escHtml(t('recall.allTags'))}</option>`
+      tags.forEach((tagName) => {
         const opt = document.createElement('option')
-        opt.value = t
-        opt.textContent = t
-        if (t === selectedTag) opt.selected = true
+        opt.value = tagName
+        opt.textContent = tagName
+        if (tagName === selectedTag) opt.selected = true
         sel.appendChild(opt)
       })
     })
@@ -130,7 +130,10 @@ async function updateStatus() {
     const res = await fetch(`${WORKER_URL}/count`, { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } })
     const data = await res.json()
     currentCount = data.count ?? 0
-    const text = currentCount === 0 ? 'always remembers' : `${currentCount} memor${currentCount === 1 ? 'y' : 'ies'} stored`
+    const text =
+      currentCount === 0
+        ? t('nav.statusEmpty')
+        : tPlural('nav.statusCount', currentCount, { n: formatNumberUI(currentCount) })
     document.getElementById('topbar-status').textContent = text
     const sb = document.getElementById('sb-status')
     if (sb) sb.textContent = text

--- a/public/js/patterns.js
+++ b/public/js/patterns.js
@@ -43,7 +43,7 @@ function backToMenuFromPatterns() {
 
 async function loadPatternQueue({ append = false } = {}) {
   const list = document.getElementById('patterns-list')
-  if (!append) list.innerHTML = `<p class="digest-note">Loading&hellip;</p>`
+  if (!append) list.innerHTML = `<p class="digest-note">${escHtml(t('integrations.loading'))}</p>`
   try {
     const res = await fetch(`${WORKER_URL}/patterns?limit=${PATTERNS_PAGE}&offset=${append ? loadedPatterns.length : 0}`, {
       headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
@@ -55,20 +55,20 @@ async function loadPatternQueue({ append = false } = {}) {
     renderPatternQueue()
   } catch {
     if (!append) {
-      list.innerHTML = `<p class="digest-note"><i class="ti ti-wifi-off"></i> Could not load your patterns.</p>`
+      list.innerHTML = `<p class="digest-note"><i class="ti ti-wifi-off"></i> ${escHtml(t('patterns.loadFailed'))}</p>`
     }
   }
 }
 
 function loadMorePatterns(btn) {
   btn.disabled = true
-  btn.textContent = 'Loading…'
+  btn.textContent = t('integrations.loading')
   loadPatternQueue({ append: true })
 }
 
 function patternRow(p) {
   const when = p.created_at
-    ? new Date(p.created_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+    ? formatDateUI(p.created_at, { year: 'numeric', month: 'short', day: 'numeric' })
     : ''
   return `
     <label class="pattern-row" id="pattern-row-${escAttr(p.id)}">
@@ -77,7 +77,7 @@ function patternRow(p) {
              onchange="togglePatternSelection('${escAttr(p.id)}', this.checked)" />
       <span class="pattern-body">
         <span class="pattern-text">${escHtml(p.content)}</span>
-        ${when ? `<span class="pattern-when">noticed ${escHtml(when)}</span>` : ''}
+        ${when ? `<span class="pattern-when">${escHtml(t('patterns.noticedWhen', { date: when }))}</span>` : ''}
       </span>
     </label>`
 }
@@ -91,8 +91,8 @@ function renderPatternQueue() {
   if (!loadedPatterns.length) {
     bar.hidden = true
     more.hidden = true
-    intro.textContent = 'Nothing is waiting on you.'
-    list.innerHTML = `<p class="digest-note"><i class="ti ti-check"></i> Every pattern your brain noticed has been ruled on.</p>`
+    intro.textContent = t('patterns.emptyIntro')
+    list.innerHTML = `<p class="digest-note"><i class="ti ti-check"></i> ${escHtml(t('patterns.emptyBody'))}</p>`
     // Still synced, even though the bar is hidden: the buttons keep whatever
     // state they had, and an emptied page that refills would otherwise show
     // "Dismiss 5" over a fresh selection of nothing.
@@ -100,15 +100,14 @@ function renderPatternQueue() {
     return
   }
 
-  intro.textContent =
-    `Your brain spotted these across several memories. Confirm one to make it a trusted, recallable fact; dismiss to discard it. Nothing here is searchable until you confirm it.`
+  intro.textContent = t('patterns.intro')
   bar.hidden = false
   list.innerHTML = loadedPatterns.map(patternRow).join('')
 
   const remaining = patternsTotal - loadedPatterns.length
   more.hidden = remaining <= 0
   more.disabled = false
-  if (remaining > 0) more.textContent = `${remaining} more ›`
+  if (remaining > 0) more.textContent = t('patterns.more', { n: remaining })
 
   syncPatternSelection()
 }
@@ -139,14 +138,14 @@ function syncPatternSelection() {
   const confirmBtn = document.getElementById('patterns-confirm-btn')
   const dismissBtn = document.getElementById('patterns-dismiss-btn')
 
-  label.textContent = n ? `${n} selected` : 'Select all'
+  label.textContent = n ? t('patterns.nSelected', { n }) : t('patterns.selectAll')
   all.checked = n > 0 && n === loadedPatterns.length
   // Some-but-not-all reads as neither ticked nor empty, which is the truth.
   all.indeterminate = n > 0 && n < loadedPatterns.length
   confirmBtn.disabled = !n
   dismissBtn.disabled = !n
-  confirmBtn.textContent = n > 1 ? `Confirm ${n}` : 'Confirm'
-  dismissBtn.textContent = n > 1 ? `Dismiss ${n}` : 'Dismiss'
+  confirmBtn.textContent = n > 1 ? t('patterns.confirmN', { n }) : t('brief.confirm')
+  dismissBtn.textContent = n > 1 ? t('patterns.dismissN', { n }) : t('brief.dismiss')
 }
 
 /**
@@ -163,7 +162,7 @@ async function resolveSelectedPatterns(action, btn) {
   bar.querySelectorAll('button, input').forEach((b) => (b.disabled = true))
   const original = btn.textContent
   btn.classList.add('digest-btn--loading')
-  btn.innerHTML = '<i class="ti ti-loader-2"></i> Working…'
+  btn.innerHTML = `<i class="ti ti-loader-2"></i> ${escHtml(t('upkeep.working'))}`
 
   try {
     const res = await fetch(`${WORKER_URL}/patterns/resolve`, {
@@ -187,7 +186,7 @@ async function resolveSelectedPatterns(action, btn) {
     if (!loadedPatterns.length && patternsTotal > 0) loadPatternQueue()
   } catch {
     btn.classList.remove('digest-btn--loading')
-    btn.innerHTML = '<i class="ti ti-alert-triangle"></i> Failed'
+    btn.innerHTML = `<i class="ti ti-alert-triangle"></i> ${escHtml(t('patterns.failed'))}`
     setTimeout(() => {
       btn.innerHTML = original
       bar.querySelectorAll('input').forEach((b) => (b.disabled = false))
@@ -209,9 +208,9 @@ function renderPatternsSection(total) {
   }
   el.style.display = ''
   el.innerHTML = `
-    <div class="digest-section-label">Patterns noticed</div>
-    <p class="digest-note">${total} ${total === 1 ? 'pattern is' : 'patterns are'} waiting on a decision. They stay out of recall until confirmed.</p>
-    <button class="digest-btn" onclick="openPatternsSheet()">Review ${total === 1 ? 'it' : 'all'} &rarr;</button>
+    <div class="digest-section-label">${escHtml(t('patterns.title'))}</div>
+    <p class="digest-note">${escHtml(tPlural('patterns.upkeepNote', total))}</p>
+    <button class="digest-btn" onclick="openPatternsSheet()">${escHtml(total === 1 ? t('patterns.reviewOne') : t('patterns.reviewAll'))}</button>
   `
 }
 

--- a/public/js/recall.js
+++ b/public/js/recall.js
@@ -36,7 +36,7 @@ async function sendRecall() {
     if (!recallRes.ok || !data.ok) throw new Error(data.error || 'recall failed')
     loadingEl.remove()
     if (!data.results || !data.results.length) {
-      appendBrainBubble(msgs, "I couldn't find anything matching that. Try different words, or browse Memories.", 'recall-sys')
+      appendBrainBubble(msgs, t('recall.empty'), 'recall-sys')
     } else {
       // REST scores are already 0–100 (one decimal); map directly rather than via
       // normalizeEntry, whose 0–1 rescale heuristic would turn a 0.8% match into 80%
@@ -117,7 +117,7 @@ async function sendRecall() {
       // "found · N sources" is the phrasing the marketing site uses for exactly
       // this moment; the dashboard should not invent a different one.
       sourcesToggle.innerHTML = `<button onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'flex' : 'none'">
-      <i class="ti ti-files"></i> found · ${entries.length} source${entries.length === 1 ? '' : 's'}
+      <i class="ti ti-files"></i> ${escHtml(tPlural('recall.sourcesFound', entries.length))}
     </button>
     <div class="brain-cards-wrapper" style="display:none"></div>`
       const wrapper = sourcesToggle.querySelector('.brain-cards-wrapper')
@@ -155,7 +155,7 @@ async function sendRecall() {
     }
   } catch {
     loadingEl.remove()
-    appendBrainBubble(msgs, 'Something went wrong. Check your connection and try again.', 'recall-sys')
+    appendBrainBubble(msgs, t('recall.error'), 'recall-sys')
   }
   msgs.scrollTop = msgs.scrollHeight
 }
@@ -168,9 +168,9 @@ function makeRecallCard(entry, citeIndex) {
   card.className = 'memory-card' + (isSynthesized ? ' card--synthesized' : '') + (isRolledUp ? ' card--rolled-up' : '') + (isStale ? ' card--stale' : '')
   card.innerHTML = `
     <div class="match-line">
-${citeIndex ? `<span class="cite-badge" title="Cited as [${citeIndex}] in the answer">${citeIndex}</span>` : ''}
+${citeIndex ? `<span class="cite-badge" title="${escAttr(t('recall.citedAs', { n: citeIndex }))}">${citeIndex}</span>` : ''}
 <span class="match-pct">${entry.score}%</span>
-${entry.hop > 0 ? `<span class="tag-chip" style="background:var(--accent-soft);color:var(--accent);flex-shrink:0">related · ${entry.hop} hop${entry.hop > 1 ? 's' : ''}</span>` : ''}
+${entry.hop > 0 ? `<span class="tag-chip" style="background:var(--accent-soft);color:var(--accent);flex-shrink:0">${escHtml(tPlural('recall.relatedHop', entry.hop))}</span>` : ''}
 <div class="match-bar-bg"><div class="match-bar-fill" style="width:${entry.score}%"></div></div>
     </div>
     <div class="card-content" style="cursor: pointer;">${escHtml(stripToPlainText(entry.content))}</div>
@@ -180,7 +180,7 @@ ${entry.hop > 0 ? `<span class="tag-chip" style="background:var(--accent-soft);c
       if (!entry.source && !at) return ''
       return `<div class="card-meta">
         <span class="card-source"><i class="ti ${badge.icon}"></i>${escHtml(badge.label)}</span>
-        ${at ? `<span class="card-time" title="${escAttr(new Date(at).toLocaleString())}">${escHtml(relativeTime(at))}</span>` : ''}
+        ${at ? `<span class="card-time" title="${escAttr(new Date(at).toLocaleString(localeTag()))}">${escHtml(relativeTime(at))}</span>` : ''}
       </div>`
     })()}
     <div class="card-footer">
@@ -188,8 +188,8 @@ ${entry.hop > 0 ? `<span class="tag-chip" style="background:var(--accent-soft);c
 <div class="card-actions">
   ${
     entry.id
-      ? `<button class="card-action-btn" onclick="openAppend('${escAttr(entry.id)}', '${escAttr(entry.content.slice(0, 80))}')"><i class="ti ti-writing"></i> Append</button>`
-      : `<button class="card-action-btn" onclick="openAppendFromContent('${escAttr(entry.content)}')"><i class="ti ti-writing"></i> Append</button>`
+      ? `<button class="card-action-btn" onclick="openAppend('${escAttr(entry.id)}', '${escAttr(entry.content.slice(0, 80))}')"><i class="ti ti-writing"></i> ${escHtml(t('memories.append'))}</button>`
+      : `<button class="card-action-btn" onclick="openAppendFromContent('${escAttr(entry.content)}')"><i class="ti ti-writing"></i> ${escHtml(t('memories.append'))}</button>`
   }
 </div>
     </div>`

--- a/public/js/recent.js
+++ b/public/js/recent.js
@@ -7,7 +7,7 @@ async function loadRecent() {
   // Only show the loading state on a cold list. A refresh after a capture
   // would otherwise blank out rows the user is reading and snap them back.
   if (!allEntries.length) {
-    list.innerHTML = `<div class="empty-state"><i class="ti ti-clock"></i><span>Loading...</span></div>`
+    list.innerHTML = `<div class="empty-state"><i class="ti ti-clock"></i><span>${escHtml(t('memories.loadingShort'))}</span></div>`
   }
   try {
     allEntries = await apiList(50)
@@ -19,7 +19,7 @@ async function loadRecent() {
     showFirstRunIfEmpty(allEntries.length === 0)
   } catch {
     if (!allEntries.length) {
-      list.innerHTML = `<div class="empty-state"><i class="ti ti-wifi-off"></i><span>Could not load memories.</span></div>`
+      list.innerHTML = `<div class="empty-state"><i class="ti ti-wifi-off"></i><span>${escHtml(t('memories.loadFailed'))}</span></div>`
     }
   }
 }
@@ -38,23 +38,21 @@ function showFirstRunIfEmpty(isEmpty) {
   if (suggestions) suggestions.style.display = 'none'
   welcome.classList.add('first-run')
   welcome.innerHTML =
-    `<div class="eyebrow">Getting started</div>` +
-    `<div class="hero-line">Your Second Brain is empty. Here is where everything lives.</div>` +
+    `<div class="eyebrow">${escHtml(t('home.firstRunEyebrow'))}</div>` +
+    `<div class="hero-line">${escHtml(t('home.firstRunHero'))}</div>` +
     `<ol class="first-run-steps">` +
     // Named after what is on screen. This used to point at a Remember tab and a
     // Recall tab, both of which are now the one box above.
-    `<li><b>The box above</b> does both: write a statement and it is saved, ask a question and it is answered. ` +
-    `It says which one it is about to do before you send.</li>` +
-    `<li><b>Memories</b> is everything you have kept — as a list by date, or as a graph of how it connects.</li>` +
-    `<li><b>Settings</b> is where you connect Claude, ChatGPT, Cursor, your email and calendar, ` +
-    `so they read from and add to this same memory.</li>` +
+    `<li>${escHtml(t('home.firstRunStep1'))}</li>` +
+    `<li>${escHtml(t('home.firstRunStep2'))}</li>` +
+    `<li>${escHtml(t('home.firstRunStep3'))}</li>` +
     `</ol>`
 }
 
 function renderRecent(entries) {
   const list = document.getElementById('recent-list')
   if (!entries.length) {
-    list.innerHTML = `<div class="empty-state"><i class="ti ti-brain"></i><span>No memories yet.<br>Use Remember to save your first one.</span></div>`
+    list.innerHTML = `<div class="empty-state"><i class="ti ti-brain"></i><span>${escHtml(t('memories.empty'))}</span></div>`
     return
   }
   const groups = {},
@@ -67,17 +65,17 @@ function renderRecent(entries) {
       ds = toDateStr(d)
     let label
     if (ds === today) {
-      label = 'Today'
+      label = t('memories.today')
     } else if (ds === yesterday) {
-      label = 'Yesterday'
+      label = t('memories.yesterday')
     } else if (entry.created_at >= sevenDaysAgo) {
-      label = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+      label = formatDateUI(d, { month: 'short', day: 'numeric' })
     } else {
       // Group by week: find the Monday of that week
       const dow = d.getDay()
       const diff = dow === 0 ? -6 : 1 - dow
       const weekStart = new Date(d.getFullYear(), d.getMonth(), d.getDate() + diff)
-      label = 'Week of ' + weekStart.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+      label = t('memories.weekOf', { date: formatDateUI(weekStart, { month: 'short', day: 'numeric' }) })
     }
     if (!groups[label]) groups[label] = []
     groups[label].push(entry)
@@ -115,10 +113,10 @@ function makeRecentCard(entry) {
 
   const vecChip =
     vec === 'on'
-      ? `<span class="tag-chip vec-chip vec-chip--on" title="Vectorized — searchable via recall"><i class="ti ti-circle-check"></i></span>`
+      ? `<span class="tag-chip vec-chip vec-chip--on" title="${escAttr(t('memories.vecOnTitle'))}"><i class="ti ti-circle-check"></i></span>`
       : vec === 'pending'
-        ? `<span class="tag-chip vec-chip vec-chip--pending" title="Vectorizing… (just captured)"><i class="ti ti-clock"></i></span>`
-        : `<span class="tag-chip vec-chip vec-chip--off" title="Not vectorized — won't appear in recall">Not indexed</span>`
+        ? `<span class="tag-chip vec-chip vec-chip--pending" title="${escAttr(t('memories.vecPendingTitle'))}"><i class="ti ti-clock"></i></span>`
+        : `<span class="tag-chip vec-chip vec-chip--off" title="${escAttr(t('memories.vecOffTitle'))}">${escHtml(t('memories.vecNotIndexed'))}</span>`
 
   const title = titleLine(entry.content)
   const preview = previewAfterTitle(entry.content, title)
@@ -136,16 +134,16 @@ function makeRecentCard(entry) {
 <div class="card-footer">
   <div class="card-meta">
     <span class="card-source"><i class="ti ${badge.icon}"></i>${escHtml(badge.label)}</span>
-    ${created ? `<span class="card-time" title="${escAttr(new Date(created).toLocaleString())}">${escHtml(relativeTime(created))}</span>` : ''}
+    ${created ? `<span class="card-time" title="${escAttr(new Date(created).toLocaleString(localeTag()))}">${escHtml(relativeTime(created))}</span>` : ''}
   </div>
   <div class="card-tags">${shown.map((t) => `<span class="tag-chip">${escHtml(t)}</span>`).join('')}${vecChip}</div>
   <div class="card-actions">
-    <button class="card-action-btn" onclick="openAppend('${escAttr(entry.id)}', '${escAttr(entry.content.slice(0, 80))}')"><i class="ti ti-writing"></i> Append</button>
-    <button class="card-action-btn edit-btn"><i class="ti ti-pencil"></i> Edit</button>
+    <button class="card-action-btn" onclick="openAppend('${escAttr(entry.id)}', '${escAttr(entry.content.slice(0, 80))}')"><i class="ti ti-writing"></i> ${escHtml(t('memories.append'))}</button>
+    <button class="card-action-btn edit-btn"><i class="ti ti-pencil"></i> ${escHtml(t('memories.edit'))}</button>
     <div class="card-overflow">
-      <button class="card-action-btn overflow-btn" aria-label="More actions" aria-haspopup="true" aria-expanded="false"><i class="ti ti-dots"></i></button>
+      <button class="card-action-btn overflow-btn" aria-label="${escAttr(t('memories.moreActions'))}" aria-haspopup="true" aria-expanded="false"><i class="ti ti-dots"></i></button>
       <div class="card-overflow-menu" hidden>
-        <button class="card-overflow-item danger forget-btn"><i class="ti ti-trash"></i> Forget this memory</button>
+        <button class="card-overflow-item danger forget-btn"><i class="ti ti-trash"></i> ${escHtml(t('memories.forgetThis'))}</button>
       </div>
     </div>
   </div>

--- a/public/js/remember.js
+++ b/public/js/remember.js
@@ -24,29 +24,29 @@ function captureReceipt(result, typedTags) {
   // pulled out of the content itself — not just the ones typed here.
   const filed = humanTags(result.tags && result.tags.length ? result.tags : typedTags || [])
 
-  let headline = 'stored to brain'
+  let headline = t('home.receiptStored')
   const notes = []
   if (result.action === 'merged') {
-    headline = 'merged into an existing memory'
-    notes.push('You had written about this before, so the two are now one memory.')
+    headline = t('home.receiptMerged')
+    notes.push(t('home.receiptMergedNote'))
   } else if (result.action === 'replaced') {
-    headline = 'replaced an outdated memory'
-    notes.push('The older version is gone; this one supersedes it.')
+    headline = t('home.receiptReplaced')
+    notes.push(t('home.receiptReplacedNote'))
   } else if (result.resolved_conflict) {
-    headline = 'stored, and something older now disagrees'
-    notes.push('Your brain noticed this conflicts with an earlier memory and kept the newer one.')
+    headline = t('home.receiptConflict')
+    notes.push(t('home.receiptConflictNote'))
   } else if (result.kept_canonical) {
-    headline = 'stored as a draft'
-    notes.push('This conflicts with a memory you have confirmed, so it is kept unconfirmed rather than overriding it.')
+    headline = t('home.receiptDraft')
+    notes.push(t('home.receiptDraftNote'))
   } else if (result.warning === 'similar') {
-    headline = 'stored, close to something you already had'
-    notes.push('Flagged as a possible duplicate so you can compare them later.')
+    headline = t('home.receiptSimilar')
+    notes.push(t('home.receiptSimilarNote'))
   }
 
   el.innerHTML =
     `<div class="receipt-headline"><span class="receipt-dot"></span>${escHtml(headline)}</div>` +
     (filed.length
-      ? `<div class="receipt-filed">filed under ${filed.map((t) => `<span class="confirm-tag">${escHtml(t)}</span>`).join('')}</div>`
+      ? `<div class="receipt-filed">${escHtml(t('home.receiptFiledUnder'))} ${filed.map((tag) => `<span class="confirm-tag">${escHtml(tag)}</span>`).join('')}</div>`
       : '') +
     notes.map((n) => `<div class="receipt-note">${escHtml(n)}</div>`).join('')
   return el

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -64,9 +64,9 @@ function digestCandidateRow(c) {
       <div class="digest-candidate-row" id="digest-row-${escAttr(c.tag)}">
         <div class="digest-candidate-label">
           <span>${escHtml(c.tag)}</span>
-          <span class="digest-candidate-count">${c.count} entries</span>
+          <span class="digest-candidate-count">${escHtml(tPlural('upkeep.digestEntries', c.count))}</span>
         </div>
-        <button class="digest-btn" onclick="runDigest('${escAttr(c.tag)}', this)">Digest →</button>
+        <button class="digest-btn" onclick="runDigest('${escAttr(c.tag)}', this)">${escHtml(t('upkeep.digestAction'))}</button>
       </div>`
 }
 
@@ -83,13 +83,13 @@ function renderDigestSection(candidates) {
   const shown = candidates.slice(0, DIGEST_VISIBLE)
   const rest = candidates.slice(DIGEST_VISIBLE)
   el.innerHTML = `
-    <div class="digest-section-label">Ready to compress</div>
-    <p class="digest-note">Originals are never deleted — digest adds a summary and ranks originals lower in recall so they don't crowd results.</p>
+    <div class="digest-section-label">${escHtml(t('upkeep.digestLabel'))}</div>
+    <p class="digest-note">${escHtml(t('upkeep.digestNote'))}</p>
     ${shown.map(digestCandidateRow).join('')}
     ${
       rest.length
         ? `<div id="digest-rest" hidden>${rest.map(digestCandidateRow).join('')}</div>
-           <button class="digest-more" id="digest-more" onclick="showAllDigestCandidates()">${rest.length} more &rsaquo;</button>`
+           <button class="digest-more" id="digest-more" onclick="showAllDigestCandidates()">${escHtml(t('upkeep.digestMore', { n: rest.length }))}</button>`
         : ''
     }
   `
@@ -105,7 +105,7 @@ function showAllDigestCandidates() {
 async function runDigest(tag, btn) {
   btn.disabled = true
   btn.classList.add('digest-btn--loading')
-  btn.innerHTML = '<i class="ti ti-loader-2"></i> Working…'
+  btn.innerHTML = `<i class="ti ti-loader-2"></i> ${escHtml(t('upkeep.working'))}`
   const row = document.getElementById('digest-row-' + tag)
   try {
     const res = await fetch(`${WORKER_URL}/digest?tag=${encodeURIComponent(tag)}`, {
@@ -114,28 +114,28 @@ async function runDigest(tag, btn) {
     const data = await res.json()
     if (data.synthesis) {
       btn.classList.remove('digest-btn--loading')
-      btn.innerHTML = '<i class="ti ti-check"></i> Done'
+      btn.innerHTML = `<i class="ti ti-check"></i> ${escHtml(t('upkeep.done'))}`
       btn.style.color = 'var(--good)'
       setTimeout(() => {
-        row.innerHTML = `<div class="digest-result"><strong>${escHtml(tag)}</strong> — ${escHtml(data.synthesis)}<div class="digest-result-meta"><i class="ti ti-lock"></i> ${data.source_count} original memories preserved &amp; still searchable</div></div>`
+        row.innerHTML = `<div class="digest-result"><strong>${escHtml(tag)}</strong> — ${escHtml(data.synthesis)}<div class="digest-result-meta"><i class="ti ti-lock"></i> ${escHtml(tPlural('upkeep.digestPreserved', data.source_count))}</div></div>`
       }, 700)
     } else {
       btn.classList.remove('digest-btn--loading')
-      btn.innerHTML = '<i class="ti ti-alert-triangle"></i> ' + escHtml(data.error ?? 'Could not create digest')
+      btn.innerHTML = '<i class="ti ti-alert-triangle"></i> ' + escHtml(data.error ?? t('upkeep.digestFailed'))
       btn.style.color = 'var(--danger)'
       setTimeout(() => {
         btn.disabled = false
-        btn.innerHTML = 'Digest →'
+        btn.innerHTML = escHtml(t('upkeep.digestAction'))
         btn.style.color = ''
       }, 3000)
     }
   } catch {
     btn.classList.remove('digest-btn--loading')
-    btn.innerHTML = '<i class="ti ti-wifi-off"></i> Request failed'
+    btn.innerHTML = `<i class="ti ti-wifi-off"></i> ${escHtml(t('upkeep.requestFailed'))}`
     btn.style.color = 'var(--danger)'
     setTimeout(() => {
       btn.disabled = false
-      btn.innerHTML = 'Digest →'
+      btn.innerHTML = escHtml(t('upkeep.digestAction'))
       btn.style.color = ''
     }, 3000)
   }
@@ -149,16 +149,16 @@ function renderVectorizeSection(count) {
   }
   el.style.display = ''
   el.innerHTML = `
-    <div class="digest-section-label">Not indexed</div>
-    <p class="digest-note">${count} ${count === 1 ? 'memory' : 'memories'} failed to embed and won't appear in recall.</p>
-    <button class="digest-btn" id="vectorize-btn" onclick="runVectorize(this)">Vectorize now →</button>
+    <div class="digest-section-label">${escHtml(t('upkeep.vectorizeLabel'))}</div>
+    <p class="digest-note">${escHtml(tPlural('upkeep.vectorizeNote', count))}</p>
+    <button class="digest-btn" id="vectorize-btn" onclick="runVectorize(this)">${escHtml(t('upkeep.vectorizeAction'))}</button>
   `
 }
 
 async function runVectorize(btn) {
   btn.disabled = true
   btn.classList.add('digest-btn--loading')
-  btn.innerHTML = '<i class="ti ti-loader-2"></i> Working…'
+  btn.innerHTML = `<i class="ti ti-loader-2"></i> ${escHtml(t('upkeep.working'))}`
   try {
     let remaining = 1
     let totalProcessed = 0
@@ -167,24 +167,24 @@ async function runVectorize(btn) {
         method: 'POST',
         headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
       })
-      if (!res.ok) throw new Error(`Server error: ${res.status}`)
+      if (!res.ok) throw new Error(t('auth.serverError', { status: res.status }))
       const data = await res.json()
       remaining = data.remaining ?? 0
       totalProcessed += data.processed ?? 0
       if ((data.processed ?? 0) === 0 && remaining > 0) break
     }
     btn.classList.remove('digest-btn--loading')
-    btn.innerHTML = `<i class="ti ti-check"></i> Done — ${totalProcessed} re-indexed`
+    btn.innerHTML = `<i class="ti ti-check"></i> ${escHtml(t('upkeep.vectorizeDone', { n: totalProcessed }))}`
     btn.style.color = 'var(--good)'
     await loadMenuStats()
     refreshAll()
   } catch {
     btn.classList.remove('digest-btn--loading')
-    btn.innerHTML = '<i class="ti ti-wifi-off"></i> Request failed'
+    btn.innerHTML = `<i class="ti ti-wifi-off"></i> ${escHtml(t('upkeep.requestFailed'))}`
     btn.style.color = 'var(--danger)'
     setTimeout(() => {
       btn.disabled = false
-      btn.innerHTML = 'Vectorize now →'
+      btn.innerHTML = escHtml(t('upkeep.vectorizeAction'))
       btn.style.color = ''
     }, 3000)
   }
@@ -195,16 +195,16 @@ function renderClassifySection(count) {
   if (!count) { el.style.display = 'none'; return }
   el.style.display = ''
   el.innerHTML = `
-    <div class="digest-section-label">Not classified</div>
-    <p class="digest-note">${count} ${count === 1 ? 'memory has' : 'memories have'} no kind or status tag yet (captured before classification existed).</p>
-    <button class="digest-btn" id="classify-btn" onclick="runClassify(this)">Classify now →</button>
+    <div class="digest-section-label">${escHtml(t('upkeep.classifyLabel'))}</div>
+    <p class="digest-note">${escHtml(tPlural('upkeep.classifyNote', count))}</p>
+    <button class="digest-btn" id="classify-btn" onclick="runClassify(this)">${escHtml(t('upkeep.classifyAction'))}</button>
   `
 }
 
 async function runClassify(btn) {
   btn.disabled = true
   btn.classList.add('digest-btn--loading')
-  btn.innerHTML = '<i class="ti ti-loader-2"></i> Working…'
+  btn.innerHTML = `<i class="ti ti-loader-2"></i> ${escHtml(t('upkeep.working'))}`
   try {
     let remaining = 1
     let prevRemaining = Infinity
@@ -214,7 +214,7 @@ async function runClassify(btn) {
         method: 'POST',
         headers: { Authorization: `Bearer ${AUTH_TOKEN}` }
       })
-      if (!res.ok) throw new Error(`Server error: ${res.status}`)
+      if (!res.ok) throw new Error(t('auth.serverError', { status: res.status }))
       const data = await res.json()
       remaining = data.remaining ?? 0
       totalProcessed += data.processed ?? 0
@@ -222,17 +222,17 @@ async function runClassify(btn) {
       prevRemaining = remaining
     }
     btn.classList.remove('digest-btn--loading')
-    btn.innerHTML = `<i class="ti ti-check"></i> Done — ${totalProcessed} classified`
+    btn.innerHTML = `<i class="ti ti-check"></i> ${escHtml(t('upkeep.classifyDone', { n: totalProcessed }))}`
     btn.style.color = 'var(--good)'
     await loadMenuStats()
     refreshAll()
   } catch {
     btn.classList.remove('digest-btn--loading')
-    btn.innerHTML = '<i class="ti ti-wifi-off"></i> Request failed'
+    btn.innerHTML = `<i class="ti ti-wifi-off"></i> ${escHtml(t('upkeep.requestFailed'))}`
     btn.style.color = 'var(--danger)'
     setTimeout(() => {
       btn.disabled = false
-      btn.innerHTML = 'Classify now →'
+      btn.innerHTML = escHtml(t('upkeep.classifyAction'))
       btn.style.color = ''
     }, 3000)
   }
@@ -285,7 +285,7 @@ async function runImportLoop(payload, post, onProgress) {
     if (onProgress) onProgress({ done: Math.min(offset + edgeOffset, totalEntries + totalEdges), total: totalEntries + totalEdges, totals })
 
     if ((data.remaining_entries || 0) === 0 && (data.remaining_edges || 0) === 0) return totals
-    if (stalled) throw new Error('Server did not advance the import cursor — is the Worker up to date?')
+    if (stalled) throw new Error(t('upkeep.importStalled'))
   }
 }
 
@@ -302,9 +302,9 @@ function renderRestoreProgress(label, done, total) {
   const el = restoreSection()
   el.style.display = ''
   el.innerHTML = `
-    <div class="digest-section-label">Restore</div>
+    <div class="digest-section-label">${escHtml(t('upkeep.restoreLabel'))}</div>
     <p class="digest-note">${label}</p>
-    <button class="digest-btn digest-btn--loading" disabled><i class="ti ti-loader-2"></i> ${done.toLocaleString()} of ${total.toLocaleString()}</button>
+    <button class="digest-btn digest-btn--loading" disabled><i class="ti ti-loader-2"></i> ${escHtml(t('upkeep.restoreOf', { done: done.toLocaleString(localeTag()), total: total.toLocaleString(localeTag()) }))}</button>
   `
 }
 
@@ -312,29 +312,29 @@ function renderRestoreFailure(message) {
   const el = restoreSection()
   el.style.display = ''
   el.innerHTML = `
-    <div class="digest-section-label">Restore</div>
-    <p class="digest-note">${message} Your backup file is untouched, and it's safe to try again — anything already restored will be skipped, not duplicated.</p>
-    <button class="digest-btn" onclick="restoreFromBackup()">Try again →</button>
+    <div class="digest-section-label">${escHtml(t('upkeep.restoreLabel'))}</div>
+    <p class="digest-note">${message} ${escHtml(t('upkeep.restoreFailureTail'))}</p>
+    <button class="digest-btn" onclick="restoreFromBackup()">${escHtml(t('upkeep.restoreTryAgain'))}</button>
   `
 }
 
 function renderRestoreDone(totals) {
   const el = restoreSection()
-  const parts = [`${totals.imported.toLocaleString()} restored`]
-  if (totals.edges_imported) parts.push(`${totals.edges_imported.toLocaleString()} connections`)
-  if (totals.skipped) parts.push(`${totals.skipped.toLocaleString()} already present`)
+  const parts = [t('upkeep.restoreSummaryRestored', { n: totals.imported.toLocaleString(localeTag()) })]
+  if (totals.edges_imported) parts.push(t('upkeep.restoreSummaryConnections', { n: totals.edges_imported.toLocaleString(localeTag()) }))
+  if (totals.skipped) parts.push(t('upkeep.restoreSummaryPresent', { n: totals.skipped.toLocaleString(localeTag()) }))
   const failures = totals.failed + totals.edges_failed
   const failNote = failures
-    ? ` ${failures.toLocaleString()} ${failures === 1 ? 'item' : 'items'} couldn't be restored — usually rows edited by hand; the rest are unaffected.`
+    ? ` ${t('upkeep.restoreFailNote', { n: failures.toLocaleString(localeTag()) })}`
     : ''
   const needsIndexing = totals.imported > 0
   el.style.display = ''
   el.innerHTML = `
-    <div class="digest-section-label">Restore</div>
-    <p class="digest-note"><i class="ti ti-check"></i> ${parts.join(' · ')}.${failNote}${
-      needsIndexing ? ' Restored memories can\'t be searched until they\'re indexed.' : ''
+    <div class="digest-section-label">${escHtml(t('upkeep.restoreLabel'))}</div>
+    <p class="digest-note"><i class="ti ti-check"></i> ${escHtml(parts.join(' · '))}.${escHtml(failNote)}${
+      needsIndexing ? ` ${escHtml(t('upkeep.restoreNeedsIndex'))}` : ''
     }</p>
-    ${needsIndexing ? '<button class="digest-btn" onclick="indexRestored(this)">Make searchable →</button>' : ''}
+    ${needsIndexing ? `<button class="digest-btn" onclick="indexRestored(this)">${escHtml(t('upkeep.restoreMakeSearchable'))}</button>` : ''}
   `
 }
 
@@ -344,7 +344,7 @@ function renderRestoreDone(totals) {
 async function indexRestored(btn) {
   btn.disabled = true
   btn.classList.add('digest-btn--loading')
-  btn.innerHTML = '<i class="ti ti-loader-2"></i> Indexing…'
+  btn.innerHTML = `<i class="ti ti-loader-2"></i> ${escHtml(t('upkeep.restoreIndexing'))}`
   try {
     let remaining = 1
     let totalProcessed = 0
@@ -353,20 +353,22 @@ async function indexRestored(btn) {
         method: 'POST',
         headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
       })
-      if (!res.ok) throw new Error(`Server error: ${res.status}`)
+      if (!res.ok) throw new Error(t('auth.serverError', { status: res.status }))
       const data = await res.json()
       remaining = data.remaining ?? 0
       totalProcessed += data.processed ?? 0
-      btn.innerHTML = `<i class="ti ti-loader-2"></i> Indexing… ${totalProcessed.toLocaleString()} done${remaining ? `, ${remaining.toLocaleString()} to go` : ''}`
+      btn.innerHTML = remaining
+        ? `<i class="ti ti-loader-2"></i> ${escHtml(t('upkeep.restoreIndexingProgress', { done: totalProcessed.toLocaleString(localeTag()), remaining: remaining.toLocaleString(localeTag()) }))}`
+        : `<i class="ti ti-loader-2"></i> ${escHtml(t('upkeep.restoreIndexingDoneOnly', { done: totalProcessed.toLocaleString(localeTag()) }))}`
       if ((data.processed ?? 0) === 0 && remaining > 0) break
     }
     btn.classList.remove('digest-btn--loading')
     if (remaining > 0) {
       // Workers AI quota ran dry mid-backfill — the daily reset finishes the job.
       btn.disabled = false
-      btn.innerHTML = `${remaining.toLocaleString()} left — daily AI limit reached, try tomorrow`
+      btn.innerHTML = escHtml(t('upkeep.restoreQuotaLeft', { n: remaining.toLocaleString(localeTag()) }))
     } else {
-      btn.innerHTML = '<i class="ti ti-check"></i> All restored memories are searchable'
+      btn.innerHTML = `<i class="ti ti-check"></i> ${escHtml(t('upkeep.restoreAllSearchable'))}`
       btn.style.color = 'var(--good)'
     }
     await loadMenuStats()
@@ -374,7 +376,7 @@ async function indexRestored(btn) {
   } catch {
     btn.classList.remove('digest-btn--loading')
     btn.disabled = false
-    btn.innerHTML = '<i class="ti ti-wifi-off"></i> Failed — tap to retry'
+    btn.innerHTML = `<i class="ti ti-wifi-off"></i> ${escHtml(t('upkeep.restoreIndexFailed'))}`
     btn.style.color = 'var(--danger)'
     btn.onclick = () => indexRestored(btn)
   }
@@ -399,16 +401,16 @@ async function restoreFromBackup() {
   try {
     payload = JSON.parse(await file.text())
   } catch {
-    renderRestoreFailure(`<strong>${file.name}</strong> isn't valid JSON.`)
+    renderRestoreFailure(t('upkeep.restoreInvalidJson', { filename: `<strong>${escHtml(file.name)}</strong>` }))
     return
   }
   if (!payload || !Array.isArray(payload.entries)) {
-    renderRestoreFailure(`<strong>${file.name}</strong> doesn't look like a Second Brain backup — it has no entries list. Use a file created by "Back up as JSON".`)
+    renderRestoreFailure(t('upkeep.restoreNotBackup', { filename: `<strong>${escHtml(file.name)}</strong>` }))
     return
   }
 
   const total = payload.entries.length + (payload.edges || []).length
-  renderRestoreProgress(`Restoring from <strong>${file.name}</strong>…`, 0, total)
+  renderRestoreProgress(t('upkeep.restoreProgress', { filename: `<strong>${escHtml(file.name)}</strong>` }), 0, total)
   try {
     const totals = await runImportLoop(
       payload,
@@ -418,16 +420,16 @@ async function restoreFromBackup() {
           headers: { Authorization: `Bearer ${AUTH_TOKEN}`, 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
         })
-        if (!res.ok) throw new Error(`Server error: ${res.status}`)
+        if (!res.ok) throw new Error(t('auth.serverError', { status: res.status }))
         return res.json()
       },
-      ({ done }) => renderRestoreProgress(`Restoring from <strong>${file.name}</strong>…`, done, total),
+      ({ done }) => renderRestoreProgress(t('upkeep.restoreProgress', { filename: `<strong>${escHtml(file.name)}</strong>` }), done, total),
     )
     renderRestoreDone(totals)
     await loadMenuStats()
     refreshAll()
   } catch (e) {
-    renderRestoreFailure('The restore stopped partway.')
+    renderRestoreFailure(t('upkeep.restoreStopped'))
   }
 }
 
@@ -437,7 +439,7 @@ async function exportMemories(format) {
     // /export returns everything — entries AND edges — in one shot; /list caps
     // at 100 rows, which used to silently truncate bigger brains
     const res = await fetch(`${WORKER_URL}/export`, { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } })
-    if (!res.ok) throw new Error(`Server error: ${res.status}`)
+    if (!res.ok) throw new Error(t('auth.serverError', { status: res.status }))
     const data = await res.json()
     const entries = data.entries || []
     const edges = data.edges || []
@@ -450,14 +452,14 @@ async function exportMemories(format) {
       filename = `second-brain-export-${ts}.json`
       mime = 'application/json'
     } else {
-      const lines = [`# Second Brain Export`, `Exported: ${ts}`, '']
+      const lines = [t('menu.exportMdTitle'), t('menu.exportMdExported', { date: ts }), '']
       entries.forEach((e, i) => {
         const tags = e.tags || []
-        const date = new Date(e.created_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
-        lines.push(`## Memory ${i + 1}`)
-        lines.push(`**Date:** ${date}`)
-        if (tags.length) lines.push(`**Tags:** ${tags.join(', ')}`)
-        if (e.source) lines.push(`**Source:** ${e.source}`)
+        const date = formatDateUI(e.created_at, { year: 'numeric', month: 'short', day: 'numeric' })
+        lines.push(t('menu.exportMdMemory', { n: i + 1 }))
+        lines.push(t('menu.exportMdDate', { date }))
+        if (tags.length) lines.push(t('menu.exportMdTags', { tags: tags.join(', ') }))
+        if (e.source) lines.push(t('menu.exportMdSource', { source: e.source }))
         lines.push('')
         lines.push(e.content)
         lines.push('')
@@ -466,7 +468,7 @@ async function exportMemories(format) {
       })
       if (edges.length) {
         const labelById = new Map(entries.map((e) => [e.id, (e.content || '').slice(0, 60)]))
-        lines.push(`## Relationships`)
+        lines.push(t('menu.exportMdRelationships'))
         lines.push('')
         edges.forEach((e) => {
           const src = labelById.get(e.source_id) || e.source_id
@@ -488,6 +490,6 @@ async function exportMemories(format) {
     a.click()
     URL.revokeObjectURL(url)
   } catch (e) {
-    alert('Export failed: ' + e.message)
+    alert(t('menu.exportFailed', { message: e.message }))
   }
 }

--- a/public/js/ui-chat.js
+++ b/public/js/ui-chat.js
@@ -18,7 +18,7 @@ function renderAnswerMarkdown(src) {
       // in the numbered list the model was given, which is the second source
       // card. Rendered as a chip that reveals and highlights that card, so a
       // claim can be checked against the memory it came from in one tap.
-      .replace(/\[(\d{1,2})\]/g, '<button class="cite" data-cite="$1" title="Show source $1">$1</button>')
+      .replace(/\[(\d{1,2})\]/g, (_, n) => `<button class="cite" data-cite="${n}" title="${escAttr(t('recall.citeTitle', { n }))}">${n}</button>`)
 
   // Some models stream lists inline ("... tools: * a * b * c") with no newlines.
   // Re-break a run of " * " markers onto their own lines so they parse as a list.
@@ -38,25 +38,25 @@ function renderAnswerMarkdown(src) {
   }
 
   lines.forEach((line) => {
-    const t = line.trim()
-    if (!t) {
+    const trimmed = line.trim()
+    if (!trimmed) {
       closeList()
       return
     }
 
     let m
-    if ((m = t.match(/^(#{1,4})\s+(.*)$/))) {
+    if ((m = trimmed.match(/^(#{1,4})\s+(.*)$/))) {
       closeList()
       const lvl = Math.min(m[1].length + 2, 4) // h3/h4
       html += `<h${lvl}>${inline(m[2])}</h${lvl}>`
-    } else if ((m = t.match(/^[*\-+•]\s+(.*)$/))) {
+    } else if ((m = trimmed.match(/^[*\-+•]\s+(.*)$/))) {
       if (listType !== 'ul') {
         closeList()
         html += '<ul>'
         listType = 'ul'
       }
       html += `<li>${inline(m[1])}</li>`
-    } else if ((m = t.match(/^\d+[.)]\s+(.*)$/))) {
+    } else if ((m = trimmed.match(/^\d+[.)]\s+(.*)$/))) {
       if (listType !== 'ol') {
         closeList()
         html += '<ol>'
@@ -65,7 +65,7 @@ function renderAnswerMarkdown(src) {
       html += `<li>${inline(m[1])}</li>`
     } else {
       closeList()
-      html += `<p>${inline(t)}</p>`
+      html += `<p>${inline(trimmed)}</p>`
     }
   })
   closeList()
@@ -74,7 +74,7 @@ function renderAnswerMarkdown(src) {
 function appendUserBubble(container, text) {
   const q = document.createElement('div')
   q.className = 'ex-q'
-  q.innerHTML = '<span class="q-label">You asked</span><span class="q-dash">\u2014</span><span class="q-text"></span>'
+  q.innerHTML = `<span class="q-label">${escHtml(t('recall.youAsked'))}</span><span class="q-dash">\u2014</span><span class="q-text"></span>`
   q.querySelector('.q-text').textContent = text
   container.appendChild(q)
 }

--- a/public/utils.js
+++ b/public/utils.js
@@ -60,7 +60,7 @@ function stripToPlainText(s) {
  */
 function titleLine(content, max = 90) {
   const plain = stripToPlainText(content)
-  if (!plain) return 'Untitled memory'
+  if (!plain) return t('memories.untitled')
   const sentence = plain.match(/^.{10,}?[.!?](\s|$)/)
   const line = (sentence ? sentence[0] : plain).trim()
   return line.length > max ? line.slice(0, max - 1).trimEnd() + '…' : line
@@ -113,23 +113,23 @@ function previewAfterTitle(content, title) {
   return plain
 }
 
-/** "2h ago" — absolute dates stay available on hover via title attributes. */
+/** Relative time for UI rows — absolute dates stay on hover via title attributes. */
 function relativeTime(ts) {
   const then = Number(ts)
   if (!Number.isFinite(then) || then <= 0) return ''
   const secs = Math.max(0, Math.round((Date.now() - then) / 1000))
-  if (secs < 60) return 'just now'
+  if (secs < 60) return t('common.justNow')
   const mins = Math.round(secs / 60)
-  if (mins < 60) return `${mins}m ago`
+  if (mins < 60) return t('common.minutesAgo', { n: formatNumberUI(mins) })
   const hours = Math.round(mins / 60)
-  if (hours < 24) return `${hours}h ago`
+  if (hours < 24) return t('common.hoursAgo', { n: formatNumberUI(hours) })
   const days = Math.round(hours / 24)
-  if (days < 7) return `${days}d ago`
+  if (days < 7) return t('common.daysAgo', { n: formatNumberUI(days) })
   const weeks = Math.round(days / 7)
-  if (weeks < 5) return `${weeks}w ago`
+  if (weeks < 5) return t('common.weeksAgo', { n: formatNumberUI(weeks) })
   const months = Math.round(days / 30)
-  if (months < 12) return `${months}mo ago`
-  return `${Math.round(days / 365)}y ago`
+  if (months < 12) return t('common.monthsAgo', { n: formatNumberUI(months) })
+  return t('common.yearsAgo', { n: formatNumberUI(Math.round(days / 365)) })
 }
 
 /**
@@ -144,6 +144,20 @@ function relativeTime(ts) {
  * Ordered most specific first — "claude-code" is a terminal, not a chat, and
  * "email-gmail" is Google before it is mail.
  */
+const SOURCE_BADGE_I18N = {
+  'claude code': 'common.sourceClaudeCode',
+  cli: 'common.sourceCli',
+  email: 'common.sourceEmail',
+  chat: 'common.sourceChat',
+  browser: 'common.sourceBrowser',
+  dashboard: 'common.sourceDashboard',
+  phone: 'common.sourcePhone',
+  voice: 'common.sourceVoice',
+  import: 'common.sourceImport',
+  system: 'common.sourceSystem',
+  manual: 'common.sourceManual',
+}
+
 const SOURCE_BADGES = [
   // Terminals and code tools. `cli` is the Second Brain CLI; an earlier version
   // of this table matched it to GitHub, which was simply wrong.
@@ -172,11 +186,16 @@ const SOURCE_BADGES = [
   [/^user$|manual|^api$/, 'ti-writing', 'manual'],
 ]
 
+function sourceBadgeLabel(label) {
+  const key = SOURCE_BADGE_I18N[label]
+  return key ? t(key) : label
+}
+
 function sourceBadge(source) {
   const raw = String(source ?? '').trim().toLowerCase()
-  if (!raw) return { icon: 'ti-writing', label: 'manual' }
+  if (!raw) return { icon: 'ti-writing', label: t('common.sourceManual') }
   for (const [pattern, icon, label] of SOURCE_BADGES) {
-    if (pattern.test(raw)) return { icon, label }
+    if (pattern.test(raw)) return { icon, label: sourceBadgeLabel(label) }
   }
   // Some rows carry a whole sentence as their source ("ChatGPT conversation on
   // AI-native SDLC"). Show something rather than nothing, but never let it set
@@ -273,9 +292,9 @@ function vectorizeHealthBanner(health) {
   if (!health || !health.vectorize || health.vectorize.ok) return null;
   const name = health.vectorize.indexName || 'second-brain-vectors';
   return {
-    title: 'Semantic search is disabled. The Vectorize index "' + name + '" was not found.',
+    title: t('upkeep.vectorizeBannerTitle', { name }),
     command: 'npx wrangler vectorize create ' + name + ' --dimensions=384 --metric=cosine',
-    gui: 'Or grant the Workers Builds API token the account-level Vectorize Edit permission in the Cloudflare dashboard (My Profile, API Tokens), then redeploy so the build creates the index automatically.'
+    gui: t('upkeep.vectorizeBannerGui'),
   };
 }
 
@@ -284,8 +303,8 @@ function vectorizeHealthBanner(health) {
 function vectorizeBannerHtml(banner) {
   return (
     '<strong>' + escHtml(banner.title) + '</strong> ' +
-    '<details style="margin-top:6px"><summary style="cursor:pointer">How to fix</summary>' +
-    '<p style="margin:6px 0 2px">Run this once in your terminal:</p>' +
+    '<details style="margin-top:6px"><summary style="cursor:pointer">' + escHtml(t('upkeep.vectorizeBannerHowToFix')) + '</summary>' +
+    '<p style="margin:6px 0 2px">' + escHtml(t('upkeep.vectorizeBannerRunOnce')) + '</p>' +
     '<pre style="white-space:pre-wrap;background:rgba(0,0,0,0.25);padding:8px;border-radius:6px;margin:0">' + escHtml(banner.command) + '</pre>' +
     '<p style="margin:6px 0 0">' + escHtml(banner.gui) + '</p></details>'
   );

--- a/test/ui/_i18n-harness.ts
+++ b/test/ui/_i18n-harness.ts
@@ -1,0 +1,22 @@
+/** Shared vm bootstrap so UI tests load dashboard i18n before utils.js. */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import vm from "node:vm";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+
+export function installI18n(ctx: any, locale: "en" | "it" = "en") {
+  if (!ctx.localStorage) {
+    const m = new Map<string, string>();
+    ctx.localStorage = {
+      getItem: (k: string) => m.get(k) ?? null,
+      setItem: (k: string, v: string) => m.set(k, v),
+    };
+  }
+  if (!ctx.navigator) ctx.navigator = { language: "en-US" };
+  if (!ctx.document) ctx.document = {};
+  if (!ctx.document.documentElement) ctx.document.documentElement = { lang: "en" };
+  if (!ctx.document.querySelectorAll) ctx.document.querySelectorAll = () => [];
+  vm.runInContext(readFileSync(resolve(ROOT, "public/js/i18n.js"), "utf8"), ctx);
+  ctx.initI18n(locale);
+}

--- a/test/ui/brief-render.test.ts
+++ b/test/ui/brief-render.test.ts
@@ -8,6 +8,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import vm from "node:vm";
 import { describe, it, expect } from "vitest";
+import { installI18n } from "./_i18n-harness";
 
 const ROOT = resolve(import.meta.dirname, "../..");
 
@@ -38,6 +39,7 @@ function load() {
   };
   ctx.globalThis = ctx;
   vm.createContext(ctx);
+  installI18n(ctx, "en");
   for (const f of ["public/utils.js", "public/js/brief.js"]) {
     vm.runInContext(readFileSync(resolve(ROOT, f), "utf8"), ctx);
   }

--- a/test/ui/dashboard-modules.test.ts
+++ b/test/ui/dashboard-modules.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from "vitest";
 const ROOT = resolve(import.meta.dirname, "../..");
 
 const DASHBOARD_SCRIPTS = [
+  "public/js/i18n.js",
   "public/utils.js",
   "public/credits.js",
   "public/js/state.js",
@@ -61,6 +62,7 @@ function makeFakeDocument() {
     onclick: null,
     setAttribute() {},
     getAttribute: () => null,
+    hasAttribute: () => false,
     appendChild() {},
     querySelector: () => el(),
     querySelectorAll: () => [],
@@ -73,7 +75,7 @@ function makeFakeDocument() {
     offsetHeight: 24,
   });
   return {
-    documentElement: { setAttribute() {}, getAttribute: () => null },
+    documentElement: { lang: "en", setAttribute() {}, getAttribute: () => null },
     querySelector: () => el(),
     querySelectorAll: () => [],
     getElementById: (_id?: string) => el(),
@@ -129,13 +131,22 @@ describe("dashboard modules", () => {
     const sandbox: Record<string, unknown> = {
       document: {
         ...makeFakeDocument(),
+        documentElement: { lang: "en" },
         getElementById: (id?: string) => (id === "about-credits" ? creditsRoot : makeFakeDocument().getElementById(id)),
       },
+      localStorage: {
+        getItem: () => null,
+        setItem() {},
+      },
+      navigator: { language: "en-US" },
       module: undefined,
       exports: undefined,
     };
     sandbox.window = sandbox;
+    sandbox.escHtml = (s: string) => String(s);
     vm.createContext(sandbox);
+    vm.runInContext(readFileSync(resolve(ROOT, "public/js/i18n.js"), "utf8"), sandbox);
+    (sandbox as any).initI18n("en");
     vm.runInContext(readFileSync(resolve(ROOT, "public/credits.js"), "utf8"), sandbox);
     expect(typeof sandbox.renderAboutCredits).toBe("function");
     (sandbox.renderAboutCredits as () => void)();

--- a/test/ui/detail-and-receipts.test.ts
+++ b/test/ui/detail-and-receipts.test.ts
@@ -10,6 +10,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import vm from "node:vm";
 import { describe, it, expect } from "vitest";
+import { installI18n } from "./_i18n-harness";
 
 const ROOT = resolve(import.meta.dirname, "../..");
 
@@ -33,6 +34,7 @@ function load(): any {
   };
   ctx.globalThis = ctx;
   vm.createContext(ctx);
+  installI18n(ctx, "en");
   for (const f of ["public/utils.js", "public/js/memory-crud.js", "public/js/remember.js"]) {
     vm.runInContext(readFileSync(resolve(ROOT, f), "utf8"), ctx);
   }
@@ -102,9 +104,15 @@ describe("memory detail — what the brain knows", () => {
 
 describe("citation chips", () => {
   function render(text: string) {
-    const ctx: any = { console };
+    const ctx: any = {
+      console,
+      document: { documentElement: { lang: "en" }, querySelectorAll: () => [] },
+      escAttr: (s: string) => String(s).replace(/"/g, "&quot;"),
+      escHtml: (s: string) => String(s),
+    };
     ctx.globalThis = ctx;
     vm.createContext(ctx);
+    installI18n(ctx, "en");
     vm.runInContext(readFileSync(resolve(ROOT, "public/js/ui-chat.js"), "utf8"), ctx);
     return ctx.renderAnswerMarkdown(text) as string;
   }

--- a/test/ui/download-app.test.ts
+++ b/test/ui/download-app.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import vm from "node:vm";
+import { installI18n } from "./_i18n-harness";
 
 const ROOT = resolve(import.meta.dirname, "../..");
 const SOURCE = readFileSync(resolve(ROOT, "public/js/download-app.js"), "utf8");
@@ -38,9 +39,12 @@ function run(opts: {
       platform: opts.platform ?? "",
       userAgent: opts.userAgent ?? "",
       maxTouchPoints: opts.maxTouchPoints ?? 0,
+      language: "en-US",
     },
     document: {
+      documentElement: { lang: "en" },
       querySelector: (sel: string) => (sel === ".sb-footer" && opts.footer !== false ? footer : null),
+      querySelectorAll: () => [],
       getElementById: (id: string) =>
         opts.existing && id === "sb-download-app" ? ({} as unknown) : null,
       createElement: () =>
@@ -52,6 +56,7 @@ function run(opts: {
   sandbox.window = sandbox;
   if (opts.desktop) sandbox.SB_DESKTOP = true;
   vm.createContext(sandbox);
+  installI18n(sandbox as any, "en");
   vm.runInContext(SOURCE + "\n;renderDownloadButton();", sandbox);
   return { prepended, sandbox };
 }
@@ -123,9 +128,17 @@ describe("download button — OS detection", () => {
   it("prefers userAgentData.platform when present", () => {
     const prepended: Anchor[] = [];
     const sandbox: Record<string, unknown> = {
-      navigator: { userAgentData: { platform: "Windows" }, platform: "", userAgent: "", maxTouchPoints: 0 },
+      navigator: {
+        userAgentData: { platform: "Windows" },
+        platform: "",
+        userAgent: "",
+        maxTouchPoints: 0,
+        language: "en-US",
+      },
       document: {
+        documentElement: { lang: "en" },
         querySelector: () => ({ prepend: (el: Anchor) => prepended.push(el) }),
+        querySelectorAll: () => [],
         getElementById: () => null,
         createElement: () => ({ id: "", className: "", href: "", target: "", rel: "", title: "", innerHTML: "" }),
       },
@@ -134,6 +147,7 @@ describe("download button — OS detection", () => {
     };
     sandbox.window = sandbox;
     vm.createContext(sandbox);
+    installI18n(sandbox as any, "en");
     vm.runInContext(SOURCE + "\n;renderDownloadButton();", sandbox);
     expect(prepended[0].innerHTML).toContain("ti-brand-windows");
   });
@@ -243,5 +257,7 @@ describe("download button — wiring", () => {
   it("the desktop app sets the flag that suppresses it", () => {
     const rs = readFileSync(resolve(ROOT, "installer/src-tauri/src/windows.rs"), "utf8");
     expect(rs).toContain("window.SB_DESKTOP = true");
+    expect(rs).toContain("sb-locale");
+    expect(rs).toContain("sync_brain_locale");
   });
 });

--- a/test/ui/edit-sheet.test.ts
+++ b/test/ui/edit-sheet.test.ts
@@ -14,6 +14,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import vm from "node:vm";
 import { describe, it, expect, vi } from "vitest";
+import { installI18n } from "./_i18n-harness";
 
 const ROOT = resolve(import.meta.dirname, "../..");
 
@@ -66,6 +67,7 @@ function load() {
   };
   ctx.globalThis = ctx;
   vm.createContext(ctx);
+  installI18n(ctx, "en");
   for (const f of ["public/utils.js", "public/js/memory-crud.js"]) {
     vm.runInContext(readFileSync(resolve(ROOT, f), "utf8"), ctx);
   }

--- a/test/ui/home-input.test.ts
+++ b/test/ui/home-input.test.ts
@@ -45,8 +45,21 @@ function load() {
       querySelectorAll: () => [],
     },
   };
+  ctx.localStorage = {
+    _m: new Map<string, string>(),
+    getItem(k: string) {
+      return this._m.get(k) ?? null;
+    },
+    setItem(k: string, v: string) {
+      this._m.set(k, v);
+    },
+  };
+  ctx.navigator = { language: "en-US" };
+  ctx.document.documentElement = { lang: "en" };
   ctx.globalThis = ctx;
   vm.createContext(ctx);
+  vm.runInContext(readFileSync(resolve(ROOT, "public/js/i18n.js"), "utf8"), ctx);
+  ctx.initI18n("en");
   vm.runInContext(readFileSync(resolve(ROOT, "public/js/home.js"), "utf8"), ctx);
   ctx.__els = els;
   return ctx;
@@ -69,6 +82,8 @@ describe("what the sentence is asking for", () => {
       "did I ever decide on the floor",
       "show me my tasks",
       "find the pricing note",
+      "cosa ho deciso sul prezzo",
+      "quando ho spedito 2.2.3",
     ]) {
       expect(detectHomeMode(q), q).toBe("ask");
     }

--- a/test/ui/home-input.test.ts
+++ b/test/ui/home-input.test.ts
@@ -82,10 +82,13 @@ describe("what the sentence is asking for", () => {
       "did I ever decide on the floor",
       "show me my tasks",
       "find the pricing note",
-      "cosa ho deciso sul prezzo",
-      "quando ho spedito 2.2.3",
     ]) {
       expect(detectHomeMode(q), q).toBe("ask");
+    }
+    const ctx = load();
+    ctx.initI18n("it");
+    for (const q of ["cosa ho deciso sul prezzo", "quando ho spedito 2.2.3"]) {
+      expect(ctx.detectHomeMode(q), q).toBe("ask");
     }
   });
 
@@ -110,6 +113,19 @@ describe("what the sentence is asking for", () => {
     // No question mark, no interrogative — ambiguous, and an unwanted search
     // costs a moment while an unwanted memory costs a cleanup.
     expect(detectHomeMode("pricing floor six thousand")).toBe("remember");
+  });
+
+  it("does not treat Italian statement starters as questions", () => {
+    const ctx = load();
+    ctx.initI18n("it");
+    for (const m of [
+      "Devo chiamare Marco",
+      "Ho finito il report",
+      "Sono in riunione",
+    ]) {
+      expect(ctx.detectHomeMode(m), m).toBe("remember");
+    }
+    expect(ctx.detectHomeMode("Come stai")).toBe("ask");
   });
 
   it("has no opinion about an empty field", () => {

--- a/test/ui/i18n.test.ts
+++ b/test/ui/i18n.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Dashboard i18n: catalogs, DOM apply, and locale boot.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import vm from "node:vm";
+import { describe, it, expect } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+
+function loadI18n(locale?: "en" | "it") {
+  const store = new Map<string, string>();
+  const els: any[] = [];
+  const makeEl = (attrs: Record<string, string> = {}) => {
+    const el: any = {
+      attrs: { ...attrs },
+      textContent: "",
+      innerHTML: "",
+      hasAttribute(name: string) {
+        return name in this.attrs || (name === "data-i18n-html" && "data-i18n-html" in this.attrs);
+      },
+      getAttribute(name: string) {
+        return this.attrs[name] ?? null;
+      },
+      setAttribute(name: string, value: string) {
+        this.attrs[name] = value;
+      },
+    };
+    els.push(el);
+    return el;
+  };
+  const ctx: any = {
+    console,
+    localStorage: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+    },
+    navigator: { language: "en-US" },
+    document: {
+      documentElement: { lang: "en" },
+      querySelectorAll(sel: string) {
+        if (sel === "[data-i18n]") return els.filter((e) => e.getAttribute("data-i18n"));
+        return [];
+      },
+    },
+  };
+  ctx.globalThis = ctx;
+  vm.createContext(ctx);
+  vm.runInContext(readFileSync(resolve(ROOT, "public/js/i18n.js"), "utf8"), ctx);
+  if (locale) ctx.initI18n(locale);
+  else ctx.initI18n();
+  return { ctx, makeEl, store };
+}
+
+describe("dashboard i18n", () => {
+  it("translates dotted keys and falls back to English", () => {
+    const { ctx } = loadI18n("it");
+    expect(ctx.t("menu.appearance")).toBe("Aspetto");
+    expect(ctx.t("menu.disconnect")).toBe("Disconnetti");
+    expect(ctx.t("no.such.key")).toBe("no.such.key");
+  });
+
+  it("interpolates and picks plurals", () => {
+    const { ctx } = loadI18n("en");
+    expect(ctx.tPlural("nav.statusCount", 1)).toBe("1 memory stored");
+    expect(ctx.tPlural("nav.statusCount", 5)).toBe("5 memories stored");
+    expect(ctx.t("auth.serverError", { status: "503" })).toBe("Server error: 503");
+  });
+
+  it("applies data-i18n to the DOM", () => {
+    const { ctx, makeEl } = loadI18n("it");
+    const label = makeEl({ "data-i18n": "menu.appearance" });
+    const input = makeEl({
+      "data-i18n": "auth.tokenPlaceholder",
+      "data-i18n-attr": "placeholder",
+    });
+    const hint = makeEl({ "data-i18n": "home.hintHtml", "data-i18n-html": "" });
+    ctx.applyI18nDom();
+    expect(label.textContent).toBe("Aspetto");
+    expect(input.getAttribute("placeholder")).toMatch(/password/i);
+    expect(hint.innerHTML).toContain("#tag");
+  });
+
+  it("persists sb-locale and sets documentElement.lang", () => {
+    const { ctx, store } = loadI18n("it");
+    expect(store.get("sb-locale")).toBe("it");
+    expect(ctx.document.documentElement.lang).toBe("it");
+    expect(ctx.getLocale()).toBe("it");
+    expect(ctx.localeTag()).toBe("it-IT");
+  });
+});

--- a/test/ui/pattern-queue.test.ts
+++ b/test/ui/pattern-queue.test.ts
@@ -13,6 +13,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import vm from "node:vm";
 import { describe, it, expect, vi } from "vitest";
+import { installI18n } from "./_i18n-harness";
 
 const ROOT = resolve(import.meta.dirname, "../..");
 
@@ -63,6 +64,7 @@ function load(pages: any[] = []) {
   };
   ctx.globalThis = ctx;
   vm.createContext(ctx);
+  installI18n(ctx, "en");
   for (const f of ["public/utils.js", "public/js/patterns.js"]) {
     vm.runInContext(readFileSync(resolve(ROOT, f), "utf8"), ctx);
   }

--- a/test/ui/restore-loop.test.ts
+++ b/test/ui/restore-loop.test.ts
@@ -12,6 +12,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import vm from "node:vm";
 import { describe, it, expect } from "vitest";
+import { installI18n } from "./_i18n-harness";
 
 const ROOT = resolve(import.meta.dirname, "../..");
 
@@ -20,6 +21,7 @@ function loadRunImportLoop(): (payload: any, post: any, onProgress?: any) => Pro
   const ctx: any = { window: {}, document: {}, fetch: () => {}, console };
   ctx.globalThis = ctx;
   vm.createContext(ctx);
+  installI18n(ctx, "en");
   vm.runInContext(src, ctx);
   return ctx.runImportLoop;
 }

--- a/test/ui/settings-groups.test.ts
+++ b/test/ui/settings-groups.test.ts
@@ -13,6 +13,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import vm from "node:vm";
 import { describe, it, expect } from "vitest";
+import { installI18n } from "./_i18n-harness";
 
 const ROOT = resolve(import.meta.dirname, "../..");
 
@@ -46,6 +47,7 @@ function load() {
   };
   ctx.globalThis = ctx;
   vm.createContext(ctx);
+  installI18n(ctx, "en");
   for (const f of ["public/utils.js", "public/js/settings.js"]) {
     vm.runInContext(readFileSync(resolve(ROOT, f), "utf8"), ctx);
   }

--- a/test/ui/tags-and-text.test.ts
+++ b/test/ui/tags-and-text.test.ts
@@ -9,6 +9,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import vm from "node:vm";
 import { describe, it, expect } from "vitest";
+import { installI18n } from "./_i18n-harness";
 
 const ROOT = resolve(import.meta.dirname, "../..");
 
@@ -16,6 +17,7 @@ function load(): any {
   const ctx: any = { console };
   ctx.globalThis = ctx;
   vm.createContext(ctx);
+  installI18n(ctx, "en");
   vm.runInContext(readFileSync(resolve(ROOT, "public/utils.js"), "utf8"), ctx);
   return ctx;
 }

--- a/test/ui/utils.test.ts
+++ b/test/ui/utils.test.ts
@@ -1,4 +1,30 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import vm from "node:vm";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+const i18nCtx: any = {
+  localStorage: {
+    _m: new Map(),
+    getItem(k: string) {
+      return this._m.get(k) ?? null;
+    },
+    setItem(k: string, v: string) {
+      this._m.set(k, v);
+    },
+  },
+  navigator: { language: "en-US" },
+  document: { documentElement: { lang: "en" }, querySelectorAll: () => [] },
+};
+vm.createContext(i18nCtx);
+vm.runInContext(readFileSync(resolve(ROOT, "public/js/i18n.js"), "utf8"), i18nCtx);
+i18nCtx.initI18n("en");
+(globalThis as any).t = i18nCtx.t;
+(globalThis as any).tPlural = i18nCtx.tPlural;
+(globalThis as any).formatNumberUI = i18nCtx.formatNumberUI;
+(globalThis as any).localeTag = i18nCtx.localeTag;
+(globalThis as any).getLocale = i18nCtx.getLocale;
 
 const { parseRecallResult, escHtml, escAttr, toDateStr, vectorizeHealthBanner, vectorizeBannerHtml, syncVectorizeBanner } = require("../../public/utils.js");
 


### PR DESCRIPTION
﻿## Summary
- Localize the entire dashboard UI (en/it) via `public/js/i18n.js`, `data-i18n` markup, and `t()` / `tPlural()` in JS modules
- Desktop app injects and syncs `sb-locale` into the brain webview (including language changes from Settings)
- UI dates follow the active locale; LLM `/chat` date payloads stay `en-US`

## Test plan
- [ ] Open dashboard in browser with `localStorage.sb-locale = 'it'` and confirm nav, home, settings, memories, integrations are Italian
- [ ] Switch language in the desktop app Settings and confirm an open dashboard reloads into the new locale
- [ ] Confirm ASK openers / remember markers work in Italian
- [ ] `npm test -- test/ui` (or project equivalent) — i18n + existing UI tests pass
- [ ] Redeploy Worker so remote dashboard assets pick up the new static files
