### PR TITLE
Backend: accept iCloud public calendar feeds (#310)

### DIFF
--- a/src/integrations/calendar.ts
+++ b/src/integrations/calendar.ts
@@ -3,10 +3,11 @@
  *
  * Read-only. Connects each provider's SECRET iCal subscription URL (Gmail's
  * "Secret address in iCal format", Outlook's published ICS link, iCloud's
- * shared webcal URL) — not CalDAV, not OAuth. One HTTPS GET per sync; ical.js
- * expands recurrences; qualifying occurrences mirror into memory. Upcoming
- * events are live-mirrored (cancellations delete); past events freeze into a
- * bounded historical log.
+ * shared webcal URL) — not CalDAV, not OAuth. One HTTPS GET per sync (two for
+ * iCloud published feeds when the `caldav` host misses and the `calendars`
+ * fallback is used); ical.js expands recurrences; qualifying occurrences
+ * mirror into memory. Upcoming events are live-mirrored (cancellations
+ * delete); past events freeze into a bounded historical log.
  */
 
 import ICAL from "ical.js";

--- a/src/integrations/calendar.ts
+++ b/src/integrations/calendar.ts
@@ -188,11 +188,125 @@ function expandRecurring(ev: any, startMs: number, endMs: number, out: Occurrenc
   }
 }
 
+/** Strip UTF-8 BOM and leading whitespace so BEGIN:VCALENDAR is findable. */
+function stripBom(text: string): string {
+  return text.replace(/^\uFEFF/, "").replace(/^\s+/, "");
+}
+
+function looksLikeIcs(text: string): boolean {
+  return /BEGIN:VCALENDAR/i.test(text);
+}
+
+/**
+ * Remove X-APPLE-STRUCTURED-LOCATION properties. Apple feeds often break RFC
+ * 5545 folding here (continuation lines without a leading space/tab), so we
+ * skip until the next real property / BEGIN / END line — not only space-folded
+ * continuations.
+ */
+function stripAppleStructuredLocation(ics: string): string {
+  const lines = ics.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  const out: string[] = [];
+  let skipping = false;
+  const isNewContentLine = (line: string) =>
+    /^(BEGIN|END|[A-Za-z0-9-]+)[;:]/i.test(line);
+
+  for (const line of lines) {
+    if (skipping) {
+      if (line.startsWith(" ") || line.startsWith("\t")) continue;
+      if (!isNewContentLine(line)) continue; // orphan / broken fold
+      skipping = false;
+    }
+    if (/^X-APPLE-STRUCTURED-LOCATION/i.test(line)) {
+      skipping = true;
+      continue;
+    }
+    out.push(line);
+  }
+  return out.join("\r\n");
+}
+
+/**
+ * Drop orphan content lines that have neither ':' nor ';' — typically Apple's
+ * non-indented continuations of X-APPLE-STRUCTURED-LOCATION after that property
+ * was already stripped, or leftover fragments that still break ical.js.
+ */
+function dropOrphanIcsLines(ics: string): string {
+  const lines = ics.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  const out: string[] = [];
+  for (const line of lines) {
+    if (line === "") {
+      out.push(line);
+      continue;
+    }
+    // Folded continuations (space/tab) are valid; keep them for other properties.
+    if (line.startsWith(" ") || line.startsWith("\t")) {
+      out.push(line);
+      continue;
+    }
+    if (line.includes(":") || line.includes(";")) {
+      out.push(line);
+      continue;
+    }
+    // Orphan bare text — drop.
+  }
+  return out.join("\r\n");
+}
+
+/**
+ * Pick a VCALENDAR jCal root. ICAL.parse may return a single component or an
+ * array of roots when the input is odd; we always want the first vcalendar.
+ */
+function asVCalendarComponent(parsed: unknown): any {
+  if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === "string") {
+    // Single jCal component: ["vcalendar", [...], [...]]
+    return new ICAL.Component(parsed as any);
+  }
+  if (Array.isArray(parsed)) {
+    for (const item of parsed as any[]) {
+      if (Array.isArray(item) && item[0] === "vcalendar") {
+        return new ICAL.Component(item);
+      }
+    }
+    if (parsed.length > 0) return new ICAL.Component(parsed[0] as any);
+  }
+  return new ICAL.Component(parsed as any);
+}
+
+/**
+ * Sanitize Apple/iCloud ICS quirks then parse. Shared by connect validation and
+ * sync expansion so both paths see the same document.
+ */
+function parseIcsDocument(icsText: string): any {
+  let text = stripBom(icsText);
+  if (!looksLikeIcs(text)) {
+    throw new Error("NO_VCALENDAR");
+  }
+
+  const attempts = [
+    text,
+    stripAppleStructuredLocation(text),
+    dropOrphanIcsLines(stripAppleStructuredLocation(text)),
+  ];
+  // Deduplicate identical attempts.
+  const seen = new Set<string>();
+  let lastErr: unknown;
+  for (const attempt of attempts) {
+    if (seen.has(attempt)) continue;
+    seen.add(attempt);
+    try {
+      return asVCalendarComponent(ICAL.parse(attempt));
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+}
+
 // Parse an .ics document and expand it into concrete occurrences within
 // [windowStartMs, windowEndMs]. Registers embedded VTIMEZONEs so TZID-based
 // times resolve to the right absolute instants.
 export function parseAndExpand(icsText: string, windowStartMs: number, windowEndMs: number): Occurrence[] {
-  const root = new ICAL.Component(ICAL.parse(icsText));
+  const root = parseIcsDocument(icsText);
 
   for (const vtz of root.getAllSubcomponents("vtimezone")) {
     try {
@@ -325,6 +439,11 @@ export interface CalendarService {
   connectHint: string;
 }
 
+const ICS_FETCH_HEADERS = {
+  Accept: "text/calendar, text/plain, */*",
+  "User-Agent": "CalendarAgent/1.0 SecondBrain/2",
+};
+
 function normalizeUrl(raw: string): string {
   const swapped = raw.trim().replace(/^webcal:\/\//i, "https://");
   const u = new URL(swapped); // throws on garbage
@@ -332,10 +451,51 @@ function normalizeUrl(raw: string): string {
   return u.toString();
 }
 
+/** One-shot rewrite: pNN-caldav.icloud.com → pNN-calendars.icloud.com. */
+function icloudCalendarsFallbackUrl(url: string): string | null {
+  try {
+    const u = new URL(url);
+    const m = u.hostname.match(/^p(\d+)-caldav\.icloud\.com$/i);
+    if (!m) return null;
+    u.hostname = `p${m[1]}-calendars.icloud.com`;
+    return u.toString();
+  } catch {
+    return null;
+  }
+}
+
+async function getIcsOnce(url: string): Promise<{ ok: boolean; status: number; body: string }> {
+  const res = await fetch(url, {
+    method: "GET",
+    redirect: "follow",
+    headers: ICS_FETCH_HEADERS,
+  });
+  const body = stripBom(await res.text());
+  return { ok: res.ok, status: res.status, body };
+}
+
+/**
+ * Fetch a secret/public iCal URL. GET-only (Apple's published-calendar endpoint
+ * returns 400 to HEAD). Strips BOM before ICS detection. For iCloud caldav
+ * hosts, retries once on the calendars hostname if the first response is not a
+ * VCALENDAR. Returns the last 2xx body even when it is not ICS so callers can
+ * distinguish HTML from transport failure; throws only when no 2xx is obtained.
+ */
 async function fetchIcs(url: string): Promise<string> {
-  const res = await fetch(url, { headers: { Accept: "text/calendar" } });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.text();
+  const first = await getIcsOnce(url);
+  if (first.ok && looksLikeIcs(first.body)) return first.body;
+
+  const fallback = icloudCalendarsFallbackUrl(url);
+  if (fallback) {
+    const second = await getIcsOnce(fallback);
+    if (second.ok && looksLikeIcs(second.body)) return second.body;
+    if (second.ok) return second.body;
+    if (first.ok) return first.body;
+    throw new Error(`HTTP ${second.status}`);
+  }
+
+  if (first.ok) return first.body;
+  throw new Error(`HTTP ${first.status}`);
 }
 
 // Validate a pasted secret iCal URL and return a display label for the UI.
@@ -350,8 +510,14 @@ export async function validateCalendarUrl(rawUrl: string): Promise<string> {
   }
   let root: any;
   try {
-    root = new ICAL.Component(ICAL.parse(body));
-  } catch {
+    root = parseIcsDocument(body);
+  } catch (e) {
+    if (e instanceof Error && e.message === "NO_VCALENDAR") {
+      throw new Error("That link didn't return a calendar. Make sure it's the secret iCal (.ics) address, not the calendar's web page.");
+    }
+    if (looksLikeIcs(stripBom(body))) {
+      throw new Error("That link returned a calendar that couldn't be parsed. Try regenerating the public calendar link in iCloud.");
+    }
     throw new Error("That link didn't return a calendar. Make sure it's the secret iCal (.ics) address, not the calendar's web page.");
   }
   if (root.name !== "vcalendar") {

--- a/test/unit/calendar.test.ts
+++ b/test/unit/calendar.test.ts
@@ -524,11 +524,25 @@ describe("validateCalendarUrl", () => {
     vi.unstubAllGlobals();
   });
 
-  function stubFetch(impl: (url: string) => { ok: boolean; status: number; text: () => Promise<string> }) {
-    const fn = vi.fn().mockImplementation(async (url: string) => impl(url));
+  function stubFetch(
+    impl: (
+      url: string,
+      init?: RequestInit,
+    ) => { ok: boolean; status: number; text: () => Promise<string> },
+  ) {
+    const fn = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => impl(url, init));
     vi.stubGlobal("fetch", fn);
     return fn;
   }
+
+  const icsHeaders = expect.objectContaining({
+    method: "GET",
+    redirect: "follow",
+    headers: expect.objectContaining({
+      Accept: "text/calendar, text/plain, */*",
+      "User-Agent": "CalendarAgent/1.0 SecondBrain/2",
+    }),
+  });
 
   it("normalizes webcal:// to https:// and resolves the X-WR-CALNAME as the label", async () => {
     const fetchMock = stubFetch(() => ({
@@ -541,10 +555,80 @@ describe("validateCalendarUrl", () => {
     }));
     const label = await validateCalendarUrl("webcal://example.com/cal.ics");
     expect(label).toBe("My Cal");
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/cal.ics", icsHeaders);
+    // Never probe with HEAD — Apple's published calendars return 400 to HEAD.
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(init?.method).not.toBe("HEAD");
+    }
+  });
+
+  it("accepts an iCloud published URL without a .ics extension (GET-only + UA)", async () => {
+    const fetchMock = stubFetch(() => ({
+      ok: true,
+      status: 200,
+      text: async () =>
+        [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//caldav.icloud.com//CALDAVJ//EN",
+          "X-WR-CALNAME:Family",
+          "END:VCALENDAR",
+        ].join("\r\n"),
+    }));
+    const label = await validateCalendarUrl("webcal://p12-caldav.icloud.com/published/2/token");
+    expect(label).toBe("Family");
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://example.com/cal.ics",
-      expect.objectContaining({ headers: { Accept: "text/calendar" } }),
+      "https://p12-caldav.icloud.com/published/2/token",
+      icsHeaders,
     );
+  });
+
+  it("retries pNN-caldav.icloud.com on pNN-calendars.icloud.com when the first body is not ICS", async () => {
+    const fetchMock = stubFetch((url) => {
+      if (url.includes("-caldav.")) {
+        return { ok: false, status: 400, text: async () => "" };
+      }
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          ["BEGIN:VCALENDAR", "VERSION:2.0", "X-WR-CALNAME:Retried Cal", "END:VCALENDAR"].join("\r\n"),
+      };
+    });
+    const label = await validateCalendarUrl("https://p55-caldav.icloud.com/published/2/abc");
+    expect(label).toBe("Retried Cal");
+    expect(fetchMock.mock.calls.map((c) => c[0])).toEqual([
+      "https://p55-caldav.icloud.com/published/2/abc",
+      "https://p55-calendars.icloud.com/published/2/abc",
+    ]);
+  });
+
+  it("retries when caldav returns 200 HTML and calendars returns ICS", async () => {
+    stubFetch((url) => {
+      if (url.includes("-caldav.")) {
+        return { ok: true, status: 200, text: async () => "<html>nope</html>" };
+      }
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          ["BEGIN:VCALENDAR", "VERSION:2.0", "X-WR-CALNAME:From Calendars Host", "END:VCALENDAR"].join("\r\n"),
+      };
+    });
+    await expect(validateCalendarUrl("https://p7-caldav.icloud.com/published/2/tok")).resolves.toBe(
+      "From Calendars Host",
+    );
+  });
+
+  it("strips a leading UTF-8 BOM before validating", async () => {
+    stubFetch(() => ({
+      ok: true,
+      status: 200,
+      text: async () =>
+        "\uFEFF" +
+        ["BEGIN:VCALENDAR", "VERSION:2.0", "X-WR-CALNAME:BOM Cal", "END:VCALENDAR"].join("\r\n"),
+    }));
+    await expect(validateCalendarUrl("https://example.com/cal.ics")).resolves.toBe("BOM Cal");
   });
 
   it("falls back to the URL host when there is no X-WR-CALNAME", async () => {
@@ -569,6 +653,49 @@ describe("validateCalendarUrl", () => {
     await expect(validateCalendarUrl("https://example.com/page.html")).rejects.toThrow(
       /didn't return a calendar/,
     );
+  });
+
+  it("uses a distinct error when BEGIN:VCALENDAR is present but still unparseable after sanitization", async () => {
+    // Truncated mid-component: looks like ICS but cannot form a closed VCALENDAR.
+    stubFetch(() => ({
+      ok: true,
+      status: 200,
+      text: async () => ["BEGIN:VCALENDAR", "VERSION:2.0", "BEGIN:VEVENT", "SUMMARY:Broken"].join("\r\n"),
+    }));
+    await expect(validateCalendarUrl("https://example.com/broken.ics")).rejects.toThrow(
+      /couldn't be parsed/i,
+    );
+  });
+});
+
+describe("parseAndExpand Apple ICS quirks", () => {
+  it("still emits the event when X-APPLE-STRUCTURED-LOCATION has a non-indented continuation", () => {
+    // Real-world Apple bug: address continuation lacks a leading space, which
+    // makes strict parsers throw "invalid line (no token ; or :)" and sink the
+    // whole feed. Second Brain must strip/ignore that property and keep the event.
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//caldav.icloud.com//CALDAVJ//EN",
+      "BEGIN:VEVENT",
+      "UID:apple-loc@test",
+      "DTSTAMP:20260101T000000Z",
+      "DTSTART:20260710T140000Z",
+      "DTEND:20260710T150000Z",
+      "SUMMARY:Office Dinner",
+      'X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-ADDRESS="123 Main Street',
+      "Seattle WA 98101",
+      '";X-TITLE=123 Main Street:geo:47.6,-122.3',
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    const occs = parseAndExpand(ics, ms("2026-07-01T00:00:00Z"), ms("2026-07-31T00:00:00Z"));
+    expect(occs).toHaveLength(1);
+    expect(occs[0]).toMatchObject({
+      uid: "apple-loc@test",
+      summary: "Office Dinner",
+    });
   });
 });
 

--- a/test/unit/calendar.test.ts
+++ b/test/unit/calendar.test.ts
@@ -697,6 +697,33 @@ describe("parseAndExpand Apple ICS quirks", () => {
       summary: "Office Dinner",
     });
   });
+
+  it("still emits the event when a bare orphan line is not attached to X-APPLE-STRUCTURED-LOCATION", () => {
+    // ical.js throws "invalid line (no token ; or :)" on a content line with
+    // neither delimiter. stripAppleStructuredLocation does not touch this
+    // feed, so only dropOrphanIcsLines can recover it.
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//caldav.icloud.com//CALDAVJ//EN",
+      "BEGIN:VEVENT",
+      "UID:orphan-bare@test",
+      "DTSTAMP:20260101T000000Z",
+      "DTSTART:20260710T140000Z",
+      "DTEND:20260710T150000Z",
+      "SUMMARY:Team Sync",
+      "Seattle WA 98101",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    const occs = parseAndExpand(ics, ms("2026-07-01T00:00:00Z"), ms("2026-07-31T00:00:00Z"));
+    expect(occs).toHaveLength(1);
+    expect(occs[0]).toMatchObject({
+      uid: "orphan-bare@test",
+      summary: "Team Sync",
+    });
+  });
 });
 
 describe("makeCalendarProvider sync (happy path)", () => {

--- a/test/unit/cron-subrequest-budget.test.ts
+++ b/test/unit/cron-subrequest-budget.test.ts
@@ -240,6 +240,47 @@ describe("nightly cron D1 subrequest cost", () => {
       expect(saved.lastSyncedAt).not.toBeNull();
     });
 
+    // An iCloud published URL that misses on caldav retries once on calendars
+    // (#310). That is two outbound fetches in the same invocation; the happy
+    // path above still asserts one, so this is the case that notices the extra.
+    it("pays two feed fetches when an iCloud caldav host misses and calendars succeeds", async () => {
+      const db = makeTestDb();
+      const kv = makeMemoryKV();
+      await kv.put("integrations:calendar-icloud", JSON.stringify({
+        provider: "calendar-icloud",
+        authKind: "token",
+        credentials: { token: "https://p12-caldav.icloud.com/published/2/token" },
+        config: {},
+        status: "connected",
+        workspaceName: "Family",
+        lastSyncedAt: null,
+        lastSyncError: null,
+        itemMap: {},
+        createdAt: 0,
+        updatedAt: 0,
+      }));
+      const ics = icsWithUpcomingEvents(120);
+      const fetchMock = vi.fn(async (url: string) => {
+        if (String(url).includes("-caldav.")) {
+          return { ok: false, status: 400, text: async () => "" } as any;
+        }
+        return { ok: true, status: 200, text: async () => ics } as any;
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const { env } = countingEnv(db, { OAUTH_KV: kv });
+
+      await runCron(env, INTEGRATION_SYNC_CRON);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls.map((c) => c[0])).toEqual([
+        "https://p12-caldav.icloud.com/published/2/token",
+        "https://p12-calendars.icloud.com/published/2/token",
+      ]);
+      expect(db.entries.filter(e => e.source === "calendar-icloud")).toHaveLength(SYNC_EVENT_BATCH);
+      const saved = JSON.parse((await kv.get("integrations:calendar-icloud")) as string);
+      expect(saved.lastSyncedAt).not.toBeNull();
+    });
+
     it("keeps its own invocation inside the D1 budget", async () => {
       const db = makeTestDb();
       seedCompressibleTags(db, 7); // a big brain must not make the sync cost more


### PR DESCRIPTION
## Summary

- Hardens ICS fetch for Apple iCloud public calendar URLs (`webcal://pXX-caldav.icloud.com/published/...`): GET-only with calendar `User-Agent`, broad `Accept`, redirect follow, BOM strip, and a one-shot retry on `pXX-calendars.icloud.com` when the first response is not a VCALENDAR.
- Sanitizes malformed Apple `X-APPLE-STRUCTURED-LOCATION` properties (broken line folding) before `ical.js` parse, shared by connect validation and sync expansion.
- Clearer connect errors: HTML page vs unparseable VCALENDAR.

Fixes the rejection reported in discussion #310. The prior diagnosis (HEAD request) did not match the code; the failure was a bare Worker GET plus strict `ical.js` parsing on Apple quirks.

## Test plan

- [x] `npm test -- test/unit/calendar.test.ts` (37 tests)
- [ ] Connect an iCloud **Public Calendar** `webcal://` URL in Settings → Integrations
- [ ] Run **Sync now** and confirm upcoming events mirror into memory