### PR TITLE
Fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,11 +390,11 @@ All release binaries are built from this repository's source by GitHub Actions (
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=rahilp%2Fsecond-brain-cloudflare&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#rahilp/second-brain-cloudflare&type=date&legend=top-left">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=rahilp/second-brain-cloudflare&type=date&theme=dark&legend=top-left" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=rahilp/second-brain-cloudflare&type=date&legend=top-left" />
-    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=rahilp/second-brain-cloudflare&type=date&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=rahilp/second-brain-cloudflare&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=rahilp/second-brain-cloudflare&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=rahilp/second-brain-cloudflare&type=date&legend=top-left" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README no longer renders because of GitHub stargazer API restrictions. This switches the chart to star-history.dera.page, which uses a different data source that needs no API token, so the chart works again. It also updates the wrapping link to match.