### PR TITLE
Harden the Claude Code hooks: redaction, free compaction, PowerShell installer (#327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to Second Brain are documented here. Version numbers match `
 - New: `install.sh --check` and `--uninstall`.
 - Session capture redacts credentials from the body before sending it — your own token, `Bearer` values, `sk-`/`ghp_`/`github_pat_`/`xoxb-`/`AKIA`/`AIza` key shapes, PEM private keys and `TOKEN=`-style assignments — while leaving UUIDs, commit SHAs, paths and ordinary prose intact.
 - SessionStart caches the block it printed and re-emits it on compaction, so compaction costs no recall at all; it falls back to a live recall when there is no cache or it is over 24 h old.
+- New: `install.ps1`, a PowerShell installer for Windows machines where Claude Code runs hooks under PowerShell rather than Git Bash.
 
 **Upgrade**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to Second Brain are documented here. Version numbers match `
 - `install.sh` reconciles instead of appending, refuses a malformed settings.json, sets the SessionEnd `timeout` the 1.5 s hook budget requires, and keeps credentials in `~/.config/second-brain/config.json` rather than the hook command line.
 - New: `install.sh --check` and `--uninstall`.
 - Session capture redacts credentials from the body before sending it — your own token, `Bearer` values, `sk-`/`ghp_`/`github_pat_`/`xoxb-`/`AKIA`/`AIza` key shapes, PEM private keys and `TOKEN=`-style assignments — while leaving UUIDs, commit SHAs, paths and ordinary prose intact.
+- SessionStart caches the block it printed and re-emits it on compaction, so compaction costs no recall at all; it falls back to a live recall when there is no cache or it is over 24 h old.
 
 **Upgrade**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to Second Brain are documented here. Version numbers match `
 - Hooks now exit 1 with one stderr line on any failure; Claude Code hides stderr from exit-0 hooks.
 - `install.sh` reconciles instead of appending, refuses a malformed settings.json, sets the SessionEnd `timeout` the 1.5 s hook budget requires, and keeps credentials in `~/.config/second-brain/config.json` rather than the hook command line.
 - New: `install.sh --check` and `--uninstall`.
+- Session capture redacts credentials from the body before sending it — your own token, `Bearer` values, `sk-`/`ghp_`/`github_pat_`/`xoxb-`/`AKIA`/`AIza` key shapes, PEM private keys and `TOKEN=`-style assignments — while leaving UUIDs, commit SHAs, paths and ordinary prose intact.
 
 **Upgrade**
 

--- a/integrations/claude-code-hooks/README.md
+++ b/integrations/claude-code-hooks/README.md
@@ -9,11 +9,18 @@ They are independent of the MCP server. Use either, or both.
 
 | Event | Runs on | Action | Cost |
 |---|---|---|---|
-| `SessionStart` | `startup`, `clear`, `compact` | `GET /recall` for this project, prints up to 5 memories into the session | one recall (~1 s) |
+| `SessionStart` | `startup`, `clear`, `compact` | `GET /recall` for this project, prints up to 5 memories into the session | one recall (~1 s), none on compaction |
 | `SessionEnd` | every reason (`clear`, `resume`, `logout`, `prompt_input_exit`, `other`) | `POST /capture` with the tail of the conversation | one capture (embedding + often a model call), 30 s hook timeout |
 
 `resume` and `fork` are skipped on start: those transcripts already contain the
 earlier injection. `compact` is not skipped — compaction discards it.
+
+On `startup` and `clear` the block that was printed is cached under
+`$XDG_CACHE_HOME/second-brain/session-<session_id>.txt` (`~/.cache/…` by
+default). Compaction re-prints that file verbatim and makes no request at all:
+the session id survives compaction and rotates on `/clear`, so a cached block is
+always the current session's context. With no cache, or one older than 24 h,
+compaction falls back to a live recall.
 
 ## Install, upgrade, check, uninstall
 

--- a/integrations/claude-code-hooks/README.md
+++ b/integrations/claude-code-hooks/README.md
@@ -68,6 +68,16 @@ Capture:
 }
 ```
 
+Before it is sent, the formatted body — header included — is scanned for
+credentials, and each one is replaced with `[redacted]`: your own configured
+token wherever it appears, `Bearer <token>` values, provider key shapes (`sk-`,
+`ghp_`/`gho_`, `github_pat_`, `xoxb-`/`xoxp-`, AWS `AKIA…`, Google `AIza…`),
+whole PEM private-key blocks, and `TOKEN=`/`SECRET=`/`PASSWORD=`/`API_KEY=`
+style assignments. Only those shapes: a UUID, a commit SHA, a file path and
+ordinary prose are left exactly as they were, because a memory redacted into
+uselessness is worse than no memory. Tool output — where secrets usually live —
+never reaches the body in the first place.
+
 The transcript is read backwards from the end until three human turns are in
 hand (1 MB ceiling), and only human-readable turns survive: `tool_use`,
 `tool_result` and `thinking` blocks, sidechain (subagent) lines, `isMeta` lines,

--- a/integrations/claude-code-hooks/README.md
+++ b/integrations/claude-code-hooks/README.md
@@ -31,6 +31,15 @@ bash install.sh --check                                     # prove the hooks re
 bash install.sh --uninstall                                 # remove only our entries
 ```
 
+PowerShell, for Windows without Git Bash — same behaviour, same guarantees:
+
+```powershell
+.\install.ps1 -WorkerUrl https://your-worker.workers.dev -Token your-token
+.\install.ps1            # reuse existing credentials, or prompt
+.\install.ps1 -Check
+.\install.ps1 -Uninstall
+```
+
 Re-running is safe: the installer replaces its own entries in
 `~/.claude/settings.json` and preserves everything else. It refuses to write a
 settings file that is not valid JSON rather than overwriting it.
@@ -144,6 +153,12 @@ capture, not the conversation.
 ## Windows
 
 The hooks run under Git Bash if it is installed; without it Claude Code falls
-back to PowerShell, where `install.sh` will not run. Install Git for Windows, or
-wait for the PowerShell installer (follow-up work). The hook scripts themselves
-are plain Node and work either way once they are in `settings.json`.
+back to PowerShell, where `install.sh` will not run. Use `install.ps1` there —
+it writes the same credentials file and the same `settings.json` entries, and
+Node does the JSON editing in both installers so the two cannot drift. The hook
+scripts themselves are plain Node and work either way once they are in
+`settings.json`.
+
+The credentials file is written with mode 600, which NTFS ignores; on Windows it
+is protected by the permissions of your user profile directory like any other
+file under `%USERPROFILE%`.

--- a/integrations/claude-code-hooks/common.js
+++ b/integrations/claude-code-hooks/common.js
@@ -95,9 +95,10 @@ function hintFor(status) {
   return '';
 }
 
-function cachePath(name) {
-  fs.mkdirSync(CACHE_DIR, { recursive: true });
-  return path.join(CACHE_DIR, name);
+/** `dir` is only ever passed by tests, so nothing writes to the real cache during a run. */
+function cachePath(name, dir = CACHE_DIR) {
+  fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, name);
 }
 
 /** Worker major version from GET /health, cached per origin for 24 h. null when unknown. */
@@ -132,5 +133,5 @@ function noticeOncePerDay(key, message, now = Date.now()) {
 module.exports = {
   CONFIG_PATH, CACHE_DIR, HEALTH_TTL_MS,
   loadCredentials, resolveWorkspace, readStdinJson, parseProjectName, gitRemoteUrl,
-  fetchWithTimeout, fail, hintFor, workerMajorVersion, noticeOncePerDay,
+  fetchWithTimeout, fail, hintFor, cachePath, workerMajorVersion, noticeOncePerDay,
 };

--- a/integrations/claude-code-hooks/install.ps1
+++ b/integrations/claude-code-hooks/install.ps1
@@ -1,0 +1,216 @@
+<#
+.SYNOPSIS
+  Installs, upgrades, checks or removes the Second Brain hooks in Claude Code's
+  user settings (%USERPROFILE%\.claude\settings.json).
+
+.DESCRIPTION
+  The PowerShell mirror of install.sh, for Windows machines where Claude Code
+  runs its hooks under PowerShell rather than Git Bash. Same guarantees:
+  credentials go to ~/.config/second-brain/config.json (the file the CLI and the
+  desktop app already use), never into settings.json and never onto the hook
+  command line; re-running reconciles our own entries instead of appending;
+  a settings.json that is not valid JSON is refused, not overwritten.
+
+  Node.js does the JSON editing so this script and install.sh cannot drift:
+  PowerShell's ConvertTo-Json would flatten deeply nested settings.
+
+.PARAMETER WorkerUrl
+  Worker origin, e.g. https://your-worker.workers.dev. Prompted for when absent.
+
+.PARAMETER Token
+  AUTH_TOKEN for that worker. Prompted for when absent.
+
+.PARAMETER Check
+  Prove the hooks reach the Worker and show what they would do.
+
+.PARAMETER Uninstall
+  Remove only our entries from settings.json. Credentials are left in place.
+
+.EXAMPLE
+  .\install.ps1 -WorkerUrl https://your-worker.workers.dev -Token your-token
+
+.EXAMPLE
+  .\install.ps1 -Check
+
+.EXAMPLE
+  .\install.ps1 -Uninstall
+#>
+
+param(
+  [string]$WorkerUrl,
+  [string]$Token,
+  [switch]$Check,
+  [switch]$Uninstall
+)
+
+$ErrorActionPreference = "Stop"
+
+# Write-Error under -ErrorActionPreference Stop always ends the script with exit
+# code 1; the installer needs its own codes (2 = no credentials and no console).
+function Stop-WithError {
+  param([string]$Message, [int]$Code = 1)
+  [Console]::Error.WriteLine($Message)
+  exit $Code
+}
+
+$HooksDir = $PSScriptRoot
+$HomeDir = if ($env:USERPROFILE) { $env:USERPROFILE } else { $HOME }
+$SettingsFile = if ($env:CLAUDE_SETTINGS_FILE) { $env:CLAUDE_SETTINGS_FILE } else { Join-Path $HomeDir ".claude/settings.json" }
+$ConfigDir = Join-Path $HomeDir ".config/second-brain"
+$ConfigFile = Join-Path $ConfigDir "config.json"
+$Mode = if ($Uninstall) { "uninstall" } else { "install" }
+
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+  Stop-WithError "Error: Node.js is required to run the hook scripts."
+}
+
+if ($Check) {
+  # check.js reports its own failures and exits non-zero; that is a result, not
+  # a terminating error, so PowerShell 7.4 must not throw on it.
+  $PSNativeCommandUseErrorActionPreference = $false
+  $ErrorActionPreference = "Continue"
+  & node (Join-Path $HooksDir "check.js")
+  exit $LASTEXITCODE
+}
+
+# Node reads the script from a temp file rather than stdin so a console encoding
+# cannot corrupt it. Node's own output goes straight to the host, so the only
+# value this function returns is node's exit code.
+function Invoke-NodeScript {
+  param([string]$Script)
+  $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("sb-hooks-" + [Guid]::NewGuid().ToString("N") + ".js")
+  try {
+    Set-Content -Path $tmp -Value $Script -Encoding utf8
+    # A non-zero exit from node is a result to inspect, not a terminating error;
+    # PowerShell 7.4 would otherwise throw before the exit code can be read.
+    # Both assignments are function-local.
+    $PSNativeCommandUseErrorActionPreference = $false
+    $ErrorActionPreference = "Continue"
+    & node $tmp 2>&1 | Out-Host
+    return $LASTEXITCODE
+  } finally {
+    Remove-Item -Force -ErrorAction SilentlyContinue $tmp
+  }
+}
+
+$ConfigWriter = @'
+const fs = require('fs');
+const { WORKER_URL, TOKEN, CONFIG_FILE } = process.env;
+let existing = {};
+try { existing = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8')) || {}; } catch {}
+const next = { ...existing, workerUrl: WORKER_URL, authToken: TOKEN };
+const tmp = `${CONFIG_FILE}.tmp-${process.pid}`;
+// mode 0600 is a no-op on NTFS; the file still stays out of settings.json.
+fs.writeFileSync(tmp, JSON.stringify(next, null, 2) + '\n', { mode: 0o600 });
+fs.renameSync(tmp, CONFIG_FILE);
+'@
+
+$SettingsWriter = @'
+const fs = require('fs');
+const { SETTINGS_FILE, HOOKS_DIR, MODE } = process.env;
+
+let settings = {};
+if (fs.existsSync(SETTINGS_FILE)) {
+  const raw = fs.readFileSync(SETTINGS_FILE, 'utf8');
+  if (raw.trim()) {
+    try { settings = JSON.parse(raw); } catch (e) {
+      console.error(`Refusing to touch ${SETTINGS_FILE}: it is not valid JSON (${e.message}).`);
+      console.error('Claude Code settings must be plain JSON — no comments or trailing commas. Fix the file and re-run.');
+      process.exit(1);
+    }
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+      console.error(`Refusing to touch ${SETTINGS_FILE}: expected a JSON object at the top level.`);
+      process.exit(1);
+    }
+  }
+}
+
+// Ours = any entry whose command runs a script from this folder, regardless of
+// the checkout path or the pre-PR-A `VAR=x node …` form. Windows paths normalised.
+const isOurs = (entry) => Array.isArray(entry?.hooks) && entry.hooks.some((h) =>
+  typeof h?.command === 'string' && h.command.replace(/\\/g, '/').includes('/claude-code-hooks/session-'));
+
+settings.hooks = settings.hooks && typeof settings.hooks === 'object' ? settings.hooks : {};
+for (const ev of ['SessionStart', 'SessionEnd']) {
+  settings.hooks[ev] = (Array.isArray(settings.hooks[ev]) ? settings.hooks[ev] : []).filter((e) => !isOurs(e));
+}
+delete settings['second-brain-hooks']; // the old idempotency marker
+
+if (MODE !== 'uninstall') {
+  const q = (p) => `"${p.replace(/"/g, '\\"')}"`;
+  settings.hooks.SessionStart.push({
+    matcher: 'startup|clear|compact',
+    hooks: [{ type: 'command', command: `node ${q(`${HOOKS_DIR}/session-start.js`)}` }],
+  });
+  settings.hooks.SessionEnd.push({
+    // SessionEnd hooks share a 1.5 s budget unless an entry asks for more; the
+    // capture waits on an embedding and often a model call before the reply.
+    hooks: [{ type: 'command', command: `node ${q(`${HOOKS_DIR}/session-end.js`)}`, timeout: 30 }],
+  });
+}
+for (const ev of ['SessionStart', 'SessionEnd']) if (!settings.hooks[ev].length) delete settings.hooks[ev];
+if (!Object.keys(settings.hooks).length) delete settings.hooks;
+
+if (fs.existsSync(SETTINGS_FILE)) fs.copyFileSync(SETTINGS_FILE, `${SETTINGS_FILE}.bak-${Date.now()}`);
+const tmp = `${SETTINGS_FILE}.tmp-${process.pid}`;
+fs.writeFileSync(tmp, JSON.stringify(settings, null, 2) + '\n');
+fs.renameSync(tmp, SETTINGS_FILE);
+console.log(`${MODE === 'uninstall' ? 'Removed Second Brain hooks from' : 'Updated'} ${SETTINGS_FILE}`);
+'@
+
+if ($Mode -eq "install") {
+  if ([string]::IsNullOrWhiteSpace($WorkerUrl) -and [string]::IsNullOrWhiteSpace($Token) -and (Test-Path $ConfigFile)) {
+    Write-Host "Using credentials from $ConfigFile"
+  } else {
+    if ([string]::IsNullOrWhiteSpace($WorkerUrl) -or [string]::IsNullOrWhiteSpace($Token)) {
+      # The analogue of bash's `[[ ! -t 0 ]]`: never hang a scripted install on a prompt.
+      if ([Console]::IsInputRedirected -or -not [Environment]::UserInteractive) {
+        Stop-WithError "Usage: .\install.ps1 -WorkerUrl <worker-url> -Token <auth-token>   (no console to prompt on)" 2
+      }
+      if ([string]::IsNullOrWhiteSpace($WorkerUrl)) {
+        $WorkerUrl = Read-Host "Enter your Second Brain worker URL (e.g. https://your-worker.workers.dev)"
+      }
+      if ([string]::IsNullOrWhiteSpace($Token)) {
+        $secure = Read-Host "Enter your AUTH_TOKEN" -AsSecureString
+        $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+        try { $Token = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr) }
+        finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr) }
+      }
+    }
+    $WorkerUrl = $WorkerUrl.Trim().TrimEnd("/")
+    if ($WorkerUrl -notmatch "^https?://") {
+      Stop-WithError "Error: worker URL must start with http:// or https:// (got: $WorkerUrl)"
+    }
+    New-Item -ItemType Directory -Path $ConfigDir -Force | Out-Null
+    $env:WORKER_URL = $WorkerUrl
+    $env:TOKEN = $Token
+    $env:CONFIG_FILE = $ConfigFile
+    $code = Invoke-NodeScript $ConfigWriter
+    $env:TOKEN = $null
+    if ($code -ne 0) { Stop-WithError "Error: could not write $ConfigFile" $code }
+    Write-Host "Wrote $ConfigFile"
+  }
+}
+
+New-Item -ItemType Directory -Path (Split-Path -Parent $SettingsFile) -Force | Out-Null
+
+$env:SETTINGS_FILE = $SettingsFile
+# Forward slashes so the written command reads the same as install.sh's; node and
+# Claude Code both accept them on Windows.
+$env:HOOKS_DIR = $HooksDir.Replace("\", "/")
+$env:MODE = $Mode
+$code = Invoke-NodeScript $SettingsWriter
+if ($code -ne 0) { exit $code }
+
+if ($Mode -eq "uninstall") {
+  Write-Host "Done. Credentials in $ConfigFile were left in place."
+  exit 0
+}
+
+Write-Host ""
+Write-Host "Done. Second Brain hooks installed."
+Write-Host "  SessionStart (startup, /clear, compaction): recalls context for the current project"
+Write-Host "  SessionEnd:                                  saves the conversation (needs Worker 3.0+)"
+Write-Host ""
+Write-Host "Sessions already open keep the old hook config — restart them."
+Write-Host "Verify with: powershell -File `"$HooksDir\install.ps1`" -Check"

--- a/integrations/claude-code-hooks/session-end.js
+++ b/integrations/claude-code-hooks/session-end.js
@@ -15,6 +15,47 @@ const ASSISTANT_LINE_CAP = 300;
 const MIN_USER_TURN_CHARS = 40;
 const MIN_BODY_CHARS = 200;
 
+const REDACTED = '[redacted]';
+
+/**
+ * High-confidence secret shapes only. What reaches this point is human and
+ * assistant prose (tool output is already dropped), so the realistic exposure is
+ * a pasted credential or one the assistant echoed back — not a config file.
+ * Over-redaction destroys the memory, so nothing here matches a UUID, a git SHA,
+ * a file path or an English sentence: every pattern needs either a provider's
+ * own prefix or an explicit `secret-ish name =` label in front of it.
+ */
+const SECRET_PATTERNS = [
+  // The whole PEM block, not just the marker line: the key is the payload.
+  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g,
+  /\bsk-[A-Za-z0-9_-]{16,}/g,                       // OpenAI / Anthropic
+  /\bgh[posur]_[A-Za-z0-9]{20,}/g,                  // GitHub classic and OAuth
+  /\bgithub_pat_[A-Za-z0-9_]{20,}/g,                // GitHub fine-grained
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}/g,                // Slack
+  /\bAKIA[0-9A-Z]{16}\b/g,                          // AWS access key id
+  /\bAIza[0-9A-Za-z_-]{35,}/g,                      // Google API key
+];
+
+// `Bearer <token>` and `NAME=<value>` keep their prefix so the sentence still reads.
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/g;
+const ASSIGNMENT_PATTERN =
+  /\b([A-Za-z0-9_.-]*(?:auth[_-]?token|access[_-]?token|api[_-]?key|apikey|token|secret|password|passwd))(\s*[:=]\s*)(["'`]?)([^\s"'`,;]{8,})\3/gi;
+
+/**
+ * Replace credentials in `text` with `[redacted]`. `token` is the caller's own
+ * configured token: the one secret we know exactly, so it goes wherever it
+ * appears, including mid-sentence.
+ */
+function redactSecrets(text, token) {
+  let out = String(text ?? '');
+  if (typeof token === 'string' && token.trim().length >= 8) {
+    out = out.split(token.trim()).join(REDACTED);
+  }
+  for (const re of SECRET_PATTERNS) out = out.replace(re, REDACTED);
+  out = out.replace(BEARER_PATTERN, `Bearer ${REDACTED}`);
+  return out.replace(ASSIGNMENT_PATTERN, (_m, name, sep, quote) => `${name}${sep}${quote}${REDACTED}${quote}`);
+}
+
 /** Text the harness injects into user turns. Compared against the trimmed start of the turn. */
 const NOISE_PREFIXES = [
   '<task-notification>', '<task-id', '<command-name>', '<command-message>',
@@ -164,8 +205,17 @@ function shouldCapture(turns) {
     && conversationChars >= MIN_BODY_CHARS;
 }
 
+/**
+ * Redaction runs on the formatted body, after formatSession, for two reasons:
+ * the header is part of what gets stored (a branch name is user-controlled), and
+ * formatSession's budget arithmetic stays exactly as PR A verified it. The order
+ * costs one thing — `[redacted]` can be longer than what it replaced — so the
+ * cap is re-applied here. That trim is the last step, so no secret can slip back
+ * in behind it.
+ */
 function buildCaptureBody(turns, meta) {
-  const content = formatSession(turns, meta);
+  let content = redactSecrets(formatSession(turns, meta), meta.token);
+  if (content.length > MAX_CONTENT_CHARS) content = content.slice(0, MAX_CONTENT_CHARS - 1) + '…';
   return {
     content,
     source: 'claude-code',
@@ -200,6 +250,7 @@ async function main() {
     timestamp: last.timestamp,
     reason: typeof payload?.reason === 'string' ? payload.reason : 'other',
     workspace: resolveWorkspace(),
+    token: creds.token, // redacted out of the body if the conversation quoted it
   };
   const body = buildCaptureBody(turns, meta);
   if (!shouldCapture(turns)) return;
@@ -227,7 +278,8 @@ async function main() {
 }
 
 module.exports = {
-  NOISE_PREFIXES, textOf, turnFromLine, readTranscriptTail, formatSession, shouldCapture, buildCaptureBody, main,
+  NOISE_PREFIXES, textOf, turnFromLine, readTranscriptTail, formatSession, shouldCapture,
+  redactSecrets, buildCaptureBody, main,
 };
 
 if (require.main === module) {

--- a/integrations/claude-code-hooks/session-end.js
+++ b/integrations/claude-code-hooks/session-end.js
@@ -41,6 +41,11 @@ const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/g;
 const ASSIGNMENT_PATTERN =
   /\b([A-Za-z0-9_.-]*(?:auth[_-]?token|access[_-]?token|api[_-]?key|apikey|token|secret|password|passwd))(\s*[:=]\s*)(["'`]?)([^\s"'`,;]{8,})\3/gi;
 
+// A name= whose value NAMES a secret rather than being one. Sessions are mostly
+// talk about code, so `apiKey = process.env.OPENAI_API_KEY` is the common case
+// and redacting it would blank the line the memory exists to keep.
+const CODE_REFERENCE = /^(?:process\.env\b|os\.environ\b|import\.meta\.env\b|env\.|Deno\.env\b|\$|<|\{)/;
+
 /**
  * Replace credentials in `text` with `[redacted]`. `token` is the caller's own
  * configured token: the one secret we know exactly, so it goes wherever it
@@ -53,7 +58,8 @@ function redactSecrets(text, token) {
   }
   for (const re of SECRET_PATTERNS) out = out.replace(re, REDACTED);
   out = out.replace(BEARER_PATTERN, `Bearer ${REDACTED}`);
-  return out.replace(ASSIGNMENT_PATTERN, (_m, name, sep, quote) => `${name}${sep}${quote}${REDACTED}${quote}`);
+  return out.replace(ASSIGNMENT_PATTERN, (m, name, sep, quote, value) =>
+    CODE_REFERENCE.test(value) ? m : `${name}${sep}${quote}${REDACTED}${quote}`);
 }
 
 /** Text the harness injects into user turns. Compared against the trimmed start of the turn. */

--- a/integrations/claude-code-hooks/session-start.js
+++ b/integrations/claude-code-hooks/session-start.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 'use strict';
+const fs = require('node:fs');
 const {
   loadCredentials, resolveWorkspace, readStdinJson, parseProjectName, gitRemoteUrl,
-  fetchWithTimeout, fail, hintFor,
+  fetchWithTimeout, fail, hintFor, cachePath,
 } = require('./common');
 
 // resume/fork transcripts already hold the earlier injection, and Claude Code
@@ -12,6 +13,33 @@ const SKIP_SOURCES = new Set(['resume', 'fork']);
 const RECALL_TIMEOUT_MS = 15000;
 const MAX_OUTPUT_CHARS = 6000;
 const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000;
+const SESSION_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Where the block printed for a session is kept so compaction can re-emit it.
+ * The id lands in a filename, so anything that is not a plain name character is
+ * folded away; `dir` is only ever passed by tests.
+ */
+function sessionCacheFile(sessionId, dir) {
+  const safe = String(sessionId ?? '').replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^[.-]+/, '').slice(0, 96);
+  return safe ? cachePath(`session-${safe}.txt`, dir) : null;
+}
+
+function writeSessionCache(sessionId, text, dir) {
+  const file = text ? sessionCacheFile(sessionId, dir) : null;
+  if (!file) return false;
+  try { fs.writeFileSync(file, text); return true; } catch { return false; }
+}
+
+/** The block cached for this session, or null when it is missing or older than 24 h. */
+function readSessionCache(sessionId, now = Date.now(), dir) {
+  const file = sessionCacheFile(sessionId, dir);
+  if (!file) return null;
+  try {
+    if (now - fs.statSync(file).mtimeMs >= SESSION_CACHE_TTL_MS) return null;
+    return fs.readFileSync(file, 'utf8') || null;
+  } catch { return null; }
+}
 
 /** The requests to try, in order. The tag arm returns [] on a miss, so the fallback is safe. */
 function buildRecallPlan(project, workspace, now = Date.now()) {
@@ -84,6 +112,15 @@ async function main() {
   const payload = await readStdinJson();
   const source = typeof payload?.source === 'string' ? payload.source : 'startup';
   if (SKIP_SOURCES.has(source)) return;
+  const sessionId = typeof payload?.session_id === 'string' ? payload.session_id : '';
+
+  // The session id survives compaction and rotates on /clear, so a block cached
+  // earlier in this session is still this session's context. Re-emitting it
+  // costs nothing; a second recall would cost a request and an embedding.
+  if (source === 'compact') {
+    const cached = readSessionCache(sessionId);
+    if (cached) { process.stdout.write(cached); return; }
+  }
 
   const cwd = typeof payload?.cwd === 'string' && payload.cwd ? payload.cwd : process.cwd();
   const project = parseProjectName(gitRemoteUrl(cwd), cwd);
@@ -108,13 +145,19 @@ async function main() {
     const results = Array.isArray(data?.results) ? data.results : [];
     if (results.length) {
       const out = frameOutput(results, data.insight);
-      if (out) process.stdout.write(out);
+      if (out) {
+        process.stdout.write(out);
+        if (source === 'startup' || source === 'clear') writeSessionCache(sessionId, out);
+      }
       return;
     }
   }
 }
 
-module.exports = { SKIP_SOURCES, buildRecallPlan, buildRecallUrl, cleanSnippet, frameOutput, main };
+module.exports = {
+  SKIP_SOURCES, SESSION_CACHE_TTL_MS, buildRecallPlan, buildRecallUrl, cleanSnippet, frameOutput,
+  sessionCacheFile, writeSessionCache, readSessionCache, main,
+};
 
 if (require.main === module) {
   main().catch((e) => fail(`recall failed: ${e?.message ?? e}`));

--- a/test/integration/claude-code-hooks-contract.test.ts
+++ b/test/integration/claude-code-hooks-contract.test.ts
@@ -161,6 +161,28 @@ describe("session-start.js", () => {
     expect((await runHook("session-start.js", startPayload("compact"))).stdout).toContain("Context recalled");
   });
 
+  it("re-emits the cached block on compaction and makes no request at all", async () => {
+    // The session id survives compaction, so the block printed at startup is
+    // still this session's context — printing it again costs nothing.
+    const first = await runHook("session-start.js", startPayload("startup"));
+    expect(first.code, first.stderr).toBe(0);
+    expect(first.stdout).toContain("Context recalled");
+    expect(captured.filter(c => c.url.startsWith("/recall?")).length).toBeGreaterThanOrEqual(1);
+
+    captured = [];
+    const second = await runHook("session-start.js", startPayload("compact"));
+    expect(second.code, second.stderr).toBe(0);
+    expect(second.stdout).toBe(first.stdout);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("falls back to a live recall when compaction finds no cached block", async () => {
+    const r = await runHook("session-start.js", { ...startPayload("compact"), session_id: "never-seen-before" });
+    expect(r.code, r.stderr).toBe(0);
+    expect(r.stdout).toContain("Context recalled");
+    expect(captured.filter(c => c.url.startsWith("/recall?")).length).toBeGreaterThanOrEqual(1);
+  });
+
   it("does nothing without credentials, and honours the opt-out", async () => {
     const r = await runHook("session-start.js", startPayload(), { SECOND_BRAIN_URL: "", SECOND_BRAIN_TOKEN: "" });
     expect(r.code).toBe(0); expect(r.stdout).toBe(""); expect(captured).toHaveLength(0);

--- a/test/unit/claude-code-hooks.test.ts
+++ b/test/unit/claude-code-hooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -345,5 +345,35 @@ describe("session-end.redactSecrets", () => {
     const body = end.buildCaptureBody(turns, meta);
     expect(body.content.length).toBeLessThanOrEqual(2000);
     expect(body.content).not.toContain("abcd1234");
+  });
+});
+
+describe("session-start session cache", () => {
+  const block = "[Second Brain] Context recalled — …\n----- second brain notes (begin) -----\n1. a note\n----- second brain notes (end) -----\n";
+
+  it("round-trips a block for a session id", () => {
+    const dir = tmp();
+    expect(start.readSessionCache("abc-123", Date.now(), dir)).toBeNull();
+    expect(start.writeSessionCache("abc-123", block, dir)).toBe(true);
+    expect(start.readSessionCache("abc-123", Date.now(), dir)).toBe(block);
+    expect(start.readSessionCache("other-id", Date.now(), dir)).toBeNull();
+  });
+
+  it("expires after 24 h and refuses an empty id or body", () => {
+    const dir = tmp();
+    start.writeSessionCache("abc-123", block, dir);
+    const old = Date.now() / 1000 - 25 * 3600;
+    utimesSync(start.sessionCacheFile("abc-123", dir), old, old);
+    expect(start.readSessionCache("abc-123", Date.now(), dir)).toBeNull();
+    expect(start.writeSessionCache("", block, dir)).toBe(false);
+    expect(start.writeSessionCache("abc-123", "", dir)).toBe(false);
+    expect(start.readSessionCache("", Date.now(), dir)).toBeNull();
+  });
+
+  it("keeps a session id from escaping the cache directory", () => {
+    const dir = tmp();
+    const file = start.sessionCacheFile("../../etc/passwd", dir);
+    expect(file.startsWith(dir)).toBe(true);
+    expect(file).not.toContain("..");
   });
 });

--- a/test/unit/claude-code-hooks.test.ts
+++ b/test/unit/claude-code-hooks.test.ts
@@ -336,6 +336,24 @@ describe("session-end.redactSecrets", () => {
     expect(body.content.startsWith("Claude Code session fx — sample@main")).toBe(true);
   });
 
+  it("keeps a value that names a secret rather than being one", () => {
+    // These sessions are mostly talk about code. Blanking the right-hand side of
+    // `apiKey = process.env.OPENAI_API_KEY` would erase the line the memory is
+    // being kept for, and there is no credential in it.
+    for (const line of [
+      "const apiKey = process.env.OPENAI_API_KEY",
+      'token = os.environ["GITHUB_TOKEN"]',
+      "api_key: import.meta.env.VITE_KEY",
+      "AUTH_TOKEN=${{ secrets.AUTH_TOKEN }}",
+      "secret = <your-token-here>",
+    ]) {
+      expect(r(line), line).toBe(line);
+    }
+    // The literal forms still go.
+    expect(r("AUTH_TOKEN=s3cr3tvalue123456")).toContain("[redacted]");
+    expect(r('api_key = "zzzz1111yyyy2222"')).toContain("[redacted]");
+  });
+
   it("holds the 2000-char cap even when redaction lengthens the body", () => {
     // Each `TOKEN=abcd1234` (15) becomes `TOKEN=[redacted]` (16): redaction grows
     // this body, so the cap has to be re-applied after it, not before.

--- a/test/unit/claude-code-hooks.test.ts
+++ b/test/unit/claude-code-hooks.test.ts
@@ -262,3 +262,88 @@ describe("session-end.formatSession / shouldCapture / buildCaptureBody", () => {
     expect(end.buildCaptureBody(turns, { ...meta, project: null }).tags).toEqual([]);
   });
 });
+
+describe("session-end.redactSecrets", () => {
+  const r = (text: string, token?: string) => end.redactSecrets(text, token);
+
+  it("redacts the caller's own configured token, including mid-sentence", () => {
+    expect(r("I pasted sb_live_9f2c1a4e7b3d into the prompt by mistake", "sb_live_9f2c1a4e7b3d"))
+      .toBe("I pasted [redacted] into the prompt by mistake");
+    expect(r("token is sb_live_9f2c1a4e7b3d.", "sb_live_9f2c1a4e7b3d")).toBe("token is [redacted].");
+  });
+
+  it("ignores a short or absent configured token rather than shredding the text", () => {
+    expect(r("the abc of it", "abc")).toBe("the abc of it");
+    expect(r("nothing to do here")).toBe("nothing to do here");
+  });
+
+  it("redacts a Bearer value and keeps the scheme", () => {
+    expect(r("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sig"))
+      .toBe("Authorization: Bearer [redacted]");
+  });
+
+  it("redacts provider key shapes", () => {
+    expect(r("key sk-proj-Ab3dEf6hIj9lMn2pQr5tUv8x here")).toBe("key [redacted] here");
+    expect(r("ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8")).toBe("[redacted]");
+    expect(r("gho_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8")).toBe("[redacted]");
+    expect(r("github_pat_11ABCDEFG0abcdefghij_KLMNOPqrstuvwx1234567890")).toBe("[redacted]");
+    expect(r("xoxb-EXAMPLE-NOT-A-REAL-SLACK-TOKEN")).toBe("[redacted]");
+    expect(r("xoxp-EXAMPLE-NOT-A-REAL-SLACK-TOKEN")).toBe("[redacted]");
+    expect(r("AKIAIOSFODNN7EXAMPLE")).toBe("[redacted]");
+    expect(r("AIzaSyD-1234567890abcdefghijklmnopqrstu")).toBe("[redacted]"); // 39 chars, the real shape
+  });
+
+  it("redacts a whole PEM block, not just its header", () => {
+    const pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA1\nnQIDAQAB\n-----END RSA PRIVATE KEY-----";
+    const out = r(`here it is:\n${pem}\nthat was it`);
+    expect(out).toBe("here it is:\n[redacted]\nthat was it");
+    expect(out).not.toContain("MIIEpAIBAAKCAQEA1");
+  });
+
+  it("redacts assignment forms in either case and with either separator", () => {
+    expect(r("TOKEN=hunter2-abcdefgh")).toBe("TOKEN=[redacted]");
+    expect(r("SECRET=s3cr3t-value-here")).toBe("SECRET=[redacted]");
+    expect(r('PASSWORD="correct-horse-battery"')).toBe('PASSWORD="[redacted]"');
+    expect(r("API_KEY: abcdef1234567890")).toBe("API_KEY: [redacted]");
+    expect(r("AUTH_TOKEN = abcdef1234567890")).toBe("AUTH_TOKEN = [redacted]");
+    expect(r("api_key='abcdef1234567890'")).toBe("api_key='[redacted]'");
+    expect(r("password: abcdef1234567890")).toBe("password: [redacted]");
+  });
+
+  it("leaves ordinary text alone — a UUID, a git SHA, a path, prose", () => {
+    const keep = [
+      "550e8400-e29b-41d4-a716-446655440000",
+      "9f2c1a4e7b3d5f8a1c4e7b9d2f5a8c1e4b7d9f2a",
+      "/home/u/.config/second-brain/config.json",
+      "We decided to move the digest off the shared cron; the token: it expired, needs rotating.",
+      "Bearer tokens are explained in the README.",
+      "sk-learn is not a secret, and neither is the word secret.",
+    ];
+    for (const line of keep) expect(r(line), line).toBe(line);
+  });
+
+  it("is applied to the formatted body — the header included — inside the character cap", () => {
+    const meta = { project: "sample", gitBranch: "main", sessionId: "fx", reason: "other", workspace: "personal", token: "sb_live_9f2c1a4e7b3d" };
+    const body = end.buildCaptureBody(
+      [{ role: "user", text: "Here is the key sk-proj-Ab3dEf6hIj9lMn2pQr5tUv8x, please use it." },
+       { role: "assistant", text: "Using sb_live_9f2c1a4e7b3d against the worker now, and the fallback TOKEN=abcdefgh12345678." }],
+      meta,
+    );
+    expect(body.content).not.toContain("sk-proj-Ab3dEf6hIj9lMn2pQr5tUv8x");
+    expect(body.content).not.toContain("sb_live_9f2c1a4e7b3d");
+    expect(body.content).not.toContain("abcdefgh12345678");
+    expect(body.content).toContain("[redacted]");
+    expect(body.content.startsWith("Claude Code session fx — sample@main")).toBe(true);
+  });
+
+  it("holds the 2000-char cap even when redaction lengthens the body", () => {
+    // Each `TOKEN=abcd1234` (15) becomes `TOKEN=[redacted]` (16): redaction grows
+    // this body, so the cap has to be re-applied after it, not before.
+    const turns = Array.from({ length: 12 }, () => ({ role: "user", text: Array.from({ length: 12 }, () => "TOKEN=abcd1234").join(" ") }));
+    const meta = { project: "sample", gitBranch: "main", sessionId: "fx", reason: "other", workspace: "personal" };
+    expect(end.formatSession(turns, meta).length).toBeGreaterThan(1900);
+    const body = end.buildCaptureBody(turns, meta);
+    expect(body.content.length).toBeLessThanOrEqual(2000);
+    expect(body.content).not.toContain("abcd1234");
+  });
+});


### PR DESCRIPTION
The third and last piece of #327.

**Stacked on #331**, because it edits the same two scripts. Base is `fix/327-hooks-client`, so the diff here is only this work; GitHub retargets it to `327-claude-code-hooks` automatically when #331 merges. Review order: #331, #332, then this.

## 1. Credentials never reach the brain

Session capture sends conversation prose, and people paste credentials into prompts. The formatted body — header included, since a branch name is user-controlled — is scanned before it is sent and each credential replaced with `[redacted]`: your own configured token wherever it appears, `Bearer` values, provider shapes (`sk-`, `ghp_`/`gho_`, `github_pat_`, `xoxb-`/`xoxp-`, AWS `AKIA…`, Google `AIza…`), whole PEM private-key blocks, and `TOKEN=`/`SECRET=`/`PASSWORD=`/`API_KEY=` assignments.

Restraint is the hard half. A memory redacted into uselessness is worse than no memory, so every pattern needs either a provider's own prefix or an explicit label in front of it. Verified against negative cases: a UUID, a 40-character commit SHA, `/home/u/.config/second-brain/config.json`, base64 in prose, and the sentence "we rotate the token: it expired on Tuesday" all survive untouched.

One over-redaction was found during review and fixed in its own commit: `apiKey = process.env.OPENAI_API_KEY` was being blanked. The value *names* a secret rather than being one, and these sessions are mostly talk about code, so environment lookups and placeholders (`process.env`, `os.environ`, `import.meta.env`, `Deno.env`, `$…`, `<…>`) are now left alone while literal assignments are still redacted.

Ordering is deliberate and commented: format, then redact, then re-apply the 2000-character cap. Redacting first would change what fits and silently alter which turns are kept; the trim runs last so nothing can slip in behind it. `[redacted]` can be longer than what it replaced, which is exactly why the cap is re-applied rather than assumed.

## 2. Compaction costs nothing

The block printed at `startup`/`clear` is cached under `$XDG_CACHE_HOME/second-brain/session-<id>.txt`. On compaction the hook prints that file verbatim and makes no request at all. The session id survives compaction and rotates on `/clear`, which is what makes a cached block always the current session's context; with no cache or one older than 24 h it falls back to a live recall with the same failure semantics as #331.

Measured end to end against a stub: three runs (startup, compact, compact-with-cold-cache) produce two requests instead of three, and the cached run's output is byte-identical to the live one.

## 3. `install.ps1`

A PowerShell mirror for Windows machines where Claude Code falls back to PowerShell instead of Git Bash — the case where `install.sh` simply cannot run. Same credentials file, same entries, same reconcile-don't-append behaviour, same refusal to overwrite a malformed `settings.json`, and `-Check`/`-Uninstall`. Node does the JSON editing in both installers, from the same script text, so the two cannot drift.

## Testing

15 new tests (3258 total in this branch), `tsc --noEmit` clean, `check:scope` clean.

- Redaction: one case per pattern, plus the negative cases above, plus a body that grows under redaction to prove the cap still holds.
- Compaction: unit tests for the cache helpers including a path-traversal case (`../../etc/passwd` cannot escape the cache directory), and contract tests that spawn the real hook twice and assert zero requests on the cached run and a live request on a cold one.

Note: the Slack fixture in the redaction test is written as `xoxb-EXAMPLE-NOT-A-REAL-SLACK-TOKEN` rather than the canonical shape. The realistic-looking placeholder tripped GitHub's push protection, and rewriting the fixture is the right answer — allowlisting a "secret" to get a push through is a habit worth not forming. It still exercises the same pattern.

**One honest gap:** there is no PowerShell on this machine, so `install.ps1` has not been executed. Rather than write a test that would silently skip, I verified what could be verified mechanically — both embedded Node payloads were extracted and run exactly as the script invokes them, covering config writing, settings writing, idempotency, upgrade from a Windows-style stale entry, uninstall, and the malformed-file refusal (exit 1, file byte-identical afterwards). The PowerShell shell code around them — the param block, prompts, and the node invocation helper — is reviewed but unexecuted. It should be smoke-tested on a Windows machine before anyone is pointed at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)