### PR TITLE
Knowledge graph: typed edges, junk-link suppression, and graph health stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,10 @@ coverage/
 docs/*
 !docs/dashboard-architecture.md
 .claude/
-.cursor/*
+# .cursor/** rather than .cursor/* so anything else added anywhere under
+# .cursor stays ignored. Only the shipped memory rule is re-included:
+# scripts/connect-ai-clients.* fetch it from the repo's raw URL for users.
+.cursor/**
 !.cursor/rules/
 !.cursor/rules/second-brain-memory.mdc
 .dev.vars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,54 @@ All notable changes to Second Brain are documented here. Version numbers match `
 
 **Team Edition (single shared team per brain)**
 
-- Personal and Shared (`company`) memory layers on one Worker — no separate team deployment.
-- Member management, invite tokens, capture defaults, sharing, author lock, and admin audit trail.
-- Dashboard team panel: members, roster, activity, rename team, share/unshare from the UI.
-- MCP and REST tools accept optional `workspace`: `personal` | `company` on reads and writes.
+Second Brain can now be a team's memory without stopping being yours. Every person gets a **Personal** workspace that nobody else can read, plus a **Shared** layer visible to the team, on one Worker with no separate team deployment.
+
+- Personal and Shared (`company`) memory layers; personal memories are private by default and only enter the Shared layer when someone deliberately shares them.
+- Member management with invite tokens, last-seen timestamps, and per-member capture visibility set as an admin policy with per-member override.
+- An owner can declare a brain a team before anyone is invited; real membership overrules any stored team mode.
+- Sharing moves one canonical memory rather than making a copy. Its author remains visible, and only the author or an admin can edit, delete, or un-share it.
+- Author lock prevents a team member from editing or deleting another member's memories.
+- Team directory: a member sees the team, its people, and their own capture default.
+- A member can set their own capture default; the composer's layer control is explained to a new team member with a dismissible onboarding coach mark.
+- Capture-default controls are pinned to their own keys and shared through one select helper.
+- Dashboard team panel: members, roster, activity, rename team, share and un-share from the UI. The roster no longer holds the memories list hostage.
+- Dashboard: memories multi-select with bulk share and a shared-badge/payer layer chip; admin activity section with CSV export.
+- Team-scoped insights with an optional company weekly insight pass (off by default) and a per-team toggle; the insight novelty floor is keyed to the workspace.
+- Integration lines and provenance are gated on team mode, and a member is told who connected an integration and where it lands.
+- MCP and REST tools accept optional `workspace` (`personal` | `company`) on reads and writes.
 - MCP `list_teams` and `GET /team/workspaces` list the teams a caller belongs to (v3.0.0 returns one team per brain).
 
 **Security and tenancy**
 
-- Identity-scoped reads and writes; digest and config admin boundaries; MCP audit events.
-- Multi-team write ambiguity resolved: optional `team` workspace id on capture, share, recall, list, graph, and digest.
+- Identity is resolved at the API edge, and every read and write is scoped to the caller's workspace and membership.
+- Personal memories are invisible to the team; shared memories are visible to all members; scoped recall searches only what the caller can see.
+- Graph walks cannot traverse a memory the reader cannot open.
+- Admin reads are scoped so an admin sees only the team data they are authorized to manage.
+- Vectorize vectors are stamped with `workspace_id` and queries filter by the readable set; vectors are re-stamped on share and un-share so they stay in the correct layer.
+- The app asks the brain who is holding the token instead of guessing from a Cloudflare login.
+- OAuth replaces query-string tokens for MCP (v3); query-string authentication is refused.
+- Imported entries and edges carry the importer's workspace.
+- Explicit links stay within one layer and are filed where their author can see them.
+- Multi-team write ambiguity is resolved with an optional `team` workspace id on capture, share, recall, list, graph, and digest.
+
+**Admin and compliance**
+
+- `GET /team/activity`: a single paged feed merging the `admin_events` and `entry_events` audit trails.
+- Every team administration action (add/remove member, share/unshare, rename, capture defaults) is recorded in `admin_events` with timestamp and actor.
+- Integration connects and disconnects are recorded in `admin_events`.
+- Team configuration select helpers reload on change; team-insights toggle is routed through the shared config select.
+- Admin activity body guard and bulk bar team gate enforced.
+- Health endpoint surfaces Vectorize degradation status.
+- Member last-seen timestamps visible to admins.
+
+**Scope and isolation hardening**
+
+- Scope checker rebuilt with an allowlist of safe clause shapes; evasive patterns (negation, wrapped SQL, dotted table names) are now rejected.
+- Outer-join detection prevents scope clauses that reduce to a nulled column.
+- Graph subrequest bound re-pinned to match current scope-checker output.
+- Tag summaries scoped at the row level, not the title.
+- Activity feed memory arm scoped to the row.
+- Negation and wrapped SQL are no longer treated as safe by the scope checker.
 
 **Recall in any language (#326)**
 
@@ -35,11 +73,39 @@ All notable changes to Second Brain are documented here. Version numbers match `
 - Hooks now exit 1 with one stderr line on any failure; Claude Code hides stderr from exit-0 hooks.
 - `install.sh` reconciles instead of appending, refuses a malformed settings.json, sets the SessionEnd `timeout` the 1.5 s hook budget requires, and keeps credentials in `~/.config/second-brain/config.json` rather than the hook command line.
 - New: `install.sh --check` and `--uninstall`.
-- Session capture redacts credentials from the body before sending it — your own token, `Bearer` values, `sk-`/`ghp_`/`github_pat_`/`xoxb-`/`AKIA`/`AIza` key shapes, PEM private keys and `TOKEN=`-style assignments — while leaving UUIDs, commit SHAs, paths and ordinary prose intact.
+- Session capture redacts credentials from the body before sending it. Your own token, `Bearer` values, `sk-`/`ghp_`/`github_pat_`/`xoxb-`/`AKIA`/`AIza` key shapes, PEM private keys and `TOKEN=`-style assignments are removed, while UUIDs, commit SHAs, paths and ordinary prose are left intact.
 - SessionStart caches the block it printed and re-emits it on compaction, so compaction costs no recall at all; it falls back to a live recall when there is no cache or it is over 24 h old.
 - New: `install.ps1`, a PowerShell installer for Windows machines where Claude Code runs hooks under PowerShell rather than Git Bash.
 - Worker: a Claude Code transcript is never merged into, never replaces, and never deprecates a memory written by any other source; it is stored as a duplicate-candidate or a draft instead. Transcripts are excluded from insight synthesis.
 - Worker: capturing a near-duplicate of a protected memory (importance ≥ 4 or canonical) now stores the newcomer as a duplicate-candidate. It used to report success with an id that did not exist.
+
+**Knowledge graph quality**
+
+- Capture-time inference now draws typed edges (`follows`, `caused_by`, `decided`) in addition to generic `relates_to`, improving traversal and recall relevance.
+- Junk-link suppression prevents near-duplicate confusion from creating misleading graph connections.
+- Update and merge paths now re-infer edges so the graph stays current when content changes.
+- The nightly backfill can emit `follows` when the entry's kind is already classified.
+- `GET /stats/graph` endpoint for graph health observability (admin only).
+- MCP `link` tool description now explains each edge type and direction.
+- The dangling sweep runs weekly instead of nightly (~7× cheaper amortized).
+
+**Desktop and installer**
+
+- Installer offers team-mode onboarding: existing-brain users choose team mode once during connect; the choice is a true one-time decision.
+- Installer provisions the company insight schedule from the manifest.
+- `install.ps1` (PowerShell) mirrors `install.sh` for Windows environments.
+- Desktop typecheck and Rust tests now run on every PR.
+- Routine "update your brain" keeps a migrated brain on its migrated search index instead of re-creating it.
+- Cost-picker notices are no longer contradictory for migration-level changes.
+
+**Bug fixes**
+
+- Admin lockout guards are atomic; email uniqueness and tombstone guards hardened.
+- Integration purge no longer deletes a colleague's memories.
+- Re-embed repairs no longer detach vectors from their workspace.
+- One member's tags no longer reach another.
+- Toast text is readable in light mode; team panel contrast, overlap, truncation, and tap targets fixed.
+- Bulk selection no longer outlives the list it is over.
 
 **Upgrade**
 
@@ -47,7 +113,7 @@ All notable changes to Second Brain are documented here. Version numbers match `
 
 ### Internal plumbing (not user-facing in v3.0.0)
 
-The codebase supports multiple company workspaces per member (many-to-many memberships, `team` query/body parameter, scoped recall). **v3.0.0 does not expose multi-team in the dashboard, admin UI, or provisioning flows** — each brain still has one shared team. Backlog: [GitHub issues labeled `multi-team`](https://github.com/rahilp/second-brain-cloudflare/issues?q=label%3Amulti-team).
+The codebase supports multiple company workspaces per member (many-to-many memberships, `team` query/body parameter, scoped recall). **v3.0.0 does not expose multi-team in the dashboard, admin UI, or provisioning flows**; each brain still has one shared team. Backlog: [GitHub issues labeled `multi-team`](https://github.com/rahilp/second-brain-cloudflare/issues?q=label%3Amulti-team).
 
 AI clients: on v3.0.0 team brains, `list_teams` returns one entry; omit `team` unless more than one team is returned.
 

--- a/src/capture/classify.ts
+++ b/src/capture/classify.ts
@@ -57,6 +57,23 @@ export async function classifyEntry(content: string, env: Env, config: Readonly<
   return parseClassification(text);
 }
 
+/** The write half of classification, shared by both schedulers below. */
+async function applyClassification(
+  entryId: string,
+  env: Env,
+  { importance, canonical, kind }: { importance: number; canonical: boolean; kind: MemoryKind | null },
+): Promise<void> {
+  await env.DB.prepare(`UPDATE entries SET importance_score = ? WHERE id = ?`).bind(importance, entryId).run();
+  if (!kind && !canonical) return;
+  // scope-exempt: by-id: the entry this background pass was queued for
+  const row = await env.DB.prepare(`SELECT tags FROM entries WHERE id = ?`).bind(entryId).first() as Record<string, any> | null;
+  if (!row) return;
+  let tags: string[] = JSON.parse(row.tags ?? "[]");
+  if (kind) tags = withKind(tags, kind);
+  if (canonical && getStatus(tags) === null) tags = withStatus(tags, "canonical");
+  await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`).bind(JSON.stringify(tags), entryId).run();
+}
+
 export function scheduleClassifyAndTag(
   entryId: string,
   content: string,
@@ -66,17 +83,35 @@ export function scheduleClassifyAndTag(
 ): void {
   ctx.waitUntil(
     classifyEntry(content, env, config)
-      .then(async ({ importance, canonical, kind }) => {
-        await env.DB.prepare(`UPDATE entries SET importance_score = ? WHERE id = ?`).bind(importance, entryId).run();
-        if (!kind && !canonical) return;
-        // scope-exempt: by-id: the entry this background pass was queued for
-        const row = await env.DB.prepare(`SELECT tags FROM entries WHERE id = ?`).bind(entryId).first() as Record<string, any> | null;
-        if (!row) return;
-        let tags: string[] = JSON.parse(row.tags ?? "[]");
-        if (kind) tags = withKind(tags, kind);
-        if (canonical && getStatus(tags) === null) tags = withStatus(tags, "canonical");
-        await env.DB.prepare(`UPDATE entries SET tags = ? WHERE id = ?`).bind(JSON.stringify(tags), entryId).run();
-      })
+      .then(c => applyClassification(entryId, env, c))
       .catch(e => console.error("Classification failed (non-fatal):", e))
+  );
+}
+
+/**
+ * Classify, then infer edges with the kind that classification just produced.
+ *
+ * One `classifyEntry` call feeding both halves, not two: the kind an edge type
+ * needs to gate on is the same kind the tagger writes, and asking twice would
+ * add a model call per capture to learn something already known.
+ *
+ * Inference runs whatever classification did. A failed or unparseable
+ * classification degrades to `kind: null`, which costs the capture its typed
+ * edge and nothing else — the generic edge is still drawn. Losing the graph
+ * write because the classifier was unavailable would be a much worse trade.
+ */
+export function classifyThenInfer(
+  entryId: string,
+  content: string,
+  env: Env,
+  ctx: ExecutionContext,
+  config: Readonly<Config>,
+  infer: (kind: MemoryKind | null) => Promise<void>,
+): void {
+  ctx.waitUntil(
+    classifyEntry(content, env, config)
+      .then(async c => { await applyClassification(entryId, env, c); return c.kind; })
+      .catch(e => { console.error("Classification failed (non-fatal):", e); return null; })
+      .then(kind => infer(kind).catch(e => console.error("Edge inference failed (non-fatal):", e)))
   );
 }

--- a/src/capture/entry.ts
+++ b/src/capture/entry.ts
@@ -3,7 +3,7 @@ import { DEFAULTS, resolveConfig, type Config } from "../config";
 import { createEdge, inferEdgesOnWrite } from "../graph/edges";
 import { getStatus, withStatus } from "../memory/status";
 import { extractHashtags } from "../text/hashtags";
-import { scheduleClassifyAndTag } from "./classify";
+import { classifyThenInfer, scheduleClassifyAndTag } from "./classify";
 import { checkDuplicateAndContradiction } from "./duplicate";
 import { deprecateEntry } from "./lifecycle";
 import { deleteStaleVectors, reembedOrThrow, storeEntry } from "./store";
@@ -115,7 +115,7 @@ export async function captureEntry(
       if (!protectedTarget) {
         let newVectorIds: string[] | null = null;
         try {
-          newVectorIds = await reembedOrThrow(env, targetId, newContent, existingTags, existingSource, cfg, writeCtx);
+          newVectorIds = (await reembedOrThrow(env, targetId, newContent, existingTags, existingSource, cfg, writeCtx)).vectorIds;
         } catch (e) {
           console.error("Merge re-embed failed — keeping both, target untouched:", e);
         }
@@ -138,7 +138,18 @@ export async function captureEntry(
             await deleteStaleVectors(env, oldVectorIds, newVectorIds);
           } catch (e) { console.error("Old vector cleanup failed (non-fatal):", e); }
 
-          scheduleClassifyAndTag(targetId, newContent, env, ctx, cfg);
+          // The survivor's content just changed, so its graph position should
+          // too. `neighbors` is the answer duplicate detection already got from
+          // Vectorize for this same text, reused rather than asked again — the
+          // merge therefore adds no query and no embed of its own.
+          // inferEdgesOnWrite drops the written id from its own candidates, so
+          // the target needs no filtering. dup.matchId does: the model picks the
+          // merge target and is free to choose the SECOND-best match, leaving
+          // the closest near-duplicate in `neighbors` — and linking the survivor
+          // to that is the junk edge suppression exists to prevent, arriving by
+          // a different door.
+          classifyThenInfer(targetId, newContent, env, ctx, cfg, kind =>
+            inferEdgesOnWrite(targetId, neighbors, env, { suppressId: dup.matchId, newKind: kind }));
 
           return mergeAction.action === "merge"
             ? { status: "merged", id: targetId }
@@ -169,7 +180,10 @@ export async function captureEntry(
   // straight off the back of the save can miss it by one refresh.
   ctx.waitUntil(rememberTags(env, finalTags, writeCtx.workspaceId));
 
-  scheduleClassifyAndTag(id, c, env, ctx, cfg);
+  // A flagged capture is a near-duplicate the writer chose to keep, so the
+  // entry it duplicates is its top neighbour by construction. Linking them
+  // spends an inference slot restating the duplicate-candidate tag.
+  const suppressId = dup.status === "flagged" ? dup.matchId : undefined;
 
   if (contradiction.detected && contradiction.conflicting_id) {
     const conflictId = contradiction.conflicting_id;
@@ -197,6 +211,8 @@ export async function captureEntry(
       } catch (e) {
         console.error("Contradiction count update failed (non-fatal):", e);
       }
+      // This path draws no edges, so there is nothing to chain onto.
+      scheduleClassifyAndTag(id, c, env, ctx, cfg);
       return { status: "contradiction_protected", id, canonicalId: conflictId, reason: contradiction.reason };
     }
 
@@ -223,11 +239,13 @@ export async function captureEntry(
     } catch (e) {
       console.error("Supersedes edge creation failed (non-fatal):", e);
     }
-    ctx.waitUntil(inferEdgesOnWrite(id, neighbors.filter(n => n.id !== conflictId), env).catch(e => console.error("Edge inference failed (non-fatal):", e)));
+    classifyThenInfer(id, c, env, ctx, cfg, kind =>
+      inferEdgesOnWrite(id, neighbors.filter(n => n.id !== conflictId), env, { suppressId, newKind: kind }));
     return { status: "contradiction", id, resolvedConflict: conflictId, reason: contradiction.reason };
   }
 
-  ctx.waitUntil(inferEdgesOnWrite(id, neighbors, env).catch(e => console.error("Edge inference failed (non-fatal):", e)));
+  classifyThenInfer(id, c, env, ctx, cfg, kind =>
+    inferEdgesOnWrite(id, neighbors, env, { suppressId, newKind: kind }));
 
   if (dup.status === "flagged") {
     return { status: "flagged", id, matchId: dup.matchId, score: dup.score };

--- a/src/capture/store.ts
+++ b/src/capture/store.ts
@@ -18,6 +18,17 @@ function embedContextForRow(row: { workspace_id?: unknown }, writeCtx: WriteCont
   return { workspaceId: typeof row.workspace_id === "string" ? row.workspace_id : "", actorId: writeCtx.actorId };
 }
 
+/**
+ * What a write left behind: the vector ids now on the row, and the vector of
+ * its first chunk — the one a neighbour query should be run with.
+ *
+ * `values` is null only when there was nothing to embed.
+ */
+export interface StoredEntry {
+  vectorIds: string[];
+  values: number[] | null;
+}
+
 export async function storeEntry(
   env: Env,
   id: string,
@@ -27,7 +38,7 @@ export async function storeEntry(
   now: number,
   config: Readonly<Config> = DEFAULTS,
   writeCtx: WriteContext = OWNER_WRITE_CONTEXT
-): Promise<string[]> {
+): Promise<StoredEntry> {
   // A mirrored record is indexed by its first chunk only. `chunkText` splits at
   // CHUNK_MAX_CHARS and every chunk below gets its own vector, so a long one from
   // an external system produces vectors whose entire content is templated trailer
@@ -83,7 +94,11 @@ export async function storeEntry(
     `UPDATE entries SET vector_ids = ? WHERE id = ?`
   ).bind(JSON.stringify(vectorIds), id).run();
 
-  return vectorIds;
+  // The first chunk's vector rides back out with the ids. Callers that need to
+  // ask "what is this entry near?" straight after writing it — the update path
+  // below — would otherwise embed the very same text a second time, and an
+  // embed is a neuron against a 10k/day budget.
+  return { vectorIds, values: vectors[0]?.values ?? null };
 }
 
 export async function deleteStaleVectors(env: Env, oldIds: string[], newIds: string[]): Promise<void> {
@@ -92,10 +107,10 @@ export async function deleteStaleVectors(env: Env, oldIds: string[], newIds: str
   if (stale.length) await env.VECTORIZE.deleteByIds(stale);
 }
 
-export async function reembedOrThrow(env: Env, id: string, content: string, tags: string[], source: string, config: Readonly<Config> = DEFAULTS, writeCtx: WriteContext = OWNER_WRITE_CONTEXT): Promise<string[]> {
-  const ids = await storeEntry(env, id, content, tags, source, Date.now(), config, writeCtx);
-  if (!ids.length) throw new Error("re-embed produced no vectors");
-  return ids;
+export async function reembedOrThrow(env: Env, id: string, content: string, tags: string[], source: string, config: Readonly<Config> = DEFAULTS, writeCtx: WriteContext = OWNER_WRITE_CONTEXT): Promise<StoredEntry> {
+  const stored = await storeEntry(env, id, content, tags, source, Date.now(), config, writeCtx);
+  if (!stored.vectorIds.length) throw new Error("re-embed produced no vectors");
+  return stored;
 }
 
 /**
@@ -107,7 +122,7 @@ export async function reembedOrThrow(env: Env, id: string, content: string, tags
  * Callers that get null MUST NOT retire the old vectors — they are the entry's
  * only remaining semantic index until Vectorize returns.
  */
-export async function reembedOrDegrade(env: Env, id: string, content: string, tags: string[], source: string, config: Readonly<Config> = DEFAULTS, writeCtx: WriteContext = OWNER_WRITE_CONTEXT): Promise<string[] | null> {
+export async function reembedOrDegrade(env: Env, id: string, content: string, tags: string[], source: string, config: Readonly<Config> = DEFAULTS, writeCtx: WriteContext = OWNER_WRITE_CONTEXT): Promise<StoredEntry | null> {
   try {
     return await reembedOrThrow(env, id, content, tags, source, config, writeCtx);
   } catch (e) {
@@ -203,13 +218,14 @@ export async function updateEntryContent(
   // surface an error, instead of committing new content and then deleting every vector —
   // which would leave the entry silently unsearchable. null means Vectorize is unreachable
   // (#270), not that this embed failed.
-  let newVectorIds: string[] | null;
+  let reembedded: StoredEntry | null;
   try {
-    newVectorIds = await reembedOrDegrade(env, id, finalContent, mergedTags, source, config, embedCtx);
+    reembedded = await reembedOrDegrade(env, id, finalContent, mergedTags, source, config, embedCtx);
   } catch (e) {
     console.error("Re-embed failed — entry left unchanged:", e);
     return { status: "reembed_failed" };
   }
+  const newVectorIds = reembedded?.vectorIds ?? null;
 
   // Safe to commit: either the embed succeeded, or Vectorize is unavailable and the old
   // vectors are kept below rather than retired.
@@ -231,6 +247,21 @@ export async function updateEntryContent(
       await deleteStaleVectors(env, oldVectorIds, newVectorIds);
     } catch (e) {
       console.error("Old vector cleanup failed (non-fatal):", e);
+    }
+  }
+
+  // An edit changes what the entry means, so it changes where the entry belongs
+  // in the graph. Run on the vector the re-embed above already produced, so this
+  // costs one Vectorize query and no second embed.
+  //
+  // Skipped on the keyword-only degrade (#270): with no fresh vector there is
+  // nothing to ask the index with, and querying on the stale one would place the
+  // entry by the text it no longer contains.
+  if (reembedded?.values) {
+    try {
+      await inferEdgesOnWrite(id, await neighborsFromVectorQuery(reembedded.values, env), env);
+    } catch (e) {
+      console.error("Update auto-link failed (non-fatal):", e);
     }
   }
 
@@ -272,7 +303,7 @@ export async function appendToEntry(
   const refreshedTags = volatility ? withVolatility(appendedTags, volatility) : appendedTags;
 
   if (newContent.length > CHUNK_MAX_CHARS) {
-    const newVectorIds = await reembedOrDegrade(env, id, newContent, tags, source, config, embedCtx);
+    const newVectorIds = (await reembedOrDegrade(env, id, newContent, tags, source, config, embedCtx))?.vectorIds ?? null;
     const now = Date.now();
 
     // Both commits below are new logical versions (rewritten body, fresh index) that

--- a/src/graph/edges.ts
+++ b/src/graph/edges.ts
@@ -1,6 +1,7 @@
-import type { MemoryKind } from "../memory/kind";
+import { getKind, type MemoryKind } from "../memory/kind";
 import type { Env } from "../env";
 import { EDGE_TYPES, type EdgeProvenance, type EdgeType } from "./types";
+import { MIRRORED_SOURCES } from "../constants";
 
 const DEFAULT_EDGE_WEIGHT = 0.5;
 
@@ -46,6 +47,64 @@ export function allowedKindsFor(type: EdgeType): readonly MemoryKind[] | null {
 }
 
 /**
+ * Does a pair of memory kinds satisfy an edge type's `allowedKinds`?
+ *
+ * One gate for every writer — POST /link, the MCP link tool, capture-time
+ * `follows` and the insight pass — because a type whose meaning depends on the
+ * kinds it joins is only as good as the least careful writer.
+ *
+ * An unknown kind is refused rather than waved through: `null` means the
+ * classifier has not spoken yet, which is not evidence the pair qualifies.
+ * Types with no constraint (`allowedKinds: null`) accept anything, unknown
+ * included.
+ */
+export function kindsAllowEdge(
+  type: EdgeType,
+  sourceKind: MemoryKind | null,
+  targetKind: MemoryKind | null,
+): boolean {
+  const allowed = allowedKindsFor(type);
+  if (!allowed) return true;
+  if (sourceKind === null || targetKind === null) return false;
+  return allowed.includes(sourceKind) && allowed.includes(targetKind);
+}
+
+/**
+ * How close two episodic captures must sit to read as one train of thought.
+ *
+ * A module constant and deliberately NOT config: it is a claim about how people
+ * write, not a deployment knob, and every brain that tuned it separately would
+ * make `follows` mean something different per brain — which is exactly what the
+ * type exists to stop. Start at 30 minutes; GET /stats/graph?deep=1 reports the
+ * real gap distribution, which is what should move it.
+ */
+export const GRAPH_FOLLOWS_WINDOW_MS = 30 * 60_000;
+
+/**
+ * What POST /link and the MCP `link` tool both say when the two memories' kinds
+ * do not permit the requested type. One sentence in one place, for the same
+ * parity reason as CROSS_WORKSPACE_LINK_MESSAGE: the two surfaces are one
+ * operation and must not drift.
+ *
+ * It names the fix, because "not allowed" alone leaves the caller guessing —
+ * an unclassified memory looks identical to a wrongly-classified one from
+ * outside.
+ */
+export function kindMismatchMessage(type: EdgeType): string {
+  const allowed = allowedKindsFor(type)?.join(" or ") ?? "";
+  return `${edgeLabel(type)} links only ${allowed} memories — both entries must be classified ${allowed} first`;
+}
+
+/** The kind on an entry row whose `tags` column was projected, or null. */
+export function kindOfRow(row: { tags?: string | null }): MemoryKind | null {
+  try {
+    return getKind(JSON.parse(row.tags ?? "[]"));
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The INSERT createEdge issues, prepared and bound but not run — so a caller
  * with several edges to write can hand them all to env.DB.batch(...) as one
  * subrequest instead of paying one subrequest per createEdge call.
@@ -62,7 +121,20 @@ export function edgeInsertStatement(
   sourceId: string,
   targetId: string,
   type: string,
-  opts: { weight?: number; provenance?: EdgeProvenance; metadata?: Record<string, unknown>; created_at?: number; workspaceId?: string },
+  opts: {
+    weight?: number; provenance?: EdgeProvenance; metadata?: Record<string, unknown>;
+    created_at?: number; workspaceId?: string;
+    /**
+     * Write nothing if the pair already carries an edge of any type other than
+     * relates_to. For the GENERIC edge only: a typed edge is the more specific
+     * statement, and laying an undirected relates_to beside it says less about
+     * the same pair while competing with it for the fanout cap.
+     *
+     * Expressed in the statement rather than as a lookup, so it costs no
+     * additional D1 call — the whole reason edge writes are batched.
+     */
+    onlyIfNoTypedEdge?: boolean;
+  },
   env: Env,
 ): D1PreparedStatement | null {
   if (!isValidEdgeType(type)) return null;
@@ -78,11 +150,29 @@ export function edgeInsertStatement(
   const now = Date.now();
   const createdAt = opts.created_at ?? now;
 
+  const values = [crypto.randomUUID(), source, target, type, weight, provenance, metadata, createdAt, now, opts.workspaceId ?? ""];
+
+  if (opts.onlyIfNoTypedEdge) {
+    // INSERT ... SELECT rather than VALUES, because only the SELECT form takes a
+    // WHERE. SQLite needs that WHERE for the upsert clause to parse unambiguously
+    // after a SELECT, which this has.
+    return env.DB.prepare(
+      // scope-exempt: by-id: the guard reads only the pair being written, whose endpoints the caller has already workspace-checked
+      `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at, workspace_id)
+       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+       WHERE NOT EXISTS (
+         SELECT 1 FROM edges g
+         WHERE ((g.source_id = ? AND g.target_id = ?) OR (g.source_id = ? AND g.target_id = ?))
+           AND g.type <> 'relates_to')
+       ON CONFLICT(source_id, target_id, type) DO UPDATE SET weight = max(weight, excluded.weight), updated_at = excluded.updated_at`
+    ).bind(...values, source, target, target, source);
+  }
+
   return env.DB.prepare(
     `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at, workspace_id)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(source_id, target_id, type) DO UPDATE SET weight = max(weight, excluded.weight), updated_at = excluded.updated_at`
-  ).bind(crypto.randomUUID(), source, target, type, weight, provenance, metadata, createdAt, now, opts.workspaceId ?? "");
+  ).bind(...values);
 }
 
 export async function createEdge(
@@ -127,9 +217,13 @@ export async function inferEdgesOnWrite(
   newId: string,
   neighbors: { id: string; score: number }[],
   env: Env,
+  opts: { suppressId?: string; newKind?: MemoryKind | null } = {},
 ): Promise<void> {
+  // `suppressId` is the entry capture already flagged this one as a duplicate
+  // of. It is the highest-scoring neighbour by construction, so left alone it
+  // takes an inference slot to record what the duplicate-candidate tag says.
   const top = neighbors
-    .filter(n => n.id !== newId && n.score >= EDGE_INFER_THRESHOLD)
+    .filter(n => n.id !== newId && n.id !== opts.suppressId && n.score >= EDGE_INFER_THRESHOLD)
     .sort((a, b) => b.score - a.score)
     .slice(0, EDGE_INFER_MAX);
   if (!top.length) return;
@@ -146,10 +240,71 @@ export async function inferEdgesOnWrite(
   const ids = [newId, ...top.map(n => n.id)];
   const { results } = await env.DB.prepare(
     // scope-exempt: by-id: reads each endpoint's own workspace, to stamp the edge with the source's and to refuse a pair whose workspaces disagree
-    `SELECT id, workspace_id FROM entries WHERE id IN (${ids.map(() => "?").join(", ")})`
-  ).bind(...ids).all() as { results: { id: string; workspace_id: string | null }[] };
+    `SELECT id, workspace_id, tags, created_at, source FROM entries WHERE id IN (${ids.map(() => "?").join(", ")})`
+  ).bind(...ids).all() as { results: { id: string; workspace_id: string | null; tags: string | null; created_at: number | null; source: string | null }[] };
   const workspaceById = new Map(results.map(r => [r.id, r.workspace_id ?? ""]));
   const workspaceId = workspaceById.get(newId) ?? "";
+  const statements: D1PreparedStatement[] = [];
+
+  // tags and created_at ride along on the statement above rather than costing a
+  // second read: the neighbour's kind is in its tags, and `follows` needs both
+  // ends' timestamps to know which way it points.
+  const kindById = new Map(results.map(r => {
+    let tags: string[] = [];
+    try { tags = JSON.parse(r.tags ?? "[]"); } catch { tags = []; }
+    return [r.id, getKind(tags)];
+  }));
+  const createdAtById = new Map(results.map(r => [r.id, r.created_at]));
+  const sourceById = new Map(results.map(r => [r.id, r.source ?? ""]));
+
+  /**
+   * The kind the `follows` gate reads.
+   *
+   * The caller passes one only on the capture path, where the classifier has
+   * just run and `null` is a real answer meaning classification failed — so an
+   * explicit null is honoured rather than second-guessed from the tags. Every
+   * other caller (the nightly backfill, the update path, the append path) passes
+   * nothing, and for those the row's own classifier kind is already in hand from
+   * the SELECT above. Without this fallback those three paths could never type
+   * an edge at all, which matters because a Vectorize write is not immediately
+   * queryable: the predecessor written moments ago is often invisible to capture
+   * and only ever seen by the backfill.
+   */
+  const newKind = opts.newKind !== undefined ? opts.newKind : (kindById.get(newId) ?? null);
+
+  /**
+   * A mirrored record is a mailbox or calendar entry, not a thought someone had
+   * next. An import writes dozens of them minutes apart, and typing those as
+   * `follows` would describe the order the mailbox synced — the shape of a bulk
+   * write, which is the artefact the burst guard already refuses by another
+   * route. Cheap to exclude: the source is on the row the workspace check reads.
+   */
+  const mirrored = (id: string) => MIRRORED_SOURCES.has(sourceById.get(id) ?? "");
+
+  const newCreatedAt = createdAtById.get(newId) ?? null;
+  // Absent from the read means the entry does not exist, which is refused
+  // below — so an unknown neighbour is not "same workspace" either.
+  const sameWorkspace = (id: string) => workspaceById.get(id) === workspaceId;
+  /** Strictly earlier than the new entry, and close enough to be one thought. */
+  const precedesInWindow = (id: string) => {
+    const at = createdAtById.get(id);
+    if (newCreatedAt === null || at === null || at === undefined) return false;
+    const gap = newCreatedAt - at;
+    return gap > 0 && gap <= GRAPH_FOLLOWS_WINDOW_MS;
+  };
+
+  // The burst guard. A bulk import or a chunked transcript writes many episodic
+  // entries at once, and each would "follow" the last — a chain that records the
+  // shape of the write rather than the thinking. So `follows` is claimed only
+  // when exactly one candidate qualifies. Measured over the neighbours that were
+  // going to be linked anyway, which costs nothing; it is not a general check
+  // for "what else was written in this window", which would need its own read.
+  const qualifying = mirrored(newId) ? [] : top.filter(n =>
+    sameWorkspace(n.id)
+    && !mirrored(n.id)
+    && kindsAllowEdge("follows", newKind, kindById.get(n.id) ?? null)
+    && precedesInWindow(n.id));
+  const followsTarget = qualifying.length === 1 ? qualifying[0].id : null;
 
   for (const n of top) {
     // Two different members' private entries are never linked, whatever the
@@ -174,25 +329,57 @@ export async function inferEdgesOnWrite(
     // `entries`, the authoritative source, never from vector metadata — is the
     // only thing that makes the invariant true.
     //
-    // A neighbour with no `entries` row at all — a vector whose entry has since
-    // been forgotten — is NOT refused here. It has no workspace to disagree
-    // with, so it is not the case this check is about, and narrowing that too
-    // would change what the pass does for a reason unrelated to tenancy.
+    // A neighbour with no `entries` row at all — a vector that outlived the
+    // entry it indexed — is refused here too, which it did NOT used to be.
     //
-    // The edge it produces is inert FOR READS, which is not the same as inert:
-    // every graph read hydrates both endpoints through the caller's scope and
-    // drops the ones that are missing, so nothing can be reached through it
-    // today. But a dangling id is not permanently dangling — src/entries/import.ts
-    // accepts caller-supplied entry ids, so a later import can create a row with
-    // that id in ANOTHER workspace and turn this into a live crossing edge that
-    // an audit query over `edges` would find. Low reachability, and the read
-    // paths still contain it, but it is a row that can become wrong rather than
-    // one that is harmless.
+    // The edge such a neighbour produces is unreachable: every graph read
+    // hydrates both endpoints through the caller's scope and drops what is
+    // missing. It was tolerated on the grounds that it changed nothing. It does
+    // now, in two ways:
     //
-    // Within one workspace nothing changes at all, which is every pair on a
-    // solo brain.
-    const neighborWorkspace = workspaceById.get(n.id);
-    if (neighborWorkspace !== undefined && neighborWorkspace !== workspaceId) continue;
-    await createEdge(newId, n.id, "relates_to", { weight: n.score, provenance: "inferred", workspaceId }, env);
+    //   - the nightly sweep (src/graph/pass.ts) deletes inferred edges with a
+    //     missing endpoint, which makes the source edgeless, which returns it to
+    //     the backfill's slate, which draws the same edge again. Left alone the
+    //     two passes trade the same row back and forth every night, spending an
+    //     embed, a Vectorize query and one of 25 backfill slots each time;
+    //   - a dangling id is not permanently dangling. src/entries/import.ts
+    //     accepts caller-supplied ids, so a later import can create a row with
+    //     that id in ANOTHER workspace and turn this into a live crossing edge.
+    //
+    // Refusing costs nothing: the absence is already visible in the endpoint
+    // read above. Within one workspace nothing else changes, which is every pair
+    // on a solo brain.
+    if (workspaceById.get(n.id) !== workspaceId) continue;
+
+    if (n.id === followsTarget) {
+      // Typed replaces generic: an earlier pass may already have drawn the
+      // undirected relates_to this edge supersedes. Only the INFERRED one goes
+      // — a relates_to the user drew themselves is a statement, not a guess.
+      //
+      // Ordered immediately before the insert in the same batch, because the
+      // two are one replacement: issued as separate calls, a failure between
+      // them leaves the pair with no edge at all, which is worse than either
+      // the old edge or the new one.
+      statements.push(env.DB.prepare(
+        // scope-exempt: by-id: the pair whose typed edge is being written, both endpoints already workspace-checked above
+        `DELETE FROM edges
+         WHERE ((source_id = ? AND target_id = ?) OR (source_id = ? AND target_id = ?))
+           AND type = 'relates_to' AND provenance = 'inferred'`,
+      ).bind(newId, n.id, n.id, newId));
+      const typed = edgeInsertStatement(newId, n.id, "follows", { weight: n.score, provenance: "inferred", workspaceId }, env);
+      if (typed) statements.push(typed);
+      continue;
+    }
+
+    // Guarded: a later write touching a pair that already has a typed edge —
+    // an edit, an append, the nightly backfill — falls to this branch outside
+    // the follows window and would otherwise stack relates_to on top of it.
+    const generic = edgeInsertStatement(newId, n.id, "relates_to", { weight: n.score, provenance: "inferred", workspaceId, onlyIfNoTypedEdge: true }, env);
+    if (generic) statements.push(generic);
   }
+
+  // One call for every edge this write produces. Capture spends most of a
+  // Worker's 50-subrequest budget embedding chunks before it ever gets here, so
+  // a call per edge is what puts a large multi-chunk capture over the line.
+  if (statements.length) await env.DB.batch(statements);
 }

--- a/src/graph/pass.ts
+++ b/src/graph/pass.ts
@@ -5,6 +5,12 @@ import { embed } from "../lib/ai";
 import { inferEdgesOnWrite } from "./edges";
 
 const GRAPH_PASS_BACKFILL_LIMIT = 25;
+
+/**
+ * The UTC weekday the dangling sweep runs on: Sunday. See the gate below for
+ * why it is a weekday rather than a cron trigger of its own.
+ */
+const GRAPH_SWEEP_WEEKDAY_UTC = 0;
 const EDGE_PRUNE_WEIGHT = 0.3;
 const EDGE_PRUNE_MIN_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -34,6 +40,47 @@ export async function runGraphPass(
     console.error("Graph prune failed (non-fatal):", e);
   }
 
+  // WEEKLY, not nightly. The sweep is a full scan of `edges` with two correlated
+  // endpoint lookups per inferred row, and it is the one scheduled full edge
+  // scan in the deployment — the cost GET /stats/graph refuses to let an
+  // operator schedule.
+  //
+  // Expressed as a weekday gate inside the nightly pass rather than as its own
+  // trigger because the free plan allows five cron schedules and all five are
+  // spoken for (see wrangler.jsonc, which says so explicitly). Gating on the day
+  // costs no query; a "last swept at" timestamp would spend a read every night
+  // to save a scan on six of them.
+  //
+  // Weekly is enough because inference no longer CREATES these rows: it refuses
+  // a neighbour missing from its endpoint read, so the sweep now clears
+  // historical rows and the occasional failed vector cascade rather than a
+  // steady stream. A missed Sunday defers idempotent cleanup by a week, which is
+  // not worth a state table to prevent.
+  if (new Date(Date.now()).getUTCDay() === GRAPH_SWEEP_WEEKDAY_UTC) {
+    try {
+      // Edges that outlived the entry they point at. Inert for reads today —
+      // every walk hydrates both endpoints and drops what is missing — but not
+      // permanently harmless: src/entries/import.ts accepts caller-supplied ids,
+      // so a later import can create a row with that id in ANOTHER workspace and
+      // turn a dead edge into a live crossing one.
+      //
+      // Inferred only. An explicit link pointing at a forgotten entry is
+      // something a person asserted, and deleting it silently would lose it;
+      // GET /stats/graph?deep=1 reports those instead.
+      await env.DB.prepare(
+        // scope-exempt: cron: sweep of inferred edges with a missing endpoint, deployment-wide by design
+        `DELETE FROM edges
+         WHERE provenance = 'inferred'
+           AND (NOT EXISTS (SELECT 1 FROM entries WHERE entries.id = edges.source_id)
+             OR NOT EXISTS (SELECT 1 FROM entries WHERE entries.id = edges.target_id))`
+      ).run();
+    } catch (e) {
+      // Its own sentence: this used to report a prune failure, which sends
+      // anyone reading the logs to the wrong statement.
+      console.error("Graph dangling sweep failed (non-fatal):", e);
+    }
+  }
+
   let unlinked: { id: string; content: string }[] = [];
   try {
     const sliceSql = workspaceId != null ? `\n         AND workspace_id = ?` : "";
@@ -41,7 +88,8 @@ export async function runGraphPass(
       // scope-exempt: cron: nightly backfill, narrowed by the workspace slice in sliceSql
       `SELECT id, content FROM entries
        WHERE id NOT IN (SELECT source_id FROM edges) AND id NOT IN (SELECT target_id FROM edges)
-         AND tags NOT LIKE '%"status:deprecated"%'${sliceSql}
+         AND tags NOT LIKE '%"status:deprecated"%'
+         AND tags NOT LIKE '%"duplicate-candidate"%'${sliceSql}
        ORDER BY created_at DESC LIMIT ${GRAPH_PASS_BACKFILL_LIMIT}`
     );
     const { results } = await (workspaceId != null ? stmt.bind(workspaceId) : stmt)

--- a/src/insight/reason.ts
+++ b/src/insight/reason.ts
@@ -46,9 +46,73 @@ export interface ReasonedInsight {
  * marked rejected forever. See src/insight/weekly.ts.
  */
 export type ReasonOutcome =
-  | { outcome: "insight"; shape: InsightShape; text: string }
-  | { outcome: "declined" }
+  | { outcome: "insight"; shape: InsightShape; text: string; relationship?: TypedRelationship }
+  | { outcome: "declined"; relationship?: TypedRelationship }
   | { outcome: "failed" };
+
+/** How the model says the pair relates, and which side the edge points FROM. */
+export interface TypedRelationship {
+  type: "caused_by" | "decided" | "follows";
+  source: "A" | "B";
+}
+
+/**
+ * The types the insight call is allowed to propose.
+ *
+ * `supersedes` is deliberately absent though it is a real edge type. It is
+ * welded to deprecation semantics — the thing it points at is treated as
+ * retired — and a model volunteering it here would retire a memory nobody
+ * asked to retire, from a call whose actual job was to write a sentence.
+ */
+const RELATIONSHIP_TYPES: ReadonlySet<string> = new Set(["caused_by", "decided", "follows"]);
+
+/**
+ * The relationship verdict, read independently of whether an insight survived.
+ *
+ * Parsed from the raw response rather than from parseInsightResponse's result,
+ * because that function returns null for everything that is not a publishable
+ * insight — which is most calls. The model had to decide how the pair relates
+ * in order to answer at all, and that verdict is just as good on a response
+ * that declined.
+ */
+/** Whether the response carries a JSON object that actually parses. */
+function isReadableJsonObject(raw: string): boolean {
+  const match = raw.match(/\{[\s\S]*\}/);
+  if (!match) return false;
+  try {
+    JSON.parse(match[0]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function parseRelationship(raw: string): TypedRelationship | null {
+  const match = raw.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(match[0]);
+  } catch {
+    return null;
+  }
+
+  const type = String(parsed.relationship ?? "");
+  if (!RELATIONSHIP_TYPES.has(type)) return null;
+
+  // No direction, no edge: a typed edge pointing the wrong way is worse than
+  // the generic one it would replace. Both ends are required and they must
+  // disagree — a response naming one memory as both source and target has not
+  // committed to a direction, and reading `source` alone would invent one.
+  const source = String(parsed.source ?? "").toUpperCase();
+  const target = String(parsed.target ?? "").toUpperCase();
+  if (source !== "A" && source !== "B") return null;
+  if (target !== "A" && target !== "B") return null;
+  if (source === target) return null;
+
+  return { type: type as TypedRelationship["type"], source };
+}
 
 const SHAPES: ReadonlySet<string> = new Set(["contradiction", "throughline", "connection"]);
 
@@ -280,7 +344,22 @@ The shape is one of:
 Write in the second person, plainly, in one or two sentences. Do not begin with a set phrase. Do not hedge.
 
 Respond with JSON only. No text outside the JSON object.
-{"insight": false} OR {"insight": true, "shape": "<shape>", "text": "<the insight>"}`;
+{"insight": false} OR {"insight": true, "shape": "<shape>", "text": "<the insight>"}
+
+Then, in that same JSON object and whichever of those you answered, say how the two memories relate.
+
+Read every type as one sentence: SOURCE <relationship> TARGET. Getting source and target the right way round matters as much as picking the type.
+
+- "caused_by" — SOURCE happened BECAUSE OF TARGET. The target is the cause, the source is the consequence. If A is a pricing review and B is a cancellation that happened because of it, then source is B and target is A.
+- "decided" — SOURCE is the decision; TARGET carries it out or reflects it. If A records choosing a vendor and B is the signed contract, then source is A and target is B.
+- "follows" — SOURCE came AFTER TARGET in the same line of thought. If A is the earlier note and B the later one, then source is B and target is A.
+- "none" — none of the three fits.
+
+"relationship": one of "caused_by", "decided", "follows", "none".
+"source": "A" or "B" — the memory the sentence starts with.
+"target": "A" or "B" — the other one. It must not be the same as source.
+
+Answer this even when you answered {"insight": false}. If none of the three fit, say "none" and omit source and target.`;
 
   let raw = "";
   try {
@@ -304,14 +383,26 @@ Respond with JSON only. No text outside the JSON object.
     return { outcome: "failed" };
   }
 
+  // A response with no JSON object in it at all — prose, or an object truncated
+  // before its closing brace — is not a judgement to record. `declined` marks
+  // the candidate rejected permanently and re-accrual cannot resurrect it, so a
+  // model that ran out of tokens mid-answer would cost the pair forever. Left
+  // `failed`, exactly like a thrown call: nothing was decided, so it stays
+  // pending and can be asked again.
+  if (!isReadableJsonObject(raw)) return { outcome: "failed" };
+
+  // Read before the insight gate: a decline is still an answer to this.
+  const relationship = parseRelationship(raw) ?? undefined;
+  const declined = (): ReasonOutcome => ({ outcome: "declined", ...(relationship && { relationship }) });
+
   const parsed = parseInsightResponse(raw);
-  if (!parsed) return { outcome: "declined" };
+  if (!parsed) return declined();
 
   // The mechanical floor. A real insight draws on vocabulary particular to
   // each side, not just what they share, and doesn't reach for the stock
   // phrases that mean the model gave up and restated the pair instead.
-  if (isRestatementFraming(parsed.text)) return { outcome: "declined" };
-  if (!sharesVocabulary(parsed.text, first, second)) return { outcome: "declined" };
+  if (isRestatementFraming(parsed.text)) return declined();
+  if (!sharesVocabulary(parsed.text, first, second)) return declined();
 
-  return { outcome: "insight", shape: parsed.shape, text: parsed.text };
+  return { outcome: "insight", shape: parsed.shape, text: parsed.text, ...(relationship && { relationship }) };
 }

--- a/src/insight/weekly.ts
+++ b/src/insight/weekly.ts
@@ -15,9 +15,57 @@ import { initializeDatabase } from "../db/init";
 import { captureEntry } from "../capture/entry";
 import { reasonOverPair, restatesRecent } from "./reason";
 import { PENDING_INSIGHT_SQL, WRITTEN_INSIGHT_SQL } from "../memory/patterns";
-import { edgeInsertStatement } from "../graph/edges";
+import { edgeInsertStatement, kindsAllowEdge } from "../graph/edges";
+import { getKind } from "../memory/kind";
+import type { TypedRelationship } from "./reason";
 import { isEligiblePair, parseTags } from "./candidates";
 import { D1_MAX_BOUND_PARAMS } from "../constants";
+
+/**
+ * Weight for an edge the reasoning model proposed.
+ *
+ * Below an explicit link (1.0) and above ordinary vector inference (<=0.85):
+ * a model that read both memories in full is better evidence than cosine
+ * similarity, and worse evidence than a person saying so.
+ */
+const INSIGHT_EDGE_WEIGHT = 0.75;
+
+/**
+ * The typed edge a relationship verdict describes, or null when it may not be
+ * drawn at all.
+ *
+ * Direction for `follows` comes from `created_at` and never from the model:
+ * the prompt does not show it timestamps, so it cannot know which memory came
+ * first, and the candidate row's own a_id/b_id ordering is lexicographic on a
+ * UUID. Taking the ordering from the ids would produce a `follows` chain
+ * pointing whichever way the random ids happened to sort.
+ *
+ * `caused_by` and `decided` keep the model's answer, because for those the
+ * direction is a claim about meaning rather than about time.
+ */
+function typedEdgeFor(
+  candidate: CandidateRow,
+  relationship: TypedRelationship,
+  workspaceId: string,
+): { sourceId: string; targetId: string; type: TypedRelationship["type"]; workspaceId: string } | null {
+  const aKind = getKind(parseTags(candidate.a_tags));
+  const bKind = getKind(parseTags(candidate.b_tags));
+
+  const sourceIsA = relationship.type === "follows"
+    ? candidate.a_created_at > candidate.b_created_at
+    : relationship.source === "A";
+
+  const [sourceId, targetId] = sourceIsA
+    ? [candidate.a_id, candidate.b_id]
+    : [candidate.b_id, candidate.a_id];
+  const [sourceKind, targetKind] = sourceIsA ? [aKind, bKind] : [bKind, aKind];
+
+  // The same gate POST /link and capture-time inference use. An unclassified
+  // memory is refused for a kind-constrained type rather than assumed to fit.
+  if (!kindsAllowEdge(relationship.type, sourceKind, targetKind)) return null;
+
+  return { sourceId, targetId, type: relationship.type, workspaceId };
+}
 
 /** Pairs considered per run. Each costs one model call. */
 export const WEEKLY_CANDIDATE_LIMIT = 10;
@@ -71,6 +119,8 @@ interface CandidateRow {
   b_content: string;
   a_tags: string;
   b_tags: string;
+  a_created_at: number;
+  b_created_at: number;
   a_workspace_id: string;
   b_workspace_id: string;
 }
@@ -194,6 +244,7 @@ export async function runWeeklyInsights(
         // scope-exempt: cron: no caller to scope to. Both workspaces are projected, and the loop below compares them BEFORE the pair reaches the model: a candidate whose two entries sit in different workspaces is skipped and settled, never reasoned over and never written anywhere. Accrual refuses to pair across workspaces (candidates.ts), so that only fires for pre-tenancy candidate rows. sliceClause is optionally present and is a list of workspace IDS read from the `workspaces` table (companyWorkspaceIds, below), never from a request — it narrows this cron's slate, it does not scope it to a caller, and there is no caller to scope to on either invocation
         `SELECT c.id, c.score, c.a_id, c.b_id, a.content AS a_content, b.content AS b_content,
                 a.tags AS a_tags, b.tags AS b_tags,
+                a.created_at AS a_created_at, b.created_at AS b_created_at,
                 a.workspace_id AS a_workspace_id, b.workspace_id AS b_workspace_id
          FROM insight_candidates c
          JOIN entries a ON a.id = c.a_id
@@ -322,6 +373,9 @@ export async function runWeeklyInsights(
     // keeps the whole batch's statements prepared together — which is what
     // lets it join the status updates as a single subrequest.
     const drawnFromPairs: { insightId: string; targetId: string; workspaceId: string }[] = [];
+    // Typed edges the reasoning produced. Collected rather than written in the
+    // loop for the same reason drawnFromPairs is: one batch, one subrequest.
+    const typedEdges: { sourceId: string; targetId: string; type: TypedRelationship["type"]; workspaceId: string }[] = [];
     // Texts to compare a new proposal against, PER WORKSPACE: the insights that
     // workspace has already been given, plus (appended below) whatever this run
     // itself writes into it. Two different candidate pairs — in this run, or one
@@ -421,6 +475,16 @@ export async function runWeeklyInsights(
       // second chance is by never having been marked settled in the first
       // place.
       if (result.outcome === "failed") continue;
+
+      // Read before the decline is handled, and deliberately so. Declining to
+      // write a publishable sentence is not the same as having no view on how
+      // the pair relates, and declines are the common outcome — typing only the
+      // accepted ones would forfeit most of what this call already paid for.
+      if (result.relationship) {
+        const typed = typedEdgeFor(candidate, result.relationship, insightWorkspace);
+        if (typed) typedEdges.push(typed);
+      }
+
       if (result.outcome === "declined") {
         rejected.push(candidate.id);
         continue;
@@ -484,6 +548,59 @@ export async function runWeeklyInsights(
         .map(({ insightId, targetId, workspaceId }) => edgeInsertStatement(
           insightId, targetId, "drawn_from", { provenance: "system", weight: 1, workspaceId }, env,
         ))
+        .filter((stmt): stmt is D1PreparedStatement => stmt !== null),
+      ...typedEdges
+        .flatMap(({ sourceId, targetId, type, workspaceId }) => [
+          // Ordered insert -> inherit -> delete, and all three in this one batch.
+          //
+          // The generic edge has to still exist when the weight is read, which
+          // is why the DELETE comes last rather than first.
+          edgeInsertStatement(sourceId, targetId, type, {
+            provenance: "system", weight: INSIGHT_EDGE_WEIGHT,
+            metadata: { via: "insight-reasoning" }, workspaceId,
+          }, env),
+          // WEIGHTS ARE HIGH-WATER MARKS, and this step propagates that into
+          // typed edges. `max(weight, excluded.weight)` on the upsert (which
+          // predates this work) means a pair that once scored 0.90 keeps 0.90
+          // even after the content is rewritten and re-inference scores it 0.79;
+          // inheriting carries that figure onto the typed edge, and nothing ever
+          // lowers it — the nightly prune's `weight < 0.3` cannot match an
+          // inferred edge, whose floor is 0.78.
+          //
+          // Taken deliberately as the lesser of two errors. Weight here decides
+          // ORDERING under a fanout cap, not truth; an overstated ordering hint
+          // keeps a historically-strong pair reachable, whereas NOT inheriting
+          // drops a 0.85 pair to 0.75 and can push it out of the cap entirely —
+          // losing the memory rather than mis-ranking it. Letting the update
+          // path SET rather than MAX its inferred weight would fix the drift at
+          // the source; that is a change to pre-existing upsert semantics and is
+          // left as follow-up.
+          //
+          // Inherit the retired edge's weight when it was stronger. Inferred
+          // edges exist only at EDGE_INFER_THRESHOLD (0.78) and above, so the
+          // flat INSIGHT_EDGE_WEIGHT is BELOW every generic edge this replaces
+          // — and graph expansion sorts by weight under a per-node fanout cap.
+          // Without this, replacing a 0.85 edge with a 0.75 one can push a
+          // neighbour past the cap and make a reachable memory unreachable,
+          // which is the opposite of what typing it was for.
+          env.DB.prepare(
+            // scope-exempt: cron: by-id pair, both endpoints already confirmed to share one workspace before the pair reached the model
+            `UPDATE edges
+             SET weight = max(weight, COALESCE((
+                   SELECT MAX(g.weight) FROM edges g
+                   WHERE ((g.source_id = ? AND g.target_id = ?) OR (g.source_id = ? AND g.target_id = ?))
+                     AND g.type = 'relates_to' AND g.provenance = 'inferred'), 0))
+             WHERE source_id = ? AND target_id = ? AND type = ?`,
+          ).bind(sourceId, targetId, targetId, sourceId, sourceId, targetId, type),
+          // Typed replaces generic, and only the INFERRED generic: a relates_to
+          // the person drew themselves is a statement, not a guess this supersedes.
+          env.DB.prepare(
+            // scope-exempt: cron: by-id pair, both endpoints already confirmed to share one workspace before the pair reached the model
+            `DELETE FROM edges
+             WHERE ((source_id = ? AND target_id = ?) OR (source_id = ? AND target_id = ?))
+               AND type = 'relates_to' AND provenance = 'inferred'`,
+          ).bind(sourceId, targetId, targetId, sourceId),
+        ])
         .filter((stmt): stmt is D1PreparedStatement => stmt !== null),
     ];
     if (statements.length) await env.DB.batch(statements);

--- a/src/integrations/mirror.ts
+++ b/src/integrations/mirror.ts
@@ -98,7 +98,7 @@ export function makeMirrorStore(env: Env, writeCtx: WriteContext = OWNER_WRITE_C
       const cfg = await config();
       let newVectorIds: string[] = [];
       try {
-        newVectorIds = await storeEntry(env, id, content, refreshedTags, row.source as string, now, cfg, writeCtx);
+        newVectorIds = (await storeEntry(env, id, content, refreshedTags, row.source as string, now, cfg, writeCtx)).vectorIds;
       } catch (e) {
         console.error("Vectorize re-embed failed (non-fatal):", e);
       }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -9,7 +9,7 @@ import { applyStatus, forgetEntry } from "../capture/lifecycle";
 import { moveEntry, restampVectorWorkspace } from "../capture/share";
 import { auditEvent } from "../lib/audit";
 import { lookupActorLabels, resolveActorFilter, resolveActorLabel } from "../lib/actors";
-import { createEdge, deleteEdge, edgeLabel, CROSS_WORKSPACE_LINK_MESSAGE } from "../graph/edges";
+import { createEdge, deleteEdge, edgeLabel, isValidEdgeType, kindMismatchMessage, kindOfRow, kindsAllowEdge, CROSS_WORKSPACE_LINK_MESSAGE } from "../graph/edges";
 import { EDGE_TYPES } from "../graph/types";
 import { getConnections } from "../graph/traverse";
 import type { Identity } from "../lib/identity";
@@ -678,17 +678,30 @@ export function buildMcpServer(env: Env, ctx: ExecutionContext, identity?: Ident
       inputSchema: {
         source_id: z.string().describe("Source entry ID"),
         target_id: z.string().describe("Target entry ID"),
-        type: z.enum(Object.keys(EDGE_TYPES) as [string, ...string[]]).default("relates_to").describe("Relationship type"),
+        type: z.enum(Object.keys(EDGE_TYPES) as [string, ...string[]]).default("relates_to").describe(
+          "How the memories relate, read as: SOURCE <type> TARGET. Direction is not cosmetic — source_id is the end the arrow points FROM. "
+          + "relates_to: they belong together, no direction implied (the default; use it when unsure). "
+          + "caused_by: the source happened BECAUSE of the target. "
+          + "decided: the source is a decision the target carries out or reflects; both memories must be episodic. "
+          + "follows: the source came AFTER the target in the same line of thought; both memories must be episodic. "
+          + "supersedes: the source replaces the target, and the target is treated as deprecated — use only when the older memory is genuinely wrong now. "
+          + "drawn_from: the source was derived from the target, as an insight is from its sources.",
+        ),
       },
     },
     async ({ source_id, target_id, type }) => {
-      const source = await getReadableEntry(env, identity, source_id);
+      // tags ride along on the reads this tool already makes, for the kind gate below.
+      const source = await getReadableEntry(env, identity, source_id, "id, workspace_id, actor_id, tags");
       if (!source) return { content: [{ type: "text", text: `No entry found with ID: ${source_id}` }] };
-      const target = await getReadableEntry(env, identity, target_id);
+      const target = await getReadableEntry(env, identity, target_id, "id, workspace_id, actor_id, tags");
       if (!target) return { content: [{ type: "text", text: `No entry found with ID: ${target_id}` }] };
       // Same rule and same sentence as POST /link — see CROSS_WORKSPACE_LINK_MESSAGE.
       if (source.workspace_id !== target.workspace_id) {
         return { content: [{ type: "text", text: CROSS_WORKSPACE_LINK_MESSAGE }] };
+      }
+      // Same gate as POST /link, same sentence — see kindMismatchMessage.
+      if (isValidEdgeType(type) && !kindsAllowEdge(type, kindOfRow(source), kindOfRow(target))) {
+        return { content: [{ type: "text", text: kindMismatchMessage(type) }] };
       }
 
       const edge = await createEdge(source_id, target_id, type, { provenance: "explicit", weight: 1.0, workspaceId: source.workspace_id }, env);

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -37,6 +37,9 @@ import { createMember, listMembers, listRoster, listTeamWorkspaces, lookupAuditN
 // than fixed: three workspaces for an admin would otherwise put a full page at
 // 103 bindings and fail the whole batch.
 
+/** How many nodes the degree ranking returns: a ranking, not a dump of the graph. */
+const GRAPH_STATS_TOP_DEGREE = 20;
+
 export async function handleAdminRoutes(
   request: Request,
   url: URL,
@@ -652,6 +655,118 @@ export async function handleAdminRoutes(
       unvectorized: (summary?.unvectorized as number) ?? 0,
       vectorize_grace_ms: graceMs(env),
       unclassified: (summary?.unclassified as number) ?? 0,
+    });
+  }
+
+  // GET /stats/graph — the edge-quality audit surface. The type histogram is a
+  // single grouped scan and always runs; the endpoint join, the degree ranking
+  // and the capture-gap histogram each cost their own pass over a table, so an
+  // operator polling the cheap half does not pay for them unless ?deep=1.
+  //
+  // ?deep=1 IS A MANUAL AUDIT. DO NOT SCHEDULE OR POLL IT.
+  //
+  // edges has no index on workspace_id, so a deep call is four full scans of
+  // the edge table plus two indexed endpoint seeks per edge — around 5M row
+  // visits at roughly 800k edges, which is D1's entire free daily allowance.
+  // Spending it fails every query on the ACCOUNT, not just this route, until
+  // 00:00 UTC. Run it by hand a few times, not on a timer.
+  //
+  // Indexing edges(workspace_id) would turn the scans into seeks, and was
+  // deliberately NOT taken: it taxes a write on every edge insert against the
+  // 100k/day write budget, to speed up a tool run manually. If this ever does
+  // get polled, cache a rollup then rather than reaching for the index.
+  if (url.pathname === "/stats/graph" && request.method === "GET") {
+    const auth = await requireAdmin(request, env);
+    if (auth instanceof Response) return auth;
+
+    // edges.workspace_id is denormalized from the source entry, so scoping the
+    // edge reads needs no join back to entries.
+    const edgeScope = scopeWhere(auth, undefined, "edges.workspace_id");
+    const typeRows = await env.DB.prepare(
+      `SELECT type, COUNT(*) AS n FROM edges WHERE ${edgeScope.clause} GROUP BY type`,
+    ).bind(...edgeScope.bindings).all();
+    const edgeTypes: Record<string, number> = {};
+    for (const r of typeRows.results as any[]) edgeTypes[r.type as string] = Number(r.n);
+
+    if (url.searchParams.get("deep") !== "1") return json({ ok: true, deep: false, edgeTypes });
+
+    // Edges with an endpoint that is not a live entry OF THE EDGE'S OWN
+    // WORKSPACE.
+    //
+    // Deliberately a SUPERSET of what the nightly sweep removes, so this number
+    // is not expected to reach zero. The sweep deletes only `inferred` edges
+    // whose endpoint has no `entries` row at all; this also counts an explicit
+    // link to a forgotten entry (deleting a link someone stated would lose it)
+    // and an edge whose endpoint exists but in another workspace (corrupt, but
+    // legacy data rather than obviously safe to delete). A reading that GROWS
+    // between sweeps is the signal worth acting on, not a non-zero one.
+    //
+    // Matching on edges.workspace_id rather than on the caller's readable list
+    // does two things. It makes the number mean the same thing for every
+    // caller: scoping the lookup to whoever is asking would count a correct
+    // edge as broken for an admin who cannot read its workspace, and count a
+    // genuinely corrupt cross-workspace edge as fine for one who can. And it
+    // costs no bindings, where repeating the scope list twice more put this
+    // statement at 3x the workspace count — past D1's 100-parameter ceiling for
+    // an admin in ~32 teams, which fails the whole request rather than
+    // degrading.
+    //
+    // It stays scoped for privacy by the outer clause: only edges the caller
+    // may read are counted at all.
+    const invalidEndpoints = await env.DB.prepare(
+      // scope-exempt: the entries reads are existence checks bound to edges.workspace_id, and the outer clause already limits the counted rows to edges the caller may read — so neither can reach or probe for an entry outside the caller's scope
+      `SELECT COUNT(*) AS n FROM edges
+       WHERE ${edgeScope.clause}
+         AND (NOT EXISTS (SELECT 1 FROM entries WHERE entries.id = edges.source_id AND entries.workspace_id = edges.workspace_id)
+           OR NOT EXISTS (SELECT 1 FROM entries WHERE entries.id = edges.target_id AND entries.workspace_id = edges.workspace_id))`,
+    ).bind(...edgeScope.bindings).first() as Record<string, any> | null;
+
+    // Both endpoints count, so a self-edge scores 2 — the same expansion a walk
+    // from that node would see.
+    const degreeRows = await env.DB.prepare(
+      `SELECT id, COUNT(*) AS degree FROM (
+         SELECT source_id AS id FROM edges WHERE ${edgeScope.clause}
+         UNION ALL
+         SELECT target_id AS id FROM edges WHERE ${edgeScope.clause}
+       ) GROUP BY id ORDER BY degree DESC, id ASC LIMIT ${GRAPH_STATS_TOP_DEGREE}`,
+    ).bind(...edgeScope.bindings, ...edgeScope.bindings).all();
+
+    // Bucketed in SQL: one row back however large the brain is. Reads the gap
+    // between consecutive captures, which is what sizes the `follows` window.
+    //
+    // PARTITIONED BY WORKSPACE, because that window is only ever applied within
+    // one: an unpartitioned LAG over a caller who reads three workspaces
+    // interleaves them and reports gaps between captures that no `follows` edge
+    // could ever join, biasing the whole distribution short.
+    const gapScope = scopeWhere(auth);
+    const gaps = await env.DB.prepare(
+      `WITH gaps AS (
+         SELECT created_at - LAG(created_at) OVER (PARTITION BY workspace_id ORDER BY created_at) AS gap
+         FROM entries WHERE ${gapScope.clause}
+       )
+       SELECT SUM(CASE WHEN gap <      300000 THEN 1 ELSE 0 END) AS under5m,
+              SUM(CASE WHEN gap >=     300000 AND gap <    1800000 THEN 1 ELSE 0 END) AS under30m,
+              SUM(CASE WHEN gap >=    1800000 AND gap <    7200000 THEN 1 ELSE 0 END) AS under2h,
+              SUM(CASE WHEN gap >=    7200000 AND gap <   86400000 THEN 1 ELSE 0 END) AS under1d,
+              SUM(CASE WHEN gap >=   86400000 AND gap <  604800000 THEN 1 ELSE 0 END) AS under7d,
+              SUM(CASE WHEN gap >=  604800000 THEN 1 ELSE 0 END) AS older
+       FROM gaps WHERE gap IS NOT NULL`,
+    ).bind(...gapScope.bindings).first() as Record<string, any> | null;
+
+    return json({
+      ok: true,
+      deep: true,
+      edgeTypes,
+      invalidEndpointEdges: Number(invalidEndpoints?.n ?? 0),
+      topDegree: (degreeRows.results as any[]).map(r => ({ id: r.id as string, degree: Number(r.degree) })),
+      gapBuckets: {
+        under5m: Number(gaps?.under5m ?? 0),
+        under30m: Number(gaps?.under30m ?? 0),
+        under2h: Number(gaps?.under2h ?? 0),
+        under1d: Number(gaps?.under1d ?? 0),
+        under7d: Number(gaps?.under7d ?? 0),
+        older: Number(gaps?.older ?? 0),
+      },
     });
   }
 

--- a/src/routes/graph.ts
+++ b/src/routes/graph.ts
@@ -2,7 +2,7 @@ import type { Env } from "../env";
 import { intParam, json, readWorkspaceParam, readTeamQueryParam } from "../lib/http";
 import { getReadableEntry } from "../lib/entry-access";
 import { requireIdentity } from "../lib/identity";
-import { createEdge, deleteEdge, isValidEdgeType, CROSS_WORKSPACE_LINK_MESSAGE } from "../graph/edges";
+import { createEdge, deleteEdge, isValidEdgeType, kindMismatchMessage, kindOfRow, kindsAllowEdge, CROSS_WORKSPACE_LINK_MESSAGE } from "../graph/edges";
 import { EDGE_TYPES } from "../graph/types";
 import { buildGraph, getConnections } from "../graph/traverse";
 import { resolveConfig } from "../config";
@@ -29,9 +29,11 @@ export async function handleGraphRoutes(
     }
     if (sourceId === targetId) return json({ ok: false, error: "Cannot link an entry to itself" }, 400);
 
-    const source = await getReadableEntry(env, auth, sourceId);
+    // tags ride along on the reads this route already makes, so the kind gate
+    // below costs no extra query.
+    const source = await getReadableEntry(env, auth, sourceId, "id, workspace_id, actor_id, tags");
     if (!source) return json({ ok: false, error: `No entry found with ID: ${sourceId}` }, 404);
-    const target = await getReadableEntry(env, auth, targetId);
+    const target = await getReadableEntry(env, auth, targetId, "id, workspace_id, actor_id, tags");
     if (!target) return json({ ok: false, error: `No entry found with ID: ${targetId}` }, 404);
     // Same-workspace only. edges.workspace_id is one denormalized column copied
     // from the source entry, and a share re-stamps it to follow the entry that
@@ -42,6 +44,14 @@ export async function handleGraphRoutes(
     // vanishes from their graph. Costs nothing on a solo brain: one workspace.
     if (source.workspace_id !== target.workspace_id) {
       return json({ ok: false, error: CROSS_WORKSPACE_LINK_MESSAGE, code: "cross_workspace_link" }, 400);
+    }
+
+    // `decided` and `follows` mean something only between episodic memories.
+    // Inference and the insight pass both check this; an explicit caller that
+    // did not would be the one writer able to create the edge the type exists
+    // to exclude.
+    if (!kindsAllowEdge(type, kindOfRow(source), kindOfRow(target))) {
+      return json({ ok: false, error: kindMismatchMessage(type), code: "kind_not_allowed" }, 400);
     }
 
     const edge = await createEdge(sourceId, targetId, type, { provenance: "explicit", weight: 1.0, workspaceId: source.workspace_id }, env);

--- a/test/helpers/d1-mock.ts
+++ b/test/helpers/d1-mock.ts
@@ -341,6 +341,17 @@ export class D1Mock {
           if (placeholderCount !== args.length) {
             throw new Error(`INSERT INTO edges placeholder/bind mismatch: ${placeholderCount} vs ${args.length}`);
           }
+          // The guarded form (edgeInsertStatement's onlyIfNoTypedEdge): the row's
+          // ten values, then the pair the guard tests. Modelled here because the
+          // rule lives in the statement, so a mock that ignored it would report
+          // an insert production would have skipped.
+          if (s.includes("WHERE NOT EXISTS")) {
+            const [ga, gb, gc, gd] = args.slice(10);
+            const typed = db.edges.some((e: any) =>
+              ((e.source_id === ga && e.target_id === gb) || (e.source_id === gc && e.target_id === gd))
+              && e.type !== "relates_to");
+            if (typed) return { meta: { changes: 0 } };
+          }
           const [id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at] = args;
           const existing = db.edges.find((e: any) => e.source_id === source_id && e.target_id === target_id && e.type === type);
           if (existing) {
@@ -571,14 +582,28 @@ export class D1Mock {
             .map((e: any) => ({ id: e.id, content: e.content, workspace_id: e.workspace_id ?? "" }));
           return { results: rows };
         }
-        if (s.includes("SELECT id, workspace_id FROM entries WHERE id IN")) {
-          // inferEdgesOnWrite: the source row's workspace (to stamp the edge with)
-          // and each candidate neighbour's (to refuse a pair that disagrees). Rows
-          // seeded without the column read as "", the pre-tenancy value, so a
-          // fixture that says nothing about workspaces still links exactly as it did.
+        if (s.includes("SELECT id, workspace_id, tags, created_at, source FROM entries WHERE id IN")) {
+          // inferEdgesOnWrite's one endpoint read: the source row's workspace (to
+          // stamp the edge with), each candidate neighbour's (to refuse a pair that
+          // disagrees), and — piggybacked on the same statement — the tags and
+          // timestamps `follows` typing needs. Rows seeded without the column read
+          // as "", the pre-tenancy value, so a fixture that says nothing about
+          // workspaces still links exactly as it did.
+          //
+          // The projection is matched in full ON PURPOSE. When this branch listed
+          // only `id, workspace_id` it silently stopped matching the moment
+          // production widened the SELECT, and every mock-backed inference then saw
+          // ZERO endpoint rows — no workspace refusal, no kind, no timestamps —
+          // while the tests kept passing for the wrong reason.
           const results = db.entries
             .filter((e: any) => args.includes(e.id))
-            .map((e: any) => ({ id: e.id, workspace_id: e.workspace_id ?? "" }));
+            .map((e: any) => ({
+              id: e.id,
+              workspace_id: e.workspace_id ?? "",
+              tags: e.tags ?? "[]",
+              created_at: e.created_at ?? 0,
+              source: e.source ?? "api",
+            }));
           return { results };
         }
         if (s.includes("SELECT id FROM entries WHERE id IN")) {

--- a/test/integration/graph-follows.test.ts
+++ b/test/integration/graph-follows.test.ts
@@ -1,0 +1,525 @@
+/**
+ * B2 — typing the one relationship capture already knows about.
+ *
+ * Two episodic memories written minutes apart are usually one train of thought,
+ * and `relates_to` throws that away. The ordering is already in `created_at` and
+ * the kinds are already in the tags the classifier writes, so `follows` costs no
+ * model call — only the decision to record what is known.
+ *
+ * Driven against real SQLite: the pair-level DELETE behind typed-replaces-
+ * generic and the `kind:` tag parsing are both things the string-matching D1
+ * mock only approximates.
+ *
+ * The burst guard is the part worth arguing with. Importing a week of notes, or
+ * a transcript splitting into many chunks, writes a dozen episodic entries in
+ * one minute; each would "follow" the last, and the chain would be an artefact
+ * of the write, not of the thinking. So `follows` is emitted only when exactly
+ * one neighbour qualifies — a claim about a specific predecessor, or nothing.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createEdge, inferEdgesOnWrite, GRAPH_FOLLOWS_WINDOW_MS } from "../../src/graph/edges";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestEnv, makeMemoryKV } from "../helpers/make-env";
+import { captureEntry } from "../../src/capture/entry";
+import { resetDatabaseInit, initializeDatabase } from "../../src/db/init";
+import type { Env } from "../../src/env";
+
+const NOW = 1_700_000_000_000;
+const EPISODIC = ["kind:episodic"];
+const SEMANTIC = ["kind:semantic"];
+
+describe("follows edges", () => {
+  let sqlite: SqliteD1;
+  let env: Env;
+
+  beforeEach(async () => {
+    resetDatabaseInit();
+    sqlite = makeSqliteD1();
+    env = makeTestEnv(undefined, { DB: sqlite.db as unknown as Env["DB"], OAUTH_KV: makeMemoryKV() });
+    await initializeDatabase(env);
+  });
+
+  afterEach(() => sqlite.close());
+
+  async function edges(): Promise<{ source_id: string; target_id: string; type: string }[]> {
+    const r = await sqlite.db.prepare(`SELECT source_id, target_id, type FROM edges`).all() as any;
+    return r.results;
+  }
+
+  /** The new entry, written at NOW, plus its neighbours at explicit offsets. */
+  function seedPair(opts: {
+    newKindTags?: string[];
+    source?: string;
+    neighbors: { id: string; agoMs: number; tags?: string[]; source?: string }[];
+  }): void {
+    sqlite.seed({ id: "new", content: "the entry being written", createdAt: NOW, tags: opts.newKindTags ?? EPISODIC, source: opts.source ?? "api" });
+    for (const n of opts.neighbors) {
+      sqlite.seed({ id: n.id, content: `neighbour ${n.id}`, createdAt: NOW - n.agoMs, tags: n.tags ?? EPISODIC, source: n.source ?? "api" });
+    }
+  }
+
+  it("holds the window at 30 minutes", () => {
+    expect(GRAPH_FOLLOWS_WINDOW_MS).toBe(30 * 60_000);
+  });
+
+  it("types the edge as follows when one episodic neighbour precedes it in the window", async () => {
+    seedPair({ neighbors: [{ id: "earlier", agoMs: 5 * 60_000 }] });
+
+    await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, { newKind: "episodic" });
+
+    expect(await edges()).toEqual([{ source_id: "new", target_id: "earlier", type: "follows" }]);
+  });
+
+  // A literal, not GRAPH_FOLLOWS_WINDOW_MS + n: deriving the fixture from the
+  // constant makes the test move with it, so widening the window to a year
+  // would still pass. The pin below is what makes such a change deliberate.
+  it("leaves the edge generic when the neighbour is two hours old", async () => {
+    seedPair({ neighbors: [{ id: "earlier", agoMs: 2 * 60 * 60_000 }] });
+
+    await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, { newKind: "episodic" });
+
+    expect((await edges()).map(e => e.type)).toEqual(["relates_to"]);
+  });
+
+  it("emits no follows when several neighbours qualify, because a burst is not a train of thought", async () => {
+    seedPair({
+      neighbors: [
+        { id: "burst-a", agoMs: 2 * 60_000 },
+        { id: "burst-b", agoMs: 3 * 60_000 },
+      ],
+    });
+
+    await inferEdgesOnWrite("new", [{ id: "burst-a", score: 0.85 }, { id: "burst-b", score: 0.84 }], env, { newKind: "episodic" });
+
+    const types = (await edges()).map(e => e.type);
+    expect(types).not.toContain("follows");
+    expect(types).toEqual(["relates_to", "relates_to"]);
+  });
+
+  it("refuses follows when the neighbour is semantic, because the type is episodic-only", async () => {
+    seedPair({ neighbors: [{ id: "earlier", agoMs: 5 * 60_000, tags: SEMANTIC }] });
+
+    await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, { newKind: "episodic" });
+
+    expect((await edges()).map(e => e.type)).toEqual(["relates_to"]);
+  });
+
+  it("refuses follows when the new entry is semantic", async () => {
+    seedPair({ newKindTags: SEMANTIC, neighbors: [{ id: "earlier", agoMs: 5 * 60_000 }] });
+
+    await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, { newKind: "semantic" });
+
+    expect((await edges()).map(e => e.type)).toEqual(["relates_to"]);
+  });
+
+  it("degrades to a generic edge when the kind is unknown", async () => {
+    seedPair({ newKindTags: [], neighbors: [{ id: "earlier", agoMs: 5 * 60_000 }] });
+
+    await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, { newKind: null });
+
+    expect((await edges()).map(e => e.type)).toEqual(["relates_to"]);
+  });
+
+  it("replaces an inferred relates_to already standing between the pair", async () => {
+    seedPair({ neighbors: [{ id: "earlier", agoMs: 5 * 60_000 }] });
+    // Written by an earlier pass, in the symmetric orientation relates_to stores.
+    await sqlite.db.prepare(
+      `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at, workspace_id)
+       VALUES ('old', 'earlier', 'new', 'relates_to', 0.8, 'inferred', '{}', 0, 0, '')`,
+    ).run();
+
+    await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, { newKind: "episodic" });
+
+    expect(await edges()).toEqual([{ source_id: "new", target_id: "earlier", type: "follows" }]);
+  });
+
+  it("keeps an explicit relates_to the user drew themselves", async () => {
+    seedPair({ neighbors: [{ id: "earlier", agoMs: 5 * 60_000 }] });
+    await sqlite.db.prepare(
+      `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at, workspace_id)
+       VALUES ('mine', 'earlier', 'new', 'relates_to', 0.9, 'explicit', '{}', 0, 0, '')`,
+    ).run();
+
+    await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, { newKind: "episodic" });
+
+    const kept = (await edges()).filter(e => e.type === "relates_to");
+    expect(kept).toHaveLength(1);
+  });
+
+  // The chain that makes any of the above reachable in production: the
+  // classifier already runs on every capture, and its `kind` is what the gate
+  // above needs. Without this the feature is dead code — inference would keep
+  // being handed `undefined`.
+  describe("the capture path", () => {
+    /** Embeddings for bge-*, one classification JSON for the LLM call. */
+    function aiReturningKind(kind: string) {
+      return {
+        run: vi.fn().mockImplementation(async (model: string) => {
+          if (model.startsWith("@cf/baai/bge")) return { data: [new Array(384).fill(0.1)] };
+          const payload = JSON.stringify({
+            response: `{"importance": 4, "canonical": false, "kind": "${kind}"}`,
+          });
+          return new ReadableStream({
+            start(c) {
+              c.enqueue(new TextEncoder().encode(`data: ${payload}\n\n`));
+              c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+              c.close();
+            },
+          });
+        }),
+      } as any;
+    }
+
+    /** 0.82: above EDGE_INFER_THRESHOLD, below DUPLICATE_FLAG_THRESHOLD. */
+    function envCapturing(ai: any): Env {
+      return makeTestEnv(undefined, {
+        DB: sqlite.db as unknown as Env["DB"],
+        OAUTH_KV: makeMemoryKV(),
+        AI: ai,
+        VECTORIZE: {
+          query: async () => ({ matches: [{ id: "earlier", score: 0.82, metadata: { parentId: "earlier" } }] }),
+          insert: async () => ({}), upsert: async () => ({}), deleteByIds: async () => ({}), getByIds: async () => [],
+        } as any,
+      });
+    }
+
+    async function capture(ai: any): Promise<void> {
+      sqlite.seed({
+        id: "earlier", content: "the earlier thought", tags: EPISODIC,
+        createdAt: Date.now() - 5 * 60_000,
+      });
+      const pending: Promise<any>[] = [];
+      const ctx = { waitUntil: (p: Promise<any>) => pending.push(p) } as unknown as ExecutionContext;
+      await captureEntry("the thought that follows it", [], "api", envCapturing(ai), ctx);
+      await Promise.all(pending);
+    }
+
+    it("types the edge as follows using the kind the classifier just produced", async () => {
+      await capture(aiReturningKind("episodic"));
+      expect((await edges()).map(e => e.type)).toEqual(["follows"]);
+    });
+
+
+    /**
+     * The end-to-end proof that B2 fires under production conditions.
+     *
+     * Every other case here seeds the neighbour's `kind:` tag directly. That
+     * assumes away the thing most likely to break the feature: classification is
+     * asynchronous, and the neighbour's kind is written by ITS OWN deferred
+     * classification. If that had not landed by the time a later capture reads
+     * its tags, the kind gate would refuse `follows` for exactly the
+     * recently-written neighbour B2 exists to link — and every seeded test here
+     * would still pass.
+     *
+     * So this captures BOTH entries through the real path, draining the first
+     * capture's deferred work before the second begins, and asserts the typed
+     * edge appears with nothing hand-seeded.
+     */
+    it("types a follows edge between two entries both captured through the real path", async () => {
+      const ai = aiReturningKind("episodic");
+      const seen: string[] = [];
+      const envFor = () => makeTestEnv(undefined, {
+        DB: sqlite.db as unknown as Env["DB"],
+        OAUTH_KV: makeMemoryKV(),
+        AI: ai,
+        VECTORIZE: {
+          // Answers with whatever has already been written, so the second
+          // capture sees the first as a neighbour without it being seeded.
+          query: async () => ({
+            matches: seen.map(id => ({ id, score: 0.82, metadata: { parentId: id } })),
+          }),
+          insert: async () => ({}), upsert: async () => ({}), deleteByIds: async () => ({}), getByIds: async () => [],
+        } as any,
+      });
+
+      const runCapture = async (content: string) => {
+        const pending: Promise<any>[] = [];
+        const c = { waitUntil: (p: Promise<any>) => pending.push(p) } as unknown as ExecutionContext;
+        const result = await captureEntry(content, [], "api", envFor(), c);
+        // Drain before the next capture, as the platform would between requests.
+        await Promise.all(pending);
+        if (result.status === "stored" || result.status === "flagged") seen.push(result.id);
+      };
+
+      await runCapture("The first thought in the thread.");
+      await runCapture("The thought that follows on from it.");
+
+      // kind:episodic reached the DB via the first capture's own classification,
+      // and the second capture's inference read it from there.
+      expect((await edges()).map(e => e.type)).toEqual(["follows"]);
+    });
+
+    it("still infers a generic edge when the classifier says semantic", async () => {
+      await capture(aiReturningKind("semantic"));
+      expect((await edges()).map(e => e.type)).toEqual(["relates_to"]);
+    });
+
+
+    /**
+     * The hard constraint this phase is built on, asserted rather than assumed.
+     *
+     * Chaining inference onto classification is only free because ONE
+     * classifyEntry call feeds both halves. A refactor that gave inference its
+     * own call would double the LLM cost of every capture in the product and
+     * leave every other test in this file green.
+     */
+    it("classifies exactly once per capture", async () => {
+      let classifyCalls = 0;
+      const ai = {
+        run: vi.fn().mockImplementation(async (model: string, opts: any) => {
+          if (model.startsWith("@cf/baai/bge")) return { data: [new Array(384).fill(0.1)] };
+          // Counted by PROMPT, not by call: capture also runs a pre-existing
+          // contradiction check on this path, which is not what is being
+          // constrained here and would make a raw call count read as 2.
+          if (String(opts?.messages?.[0]?.content ?? "").includes("Classify this memory")) classifyCalls++;
+          const payload = JSON.stringify({ response: '{"importance": 4, "canonical": false, "kind": "episodic"}' });
+          return new ReadableStream({
+            start(c) {
+              c.enqueue(new TextEncoder().encode(`data: ${payload}\n\n`));
+              c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+              c.close();
+            },
+          });
+        }),
+      } as any;
+
+      await capture(ai);
+
+      expect(classifyCalls).toBe(1);
+    });
+
+    /**
+     * classifyEntry swallows its own model failures, so the earlier test only
+     * exercises that. This one breaks the DB write that runs AFTER it — the
+     * other half of the chain, and the one whose failure would otherwise take
+     * edge inference down with it.
+     */
+    it("still infers an edge when the classification WRITE fails", async () => {
+      sqlite.seed({
+        id: "earlier", content: "the earlier thought", tags: EPISODIC,
+        createdAt: Date.now() - 5 * 60_000,
+      });
+      const inner = sqlite.db as any;
+      const failingDb = {
+        prepare(sql: string) {
+          if (sql.includes("UPDATE entries SET importance_score")) {
+            throw new Error("D1 unavailable");
+          }
+          return inner.prepare(sql);
+        },
+        batch: (st: any) => inner.batch(st),
+        exec: (sql: string) => inner.exec(sql),
+      };
+      const env2 = makeTestEnv(undefined, {
+        DB: failingDb as unknown as Env["DB"],
+        OAUTH_KV: makeMemoryKV(),
+        AI: aiReturningKind("episodic"),
+        VECTORIZE: {
+          query: async () => ({ matches: [{ id: "earlier", score: 0.82, metadata: { parentId: "earlier" } }] }),
+          insert: async () => ({}), upsert: async () => ({}), deleteByIds: async () => ({}), getByIds: async () => [],
+        } as any,
+      });
+      const pending: Promise<any>[] = [];
+      const ctx2 = { waitUntil: (p: Promise<any>) => pending.push(p) } as unknown as ExecutionContext;
+
+      await captureEntry("the thought that follows it", [], "api", env2, ctx2);
+      await Promise.all(pending);
+
+      // Degraded, not lost: no kind survived the failed write, so no `follows`,
+      // but the pair is still connected.
+      expect((await edges()).map(e => e.type)).toEqual(["relates_to"]);
+    });
+
+    it("still infers an edge when classification fails outright", async () => {
+      const ai = {
+        run: vi.fn().mockImplementation(async (model: string) => {
+          if (model.startsWith("@cf/baai/bge")) return { data: [new Array(384).fill(0.1)] };
+          throw new Error("model unavailable");
+        }),
+      } as any;
+      await capture(ai);
+      // Degraded, not lost: no kind means no `follows`, but the pair is still linked.
+      expect((await edges()).map(e => e.type)).toEqual(["relates_to"]);
+    });
+  });
+
+  /**
+   * The conflict clause every edge writer depends on, pinned where a constraint
+   * violation is actually observable.
+   *
+   * Two writers legitimately produce the same edge: capture-time inference and
+   * the weekly insight pass. Without ON CONFLICT the second INSERT raises a
+   * UNIQUE violation, and in production that aborts the whole D1 batch it rides
+   * in — taking unrelated writes in the same batch down with it.
+   */
+  describe("edge upsert", () => {
+    it("writes the same edge twice without raising, keeping the stronger weight", async () => {
+      sqlite.seed({ id: "one", content: "first", createdAt: NOW - 1000, tags: EPISODIC });
+      sqlite.seed({ id: "two", content: "second", createdAt: NOW, tags: EPISODIC });
+
+      await createEdge("two", "one", "follows", { weight: 0.9, provenance: "explicit", workspaceId: "" }, env);
+      await createEdge("two", "one", "follows", { weight: 0.75, provenance: "system", workspaceId: "" }, env);
+
+      const rows = await edges();
+      expect(rows).toHaveLength(1);
+      const [row] = await sqlite.db.prepare(`SELECT weight FROM edges`).all().then((r: any) => r.results);
+      expect(row.weight).toBe(0.9);
+    });
+  });
+
+  /**
+   * Edge writes cost one D1 call, not one per edge.
+   *
+   * Two reasons, and the second is the sharper one:
+   *
+   *   - ATOMICITY. Retiring the generic edge and writing the typed one are the
+   *     two halves of a replacement. Issued separately, a failure between them
+   *     leaves the pair with NO edge at all — strictly worse than either state.
+   *   - BUDGET. A Worker request may make 50 subrequests. Capture already spends
+   *     most of that on chunk embedding, and inference at one call per edge put
+   *     a large multi-chunk capture over the line.
+   *
+   * The sqlite facade counts a batch as one entry in `issued`, matching what the
+   * platform actually charges.
+   */
+  it("writes every edge for one capture in a single batched D1 call", async () => {
+    seedPair({
+      neighbors: [
+        { id: "earlier", agoMs: 5 * 60_000 },
+        { id: "other-a", agoMs: 3 * 60 * 60_000, tags: SEMANTIC },
+        { id: "other-b", agoMs: 4 * 60 * 60_000, tags: SEMANTIC },
+      ],
+    });
+
+    const before = sqlite.issued.length;
+    await inferEdgesOnWrite("new", [
+      { id: "earlier", score: 0.9 },
+      { id: "other-a", score: 0.85 },
+      { id: "other-b", score: 0.8 },
+    ], env, { newKind: "episodic" });
+
+    // One endpoint SELECT, then one batch carrying the DELETE and all three
+    // edge writes. Per-edge calls would make this five.
+    expect(sqlite.issued.length - before).toBe(2);
+    expect((await edges()).map(e => e.type).sort()).toEqual(["follows", "relates_to", "relates_to"]);
+  });
+
+  /**
+   * B#5 — a typed edge must not collect a generic one beside it.
+   *
+   * `follows` is emitted only inside the 30-minute window and only with a known
+   * kind. Every LATER write touching the same pair — an edit, an append, a
+   * nightly backfill — re-runs inference outside those conditions, falls to the
+   * generic branch, and inserts `relates_to` alongside the `follows` that is
+   * already there. The pair then carries both, and "typed replaces generic"
+   * holds only for the instant the typed edge was written.
+   *
+   * The guard rides on the INSERT itself rather than on a lookup, so it costs no
+   * additional D1 call.
+   */
+  describe("a pair that already carries a typed edge", () => {
+    it("does not lay a generic edge beside it", async () => {
+      seedPair({ neighbors: [{ id: "earlier", agoMs: 5 * 60_000 }] });
+      await createEdge("new", "earlier", "follows", { weight: 0.85, provenance: "inferred", workspaceId: "" }, env);
+
+      // An edit re-runs inference with no kind, so `follows` cannot be re-emitted
+      // and the pair falls to the generic branch.
+      await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, {});
+
+      expect((await edges()).map(e => e.type)).toEqual(["follows"]);
+    });
+
+    it("still draws the generic edge when the pair has no typed edge", async () => {
+      // Two hours apart, so the generic branch is reached because the pair is
+      // outside the follows window — not because the kind is unavailable. The
+      // caller passing no kind no longer implies "unknown": inference falls back
+      // to the row's own classifier kind.
+      seedPair({ neighbors: [{ id: "earlier", agoMs: 2 * 60 * 60_000 }] });
+
+      await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, {});
+
+      expect((await edges()).map(e => e.type)).toEqual(["relates_to"]);
+    });
+
+    it("does not let one pair's typed edge suppress another pair's generic edge", async () => {
+      seedPair({
+        neighbors: [
+          { id: "earlier", agoMs: 5 * 60_000 },
+          { id: "unrelated", agoMs: 3 * 60 * 60_000 },
+        ],
+      });
+      await createEdge("new", "earlier", "follows", { weight: 0.85, provenance: "inferred", workspaceId: "" }, env);
+
+      await inferEdgesOnWrite("new", [
+        { id: "earlier", score: 0.9 },
+        { id: "unrelated", score: 0.85 },
+      ], env, {});
+
+      const rows = await edges();
+      expect(rows.map(e => e.type).sort()).toEqual(["follows", "relates_to"]);
+      expect(rows.find(e => e.type === "relates_to")!.target_id).toBe("unrelated");
+    });
+  });
+
+  /**
+   * Finding 2 — the kind the gate needs is already in hand on every path.
+   *
+   * `follows` was reachable only from the capture path, because only that path
+   * passes the classifier's kind. The nightly backfill, the update path and the
+   * append path all call inference with no kind at all, so the gate refused
+   * every time — even though the endpoint SELECT already reads the row's own
+   * `kind:` tag for the workspace check.
+   *
+   * That is not academic. A Vectorize write takes a median under 30 seconds to
+   * become queryable, so the predecessor written moments earlier is exactly the
+   * neighbour capture-time inference cannot see; when that capture finds nothing
+   * else it becomes an orphan, and the backfill is the only pass that revisits
+   * it. An imported or restored brain is worse still: import never infers at
+   * all, so its whole graph comes from the backfill.
+   */
+  describe("falling back to the entry's own kind", () => {
+    it("types the edge when the caller passes no kind at all", async () => {
+      seedPair({ neighbors: [{ id: "earlier", agoMs: 5 * 60_000 }] });
+
+      await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, {});
+
+      expect((await edges()).map(e => e.type)).toEqual(["follows"]);
+    });
+
+    it("still honours an explicit null kind as unknown", async () => {
+      seedPair({ neighbors: [{ id: "earlier", agoMs: 5 * 60_000 }] });
+
+      // The capture path passes what the classifier returned. `null` there means
+      // classification failed, which must not be second-guessed from the tags.
+      await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, { newKind: null });
+
+      expect((await edges()).map(e => e.type)).toEqual(["relates_to"]);
+    });
+
+    /**
+     * Mirrored records are classified like anything else, and a mailbox import
+     * writes dozens of episodic rows minutes apart. Left alone, the backfill
+     * would chain them into a `follows` sequence describing the order the
+     * mailbox happened to sync — the artefact of a bulk write, not a train of
+     * thought, which is the same thing the burst guard exists to refuse.
+     */
+    it("refuses follows between two mirrored records", async () => {
+      seedPair({
+        source: "email-gmail",
+        neighbors: [{ id: "earlier", agoMs: 5 * 60_000, source: "email-gmail" }],
+      });
+
+      await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, {});
+
+      expect((await edges()).map(e => e.type)).toEqual(["relates_to"]);
+    });
+
+    it("refuses follows when only one side is a mirrored record", async () => {
+      seedPair({ neighbors: [{ id: "earlier", agoMs: 5 * 60_000, source: "calendar-google" }] });
+
+      await inferEdgesOnWrite("new", [{ id: "earlier", score: 0.85 }], env, {});
+
+      expect((await edges()).map(e => e.type)).toEqual(["relates_to"]);
+    });
+  });
+});

--- a/test/integration/graph-junk-links.test.ts
+++ b/test/integration/graph-junk-links.test.ts
@@ -1,0 +1,383 @@
+/**
+ * B1 — a near-duplicate the writer chose to keep is not a discovery.
+ *
+ * When capture flags a duplicate and the writer keeps both, the two entries are
+ * by definition the most similar pair in the brain, so edge inference links them
+ * every time. That edge carries no information: it says "these two say the same
+ * thing", which the `duplicate-candidate` tag already says, and it outranks the
+ * genuinely-related neighbours it competes with for the three inference slots.
+ *
+ * Two places produce it and both are closed here: the capture path, which infers
+ * edges straight after flagging, and the nightly backfill, which walks entries
+ * that have no edges yet — a flagged entry that got no edge at capture time is
+ * precisely the row that reaches it.
+ *
+ * The merge and replace paths are deliberately untouched: they return before
+ * inference ever runs, and the edge they would draw points at an entry that no
+ * longer holds the same content.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { inferEdgesOnWrite } from "../../src/graph/edges";
+import { runGraphPass } from "../../src/graph/pass";
+import { captureEntry } from "../../src/capture/entry";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestEnv, makeTestDb, makeMemoryKV, makeVectorizeMock } from "../helpers/make-env";
+import { resetDatabaseInit, initializeDatabase } from "../../src/db/init";
+import type { D1Mock } from "../helpers/d1-mock";
+import type { Env } from "../../src/env";
+
+describe("junk-link suppression", () => {
+  describe("inferEdgesOnWrite", () => {
+    let env: Env;
+    let db: D1Mock;
+
+    /** Inference refuses a neighbour with no entries row, so link targets need one. */
+    function present(...ids: string[]): void {
+      for (const id of ids) {
+        db.entries.push({
+          id, content: `entry ${id}`, tags: "[]", source: "api",
+          created_at: 1000, vector_ids: "[]", recall_count: 0, importance_score: 0,
+        });
+      }
+    }
+
+    beforeEach(() => {
+      db = makeTestDb();
+      env = makeTestEnv(db);
+    });
+
+    it("draws no edge to the neighbour the caller named as the duplicate", async () => {
+      present("new", "the-duplicate", "related");
+      await inferEdgesOnWrite(
+        "new",
+        [{ id: "the-duplicate", score: 0.97 }, { id: "related", score: 0.83 }],
+        env,
+        { suppressId: "the-duplicate" },
+      );
+      const linked = db.edges.flatMap((e: any) => [e.source_id, e.target_id]).filter((id: string) => id !== "new");
+      expect(linked).toEqual(["related"]);
+    });
+
+    /**
+     * Parity with the real-SQLite case in graph-follows.test.ts, driven through
+     * the D1 double.
+     *
+     * The typed-edge guard lives in the INSERT statement, so the string-matching
+     * mock has to model it explicitly (test/helpers/d1-mock.ts). Without this
+     * case, disabling that branch of the mock leaves the whole suite green while
+     * the double reports an insert production would have skipped — and every
+     * mock-backed edge test then measures the wrong behaviour.
+     */
+    it("honours the typed-edge guard, matching real SQLite", async () => {
+      present("new", "related");
+      db.edges.push({
+        id: "existing", source_id: "new", target_id: "related", type: "follows",
+        weight: 0.85, provenance: "inferred", metadata: "{}", created_at: 1, updated_at: 1,
+      });
+
+      await inferEdgesOnWrite("new", [{ id: "related", score: 0.83 }], env);
+
+      expect(db.edges.map((e: any) => e.type)).toEqual(["follows"]);
+    });
+
+    it("still links that neighbour when no duplicate was named", async () => {
+      present("new", "the-duplicate", "related");
+      await inferEdgesOnWrite(
+        "new",
+        [{ id: "the-duplicate", score: 0.97 }, { id: "related", score: 0.83 }],
+        env,
+      );
+      const linked = db.edges.flatMap((e: any) => [e.source_id, e.target_id]).filter((id: string) => id !== "new");
+      expect(linked.sort()).toEqual(["related", "the-duplicate"]);
+    });
+  });
+
+  describe("the capture path", () => {
+    /** A match between the flag and block thresholds: stored, tagged, kept. */
+    function envFlagging(db: D1Mock): Env {
+      return makeTestEnv(db, {
+        VECTORIZE: makeVectorizeMock({
+          query: vi.fn().mockResolvedValue({
+            matches: [{ id: "near", score: 0.88, metadata: { parentId: "near" } }],
+          }),
+        }),
+      });
+    }
+
+    it("draws no edge from a flagged capture to the entry it duplicates", async () => {
+      const db = makeTestDb();
+      const env = envFlagging(db);
+      const pending: Promise<any>[] = [];
+      const ctx = { waitUntil: (p: Promise<any>) => pending.push(p) } as unknown as ExecutionContext;
+
+      const result = await captureEntry("Similar note", [], "api", env, ctx);
+      expect(result.status).toBe("flagged");
+      await Promise.all(pending);
+
+      // 0.88 clears EDGE_INFER_THRESHOLD, so before suppression this pair was
+      // linked every time — the edge is not absent for want of similarity.
+      expect(db.edges.flatMap((e: any) => [e.source_id, e.target_id])).not.toContain("near");
+    });
+
+    it("still links the other neighbours of a flagged capture", async () => {
+      const db = makeTestDb();
+      for (const id of ["near", "other"]) {
+        db.entries.push({
+          id, content: `entry ${id}`, tags: "[]", source: "api",
+          created_at: 1000, vector_ids: "[]", recall_count: 0, importance_score: 0,
+        });
+      }
+      const env = makeTestEnv(db, {
+        VECTORIZE: makeVectorizeMock({
+          query: vi.fn().mockResolvedValue({
+            matches: [
+              { id: "near", score: 0.88, metadata: { parentId: "near" } },
+              { id: "other", score: 0.81, metadata: { parentId: "other" } },
+            ],
+          }),
+        }),
+      });
+      const pending: Promise<any>[] = [];
+      const ctx = { waitUntil: (p: Promise<any>) => pending.push(p) } as unknown as ExecutionContext;
+
+      expect((await captureEntry("Similar note", [], "api", env, ctx)).status).toBe("flagged");
+      await Promise.all(pending);
+
+      // Suppression is aimed at one neighbour, not at the whole inference pass.
+      expect(db.edges.flatMap((e: any) => [e.source_id, e.target_id])).toContain("other");
+    });
+  });
+
+  describe("nightly backfill", () => {
+    let sqlite: SqliteD1;
+    let env: Env;
+
+    beforeEach(async () => {
+      resetDatabaseInit();
+      sqlite = makeSqliteD1();
+      env = makeTestEnv(undefined, {
+        DB: sqlite.db as unknown as Env["DB"],
+        OAUTH_KV: makeMemoryKV(),
+        // Any candidate at all: the point is which entries are OFFERED to
+        // inference, not what the index returns for them.
+        VECTORIZE: {
+          query: async () => ({ matches: [{ id: "partner", score: 0.95, metadata: {} }] }),
+          insert: async () => ({}), upsert: async () => ({}), deleteByIds: async () => ({}),
+          getByIds: async () => [],
+        } as any,
+      });
+      await initializeDatabase(env);
+    });
+
+    afterEach(() => sqlite.close());
+
+    const passCtx = { waitUntil: (_: Promise<any>) => {} } as ExecutionContext;
+
+
+    /**
+     * The case Finding 2 was actually about: the backfill is where an orphaned
+     * capture gets its edges, because a Vectorize write is not queryable
+     * immediately and the predecessor written moments earlier is often invisible
+     * to capture-time inference. Before the kind fallback the backfill passed no
+     * kind, so everything it drew was generic — the pass that most needs to type
+     * an edge was the one that never could.
+     */
+    it("types a follows edge, using each entry's own classifier kind", async () => {
+      const t = Date.now();
+      sqlite.seed({ id: "first", content: "the earlier thought", createdAt: t - 5 * 60_000, tags: ["kind:episodic"] });
+      sqlite.seed({ id: "second", content: "the thought that follows", createdAt: t, tags: ["kind:episodic"] });
+      const pairEnv = makeTestEnv(undefined, {
+        DB: sqlite.db as unknown as Env["DB"],
+        OAUTH_KV: makeMemoryKV(),
+        VECTORIZE: {
+          query: async () => ({ matches: [{ id: "first", score: 0.9, metadata: { parentId: "first" } }] }),
+          insert: async () => ({}), upsert: async () => ({}), deleteByIds: async () => ({}), getByIds: async () => [],
+        } as any,
+      });
+
+      await runGraphPass(pairEnv, passCtx);
+
+      const rows = await sqlite.db.prepare(`SELECT source_id, target_id, type FROM edges`).all() as any;
+      expect(rows.results.map((e: any) => e.type)).toContain("follows");
+    });
+
+    it("skips entries tagged duplicate-candidate", async () => {
+      sqlite.seed({ id: "dup", content: "a flagged near-duplicate", createdAt: 2000, tags: ["duplicate-candidate"] });
+      sqlite.seed({ id: "partner", content: "the entry it duplicates", createdAt: 1000 });
+
+      await runGraphPass(env, passCtx);
+
+      const edges = await sqlite.db.prepare(`SELECT source_id, target_id FROM edges`).all() as any;
+      expect(edges.results.flatMap((e: any) => [e.source_id, e.target_id])).not.toContain("dup");
+    });
+
+    it("still backfills an untagged entry with no edges", async () => {
+      sqlite.seed({ id: "lonely", content: "an ordinary unlinked entry", createdAt: 2000 });
+      sqlite.seed({ id: "partner", content: "something related", createdAt: 1000 });
+
+      await runGraphPass(env, passCtx);
+
+      const edges = await sqlite.db.prepare(`SELECT source_id, target_id FROM edges`).all() as any;
+      expect(edges.results.flatMap((e: any) => [e.source_id, e.target_id])).toContain("lonely");
+    });
+  });
+
+  /**
+   * The sweep that keeps the edge table honest as entries are forgotten.
+   *
+   * An edge outliving the entry it points at is inert for reads — every graph
+   * walk hydrates both endpoints through the caller's scope and drops what is
+   * missing — but it is not harmless. src/entries/import.ts accepts
+   * caller-supplied ids, so a later import can create a row with that id in
+   * ANOTHER workspace and turn a dead edge into a live crossing one.
+   *
+   * Only inferred edges are swept. An explicit link pointing at a missing entry
+   * is a statement someone made, and deleting it silently would lose it; it is
+   * `GET /stats/graph?deep=1`'s invalidEndpointEdges count that surfaces those.
+   */
+  describe("the dangling-edge sweep", () => {
+    let sqlite: SqliteD1;
+    let env: Env;
+    const passCtx = { waitUntil: (_: Promise<any>) => {} } as ExecutionContext;
+
+    beforeEach(async () => {
+      resetDatabaseInit();
+      sqlite = makeSqliteD1();
+      env = makeTestEnv(undefined, {
+        DB: sqlite.db as unknown as Env["DB"],
+        OAUTH_KV: makeMemoryKV(),
+        VECTORIZE: {
+          query: async () => ({ matches: [] }),
+          insert: async () => ({}), upsert: async () => ({}), deleteByIds: async () => ({}), getByIds: async () => [],
+        } as any,
+      });
+      await initializeDatabase(env);
+    });
+
+    afterEach(() => {
+      sqlite.close();
+      vi.restoreAllMocks();
+    });
+
+    /** 2026-01-04 is a Sunday; 2026-01-05 a Monday. */
+    const SUNDAY = Date.UTC(2026, 0, 4, 1, 0, 0);
+    const MONDAY = Date.UTC(2026, 0, 5, 1, 0, 0);
+    const onDay = (t: number) => vi.spyOn(Date, "now").mockReturnValue(t);
+
+    function edge(id: string, source: string, target: string, provenance: string): void {
+      sqlite.db.prepare(
+        `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at, workspace_id)
+         VALUES (?, ?, ?, 'relates_to', 0.9, ?, '{}', 0, 0, '')`,
+      ).bind(id, source, target, provenance).run();
+    }
+
+    const remaining = async (): Promise<string[]> =>
+      ((await sqlite.db.prepare(`SELECT id FROM edges ORDER BY id`).all()) as any)
+        .results.map((r: any) => r.id);
+
+
+    /**
+     * The loop the sweep would otherwise run forever.
+     *
+     * Inference used to draw an edge to a neighbour with no `entries` row — a
+     * vector that outlived the entry it indexed, which happens whenever a
+     * `deleteByIds` fails (both forgetEntry and member removal swallow that).
+     * The sweep then deletes exactly those rows, which makes the entry edgeless
+     * again, which puts it back in the backfill's slate, which re-infers the
+     * same edge. Order within one pass is prune -> sweep -> backfill, so every
+     * night deleted the previous night's edge and wrote it straight back:
+     * one embed, one Vectorize query and one of 25 backfill slots per affected
+     * entry, forever, silently.
+     *
+     * Refusing the neighbour at write time costs nothing — its absence is
+     * already visible in the endpoint read — and leaves the sweep responsible
+     * only for rows a failed cascade left behind.
+     */
+    it("does not recreate an edge to a vector whose entry is gone, run after run", async () => {
+      sqlite.seed({ id: "alive", content: "an entry whose neighbour vector is stale", createdAt: 1000 });
+      const ghostEnv = makeTestEnv(undefined, {
+        DB: sqlite.db as unknown as Env["DB"],
+        OAUTH_KV: makeMemoryKV(),
+        VECTORIZE: {
+          query: async () => ({ matches: [{ id: "ghost", score: 0.9, metadata: { parentId: "ghost" } }] }),
+          insert: async () => ({}), upsert: async () => ({}), deleteByIds: async () => ({}), getByIds: async () => [],
+        } as any,
+      });
+
+      await runGraphPass(ghostEnv, passCtx);
+      const afterFirst = await remaining();
+      await runGraphPass(ghostEnv, passCtx);
+      const afterSecond = await remaining();
+
+      expect(afterFirst).toEqual([]);
+      expect(afterSecond).toEqual([]);
+    });
+
+
+    /**
+     * The sweep runs weekly, not nightly.
+     *
+     * It is a full scan of `edges` with two correlated endpoint lookups per
+     * inferred row, and the free plan allows only five cron triggers — all five
+     * are already spoken for (see wrangler.jsonc), so "weekly" has to be a gate
+     * inside the nightly pass rather than a schedule of its own. Gating on the
+     * UTC weekday costs no query, where a last-swept timestamp would cost a read
+     * every night to save a scan six nights in seven.
+     *
+     * Weekly is enough because inference no longer CREATES dangling edges: the
+     * sweep now cleans up historical rows and the rare failed vector cascade,
+     * not an ongoing stream. Trade-off: a missed Sunday defers the sweep a week,
+     * which for idempotent cleanup is not worth a state table to avoid.
+     */
+    it("does not sweep on other days of the week", async () => {
+      onDay(MONDAY);
+      sqlite.seed({ id: "alive", content: "still here", createdAt: 1000 });
+      edge("dead-target", "alive", "forgotten", "inferred");
+
+      await runGraphPass(env, passCtx);
+
+      expect(await remaining()).toContain("dead-target");
+    });
+
+    it("drops an inferred edge whose target no longer exists", async () => {
+      onDay(SUNDAY);
+      sqlite.seed({ id: "alive", content: "still here", createdAt: 1000 });
+      edge("dead-target", "alive", "forgotten", "inferred");
+
+      await runGraphPass(env, passCtx);
+
+      expect(await remaining()).not.toContain("dead-target");
+    });
+
+    it("drops an inferred edge whose source no longer exists", async () => {
+      onDay(SUNDAY);
+      sqlite.seed({ id: "alive", content: "still here", createdAt: 1000 });
+      edge("dead-source", "forgotten", "alive", "inferred");
+
+      await runGraphPass(env, passCtx);
+
+      expect(await remaining()).not.toContain("dead-source");
+    });
+
+    it("keeps a dangling edge the user drew themselves", async () => {
+      onDay(SUNDAY);
+      sqlite.seed({ id: "alive", content: "still here", createdAt: 1000 });
+      edge("mine", "alive", "forgotten", "explicit");
+
+      await runGraphPass(env, passCtx);
+
+      expect(await remaining()).toContain("mine");
+    });
+
+    it("keeps an inferred edge whose endpoints both exist", async () => {
+      onDay(SUNDAY);
+      sqlite.seed({ id: "one", content: "a", createdAt: 1000 });
+      sqlite.seed({ id: "two", content: "b", createdAt: 1001 });
+      edge("healthy", "one", "two", "inferred");
+
+      await runGraphPass(env, passCtx);
+
+      expect(await remaining()).toContain("healthy");
+    });
+  });
+});

--- a/test/integration/graph-update-merge-edges.test.ts
+++ b/test/integration/graph-update-merge-edges.test.ts
@@ -1,0 +1,187 @@
+/**
+ * B3 — the two writes that changed an entry's meaning and drew nothing.
+ *
+ * Capture infers edges; editing and merging did not. An entry whose content was
+ * rewritten kept the graph position of the text it no longer contains, and a
+ * merge — which is the one write that combines two memories — left the survivor
+ * connected to whatever the older half happened to match.
+ *
+ * Both are fixed without spending anything new, which is the whole constraint:
+ *
+ *   - the update path re-embeds through `storeEntry` anyway, so it now returns
+ *     the vector it just computed and the neighbour query reuses it. No second
+ *     embed call.
+ *   - the merge path already asked Vectorize for neighbours during duplicate
+ *     detection. It reuses that answer. No second query.
+ *
+ * The counts asserted here are the point. Getting the edges by paying for
+ * another embed or another query would pass a "does it draw an edge" test and
+ * fail the reason the work was worth doing.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { updateEntryContent } from "../../src/capture/store";
+import { captureEntry } from "../../src/capture/entry";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestEnv, makeMemoryKV } from "../helpers/make-env";
+import { resetDatabaseInit, initializeDatabase } from "../../src/db/init";
+import type { Env } from "../../src/env";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as ExecutionContext;
+
+describe("edges from the update and merge paths", () => {
+  let sqlite: SqliteD1;
+  let embeds: number;
+  let queries: number;
+
+  beforeEach(async () => {
+    resetDatabaseInit();
+    sqlite = makeSqliteD1();
+    embeds = 0;
+    queries = 0;
+    await initializeDatabase(makeTestEnv(undefined, { DB: sqlite.db as unknown as Env["DB"] }));
+  });
+
+  afterEach(() => sqlite.close());
+
+  /** Counts embeds; answers any streamed call with `verdict`. */
+  function ai(verdict: string) {
+    return {
+      run: vi.fn().mockImplementation(async (model: string) => {
+        if (model.startsWith("@cf/baai/bge")) {
+          embeds++;
+          return { data: [new Array(384).fill(0.1)] };
+        }
+        return new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(verdict)}}\n\n`));
+            c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+            c.close();
+          },
+        });
+      }),
+    } as any;
+  }
+
+  function vectorize(matches: { id: string; score: number }[]) {
+    return {
+      query: vi.fn().mockImplementation(async () => {
+        queries++;
+        return { matches: matches.map(m => ({ ...m, metadata: { parentId: m.id } })) };
+      }),
+      insert: async () => ({}), upsert: async () => ({}), deleteByIds: async () => ({}), getByIds: async () => [],
+    } as any;
+  }
+
+  function envWith(matches: { id: string; score: number }[], verdict: string): Env {
+    return makeTestEnv(undefined, {
+      DB: sqlite.db as unknown as Env["DB"],
+      OAUTH_KV: makeMemoryKV(),
+      AI: ai(verdict),
+      VECTORIZE: vectorize(matches),
+    });
+  }
+
+  async function edges(): Promise<{ source_id: string; target_id: string; type: string }[]> {
+    const r = await sqlite.db.prepare(`SELECT source_id, target_id, type FROM edges`).all() as any;
+    return r.results;
+  }
+
+  describe("editing an entry's content", () => {
+    it("links the rewritten entry to its new neighbours", async () => {
+      sqlite.seed({ id: "edited", content: "the original text", createdAt: 1000 });
+      sqlite.seed({ id: "friend", content: "a related memory", createdAt: 900 });
+      const env = envWith([{ id: "friend", score: 0.85 }], "3");
+
+      const result = await updateEntryContent(env, "edited", "an entirely different subject");
+      expect(result.status).toBe("updated");
+
+      expect((await edges()).flatMap(e => [e.source_id, e.target_id])).toContain("friend");
+    });
+
+    it("spends no extra embed call doing it", async () => {
+      sqlite.seed({ id: "edited", content: "the original text", createdAt: 1000 });
+      sqlite.seed({ id: "friend", content: "a related memory", createdAt: 900 });
+      const env = envWith([{ id: "friend", score: 0.85 }], "3");
+
+      await updateEntryContent(env, "edited", "an entirely different subject");
+
+      // One: the re-embed the update already owed. The neighbour query reuses
+      // that vector rather than embedding the same text a second time.
+      expect(embeds).toBe(1);
+    });
+  });
+
+  describe("merging a near-duplicate into its target", () => {
+    /** 0.9 sits between the flag and block thresholds, where merge is decided. */
+    const MATCHES = [{ id: "target", score: 0.9 }, { id: "friend", score: 0.82 }];
+    const MERGE = '{"action":"merge","target_id":"target","merged_content":"the combined memory"}';
+
+    let pending: Promise<any>[];
+    let mergeCtx: ExecutionContext;
+
+    beforeEach(() => {
+      sqlite.seed({ id: "target", content: "the memory being merged into", createdAt: 1000 });
+      sqlite.seed({ id: "friend", content: "a related memory", createdAt: 900 });
+      pending = [];
+      mergeCtx = { waitUntil: (p: Promise<any>) => pending.push(p) } as unknown as ExecutionContext;
+    });
+
+    it("links the surviving entry to its neighbours", async () => {
+      const env = envWith(MATCHES, MERGE);
+
+      const result = await captureEntry("the memory being merged in", [], "api", env, mergeCtx);
+      expect(result.status).toBe("merged");
+      await Promise.all(pending);
+
+      expect((await edges()).flatMap(e => [e.source_id, e.target_id])).toContain("friend");
+    });
+
+    it("asks Vectorize nothing it did not already ask during duplicate detection", async () => {
+      const env = envWith(MATCHES, MERGE);
+
+      await captureEntry("the memory being merged in", [], "api", env, mergeCtx);
+      await Promise.all(pending);
+
+      // One: the duplicate check. Its neighbours are reused for inference.
+      expect(queries).toBe(1);
+    });
+
+    it("never links the survivor to itself", async () => {
+      const env = envWith(MATCHES, MERGE);
+
+      await captureEntry("the memory being merged in", [], "api", env, mergeCtx);
+      await Promise.all(pending);
+
+      expect(await edges()).not.toContainEqual(
+        expect.objectContaining({ source_id: "target", target_id: "target" }),
+      );
+    });
+  });
+
+  /**
+   * The merge target is chosen by the model, not by score. When it picks the
+   * SECOND-best match, the best one is still sitting in `neighbors` — and it is
+   * a near-duplicate of the very content just merged in. Linking to it is
+   * exactly the junk edge B1 exists to suppress, arriving by a different door.
+   */
+  describe("merging into a target that is not the top match", () => {
+    it("still refuses to link the survivor to the duplicate match", async () => {
+      sqlite.seed({ id: "top-match", content: "the closest near-duplicate", createdAt: 1100 });
+      sqlite.seed({ id: "second", content: "the memory being merged into", createdAt: 1000 });
+      const pending: Promise<any>[] = [];
+      const mergeCtx = { waitUntil: (p: Promise<any>) => pending.push(p) } as unknown as ExecutionContext;
+
+      // top-match scores highest, so it is dup.matchId; the model merges into `second`.
+      const env = envWith(
+        [{ id: "top-match", score: 0.93 }, { id: "second", score: 0.9 }],
+        '{"action":"merge","target_id":"second","merged_content":"the combined memory"}',
+      );
+
+      const result = await captureEntry("the memory being merged in", [], "api", env, mergeCtx);
+      expect(result.status).toBe("merged");
+      await Promise.all(pending);
+
+      expect((await edges()).flatMap(e => [e.source_id, e.target_id])).not.toContain("top-match");
+    });
+  });
+});

--- a/test/integration/insight-typed-edges.test.ts
+++ b/test/integration/insight-typed-edges.test.ts
@@ -1,0 +1,247 @@
+/**
+ * C — turning the weekly insight call's spare verdict into typed edges.
+ *
+ * The call already reasons over two whole memories. It was returning prose and
+ * nothing else, so the pass wrote at most three edges a week (the `drawn_from`
+ * pair for each accepted insight) and learned nothing from the calls that
+ * declined — which is most of them. Reading the relationship off every settled
+ * response types roughly ten pairs a week at no extra model cost.
+ *
+ * The decline path is therefore the important one to test, not an edge case:
+ * a version of this that only fired on accepted insights would be worth about
+ * a third of it.
+ *
+ * Direction is taken from `created_at`, never from the candidate row's id
+ * ordering. `insight_candidates` stores its pair with a_id < b_id, which is
+ * lexicographic on a UUID and says nothing whatever about which was written
+ * first.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { runWeeklyInsights } from "../../src/insight/weekly";
+import { resetDatabaseInit } from "../../src/db/init";
+import { makeTestEnv, makeMemoryKV } from "../helpers/make-env";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import type { Env } from "../../src/env";
+
+const DAY = 86400000;
+const NOW = 400 * DAY;
+const ctx = { waitUntil: () => {} } as unknown as ExecutionContext;
+
+/** Long enough and specific enough to clear the insight quality floor. */
+const GOOD_TEXT =
+  "You priced that tier at nine dollars flat, then reversed course to usage-based billing once the margin review landed.";
+
+function makeAI(insightPayload: string) {
+  const sse = (text: string) => new ReadableStream({
+    start(c) {
+      c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(text)}}\n\n`));
+      c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+      c.close();
+    },
+  });
+  return {
+    run: vi.fn().mockImplementation(async (model: string, opts: any) => {
+      if (model === "@cf/baai/bge-small-en-v1.5") return { data: [new Array(384).fill(0.1)] };
+      const prompt = String(opts?.messages?.[0]?.content ?? "");
+      return sse(prompt.includes("Memory A:") ? insightPayload : "3");
+    }),
+  } as unknown as Ai;
+}
+
+describe("typed edges from the insight pass", () => {
+  let sqlite: SqliteD1;
+
+  beforeEach(() => {
+    resetDatabaseInit();
+    sqlite = makeSqliteD1();
+  });
+
+  afterEach(() => sqlite.close());
+
+  /**
+   * One candidate. `older` is written 120 days before `newer`, and the ids are
+   * chosen so a_id < b_id lexicographically matches chronology — the direction
+   * tests below then deliberately invert the model's claim to prove which of
+   * the two the code actually uses.
+   */
+  function seedPair(opts: { aTags?: string[]; bTags?: string[] } = {}): void {
+    sqlite.seed({
+      id: "a-older", createdAt: NOW - 120 * DAY, tags: opts.aTags ?? ["kind:episodic"],
+      content: "Decision: price the starter tier flat at nine dollars a month for predictable billing.",
+    });
+    sqlite.seed({
+      id: "b-newer", createdAt: NOW, tags: opts.bTags ?? ["kind:episodic"],
+      content: "Decision: move the starter tier to usage-based billing; flat pricing left margin on the table.",
+    });
+    sqlite.db.prepare(
+      `INSERT INTO insight_candidates (id, a_id, b_id, similarity, gap_ms, score, signal, status, created_at)
+       VALUES ('cand-0', 'a-older', 'b-newer', 0.87, ?, 10, 'vector', 'pending', ?)`,
+    ).bind(120 * DAY, NOW).run();
+  }
+
+  function envWith(payload: string): Env {
+    return makeTestEnv(undefined, {
+      DB: sqlite.db as any, AI: makeAI(payload), OAUTH_KV: makeMemoryKV(),
+    });
+  }
+
+  async function typedEdges(): Promise<{ source_id: string; target_id: string; type: string; provenance: string; weight: number; metadata: string }[]> {
+    const r = await sqlite.db.prepare(
+      `SELECT source_id, target_id, type, provenance, weight, metadata FROM edges
+       WHERE type != 'drawn_from' ORDER BY type`,
+    ).all() as any;
+    return r.results;
+  }
+
+  it("types the pair when the model declined to write an insight", async () => {
+    seedPair();
+    await runWeeklyInsights(envWith('{"insight": false, "relationship": "caused_by", "source": "B", "target": "A"}'), ctx);
+
+    expect(await typedEdges()).toEqual([
+      expect.objectContaining({ source_id: "b-newer", target_id: "a-older", type: "caused_by" }),
+    ]);
+  });
+
+  it("types the pair when the model also wrote an insight", async () => {
+    seedPair();
+    await runWeeklyInsights(
+      envWith(`{"insight": true, "shape": "contradiction", "text": ${JSON.stringify(GOOD_TEXT)}, "relationship": "caused_by", "source": "A", "target": "B"}`),
+      ctx,
+    );
+
+    expect((await typedEdges()).map(e => e.type)).toContain("caused_by");
+  });
+
+  it("stamps the edge as system-authored with its reasoning provenance", async () => {
+    seedPair();
+    await runWeeklyInsights(envWith('{"insight": false, "relationship": "caused_by", "source": "B", "target": "A"}'), ctx);
+
+    const [edge] = await typedEdges();
+    expect(edge.provenance).toBe("system");
+    expect(edge.weight).toBe(0.75);
+    expect(JSON.parse(edge.metadata)).toMatchObject({ via: "insight-reasoning" });
+  });
+
+  it("writes nothing when the model names no relationship", async () => {
+    seedPair();
+    await runWeeklyInsights(envWith('{"insight": false}'), ctx);
+
+    expect(await typedEdges()).toEqual([]);
+  });
+
+  // The model is asked which side is the source, but for `follows` chronology
+  // is not its to decide: it cannot see created_at. Here it claims the OLDER
+  // memory follows the newer one, which is backwards.
+  it("orients follows by created_at even when the model says otherwise", async () => {
+    seedPair();
+    await runWeeklyInsights(envWith('{"insight": false, "relationship": "follows", "source": "A", "target": "B"}'), ctx);
+
+    expect(await typedEdges()).toEqual([
+      expect.objectContaining({ source_id: "b-newer", target_id: "a-older", type: "follows" }),
+    ]);
+  });
+
+  it("refuses a decided edge between two semantic memories", async () => {
+    seedPair({ aTags: ["kind:semantic"], bTags: ["kind:semantic"] });
+    await runWeeklyInsights(envWith('{"insight": false, "relationship": "decided", "source": "B", "target": "A"}'), ctx);
+
+    // decided is episodic-only in the edge-type registry.
+    expect(await typedEdges()).toEqual([]);
+  });
+
+  it("allows caused_by between semantic memories, which it does not constrain", async () => {
+    seedPair({ aTags: ["kind:semantic"], bTags: ["kind:semantic"] });
+    await runWeeklyInsights(envWith('{"insight": false, "relationship": "caused_by", "source": "B", "target": "A"}'), ctx);
+
+    expect((await typedEdges()).map(e => e.type)).toEqual(["caused_by"]);
+  });
+
+  it("retires the inferred relates_to it supersedes", async () => {
+    seedPair();
+    await sqlite.db.prepare(
+      `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at, workspace_id)
+       VALUES ('old', 'a-older', 'b-newer', 'relates_to', 0.8, 'inferred', '{}', 0, 0, '')`,
+    ).run();
+
+    await runWeeklyInsights(envWith('{"insight": false, "relationship": "caused_by", "source": "B", "target": "A"}'), ctx);
+
+    expect((await typedEdges()).map(e => e.type)).toEqual(["caused_by"]);
+  });
+
+  it("keeps a relates_to the user drew themselves", async () => {
+    seedPair();
+    await sqlite.db.prepare(
+      `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at, workspace_id)
+       VALUES ('mine', 'a-older', 'b-newer', 'relates_to', 0.9, 'explicit', '{}', 0, 0, '')`,
+    ).run();
+
+    await runWeeklyInsights(envWith('{"insight": false, "relationship": "caused_by", "source": "B", "target": "A"}'), ctx);
+
+    expect((await typedEdges()).map(e => e.type).sort()).toEqual(["caused_by", "relates_to"]);
+  });
+
+  /**
+   * Phase B can already have drawn the very same typed edge for this pair at
+   * capture time, so the pass must upsert rather than collide.
+   *
+   * What this proves: the existing edge survives and keeps the STRONGER weight
+   * — an explicit 0.9 is better evidence than the pass's flat 0.75 and must not
+   * be written down to it. That is sensitive to the `max(weight, excluded.weight)`
+   * in edgeInsertStatement's ON CONFLICT clause.
+   *
+   * What it CANNOT prove, and is not claimed: that a failed INSERT would take
+   * the candidate status updates down with it. Real D1 runs a batch in one
+   * transaction, so a constraint failure would roll back the status writes and
+   * leave the pass re-reasoning the same pairs forever. The test facade
+   * (test/helpers/sqlite-d1.ts) executes batched statements sequentially and
+   * non-atomically, and the status updates are ordered first, so they commit
+   * before any edge statement can throw. The protection is the ON CONFLICT
+   * clause itself, pinned directly in the edge-upsert test in
+   * test/integration/graph-follows.test.ts.
+   */
+  it("upserts onto an identical edge rather than colliding with it", async () => {
+    seedPair();
+    await sqlite.db.prepare(
+      `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at, workspace_id)
+       VALUES ('already', 'b-newer', 'a-older', 'caused_by', 0.9, 'explicit', '{}', 0, 0, '')`,
+    ).run();
+
+    await runWeeklyInsights(envWith('{"insight": false, "relationship": "caused_by", "source": "B", "target": "A"}'), ctx);
+
+    const edges = await typedEdges();
+    expect(edges).toHaveLength(1);
+    expect(edges[0].weight).toBe(0.9);
+  });
+
+  /**
+   * A replacement must not cost the pair its place in the graph.
+   *
+   * Inferred edges only exist at EDGE_INFER_THRESHOLD (0.78) and above, so a
+   * flat 0.75 is BELOW every generic edge this replaces. Graph expansion sorts
+   * `ORDER BY weight DESC` and applies a per-node fanout cap, so on a
+   * well-connected root the typed edge can sort below the cut that the generic
+   * edge cleared — turning "typed replaces generic" into "reachable becomes
+   * unreachable". The typed edge therefore inherits the weight it retires when
+   * that is higher.
+   */
+  it("keeps the weight of the stronger generic edge it replaces", async () => {
+    seedPair();
+    await sqlite.db.prepare(
+      `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at, workspace_id)
+       VALUES ('old', 'a-older', 'b-newer', 'relates_to', 0.85, 'inferred', '{}', 0, 0, '')`,
+    ).run();
+
+    await runWeeklyInsights(envWith('{"insight": false, "relationship": "caused_by", "source": "B", "target": "A"}'), ctx);
+
+    const edges = await typedEdges();
+    expect(edges.map(e => e.type)).toEqual(["caused_by"]);
+    expect(edges[0].weight).toBe(0.85);
+  });
+
+  it("uses its own weight when nothing stronger was there", async () => {
+    seedPair();
+    await runWeeklyInsights(envWith('{"insight": false, "relationship": "caused_by", "source": "B", "target": "A"}'), ctx);
+
+    expect((await typedEdges())[0].weight).toBe(0.75);
+  });
+});

--- a/test/integration/link-kind-gate.test.ts
+++ b/test/integration/link-kind-gate.test.ts
@@ -1,0 +1,138 @@
+/**
+ * One kind gate, applied by every writer of a kind-constrained edge.
+ *
+ * `decided` and `follows` are episodic-only in EDGE_TYPES. Capture-time
+ * inference and the weekly insight pass both check that through
+ * `kindsAllowEdge`, but the two EXPLICIT surfaces — POST /link and the MCP
+ * `link` tool — went straight to createEdge, so a caller could hand-link two
+ * semantic memories as `follows` and produce exactly the edge the type is
+ * defined to exclude. An invariant only one writer honours is not an invariant.
+ *
+ * Both surfaces already read each endpoint to check readability and workspace,
+ * so the gate costs nothing: the kind rides along on those reads.
+ *
+ * The two are tested together on purpose — the repo's parity convention is that
+ * POST /link and MCP `link` are one operation and must not drift.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import worker from "../../src/index";
+import { buildMcpServer } from "../../src/mcp/server";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestEnv, makeMemoryKV } from "../helpers/make-env";
+import { resetDatabaseInit, initializeDatabase } from "../../src/db/init";
+import { ensureTenantBootstrap } from "../../src/lib/tenancy";
+import type { Env } from "../../src/env";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as ExecutionContext;
+const ADMIN = "test-token";
+
+describe("the kind gate on explicit links", () => {
+  let sqlite: SqliteD1;
+  let env: Env;
+
+  beforeEach(async () => {
+    resetDatabaseInit();
+    sqlite = makeSqliteD1();
+    env = makeTestEnv(undefined, {
+      DB: sqlite.db as unknown as Env["DB"],
+      OAUTH_KV: makeMemoryKV(),
+    });
+    await initializeDatabase(env);
+    await ensureTenantBootstrap(env);
+  });
+
+  afterEach(() => sqlite.close());
+
+  function seed(id: string, tags: string[]): void {
+    sqlite.seed({ id, content: `memory ${id}`, createdAt: 1000, tags });
+  }
+
+  async function postLink(source: string, target: string, type: string): Promise<{ status: number; body: any }> {
+    const res = await worker.fetch(
+      new Request("http://localhost/link", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${ADMIN}` },
+        body: JSON.stringify({ source_id: source, target_id: target, type }),
+      }),
+      env,
+      ctx,
+    );
+    return { status: res.status, body: await res.json() };
+  }
+
+  async function mcpLink(source: string, target: string, type: string): Promise<string> {
+    const server = buildMcpServer(env, ctx);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+    try {
+      const out: any = await client.callTool({
+        name: "link",
+        arguments: { source_id: source, target_id: target, type },
+      });
+      return String(out.content?.[0]?.text ?? "");
+    } finally {
+      await client.close();
+    }
+  }
+
+  const edgeCount = async () =>
+    ((await sqlite.db.prepare(`SELECT COUNT(*) AS n FROM edges`).first()) as any).n as number;
+
+  describe("POST /link", () => {
+    it("refuses follows between two semantic memories", async () => {
+      seed("a", ["kind:semantic"]);
+      seed("b", ["kind:semantic"]);
+
+      const { status, body } = await postLink("a", "b", "follows");
+      expect(status).toBe(400);
+      expect(body.ok).toBe(false);
+      expect(await edgeCount()).toBe(0);
+    });
+
+    it("refuses decided when a memory has no kind yet", async () => {
+      seed("a", []);
+      seed("b", ["kind:episodic"]);
+
+      // Unclassified is not permission: the classifier simply has not spoken.
+      expect((await postLink("a", "b", "decided")).status).toBe(400);
+      expect(await edgeCount()).toBe(0);
+    });
+
+    it("allows follows between two episodic memories", async () => {
+      seed("a", ["kind:episodic"]);
+      seed("b", ["kind:episodic"]);
+
+      expect((await postLink("a", "b", "follows")).status).toBe(200);
+      expect(await edgeCount()).toBe(1);
+    });
+
+    it("still allows relates_to between anything, which it does not constrain", async () => {
+      seed("a", ["kind:semantic"]);
+      seed("b", []);
+
+      expect((await postLink("a", "b", "relates_to")).status).toBe(200);
+      expect(await edgeCount()).toBe(1);
+    });
+  });
+
+  describe("MCP link", () => {
+    it("refuses follows between two semantic memories", async () => {
+      seed("a", ["kind:semantic"]);
+      seed("b", ["kind:semantic"]);
+
+      expect(await mcpLink("a", "b", "follows")).toMatch(/episodic/i);
+      expect(await edgeCount()).toBe(0);
+    });
+
+    it("allows follows between two episodic memories", async () => {
+      seed("a", ["kind:episodic"]);
+      seed("b", ["kind:episodic"]);
+
+      expect(await mcpLink("a", "b", "follows")).toMatch(/Linked/);
+      expect(await edgeCount()).toBe(1);
+    });
+  });
+});

--- a/test/integration/stats-graph-budget.test.ts
+++ b/test/integration/stats-graph-budget.test.ts
@@ -1,0 +1,136 @@
+/**
+ * What GET /stats/graph costs D1, pinned.
+ *
+ * The endpoint exists to audit edge quality, so it is the one surface that
+ * deliberately reads the whole edges table. That makes the split the load-
+ * bearing part: the type histogram is one pass and always runs, while the
+ * endpoint join, the degree ranking and the capture-gap histogram are three
+ * more passes that must not happen unless the caller asked with ?deep=1. An
+ * operator polling the cheap half on a schedule is the case this protects —
+ * D1's free plan allows 5M rows read per day and fails every query
+ * account-wide once that is spent.
+ *
+ * Driven against real SQLite rather than the string-matching D1 mock, for the
+ * same reason as graph-read-budget: the mock cannot fail a plan assertion.
+ * Plans are taken from the SQL captured off the binding, never restated here,
+ * so they cannot drift into describing a query the Worker does not issue.
+ *
+ * Identity resolution runs before the route and is not what this measures, so
+ * "route statements" are the ones touching edges/entries — the auth pair reads
+ * users and workspaces only.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import worker from "../../src/index";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestEnv, makeMemoryKV } from "../helpers/make-env";
+import { resetDatabaseInit, initializeDatabase } from "../../src/db/init";
+import { ensureTenantBootstrap } from "../../src/lib/tenancy";
+import type { Env } from "../../src/env";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as ExecutionContext;
+const ADMIN = "test-token";
+
+/** The route's own reads: identity resolution touches users and workspaces only. */
+const TOUCHES_GRAPH = /FROM edges|FROM entries/;
+
+describe("GET /stats/graph read budget", () => {
+  let sqlite: SqliteD1;
+  let env: Env;
+  let issued: string[];
+
+  beforeEach(async () => {
+    resetDatabaseInit();
+    sqlite = makeSqliteD1();
+    issued = [];
+    const inner = sqlite.db as any;
+    const DB = {
+      prepare(sql: string) { issued.push(sql); return inner.prepare(sql); },
+      batch: (s: any) => inner.batch(s),
+      exec: (s: string) => inner.exec(s),
+    };
+    env = makeTestEnv(undefined, { DB: DB as unknown as Env["DB"], OAUTH_KV: makeMemoryKV() });
+    await initializeDatabase(env);
+    await ensureTenantBootstrap(env);
+    issued.length = 0;
+  });
+
+  afterEach(() => sqlite.close());
+
+  async function call(path: string): Promise<string[]> {
+    issued.length = 0;
+    const res = await worker.fetch(
+      new Request(`http://localhost${path}`, { headers: { Authorization: `Bearer ${ADMIN}` } }),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    return issued.filter(s => TOUCHES_GRAPH.test(s));
+  }
+
+  /** The plan for a statement the route actually issued, bound with throwaway values. */
+  async function planOf(sql: string): Promise<string> {
+    const n = (sql.match(/\?/g) ?? []).length;
+    const plan: any = await (sqlite.db as any)
+      .prepare(`EXPLAIN QUERY PLAN ${sql}`)
+      .bind(...Array(n).fill("x"))
+      .all();
+    return (plan.results as any[]).map(r => r.detail).join("\n");
+  }
+
+  it("issues exactly one read, over edges alone, without ?deep=1", async () => {
+    const stmts = await call("/stats/graph");
+    expect(stmts).toHaveLength(1);
+    // The cheap half must never reach entries: that is the whole split.
+    expect(stmts[0]).not.toMatch(/FROM entries/);
+    expect(stmts[0]).toMatch(/GROUP BY type/);
+  });
+
+  it("issues exactly four reads under ?deep=1", async () => {
+    expect(await call("/stats/graph?deep=1")).toHaveLength(4);
+  });
+
+  it("resolves both edge endpoints through an index rather than per-row scans", async () => {
+    const join = (await call("/stats/graph?deep=1")).find(s => s.includes("NOT EXISTS"))!;
+    const plan = await planOf(join);
+    // Two correlated lookups per edge, and both must seek on the id. Seeking
+    // instead on the workspace — which the scope clause also offers an index
+    // for — walks that whole workspace once per edge, so asserting merely
+    // "an index was used" would pass on the O(edges x entries) plan.
+    expect(plan.match(/SEARCH entries USING (?:COVERING )?INDEX \w+ \(id=\?\)/g) ?? []).toHaveLength(2);
+    expect(plan).not.toMatch(/SCAN entries/);
+  });
+
+  it("reads the capture-gap histogram through the workspace/created index", async () => {
+    const gaps = (await call("/stats/graph?deep=1")).find(s => s.includes("LAG(created_at)"))!;
+    const plan = await planOf(gaps);
+    expect(plan).toMatch(/idx_entries_workspace_created/);
+    expect(plan).not.toMatch(/SCAN entries/);
+  });
+
+  it("scans edges once per aggregate, and no more", async () => {
+    const stmts = await call("/stats/graph?deep=1");
+    const scans = async (sql: string) => ((await planOf(sql)).match(/SCAN edges/g) ?? []).length;
+
+    // Counted, not matched: `toMatch(/SCAN edges/)` proves at least one scan, so
+    // an extra subquery re-reading edges would leave it green while doubling the
+    // bill. edges has no index on workspace_id, so each of these IS a full scan.
+    // If one ever reads SEARCH, an index was added: re-measure and update this
+    // pin rather than deleting it.
+    expect(await scans(stmts.find(s => s.includes("GROUP BY type"))!)).toBe(1);
+    expect(await scans(stmts.find(s => s.includes("NOT EXISTS"))!)).toBe(1);
+    // The degree ranking reads both endpoint columns, so two is its floor.
+    expect(await scans(stmts.find(s => s.includes("UNION ALL"))!)).toBe(2);
+  });
+
+  it("does not multiply the workspace scope across the endpoint join", async () => {
+    const stmts = await call("/stats/graph?deep=1");
+    const params = (sql: string) => (sql.match(/\?/g) ?? []).length;
+    const scopeSize = params(stmts.find(s => s.includes("GROUP BY type"))!);
+
+    // Repeating the caller's workspace list once per endpoint put this
+    // statement at 3x the scope size, which passes D1's 100-parameter ceiling
+    // for an admin in ~32 teams and fails the request outright. The endpoints
+    // are matched against edges.workspace_id instead, which binds nothing.
+    expect(params(stmts.find(s => s.includes("NOT EXISTS"))!)).toBe(scopeSize);
+  });
+});

--- a/test/integration/stats-graph.test.ts
+++ b/test/integration/stats-graph.test.ts
@@ -1,0 +1,251 @@
+/**
+ * GET /stats/graph — the edge-quality baseline audit surface.
+ *
+ * Admin-only, and split: the edge-type aggregate is one grouped scan and always
+ * runs, while the endpoint join, top-degree ranking and capture-gap histogram
+ * each need their own pass over a table and only run behind ?deep=1. The split
+ * is the point of the endpoint — an operator polling the cheap half must not be
+ * paying for the expensive half.
+ *
+ * The scope assertions derive the admin's readable workspaces from the identity
+ * rather than restating an id, so they still mean "what this caller may read"
+ * if tenancy bootstrap ever changes the ids it mints.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import worker from "../../src/index";
+import { makeSqliteD1, type SqliteD1 } from "../helpers/sqlite-d1";
+import { makeTestEnv, makeMemoryKV } from "../helpers/make-env";
+import { resetDatabaseInit, initializeDatabase } from "../../src/db/init";
+import { ensureTenantBootstrap } from "../../src/lib/tenancy";
+import { createMember } from "../../src/lib/team-admin";
+import { requireAdmin } from "../../src/lib/identity";
+import { scopeWorkspaces } from "../../src/lib/scope";
+import type { Env } from "../../src/env";
+
+const ctx = { waitUntil: (_: Promise<any>) => {} } as ExecutionContext;
+const ADMIN = "test-token";
+const OUTSIDE = "ws-not-readable-by-anyone";
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+function get(path: string, token?: string): Request {
+  return new Request(`http://localhost${path}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+describe("GET /stats/graph", () => {
+  let sqlite: SqliteD1;
+  let env: Env;
+  let memberToken = "";
+  let readable: string[] = [];
+
+  /** Edges are inserted directly: seed() has no workspace column and scope is what is under test. */
+  function edge(id: string, source: string, target: string, type: string, workspaceId: string): void {
+    sqlite.db
+      .prepare(
+        `INSERT INTO edges (id, source_id, target_id, type, weight, provenance, metadata, created_at, updated_at, workspace_id)
+         VALUES (?, ?, ?, ?, 0.5, 'inferred', '{}', 0, 0, ?)`,
+      )
+      .bind(id, source, target, type, workspaceId)
+      .run();
+  }
+
+  /** entries.seed() has no workspace column, and workspace placement is under test. */
+  function entry(id: string, createdAt: number, workspaceId: string): void {
+    sqlite.db
+      .prepare(
+        `INSERT INTO entries (id, content, tags, source, created_at, updated_at, vector_ids, recall_count, importance_score, workspace_id)
+         VALUES (?, ?, '[]', 'api', ?, ?, '[]', 0, 0, ?)`,
+      )
+      .bind(id, `entry ${id}`, createdAt, createdAt, workspaceId)
+      .run();
+  }
+
+  beforeEach(async () => {
+    resetDatabaseInit();
+    sqlite = makeSqliteD1();
+    env = makeTestEnv(undefined, {
+      DB: sqlite.db as unknown as Env["DB"],
+      OAUTH_KV: makeMemoryKV(),
+    });
+    await initializeDatabase(env);
+    await ensureTenantBootstrap(env);
+    memberToken = (await createMember(env, { name: "Bob" })).token;
+
+    const auth = await requireAdmin(get("/stats/graph", ADMIN), env);
+    if (auth instanceof Response) throw new Error("admin fixture failed to authenticate");
+    readable = scopeWorkspaces(auth);
+  });
+
+  afterEach(() => sqlite.close());
+
+  it("rejects an unauthenticated caller with 401", async () => {
+    const res = await worker.fetch(get("/stats/graph"), env, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a member who is not an admin with 403", async () => {
+    const res = await worker.fetch(get("/stats/graph", memberToken), env, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("counts edges by type for an admin", async () => {
+    edge("e1", "a", "b", "relates_to", readable[0]);
+    edge("e2", "b", "c", "relates_to", readable[0]);
+    edge("e3", "c", "d", "follows", readable[0]);
+
+    const res = await worker.fetch(get("/stats/graph", ADMIN), env, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.edgeTypes).toEqual({ relates_to: 2, follows: 1 });
+  });
+
+  it("omits the deep sections unless ?deep=1 is asked for", async () => {
+    edge("e1", "a", "b", "relates_to", readable[0]);
+
+    const body = await (await worker.fetch(get("/stats/graph", ADMIN), env, ctx)).json() as any;
+    expect(body.deep).toBe(false);
+    expect(body.topDegree).toBeUndefined();
+    expect(body.dangling).toBeUndefined();
+    expect(body.gapBuckets).toBeUndefined();
+  });
+
+  // Inbound only: with a source-side fixture alone, dropping the target half of
+  // the UNION ALL still reports the hub correctly.
+  it("counts inbound edges towards a node's degree", async () => {
+    entry("sink", 1000, readable[0]);
+    edge("e1", "a", "sink", "relates_to", readable[0]);
+    edge("e2", "b", "sink", "relates_to", readable[0]);
+
+    const body = await (await worker.fetch(get("/stats/graph?deep=1", ADMIN), env, ctx)).json() as any;
+    expect(body.topDegree[0]).toEqual({ id: "sink", degree: 2 });
+  });
+
+  it("ranks nodes by degree under ?deep=1", async () => {
+    sqlite.seed({ id: "hub", content: "hub", createdAt: 1000 });
+    sqlite.seed({ id: "leaf1", content: "leaf1", createdAt: 1001 });
+    sqlite.seed({ id: "leaf2", content: "leaf2", createdAt: 1002 });
+    edge("e1", "hub", "leaf1", "relates_to", readable[0]);
+    edge("e2", "hub", "leaf2", "relates_to", readable[0]);
+
+    const body = await (await worker.fetch(get("/stats/graph?deep=1", ADMIN), env, ctx)).json() as any;
+    expect(body.deep).toBe(true);
+    expect(body.topDegree[0]).toEqual({ id: "hub", degree: 2 });
+  });
+
+  it("counts an edge whose target has no entries row under ?deep=1", async () => {
+    entry("real", 1000, readable[0]);
+    edge("kept", "real", "real", "relates_to", readable[0]);
+    edge("missing-target", "real", "deleted-entry", "relates_to", readable[0]);
+
+    const body = await (await worker.fetch(get("/stats/graph?deep=1", ADMIN), env, ctx)).json() as any;
+    expect(body.invalidEndpointEdges).toBe(1);
+  });
+
+  // The source side needs its own fixture: with only a missing-target case,
+  // pointing both subqueries at target_id still returns the right number.
+  it("counts an edge whose SOURCE has no entries row", async () => {
+    entry("real", 1000, readable[0]);
+    edge("missing-source", "deleted-entry", "real", "relates_to", readable[0]);
+
+    const body = await (await worker.fetch(get("/stats/graph?deep=1", ADMIN), env, ctx)).json() as any;
+    expect(body.invalidEndpointEdges).toBe(1);
+  });
+
+  // Caller-independent: an endpoint living in another workspace is a corrupt
+  // edge whether or not this admin happens to read that workspace, so the
+  // count must not depend on the caller's membership.
+  it("counts an edge whose endpoint sits in a different workspace from the edge", async () => {
+    entry("elsewhere", 1000, "ws-somewhere-else");
+    edge("crossing", "elsewhere", "elsewhere", "relates_to", readable[0]);
+
+    const body = await (await worker.fetch(get("/stats/graph?deep=1", ADMIN), env, ctx)).json() as any;
+    expect(body.invalidEndpointEdges).toBe(1);
+  });
+
+  it("buckets the gaps between consecutive captures under ?deep=1", async () => {
+    // One gap per bucket, accumulated rather than written out as absolute
+    // timestamps so a bucket boundary cannot be mis-added by hand.
+    const gaps = [2 * MINUTE, 20 * MINUTE, HOUR, 5 * HOUR, 3 * DAY, 30 * DAY];
+    let at = 1_700_000_000_000;
+    sqlite.seed({ id: "g0", content: "gap 0", createdAt: at });
+    gaps.forEach((gap, i) => {
+      at += gap;
+      sqlite.seed({ id: `g${i + 1}`, content: `gap ${i + 1}`, createdAt: at });
+    });
+
+    const body = await (await worker.fetch(get("/stats/graph?deep=1", ADMIN), env, ctx)).json() as any;
+    expect(body.gapBuckets).toEqual({
+      under5m: 1, under30m: 1, under2h: 1, under1d: 1, under7d: 1, older: 1,
+    });
+  });
+
+  // Both workspaces are readable, so nothing here is about privacy: it is about
+  // measuring the right population. `follows` is only ever drawn within one
+  // workspace, so a gap between two workspaces is not a gap it could describe.
+  it("measures capture gaps within a workspace, not across two readable ones", async () => {
+    const t0 = 1_700_000_000_000;
+    entry("a1", t0, readable[0]);
+    entry("b1", t0 + 1 * MINUTE, "");
+    entry("a2", t0 + 60 * MINUTE, readable[0]);
+    entry("b2", t0 + 61 * MINUTE, "");
+
+    const body = await (await worker.fetch(get("/stats/graph?deep=1", ADMIN), env, ctx)).json() as any;
+    // Interleaved globally this reads as 1m/59m/1m; per workspace it is 60m twice.
+    expect(body.gapBuckets).toEqual({
+      under5m: 0, under30m: 0, under2h: 2, under1d: 0, under7d: 0, older: 0,
+    });
+  });
+
+  // Each boundary lands in the HIGHER bucket, so < cannot drift to <=.
+  it("puts a gap exactly on a boundary into the wider bucket", async () => {
+    const t0 = 1_700_000_000_000;
+    const bounds = [5 * MINUTE, 30 * MINUTE, 2 * HOUR, DAY, 7 * DAY];
+    let at = t0;
+    entry("b0", at, readable[0]);
+    bounds.forEach((gap, i) => {
+      at += gap;
+      entry(`b${i + 1}`, at, readable[0]);
+    });
+
+    const body = await (await worker.fetch(get("/stats/graph?deep=1", ADMIN), env, ctx)).json() as any;
+    expect(body.gapBuckets).toEqual({
+      under5m: 0, under30m: 1, under2h: 1, under1d: 1, under7d: 1, older: 1,
+    });
+  });
+
+  it("never counts edges from a workspace the caller cannot read", async () => {
+    // Well-formed: endpoint and edge share a workspace, so it is not counted
+    // as invalid and the assertion below is about scope alone.
+    entry("mine", 1000, readable[0]);
+    sqlite.seed({ id: "theirs", content: "theirs", createdAt: 1001 });
+    edge("in", "mine", "mine", "relates_to", readable[0]);
+    // Same shape, higher degree, outside the caller's scope: it would top the
+    // ranking and double the type count if the scope clause were dropped.
+    edge("out1", "theirs", "mine", "relates_to", OUTSIDE);
+    edge("out2", "theirs", "mine", "follows", OUTSIDE);
+
+    const body = await (await worker.fetch(get("/stats/graph?deep=1", ADMIN), env, ctx)).json() as any;
+    expect(body.edgeTypes).toEqual({ relates_to: 1 });
+    expect(body.topDegree.map((n: any) => n.id)).not.toContain("theirs");
+    // The deep aggregates are scoped too: the out-of-scope edges point at an
+    // entry that does not exist, so an unscoped count would see them.
+    expect(body.invalidEndpointEdges).toBe(0);
+  });
+
+  it("never measures capture gaps from a workspace the caller cannot read", async () => {
+    const t0 = 1_700_000_000_000;
+    entry("mine-1", t0, readable[0]);
+    entry("mine-2", t0 + 10 * MINUTE, readable[0]);
+    // A dense burst outside the caller's scope: it would dominate the histogram.
+    for (let i = 0; i < 5; i++) entry(`theirs-${i}`, t0 + i * 1000, OUTSIDE);
+
+    const body = await (await worker.fetch(get("/stats/graph?deep=1", ADMIN), env, ctx)).json() as any;
+    expect(body.gapBuckets).toEqual({
+      under5m: 0, under30m: 1, under2h: 0, under1d: 0, under7d: 0, older: 0,
+    });
+  });
+});

--- a/test/integration/typed-edge-recall.test.ts
+++ b/test/integration/typed-edge-recall.test.ts
@@ -1,0 +1,209 @@
+/**
+ * The recall gate for Phases B and C: typing an edge must not hide it.
+ *
+ * Both phases REPLACE edges rather than adding them — a capture-time `follows`
+ * retires the inferred `relates_to` between the same pair, and an insight-pass
+ * `caused_by` does the same. So every edge these phases produce is one that
+ * recall could previously reach by another name, and the failure mode is not a
+ * missing feature but a silent loss: evidence that used to arrive at hops=1 and
+ * now does not.
+ *
+ * Graph expansion applies no type filter, but it does `ORDER BY weight DESC`,
+ * and the replacement is not weight-neutral. An inferred `relates_to` carries
+ * the pair's similarity score (0.78 and up); an insight-reasoned `caused_by`
+ * carries a flat 0.75. So a typed edge can sort BELOW the generic edge it
+ * retired, which is the specific regression these fixtures are here to catch.
+ *
+ * Modelled on graph-aware-recall-benchmark: five strong direct matches crowd
+ * Recall@5, and the answer can only enter through the edge.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { recallEntries } from "../../src/recall/search";
+import { makeTestDb, makeTestEnv, makeVectorizeMock } from "../helpers/make-env";
+
+const QUERY = "pricing rollback";
+const ANSWER = "The flat tier was withdrawn after the margin review";
+
+function suppressKeywordSearch(db: ReturnType<typeof makeTestDb>) {
+  const prepare = db.prepare.bind(db);
+  (db as any).prepare = (sql: string) => {
+    if (sql.includes("WHERE content LIKE") && sql.includes("ORDER BY created_at DESC LIMIT")) {
+      return { bind: () => ({ all: async () => ({ results: [] }) }) };
+    }
+    return prepare(sql);
+  };
+}
+
+/** Root plus linked answer, joined by whatever edges the case is about. */
+function fixture(edges: { type: string; weight: number; provenance: string }[]) {
+  const db = makeTestDb();
+  for (let i = 0; i < 5; i++) {
+    db.entries.push({
+      id: `direct-${i}`, content: `unrelated direct note ${i}`, tags: "[]", source: "api",
+      created_at: 2000 - i, vector_ids: "[]", recall_count: 0, importance_score: 0,
+    });
+  }
+  db.entries.push({
+    id: "root", content: "decision root", tags: '["kind:episodic"]', source: "api",
+    created_at: 1000, vector_ids: "[]", recall_count: 0, importance_score: 0,
+  });
+  db.entries.push({
+    id: "answer", content: `${QUERY} ${ANSWER}`, tags: '["kind:episodic"]', source: "api",
+    created_at: 900, vector_ids: "[]", recall_count: 0, importance_score: 0,
+  });
+
+  edges.forEach((e, i) => {
+    db.edges.push({
+      id: `edge-${i}`, source_id: "root", target_id: "answer",
+      type: e.type, weight: e.weight, provenance: e.provenance,
+      metadata: "{}", created_at: 1, updated_at: 1,
+    });
+  });
+  suppressKeywordSearch(db);
+
+  const matches = [
+    ...[0, 1, 2, 3, 4].map(i => ({
+      id: `direct-${i}`, score: 0.95 - i * 0.04,
+      metadata: { parentId: `direct-${i}`, isUpdate: false },
+    })),
+    { id: "root", score: 0.7, metadata: { parentId: "root", isUpdate: false } },
+  ];
+  const env = makeTestEnv(db, {
+    VECTORIZE: makeVectorizeMock({ query: vi.fn().mockResolvedValue({ matches }) }),
+  });
+  return { env, ctx: { waitUntil: () => undefined } as any as ExecutionContext };
+}
+
+async function idsAtHop1(edges: { type: string; weight: number; provenance: string }[]): Promise<string[]> {
+  const { env, ctx } = fixture(edges);
+  const result = await recallEntries({ query: QUERY, topK: 5, hops: 1, synthesize: false }, env, ctx);
+  return result.matches.map(m => m.id);
+}
+
+describe("typed edges still carry linked evidence into recall", () => {
+  // The pre-Phase-B state of the pair: what the typed edges below replace.
+  it("baseline: an inferred relates_to reaches the answer at hops=1", async () => {
+    expect(await idsAtHop1([{ type: "relates_to", weight: 0.85, provenance: "inferred" }]))
+      .toContain("answer");
+  });
+
+  it("a capture-time follows reaches it just as well", async () => {
+    expect(await idsAtHop1([{ type: "follows", weight: 0.85, provenance: "inferred" }]))
+      .toContain("answer");
+  });
+
+  // The weight drop is the point: 0.75 is what the insight pass stamps, and it
+  // is LOWER than the 0.85 relates_to it deletes.
+  it("an insight-reasoned caused_by reaches it at its lower weight", async () => {
+    expect(await idsAtHop1([{ type: "caused_by", weight: 0.75, provenance: "system" }]))
+      .toContain("answer");
+  });
+
+  it("an insight-reasoned decided reaches it too", async () => {
+    expect(await idsAtHop1([{ type: "decided", weight: 0.75, provenance: "system" }]))
+      .toContain("answer");
+  });
+
+  // Typed-replaces-generic is not instantaneous everywhere: a backfill or an
+  // explicit link can leave both standing on one pair.
+  it("a pair carrying both relates_to and follows surfaces the answer exactly once", async () => {
+    const ids = await idsAtHop1([
+      { type: "relates_to", weight: 0.85, provenance: "explicit" },
+      { type: "follows", weight: 0.85, provenance: "inferred" },
+    ]);
+    expect(ids).toContain("answer");
+    expect(ids.filter(id => id === "answer")).toHaveLength(1);
+  });
+
+  it("still spends the whole Recall@5 budget rather than dropping a result", async () => {
+    expect(await idsAtHop1([{ type: "follows", weight: 0.85, provenance: "inferred" }]))
+      .toHaveLength(5);
+  });
+
+  it("leaves the strongest direct match on top", async () => {
+    const ids = await idsAtHop1([{ type: "caused_by", weight: 0.75, provenance: "system" }]);
+    expect(ids[0]).toBe("direct-0");
+  });
+});
+
+/**
+ * The case the single-edge fixtures above cannot reach.
+ *
+ * Graph expansion takes at most GRAPH_FANOUT_CAP (8) neighbours per node,
+ * ordered by weight. With one edge on the root, any weight clears the cut, so
+ * those fixtures say nothing about what replacing a 0.85 edge with a 0.75 one
+ * does. Here the root is well-connected — eight competitors between 0.76 and
+ * 0.84 — so the answer's weight decides whether it is expanded at all.
+ */
+describe("a typed edge on a well-connected root", () => {
+  const COMPETITORS = 8;
+
+  function crowdedFixture(answerEdge: { type: string; weight: number; provenance: string }) {
+    const db = makeTestDb();
+    for (let i = 0; i < 5; i++) {
+      db.entries.push({
+        id: `direct-${i}`, content: `unrelated direct note ${i}`, tags: "[]", source: "api",
+        created_at: 2000 - i, vector_ids: "[]", recall_count: 0, importance_score: 0,
+      });
+    }
+    db.entries.push({
+      id: "root", content: "decision root", tags: "[]", source: "api",
+      created_at: 1000, vector_ids: "[]", recall_count: 0, importance_score: 0,
+    });
+    db.entries.push({
+      id: "answer", content: `${QUERY} ${ANSWER}`, tags: "[]", source: "api",
+      created_at: 900, vector_ids: "[]", recall_count: 0, importance_score: 0,
+    });
+
+    // Eight rivals for the eight slots, all weighted above 0.75 and below 0.85.
+    for (let i = 0; i < COMPETITORS; i++) {
+      db.entries.push({
+        id: `rival-${i}`, content: `an unrelated neighbour ${i}`, tags: "[]", source: "api",
+        created_at: 800 - i, vector_ids: "[]", recall_count: 0, importance_score: 0,
+      });
+      db.edges.push({
+        id: `rival-edge-${i}`, source_id: "root", target_id: `rival-${i}`,
+        type: "relates_to", weight: 0.76 + i * 0.01, provenance: "inferred",
+        metadata: "{}", created_at: 1, updated_at: 1,
+      });
+    }
+    db.edges.push({
+      id: "answer-edge", source_id: "root", target_id: "answer",
+      type: answerEdge.type, weight: answerEdge.weight, provenance: answerEdge.provenance,
+      metadata: "{}", created_at: 1, updated_at: 1,
+    });
+    suppressKeywordSearch(db);
+
+    const matches = [
+      ...[0, 1, 2, 3, 4].map(i => ({
+        id: `direct-${i}`, score: 0.95 - i * 0.04,
+        metadata: { parentId: `direct-${i}`, isUpdate: false },
+      })),
+      { id: "root", score: 0.7, metadata: { parentId: "root", isUpdate: false } },
+    ];
+    const env = makeTestEnv(db, {
+      VECTORIZE: makeVectorizeMock({ query: vi.fn().mockResolvedValue({ matches }) }),
+    });
+    return { env, ctx: { waitUntil: () => undefined } as any as ExecutionContext };
+  }
+
+  async function reaches(answerEdge: { type: string; weight: number; provenance: string }): Promise<boolean> {
+    const { env, ctx } = crowdedFixture(answerEdge);
+    const result = await recallEntries({ query: QUERY, topK: 5, hops: 1, synthesize: false }, env, ctx);
+    return result.matches.map(m => m.id).includes("answer");
+  }
+
+  it("reaches the answer through the generic edge it starts with", async () => {
+    expect(await reaches({ type: "relates_to", weight: 0.85, provenance: "inferred" })).toBe(true);
+  });
+
+  // The regression the weight carry-forward exists to prevent: the insight
+  // pass's flat 0.75 sorts below all eight rivals and never gets expanded.
+  it("loses the answer if the replacement drops to the flat insight weight", async () => {
+    expect(await reaches({ type: "caused_by", weight: 0.75, provenance: "system" })).toBe(false);
+  });
+
+  it("keeps the answer when the replacement inherits the weight it retired", async () => {
+    expect(await reaches({ type: "caused_by", weight: 0.85, provenance: "system" })).toBe(true);
+  });
+});

--- a/test/unit/edges.test.ts
+++ b/test/unit/edges.test.ts
@@ -180,12 +180,27 @@ describe("inferEdgesOnWrite", () => {
   let env: Env;
   let db: D1Mock;
 
+  /**
+   * Inference refuses a neighbour with no `entries` row, so every id a case
+   * expects to be linked needs one. Seeded with no workspace and no kind, the
+   * pre-tenancy shape, so these cases still say only what they always said.
+   */
+  function present(...ids: string[]): void {
+    for (const id of ids) {
+      db.entries.push({
+        id, content: `entry ${id}`, tags: "[]", source: "api",
+        created_at: 1000, vector_ids: "[]", recall_count: 0, importance_score: 0,
+      });
+    }
+  }
+
   beforeEach(() => {
     db = makeTestDb();
     env = makeTestEnv(db);
   });
 
   it("auto-links only genuinely-related neighbors, not loose keyword-overlap ones", async () => {
+    present("new", "strong", "loose", "weak");
     await inferEdgesOnWrite("new", [
       { id: "strong", score: 0.84 }, // clearly related — link
       { id: "loose", score: 0.66 },  // shares a keyword but not really related — must NOT link
@@ -198,13 +213,30 @@ describe("inferEdgesOnWrite", () => {
     expect(db.edges[0].provenance).toBe("inferred");
   });
 
+  /**
+   * A neighbour with no `entries` row is a vector that outlived its entry. The
+   * edge it produces is unreachable — every graph read hydrates both endpoints
+   * and drops what is missing — and the nightly sweep deletes it, which returns
+   * the source to the backfill's slate to have it drawn again.
+   */
+  it("refuses a neighbour that has no entries row", async () => {
+    present("new", "real");
+
+    await inferEdgesOnWrite("new", [{ id: "ghost", score: 0.95 }, { id: "real", score: 0.84 }], env);
+
+    const linked = db.edges.flatMap((e: any) => [e.source_id, e.target_id]).filter((id: string) => id !== "new");
+    expect(linked).toEqual(["real"]);
+  });
+
   it("never links the new entry to itself", async () => {
+    present("new", "a");
     await inferEdgesOnWrite("new", [{ id: "new", score: 0.99 }, { id: "a", score: 0.8 }], env);
     expect(db.edges).toHaveLength(1);
     expect([db.edges[0].source_id, db.edges[0].target_id].sort()).toEqual(["a", "new"]);
   });
 
   it("caps at the top 3 strongest neighbors", async () => {
+    present("new", "a", "b", "c", "d", "e");
     await inferEdgesOnWrite("new", [
       { id: "a", score: 0.9 }, { id: "b", score: 0.85 }, { id: "c", score: 0.8 },
       { id: "d", score: 0.75 }, { id: "e", score: 0.7 },
@@ -215,11 +247,13 @@ describe("inferEdgesOnWrite", () => {
   });
 
   it("uses the similarity score as the edge weight", async () => {
+    present("new", "a");
     await inferEdgesOnWrite("new", [{ id: "a", score: 0.82 }], env);
     expect(db.edges[0].weight).toBeCloseTo(0.82);
   });
 
   it("writes nothing when there are no qualifying neighbors", async () => {
+    present("new", "a");
     await inferEdgesOnWrite("new", [{ id: "a", score: 0.3 }], env);
     expect(db.edges).toHaveLength(0);
   });

--- a/test/unit/insight-relationship.test.ts
+++ b/test/unit/insight-relationship.test.ts
@@ -1,0 +1,211 @@
+/**
+ * C — reading a typed relationship out of the insight call that already runs.
+ *
+ * The weekly pass already asks a reasoning model to look at two memories
+ * together. It was throwing away everything except the prose: the model had
+ * plainly decided how the two relate in order to answer at all, and that verdict
+ * was discarded. Asking for it costs no extra call — only a few more output
+ * tokens on a call already made.
+ *
+ * Two things make this worth testing carefully rather than trusting:
+ *
+ *   - the relationship is parsed BEFORE the `insight: true` gate, because the
+ *     model refusing to write a publishable insight is not the same as it having
+ *     no opinion about how the pair relates. Most calls decline; if the
+ *     relationship only survived on the accepted path, the feature would fire on
+ *     the small minority of runs.
+ *   - `supersedes` is deliberately NOT in the enum. It is welded to deprecation
+ *     semantics elsewhere in the codebase, and a model volunteering it here
+ *     would retire a memory the person never asked to retire.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { parseRelationship, reasonOverPair } from "../../src/insight/reason";
+import { makeTestEnv, makeTestDb } from "../helpers/make-env";
+
+function makeAI(payload: string) {
+  return {
+    run: vi.fn().mockResolvedValue(new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode(`data: {"response":${JSON.stringify(payload)}}\n\n`));
+        c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+        c.close();
+      },
+    })),
+  } as any;
+}
+
+const A = { content: "The vendor contract renewal was signed on Tuesday under the Halloway terms." };
+const B = { content: "We cancelled the Halloway renewal after the pricing review came back." };
+/** Names something only A has and something only B has, so it clears the vocabulary floor. */
+const GOOD_TEXT =
+  "You signed the vendor contract on Tuesday and then cancelled it once the pricing review came back, so the commitment held for less than a week.";
+
+describe("parseRelationship", () => {
+  it("reads the type and which side is the source", () => {
+    expect(parseRelationship('{"relationship": "caused_by", "source": "B", "target": "A"}'))
+      .toEqual({ type: "caused_by", source: "B" });
+  });
+
+  it("reads a relationship out of a response that also carries an insight", () => {
+    expect(parseRelationship(`{"insight": true, "shape": "connection", "text": "x", "relationship": "decided", "source": "A", "target": "B"}`))
+      .toEqual({ type: "decided", source: "A" });
+  });
+
+  it("returns null for none", () => {
+    expect(parseRelationship('{"relationship": "none"}')).toBeNull();
+  });
+
+  it("returns null when no relationship is offered at all", () => {
+    expect(parseRelationship('{"insight": false}')).toBeNull();
+  });
+
+  // Not an oversight: supersedes deprecates the memory it points at, and no
+  // model volunteering it here should be able to retire something silently.
+  it("refuses supersedes even though it is a real edge type", () => {
+    expect(parseRelationship('{"relationship": "supersedes", "source": "A", "target": "B"}')).toBeNull();
+  });
+
+  it("refuses a type that is not in the enum", () => {
+    expect(parseRelationship('{"relationship": "vibes_with", "source": "A", "target": "B"}')).toBeNull();
+  });
+
+  it("refuses a relationship with no usable direction", () => {
+    expect(parseRelationship('{"relationship": "caused_by", "source": "C"}')).toBeNull();
+  });
+
+  // A response naming one memory as both ends is not a direction the model
+  // committed to; taking `source` alone would silently invent one.
+  it("refuses a relationship whose target is the same side as its source", () => {
+    expect(parseRelationship('{"relationship": "caused_by", "source": "A", "target": "A"}')).toBeNull();
+  });
+
+  it("refuses a relationship with no target at all", () => {
+    expect(parseRelationship('{"relationship": "caused_by", "source": "A"}')).toBeNull();
+  });
+
+  it("returns null on unparseable output rather than throwing", () => {
+    expect(parseRelationship("the model wrote prose instead")).toBeNull();
+  });
+});
+
+describe("reasonOverPair carries the relationship", () => {
+  it("returns it alongside an accepted insight", async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeAI(`{"insight": true, "shape": "contradiction", "text": ${JSON.stringify(GOOD_TEXT)}, "relationship": "caused_by", "source": "B", "target": "A"}`),
+    });
+
+    expect(await reasonOverPair(A, B, env)).toEqual({
+      outcome: "insight",
+      shape: "contradiction",
+      text: GOOD_TEXT,
+      relationship: { type: "caused_by", source: "B" },
+    });
+  });
+
+  // The whole yield of this phase. Declines are the common case, and the model
+  // still answered the relationship question on the way to declining.
+  it("returns it when the model declined to write an insight", async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeAI('{"insight": false, "relationship": "follows", "source": "B", "target": "A"}'),
+    });
+
+    expect(await reasonOverPair(A, B, env)).toEqual({
+      outcome: "declined",
+      relationship: { type: "follows", source: "B" },
+    });
+  });
+
+  it("returns it when the insight was rejected by the quality floor", async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      // Too short for MIN_INSIGHT_TEXT_CHARS, so the insight is dropped.
+      AI: makeAI('{"insight": true, "shape": "connection", "text": "too short", "relationship": "decided", "source": "A", "target": "B"}'),
+    });
+
+    expect(await reasonOverPair(A, B, env)).toEqual({
+      outcome: "declined",
+      relationship: { type: "decided", source: "A" },
+    });
+  });
+
+  it("omits the field entirely when the model offers no relationship", async () => {
+    const env = makeTestEnv(makeTestDb(), { AI: makeAI('{"insight": false}') });
+
+    expect(await reasonOverPair(A, B, env)).toEqual({ outcome: "declined" });
+  });
+
+  /**
+   * A truncated or non-JSON response is NOT a considered refusal.
+   *
+   * `declined` marks the candidate `rejected` forever, and re-accrual cannot
+   * resurrect it. The model running out of tokens mid-object — likelier now
+   * that the prompt asks for a second answer — must therefore leave the pair
+   * `pending`, exactly as a thrown call does, or one truncation permanently
+   * costs a pair that would otherwise have produced an insight.
+   */
+  it("treats an unparseable response as failed, not as a decline", async () => {
+    const env = makeTestEnv(makeTestDb(), { AI: makeAI("the model wrote prose and never opened a brace") });
+    expect(await reasonOverPair(A, B, env)).toEqual({ outcome: "failed" });
+  });
+
+  it("treats a truncated JSON object as failed", async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: makeAI('{"insight": true, "shape": "connection", "text": "cut off mid'),
+    });
+    expect(await reasonOverPair(A, B, env)).toEqual({ outcome: "failed" });
+  });
+
+  it("still reports failure when the call itself fails", async () => {
+    const env = makeTestEnv(makeTestDb(), {
+      AI: { run: vi.fn().mockRejectedValue(new Error("model unavailable")) } as any,
+    });
+
+    expect(await reasonOverPair(A, B, env)).toEqual({ outcome: "failed" });
+  });
+});
+
+/**
+ * The prompt is the contract with the model, and the yield of this phase rests
+ * on two properties of it that are easy to break while editing prose.
+ */
+describe("the reasoning prompt", () => {
+  async function promptSent(): Promise<string> {
+    const prompts: string[] = [];
+    const env = makeTestEnv(makeTestDb(), {
+      AI: {
+        run: vi.fn().mockImplementation(async (_m: string, opts: any) => {
+          prompts.push(String(opts?.messages?.[0]?.content ?? ""));
+          return new ReadableStream({
+            start(c) {
+              c.enqueue(new TextEncoder().encode('data: {"response":"{\\"insight\\": false}"}\n\n'));
+              c.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+              c.close();
+            },
+          });
+        }),
+      } as any,
+    });
+    await reasonOverPair(A, B, env);
+    return prompts[0];
+  }
+
+  it("still offers both original response alternatives verbatim", async () => {
+    const prompt = await promptSent();
+    // The insight half of the contract predates this work and must survive it:
+    // an edit that replaced these with a relationship-only schema would quietly
+    // turn the weekly pass into an edge generator that writes no insights.
+    expect(prompt).toContain('{"insight": false}');
+    expect(prompt).toContain('{"insight": true, "shape": "<shape>", "text": "<the insight>"}');
+  });
+
+  it("puts the relationship spec last, after the insight instructions", async () => {
+    const prompt = await promptSent();
+    // Last on purpose: the insight is still the primary task, and instructions
+    // placed after it read as the refinement rather than the headline.
+    expect(prompt.indexOf('"relationship"')).toBeGreaterThan(prompt.indexOf('{"insight": false}'));
+    expect(prompt).toMatch(/caused_by[\s\S]*decided[\s\S]*follows[\s\S]*none/);
+  });
+
+  it("never offers supersedes to the model", async () => {
+    expect(await promptSent()).not.toContain("supersedes");
+  });
+});

--- a/test/unit/scope-checker.test.ts
+++ b/test/unit/scope-checker.test.ts
@@ -1108,10 +1108,10 @@ describe("the checker over the real source tree", () => {
   // than by the slice, which is the fix, and the lexer's opinion of it followed.
   //
   // As the tool printed it:
-  //   ✔ scope check: 90 queries, 47 documented exceptions, 7 scope-checked
+  //   ✔ scope check: 99 queries, 53 documented exceptions, 7 scope-checked
   //     (clause assembled in JS), 1 scope-outer-join (clause governs a column,
   //     not the row set)
-  it("reports exactly 90 queries, 47 exceptions, 7 scope-checked and 1 outer-join", () => {
+  it("reports exactly 99 queries, 53 exceptions, 7 scope-checked and 1 outer-join", () => {
     const run = spawnSync("node", [resolve(ROOT, "scripts/check-scope.mjs")], {
       cwd: ROOT,
       encoding: "utf8",
@@ -1126,7 +1126,7 @@ describe("the checker over the real source tree", () => {
       { queries, exempt, checked, outerJoin },
       "check:scope counts moved. If that was deliberate, say so out loud and " +
         "update this expectation in the same commit.",
-    ).toEqual({ queries: 90, exempt: 47, checked: 7, outerJoin: 1 });
+    ).toEqual({ queries: 99, exempt: 53, checked: 7, outerJoin: 1 });
   });
 
   it("is wired into package.json and CI, or nothing runs it", () => {

--- a/test/unit/store-mirrored-chunks.test.ts
+++ b/test/unit/store-mirrored-chunks.test.ts
@@ -39,7 +39,7 @@ describe("storeEntry chunk indexing for mirrored sources", () => {
     const content = longMirroredRecord();
     expect(content.length).toBeGreaterThan(CHUNK_MAX_CHARS);
 
-    const vectorIds = await storeEntry(env, "entry-1", content, ["email"], "email-gmail", Date.now());
+    const { vectorIds } = await storeEntry(env, "entry-1", content, ["email"], "email-gmail", Date.now());
 
     const upserted = (env.VECTORIZE.upsert as any).mock.calls[0][0];
     expect(upserted).toHaveLength(1);


### PR DESCRIPTION
## What

Turns the knowledge graph into a real typed graph instead of 94% generic `relates_to` edges, per the amended v3 plan.

- **Typed edge inference at capture time**: `follows`, `caused_by`, `decided` drawn in addition to generic `relates_to` (junk-link suppression prevents near-duplicate confusion from creating misleading connections).
- **Update and merge paths re-infer edges** so the graph stays current when content changes; typed edges replace only inferred `relates_to` pairs, never explicit links.
- **Nightly backfill** can emit `follows` when an entry's kind is already classified; refuses long-mirrored sources.
- **Insight calls parse a relationship + direction** before the insight gate, retiring only inferred `relates_to` edges.
- **`GET /stats/graph`** (admin only, gated behind `?deep=1`, unscheduled) reports graph health with gap distribution and EXPLAIN-planned query assertions.
- **Weekly sweep** instead of nightly (~7x cheaper amortized).
- MCP `link` tool description now explains each edge type and direction; kind gating wired into POST `/link` and MCP `link`.

## Constraints honored

- Brain-agnostic, zero added AI/LLM calls, no recall-scoring changes, free-tier D1/Workers AI/subrequest budgets respected (edge writes batched 5→2 subrequests).

## Verification

- 3379 tests passing (from 3266 baseline, +113)
- `tsc --noEmit` clean; `check:scope` 99 queries / 53 exceptions
- ADR/decisions: `?deep=1` stays manual/unscheduled (no `edges(workspace_id)` index, user decision; ~5M row-visit cost documented)