### PR TITLE
Release app 3.1.0 + Worker 3.1.0

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,31 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|apply_patch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ ! -f '/home/rahil/.agents/skills/impeccable/scripts/impeccable' ] || '/home/rahil/.agents/skills/impeccable/scripts/impeccable' hook",
+            "commandWindows": "if exist \"/home/rahil/.agents/skills/impeccable/scripts/impeccable.cmd\" (\"/home/rahil/.agents/skills/impeccable/scripts/impeccable.cmd\" hook & exit /b)",
+            "timeout": 5,
+            "statusMessage": "Checking UI changes"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ ! -f '/home/rahil/.agents/skills/impeccable/scripts/impeccable' ] || '/home/rahil/.agents/skills/impeccable/scripts/impeccable' hook",
+            "commandWindows": "if exist \"/home/rahil/.agents/skills/impeccable/scripts/impeccable.cmd\" (\"/home/rahil/.agents/skills/impeccable/scripts/impeccable.cmd\" hook & exit /b)",
+            "timeout": 30,
+            "statusMessage": "Design deep pass"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/hooks/impeccable.json
+++ b/.github/hooks/impeccable.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "postToolUse": [
+      {
+        "type": "command",
+        "matcher": "edit|create|apply_patch",
+        "bash": "[ ! -f \"$(git rev-parse --show-toplevel)/.github/skills/impeccable/scripts/impeccable\" ] || \"$(git rev-parse --show-toplevel)/.github/skills/impeccable/scripts/impeccable\" hook",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Second Brain are documented here. Version numbers match `SB_VERSION` in `src/env.ts` and the desktop app release.
 
+## [3.1.0] — Prompt Capsules
+
+Contributed by @oudouusa.
+
+**Prompt Capsules (#329)**
+
+- New: `GET|HEAD /prompt-capsules/core`, `GET|HEAD /prompt-capsules/projects/<id>`, and the `get_prompt_capsule` MCP tool return a deterministic, read-only prompt prefix built from canonical memories tagged `capsule:core` or `capsule:project:<id>` plus one `capsule-slot:<slot>` each, with a strong `ETag` and `304` support.
+- Slots are emitted in a fixed order inside a 12,000-character budget; a slot that does not fit is omitted whole together with every later slot, and ambiguous or malformed definitions are skipped and reported without discarding unrelated slots. Empty or partially invalid responses have `complete: false`; `populated` distinguishes empty results.
+- Capsule bookkeeping tags are reserved: they never appear in `/stats` or `/brief` topic lists, never become digest members, and replacing an entry's tags with a new `capsule:` or `capsule-slot:` tag drops the old ones.
+- Capsule bodies are served from a per-workspace KV cache (one-hour orphan TTL; normally 24 TTL refresh writes/day for an unchanged hot target after propagation) keyed by an authoritative opaque D1 revision. Entry triggers advance the revision atomically on every capsule-tagged insert, id/content/tag update, workspace move, or delete, while ordinary entry writes leave it alone. A missing revision is initialized randomly rather than mapped to a reusable sentinel, so D1 restore/import cannot address a future cache key. Candidate rows and their revision are read in one D1 batch transaction, closing concurrent update and Time Travel ABA races. Empty caller-selected project ids are not cached, bounding KV key/write amplification; empty core is cached because it is one fixed target per workspace. A cached request reads one indexed D1 row instead of every row in the workspace, and KV eventual consistency can cause a rebuild but cannot revive a body from before an edit or share change. A capture carrying capsule tags is stored as its own row even at the duplicate-block threshold. Missing status starts as draft and classification cannot auto-publish it; protected contradictions are demoted to draft. MCP `update.tags` supports re-slotting. REST/MCP capture and update bound tags to 64 strings of 128 characters. A partial capsule-only index prevents missing-project reads from scanning ordinary memories. Installed trigger bodies are checked and repaired transactionally, with revision invalidation also when a trigger was missing. The candidate query explicitly selects the capsule index; NUL-containing rows cannot publish a truncated prefix.
+- Upgrade warning: `capsule:*` and `capsule-slot:*` reserve previously user-defined namespaces. Review existing canonical rows before gateway use. Shared malformed, duplicate, and oversized definitions are skipped and reported; authors/admins can repair via MCP `update` or unpublish with `set_status`. Other members gain no editing authority. Personal oversized content still returns 409, and the 200-candidate resource limit remains explicit.
+
 ## [3.0.0] — Team Edition
 
 ### Shipped in v3.0.0
@@ -114,14 +126,6 @@ Second Brain can now be a team's memory without stopping being yours. Every pers
 - One member's tags no longer reach another.
 - Toast text is readable in light mode; team panel contrast, overlap, truncation, and tap targets fixed.
 - Bulk selection no longer outlives the list it is over.
-
-**Prompt Capsules (#329)**
-
-- New: `GET|HEAD /prompt-capsules/core`, `GET|HEAD /prompt-capsules/projects/<id>`, and the `get_prompt_capsule` MCP tool return a deterministic, read-only prompt prefix built from canonical memories tagged `capsule:core` or `capsule:project:<id>` plus one `capsule-slot:<slot>` each, with a strong `ETag` and `304` support.
-- Slots are emitted in a fixed order inside a 12,000-character budget; a slot that does not fit is omitted whole together with every later slot, and ambiguous or malformed definitions are skipped and reported without discarding unrelated slots. Empty or partially invalid responses have `complete: false`; `populated` distinguishes empty results.
-- Capsule bookkeeping tags are reserved: they never appear in `/stats` or `/brief` topic lists, never become digest members, and replacing an entry's tags with a new `capsule:` or `capsule-slot:` tag drops the old ones.
-- Capsule bodies are served from a per-workspace KV cache (one-hour orphan TTL; normally 24 TTL refresh writes/day for an unchanged hot target after propagation) keyed by an authoritative opaque D1 revision. Entry triggers advance the revision atomically on every capsule-tagged insert, id/content/tag update, workspace move, or delete, while ordinary entry writes leave it alone. A missing revision is initialized randomly rather than mapped to a reusable sentinel, so D1 restore/import cannot address a future cache key. Candidate rows and their revision are read in one D1 batch transaction, closing concurrent update and Time Travel ABA races. Empty caller-selected project ids are not cached, bounding KV key/write amplification; empty core is cached because it is one fixed target per workspace. A cached request reads one indexed D1 row instead of every row in the workspace, and KV eventual consistency can cause a rebuild but cannot revive a body from before an edit or share change. A capture carrying capsule tags is stored as its own row even at the duplicate-block threshold. Missing status starts as draft and classification cannot auto-publish it; protected contradictions are demoted to draft. MCP `update.tags` supports re-slotting. REST/MCP capture and update bound tags to 64 strings of 128 characters. A partial capsule-only index prevents missing-project reads from scanning ordinary memories. Installed trigger bodies are checked and repaired transactionally, with revision invalidation also when a trigger was missing. The candidate query explicitly selects the capsule index; NUL-containing rows cannot publish a truncated prefix.
-- Upgrade warning: `capsule:*` and `capsule-slot:*` reserve previously user-defined namespaces. Review existing canonical rows before gateway use. Shared malformed, duplicate, and oversized definitions are skipped and reported; authors/admins can repair via MCP `update` or unpublish with `set_status`. Other members gain no editing authority. Personal oversized content still returns 409, and the 200-candidate resource limit remains explicit.
 
 **Upgrade**
 

--- a/installer/package-lock.json
+++ b/installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "second-brain-installer",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "second-brain-installer",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2.9.0"
       },

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "second-brain-installer",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -3599,7 +3599,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "second-brain-desktop"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain-desktop"
-version = "3.0.0"
+version = "3.1.0"
 description = "Second Brain desktop app — one-click setup and a native shell for your own memory dashboard"
 edition = "2021"
 rust-version = "1.82"

--- a/installer/src-tauri/src/credits.rs
+++ b/installer/src-tauri/src/credits.rs
@@ -40,6 +40,10 @@ pub const MAINTAINERS: &[Person] = &[
         name: "Robert Brandin",
         github: Some("tumes"),
     },
+    Person {
+        name: "oudouusa",
+        github: Some("oudouusa"),
+    },
 ];
 
 fn line(person: &Person) -> String {

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Second Brain",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "identifier": "com.secondbrain.desktop",
   "build": {
     "beforeDevCommand": "npm run bundle-worker && npm run dev",

--- a/public/credits.js
+++ b/public/credits.js
@@ -8,6 +8,7 @@ window.SB_CREDITS = {
     { name: "Mochammad Fadhlan Al-Ghiffari", github: "MFA-G" },
     { name: "Phillip Smith", github: "phillipadsmith" },
     { name: "Robert Brandin", github: "tumes" },
+    { name: "oudouusa", github: "oudouusa" },
   ],
 };
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -8,4 +8,4 @@ export interface Env extends Omit<Cloudflare.Env, "VECTORIZE_GRACE_MS"> {
 // Worker version, echoed by GET /health. The desktop app compares this against
 // the version it bundles to offer a one-click "update your Second Brain".
 // Bump (semver) when the Worker changes; see installer/README "Worker versioning".
-export const SB_VERSION = "3.0.0";
+export const SB_VERSION = "3.1.0";


### PR DESCRIPTION
Bumps the app to 3.1.0 and `SB_VERSION` to 3.1.0. Tag builds + publishes; app users are then offered the Worker update.